### PR TITLE
core strings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -51,5 +51,6 @@ file_length:
 cyclomatic_complexity:
   warning: 20
   error: 25
+  ignores_case_statements: true
 
 reporter: "xcode"

--- a/deltachat-ios/DC/events.swift
+++ b/deltachat-ios/DC/events.swift
@@ -183,6 +183,7 @@ public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLon
         case DC_STR_NOMESSAGES: string = String.localized("chat_no_messages")
         case DC_STR_SELF: string = String.localized("self")
         case DC_STR_DRAFT: string = String.localized("draft")
+        case DC_STR_MEMBER: return nil // we create this string in hackPluralsString()
         case DC_STR_VOICEMESSAGE: string = String.localized("voice_message")
         case DC_STR_DEADDROP: string = String.localized("chat_contact_request")
         case DC_STR_IMAGE: string = String.localized("image")

--- a/deltachat-ios/DC/events.swift
+++ b/deltachat-ios/DC/events.swift
@@ -178,7 +178,43 @@ public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLon
         }
 
     case DC_EVENT_GET_STRING:
-        break
+        var string = ""
+        switch Int32(data1) {
+        case DC_STR_NOMESSAGES: string = String.localized("chat_no_messages")
+        case DC_STR_SELF: string = String.localized("self")
+        case DC_STR_DRAFT: string = String.localized("draft")
+        case DC_STR_VOICEMESSAGE: string = String.localized("voice_message")
+        case DC_STR_DEADDROP: string = String.localized("chat_contact_request")
+        case DC_STR_IMAGE: string = String.localized("image")
+        case DC_STR_VIDEO: string = String.localized("video")
+        case DC_STR_AUDIO: string = String.localized("audio")
+        case DC_STR_FILE: string = String.localized("file")
+        case DC_STR_STATUSLINE: string = String.localized("pref_default_status_text")
+        case DC_STR_NEWGROUPDRAFT: string = String.localized("group_hello_draft")
+        case DC_STR_MSGGRPNAME: string = String.localized("systemmsg_group_name_changed")
+        case DC_STR_MSGGRPIMGCHANGED: string = String.localized("systemmsg_group_image_changed")
+        case DC_STR_MSGADDMEMBER: string = String.localized("systemmsg_member_added")
+        case DC_STR_MSGDELMEMBER: string = String.localized("systemmsg_member_removed")
+        case DC_STR_MSGGROUPLEFT: string = String.localized("systemmsg_group_left")
+        case DC_STR_GIF: string = String.localized("gif")
+        case DC_STR_CANTDECRYPT_MSG_BODY: string = String.localized("systemmsg_cannot_decrypt")
+        case DC_STR_READRCPT: string = String.localized("systemmsg_read_receipt_subject")
+        case DC_STR_READRCPT_MAILBODY: string = String.localized("systemmsg_read_receipt_body")
+        case DC_STR_MSGGRPIMGDELETED: string = String.localized("systemmsg_group_image_deleted")
+        case DC_STR_CONTACT_VERIFIED: string = String.localized("contact_verified")
+        case DC_STR_CONTACT_NOT_VERIFIED: string = String.localized("contact_not_verified")
+        case DC_STR_CONTACT_SETUP_CHANGED: string = String.localized("contact_setup_changed")
+        case DC_STR_ARCHIVEDCHATS: string = String.localized("chat_archived_chats_title")
+        case DC_STR_AC_SETUP_MSG_SUBJECT: string = String.localized("autocrypt_asm_subject")
+        case DC_STR_AC_SETUP_MSG_BODY: string = String.localized("autocrypt_asm_general_body")
+        case DC_STR_SELFTALK_SUBTITLE: string = String.localized("chat_self_talk_subtitle")
+        case DC_STR_CANNOT_LOGIN: string = String.localized("login_error_cannot_login")
+        case DC_STR_SERVER_RESPONSE: string = String.localized("login_error_server_response")
+        case DC_STR_MSGACTIONBYUSER: string = String.localized("systemmsg_action_by_user")
+        case DC_STR_MSGACTIONBYME: string = String.localized("systemmsg_action_by_me")
+        default: return nil
+        }
+        return UnsafePointer(strdup(string))
 
     default:
         logger.warning("unknown event: \(event)")

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -47,6 +47,17 @@ class ChatTitleView: UIView {
         subtitleLabel.textColor = baseColor.withAlphaComponent(0.95)
         titleLabel.textColor = baseColor
         titleLabel.text = title
-        subtitleLabel.text = subtitle
+        subtitleLabel.text = hackPluralsString(string: subtitle)
     }
+}
+
+func hackPluralsString(string: String?) -> String? {
+    // the rust-core does not care about plural forms (there is just once case that was not worth the effort up to now)
+    // therefore, we check if the returned string has the form "N member(s)" and localized the corrently to one/few/many/other
+    guard var string = string else { return nil }
+    if string.hasSuffix(" member(s)") {
+        guard let value = Int(string.components(separatedBy: " ")[0]) else { return string }
+        string = String.localizedStringWithFormat(NSLocalizedString("n_members", comment: ""), value)
+    }
+    return string
 }


### PR DESCRIPTION
this pr supplies translated strings to the core.

in some future, we may get rid of DC_EVENT_GET_STRING, however, currently it is there and this is the way to have a fully-translated ui.

as the core does no longer care about plural forms currently, i had to do a small hack. also this may change in some future :)