### PR TITLE
Remove “beta” tag

### DIFF
--- a/deltachat-ios/Info.plist
+++ b/deltachat-ios/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Delta Chat Beta</string>
+	<string>Delta Chat</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
iOS already displays a beta tag. Not requires to display beta two times.