### PR TITLE
combine name and signature row

### DIFF
--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -73,13 +73,4 @@ class EditSettingsController: UITableViewController {
             return nil
         }
     }
-
-    func activateField(option: SettingsEditOption) {
-        switch option {
-        case .DISPLAYNAME:
-            displayNameCell.textField.becomeFirstResponder()
-        case .STATUS:
-            statusCell.textField.becomeFirstResponder()
-        }
-    }
 }

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -92,19 +92,17 @@ internal final class SettingsViewController: QuickTableViewController {
     }
 
     private func setTable() {
+        let subtitle = String.localized("pref_default_status_label") + ": "
+            + (DcConfig.selfstatus ?? "-")
+
         tableContents = [
             Section(
                 title: String.localized("pref_profile_info_headline"),
                 rows: [
-                    NavigationRow(text: String.localized("pref_your_name"),
-                        detailText: .value1(DcConfig.displayname ?? ""),
+                    NavigationRow(text: DcConfig.displayname ?? String.localized("pref_your_name"),
+                        detailText: .subtitle(subtitle),
                         action: { [weak self] in
-                            self?.editNameAndStatus($0, option: SettingsEditOption.DISPLAYNAME)
-                    }),
-                    NavigationRow(text: String.localized("pref_default_status_label"),
-                        detailText: .value1(DcConfig.selfstatus ?? ""),
-                        action: { [weak self] in
-                            self?.editNameAndStatus($0, option: SettingsEditOption.STATUS)
+                            self?.editNameAndStatus($0)
                     }),
                     NavigationRow(text: String.localized("pref_password_and_account_settings"),
                         detailText: .none,
@@ -250,12 +248,7 @@ internal final class SettingsViewController: QuickTableViewController {
         coordinator?.showAccountSetupController()
     }
 
-    private func editNameAndStatus(_ row: Row, option: SettingsEditOption) {
-        coordinator?.showEditSettingsController(option: option)
+    private func editNameAndStatus(_ row: Row) {
+        coordinator?.showEditSettingsController()
     }
-}
-
-enum SettingsEditOption: String {
-    case DISPLAYNAME = "Display Name"
-    case STATUS = "Status"
 }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -257,9 +257,8 @@ class SettingsCoordinator: Coordinator {
         navigationController.pushViewController(accountSetupVC, animated: true)
     }
 
-    func showEditSettingsController(option: SettingsEditOption) {
+    func showEditSettingsController() {
         let editController = EditSettingsController()
-        editController.activateField(option: option)
         navigationController.pushViewController(editController, animated: true)
     }
 


### PR DESCRIPTION
this pr combines the name- and signature row, to avoid the ux glitch of two rows navigating to the same screen.

later on, this should also contain the profile image and in the EditSettingsController the profile image should be selectable.

closes #217 
tackles #218 

<img width=400  src=https://user-images.githubusercontent.com/9800740/64133731-baac6100-cdd8-11e9-99d7-5ec8dcc4dede.png>
