### PR TITLE
avoid force casts

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -227,26 +227,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     @objc private func reachabilityChanged(note: Notification) {
-        if let reachability = note.object as? Reachability {
-            switch reachability.connection {
-            case .wifi, .cellular:
-                logger.info("network: reachable", reachability.connection.description)
-                dc_maybe_network(mailboxPointer)
+        guard let reachability = note.object as? Reachability else {
+            logger.info("reachability object missing")
+            return
+        }
 
-                let nc = NotificationCenter.default
-                DispatchQueue.main.async {
-                    nc.post(name: dcNotificationStateChanged,
-                            object: nil,
-                            userInfo: ["state": "online"])
-                }
-            case .none:
-                logger.info("network: not reachable")
-                let nc = NotificationCenter.default
-                DispatchQueue.main.async {
-                    nc.post(name: dcNotificationStateChanged,
-                            object: nil,
-                            userInfo: ["state": "offline"])
-                }
+        switch reachability.connection {
+        case .wifi, .cellular:
+            logger.info("network: reachable", reachability.connection.description)
+            dc_maybe_network(mailboxPointer)
+
+            let nc = NotificationCenter.default
+            DispatchQueue.main.async {
+                nc.post(name: dcNotificationStateChanged,
+                        object: nil,
+                        userInfo: ["state": "online"])
+            }
+        case .none:
+            logger.info("network: not reachable")
+            let nc = NotificationCenter.default
+            DispatchQueue.main.async {
+                nc.post(name: dcNotificationStateChanged,
+                        object: nil,
+                        userInfo: ["state": "offline"])
             }
         }
     }

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -227,26 +227,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     @objc private func reachabilityChanged(note: Notification) {
-        let reachability = note.object as! Reachability
+        if let reachability = note.object as? Reachability {
+            switch reachability.connection {
+            case .wifi, .cellular:
+                logger.info("network: reachable", reachability.connection.description)
+                dc_maybe_network(mailboxPointer)
 
-        switch reachability.connection {
-        case .wifi, .cellular:
-            logger.info("network: reachable", reachability.connection.description)
-            dc_maybe_network(mailboxPointer)
-
-            let nc = NotificationCenter.default
-            DispatchQueue.main.async {
-                nc.post(name: dcNotificationStateChanged,
-                        object: nil,
-                        userInfo: ["state": "online"])
-            }
-        case .none:
-            logger.info("network: not reachable")
-            let nc = NotificationCenter.default
-            DispatchQueue.main.async {
-                nc.post(name: dcNotificationStateChanged,
-                        object: nil,
-                        userInfo: ["state": "offline"])
+                let nc = NotificationCenter.default
+                DispatchQueue.main.async {
+                    nc.post(name: dcNotificationStateChanged,
+                            object: nil,
+                            userInfo: ["state": "online"])
+                }
+            case .none:
+                logger.info("network: not reachable")
+                let nc = NotificationCenter.default
+                DispatchQueue.main.async {
+                    nc.post(name: dcNotificationStateChanged,
+                            object: nil,
+                            userInfo: ["state": "offline"])
+                }
             }
         }
     }

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -451,7 +451,6 @@ class AccountSetupController: UITableViewController {
             if let ui = notification.userInfo {
                 if ui["error"] as! Bool {
                     self.updateProgressHud(error: ui["errorMessage"] as? String)
-                    // self.hudHandler.setHudError(ui["errorMessage"] as? String)
                 } else if ui["done"] as! Bool {
                     self.updateProgressHudSuccess(callback: self.handleLoginSuccess)
                 } else {
@@ -468,7 +467,6 @@ class AccountSetupController: UITableViewController {
             if let ui = notification.userInfo {
                 if ui["error"] as! Bool {
                     self.updateProgressHud(error: ui["errorMessage"] as? String)
-                    // self.hudHandler.setHudError(ui["errorMessage"] as? String)
                 } else if ui["done"] as! Bool {
                     self.updateProgressHudSuccess(callback: self.handleLoginSuccess)
                 } else {

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -127,10 +127,11 @@ class ChatViewController: MessagesViewController {
             object: nil, queue: OperationQueue.main
         ) { notification in
             if let ui = notification.userInfo {
-                if self.chatId == ui["chat_id"] as! Int {
-                    let id = ui["message_id"] as! Int
-                    if id > 0 {
-                        self.insertMessage(DCMessage(id: id))
+                if self.chatId == ui["chat_id"] as? Int {
+                    if let id = ui["message_id"] as? Int {
+                        if id > 0 {
+                            self.insertMessage(DCMessage(id: id))
+                        }
                     }
                 }
             }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -158,7 +158,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             } else {
                 let cell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath)
                 if let contactCell = cell as? ContactCell {
-                let contact = groupMembers[row - staticCellCountMemberSection]
+                    let contact = groupMembers[row - staticCellCountMemberSection]
                     contactCell.nameLabel.text = contact.name
                     contactCell.emailLabel.text = contact.email
                     contactCell.initialsLabel.text = Utils.getInitials(inputName: contact.name)

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -150,22 +150,28 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             return cell
         } else if section == 1 {
             if row == 0 {
-                let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath) as! ActionCell
-                cell.actionTitle = String.localized("group_add_members")
+                let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
+                if let actionCell = cell as? ActionCell {
+                    actionCell.actionTitle = String.localized("group_add_members")
+                }
                 return cell
             } else {
-                let cell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath) as! ContactCell
+                let cell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath)
+                if let contactCell = cell as? ContactCell {
                 let contact = groupMembers[row - staticCellCountMemberSection]
-                cell.nameLabel.text = contact.name
-                cell.emailLabel.text = contact.email
-                cell.initialsLabel.text = Utils.getInitials(inputName: contact.name)
-                cell.setColor(contact.color)
+                    contactCell.nameLabel.text = contact.name
+                    contactCell.emailLabel.text = contact.email
+                    contactCell.initialsLabel.text = Utils.getInitials(inputName: contact.name)
+                    contactCell.setColor(contact.color)
+                }
                 return cell
             }
         } else if section == 2 {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath) as! ActionCell
-            cell.actionTitle = String.localized("menu_leave_group")
-            cell.actionColor = UIColor.red
+            let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
+            if let actionCell = cell as? ActionCell {
+                actionCell.actionTitle = String.localized("menu_leave_group")
+                actionCell.actionColor = UIColor.red
+            }
             return cell
         }
 

--- a/deltachat-ios/Controller/GroupNameController.swift
+++ b/deltachat-ios/Controller/GroupNameController.swift
@@ -60,20 +60,20 @@ class GroupNameController: UITableViewController {
         let row = indexPath.row
 
         if section == 0 {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "groupLabelCell", for: indexPath) as! GroupLabelCell
-            cell.onTextChanged = updateGroupName
-
+            let cell = tableView.dequeueReusableCell(withIdentifier: "groupLabelCell", for: indexPath)
+            if let groupLabelCell = cell as? GroupLabelCell {
+                groupLabelCell.onTextChanged = updateGroupName
+            }
             return cell
-
         } else {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath) as! ContactCell
-
-            let contact = DCContact(id: groupContactIds[row])
-            cell.nameLabel.text = contact.name
-            cell.emailLabel.text = contact.email
-            cell.initialsLabel.text = Utils.getInitials(inputName: contact.name)
-            cell.setColor(contact.color)
-
+            let cell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath)
+            if let contactCell = cell as? ContactCell {
+                let contact = DCContact(id: groupContactIds[row])
+                contactCell.nameLabel.text = contact.name
+                contactCell.emailLabel.text = contact.email
+                contactCell.initialsLabel.text = Utils.getInitials(inputName: contact.name)
+                contactCell.setColor(contact.color)
+            }
             return cell
         }
     }

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -92,12 +92,12 @@ class NewChatViewController: UITableViewController {
         ) {
             notification in
             if let ui = notification.userInfo {
-                if ui["error"] as! Bool {
+                if ui["error"] as? Bool ?? false {
                     self.hud?.error(ui["errorMessage"] as? String)
-                } else if ui["done"] as! Bool {
+                } else if ui["done"] as? Bool ?? false {
                     self.hud?.done()
                 } else {
-                    self.hud?.progress(ui["progress"] as! Int)
+                    self.hud?.progress(ui["progress"] as? Int ?? 0)
                 }
             }
         }

--- a/deltachat-ios/Controller/NewProfileViewController.swift
+++ b/deltachat-ios/Controller/NewProfileViewController.swift
@@ -171,11 +171,12 @@ class NewProfileViewController: UIViewController, QrCodeReaderDelegate {
         ) { notification in
             print("secure join: ", notification)
             if let ui = notification.userInfo {
-                if ui["progress"] as! Int == 400 {
-                    let contactId = ui["contact_id"] as! Int
-                    self.progressAlert.message = String.localizedStringWithFormat(
-                        String.localized("qrscan_x_verified_introduce_myself"),
-                        DCContact(id: contactId).nameNAddr)
+                if ui["progress"] as? Int == 400 {
+                    if let contactId = ui["contact_id"] as? Int {
+                        self.progressAlert.message = String.localizedStringWithFormat(
+                            String.localized("qrscan_x_verified_introduce_myself"),
+                            DCContact(id: contactId).nameNAddr)
+                    }
                 }
             }
         }

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -80,11 +80,11 @@ class QrCodeReaderController: UIViewController {
 extension QrCodeReaderController: AVCaptureMetadataOutputObjectsDelegate {
     func metadataOutput(_: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from _: AVCaptureConnection) {
 
-        let metadataObj = metadataObjects[0] as! AVMetadataMachineReadableCodeObject
-
-        if supportedCodeTypes.contains(metadataObj.type) {
-            if metadataObj.stringValue != nil {
-                self.delegate?.handleQrCode(metadataObj.stringValue!)
+        if let metadataObj = metadataObjects[0] as? AVMetadataMachineReadableCodeObject {
+            if supportedCodeTypes.contains(metadataObj.type) {
+                if metadataObj.stringValue != nil {
+                    self.delegate?.handleQrCode(metadataObj.stringValue!)
+                }
             }
         }
     }

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -39,12 +39,12 @@ internal final class SettingsViewController: QuickTableViewController {
             queue: nil
         ) { notification in
             if let ui = notification.userInfo {
-                if ui["error"] as! Bool {
+                if ui["error"] as? Bool ?? false {
                     self.hudHandler.setHudError(ui["errorMessage"] as? String)
-                } else if ui["done"] as! Bool {
+                } else if ui["done"] as? Bool ?? false {
                     self.hudHandler.setHudDone(callback: nil)
                 } else {
-                    self.hudHandler.setHudProgress(ui["progress"] as! Int)
+                    self.hudHandler.setHudProgress(ui["progress"] as? Int ?? 0)
                 }
             }
         }
@@ -54,12 +54,12 @@ internal final class SettingsViewController: QuickTableViewController {
             queue: nil
         ) { notification in
             if let ui = notification.userInfo {
-                if ui["error"] as! Bool {
+                if ui["error"] as? Bool ?? false {
                     self.hudHandler.setHudError(ui["errorMessage"] as? String)
-                } else if ui["done"] as! Bool {
+                } else if ui["done"] as? Bool ?? false {
                     self.hudHandler.setHudDone(callback: nil)
                 } else {
-                    self.hudHandler.setHudProgress(ui["progress"] as! Int)
+                    self.hudHandler.setHudProgress(ui["progress"] as? Int ?? 0)
                 }
             }
         }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -100,11 +100,12 @@ class AppCoordinator: NSObject, Coordinator {
 
     func showChat(chatId: Int) {
         showTab(index: 3)
-        let navController = self.chatListController as! UINavigationController
-        let chatVC = ChatViewController(dcContext: dcContext, chatId: chatId)
-        let coordinator = ChatViewCoordinator(dcContext: dcContext, navigationController: navController, chatId: chatId)
-        chatVC.coordinator = coordinator
-        navController.pushViewController(chatVC, animated: true)
+        if let navController = self.chatListController as? UINavigationController {
+            let chatVC = ChatViewController(dcContext: dcContext, chatId: chatId)
+            let coordinator = ChatViewCoordinator(dcContext: dcContext, navigationController: navController, chatId: chatId)
+            chatVC.coordinator = coordinator
+            navController.pushViewController(chatVC, animated: true)
+        }
     }
 
     func presentLoginController() {
@@ -195,8 +196,9 @@ class ProfileCoordinator: Coordinator {
     }
 
     func showChat(chatId: Int) {
-        let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        appDelegate.appCoordinator.showChat(chatId: chatId)
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.appCoordinator.showChat(chatId: chatId)
+        }
     }
 }
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -100,12 +100,14 @@ class AppCoordinator: NSObject, Coordinator {
 
     func showChat(chatId: Int) {
         showTab(index: 3)
-        if let navController = self.chatListController as? UINavigationController {
-            let chatVC = ChatViewController(dcContext: dcContext, chatId: chatId)
-            let coordinator = ChatViewCoordinator(dcContext: dcContext, navigationController: navController, chatId: chatId)
-            chatVC.coordinator = coordinator
-            navController.pushViewController(chatVC, animated: true)
+        guard let navController = self.chatListController as? UINavigationController else {
+            assertionFailure("huh? why no nav controller?")
+            return
         }
+        let chatVC = ChatViewController(dcContext: dcContext, chatId: chatId)
+        let coordinator = ChatViewCoordinator(dcContext: dcContext, navigationController: navController, chatId: chatId)
+        chatVC.coordinator = coordinator
+        navController.pushViewController(chatVC, animated: true)
     }
 
     func presentLoginController() {

--- a/deltachat-ios/DC/events.swift
+++ b/deltachat-ios/DC/events.swift
@@ -48,9 +48,9 @@ public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLon
             if done {
                 UserDefaults.standard.set(true, forKey: Constants.Keys.deltachatUserProvidedCredentialsKey)
                 UserDefaults.standard.synchronize()
-                let appDelegate = UIApplication.shared.delegate as! AppDelegate
-                // appDelegate.appCoordinator?.showTab(index: 3)
-                AppDelegate.lastErrorDuringConfig = nil
+                if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                    AppDelegate.lastErrorDuringConfig = nil
+                }
             }
         }
     case DC_EVENT_ERROR_NETWORK:

--- a/deltachat-ios/DC/events.swift
+++ b/deltachat-ios/DC/events.swift
@@ -41,7 +41,7 @@ public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLon
                     "progress": Int(data1),
                     "error": Int(data1) == 0,
                     "done": done,
-                    "errorMessage": AppDelegate.lastErrorDuringConfig,
+                    "errorMessage": AppDelegate.lastErrorDuringConfig as Any,
                 ]
             )
 
@@ -133,7 +133,7 @@ public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLon
                     "progress": Int(data1),
                     "error": Int(data1) == 0,
                     "done": Int(data1) == 1000,
-                    "errorMessage": AppDelegate.lastErrorDuringConfig,
+                    "errorMessage": AppDelegate.lastErrorDuringConfig as Any,
                 ]
             )
         }

--- a/deltachat-ios/DC/events.swift
+++ b/deltachat-ios/DC/events.swift
@@ -48,9 +48,7 @@ public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLon
             if done {
                 UserDefaults.standard.set(true, forKey: Constants.Keys.deltachatUserProvidedCredentialsKey)
                 UserDefaults.standard.synchronize()
-                if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                    AppDelegate.lastErrorDuringConfig = nil
-                }
+                AppDelegate.lastErrorDuringConfig = nil
             }
         }
     case DC_EVENT_ERROR_NETWORK:


### PR DESCRIPTION
this pr tries to remove all `as!` casts that are potentially dangerous as, when failing, the app panics. esp. when it comes to calling into UIKit or so, we cannot really guarantee that sth. is of a given type.

swiftlint also treats this as bad practice and throws warnings

so, if needed, we'll cast using `as?` and check for `nil`.

cmp https://developer.apple.com/swift/blog/?id=23

targets #171 