### PR TITLE
tweak alerts

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -216,11 +216,11 @@ extension ChatListController: UITableViewDataSource, UITableViewDelegate {
 
     private func showDeleteChatConfirmationAlert(chatId: Int) {
         let alert = UIAlertController(
-            title: String.localized("ask_delete_chat_desktop"),
-            message: nil,
-            preferredStyle: .alert
+            title: nil,
+            message: String.localized("ask_delete_chat_desktop"),
+            preferredStyle: .actionSheet
         )
-        alert.addAction(UIAlertAction(title: String.localized("global_menu_edit_delete_desktop"), style: .default, handler: { _ in
+        alert.addAction(UIAlertAction(title: String.localized("menu_delete_chat"), style: .destructive, handler: { _ in
             self.dcContext.deleteChat(chatId: chatId)
             self.getChatList()
         }))

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -30,7 +30,7 @@ class ContactDetailViewController: UITableViewController {
         let cell = ActionCell()
         cell.accessibilityIdentifier = CellIdentifiers.chat.rawValue
         cell.actionColor = SystemColor.blue.uiColor
-        cell.actionTitle = String.localizedStringWithFormat(String.localized("ask_start_chat_with"), contact.nameNAddr)
+        cell.actionTitle = String.localizedStringWithFormat(String.localized("menu_new_chat"), contact.nameNAddr)
         cell.selectionStyle = .none
         return cell
     }()

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -30,7 +30,7 @@ class ContactDetailViewController: UITableViewController {
         let cell = ActionCell()
         cell.accessibilityIdentifier = CellIdentifiers.chat.rawValue
         cell.actionColor = SystemColor.blue.uiColor
-        cell.actionTitle = String.localizedStringWithFormat(String.localized("menu_new_chat"), contact.nameNAddr)
+        cell.actionTitle = String.localized("menu_new_chat")
         cell.selectionStyle = .none
         return cell
     }()

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -104,12 +104,27 @@ class ContactDetailViewController: UITableViewController {
             case .block:
                 toggleBlockContact()
             case .chat:
-                let chatId = Int(dc_create_chat_by_contact_id(mailboxPointer, UInt32(contactId)))
-                coordinator?.showChat(chatId: chatId)
+                askToChatWith(contactId: contactId)
             case .notification:
                 showNotificationSetup()
             }
         }
+    }
+
+    private func askToChatWith(contactId: Int) {
+        let dcContact = DcContact(id: contactId)
+        let alert = UIAlertController(title: String.localizedStringWithFormat(String.localized("ask_start_chat_with"), dcContact.nameNAddr),
+                                      message: nil,
+                                      preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { _ in
+            self.dismiss(animated: true, completion: nil)
+            let chatId = Int(dc_create_chat_by_contact_id(mailboxPointer, UInt32(contactId)))
+            self.coordinator?.showChat(chatId: chatId)
+        }))
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
+            self.dismiss(animated: true, completion: nil)
+        }))
+        present(alert, animated: true, completion: nil)
     }
 
     override func tableView(_: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -3,7 +3,6 @@ import UIKit
 // this is also used as ChatDetail for SingleChats
 class ContactDetailViewController: UITableViewController {
     weak var coordinator: ContactDetailCoordinatorProtocol?
-    var showChatCell: Bool = false // if this is set to true it will show a "goToChat-cell"
 
     private enum CellIdentifiers: String {
         case notification = "notificationCell"
@@ -73,7 +72,7 @@ class ContactDetailViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if section == 0 {
-            return showChatCell ? 2 : 1
+            return 2
         } else if section == 1 {
             return 1
         }

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -302,10 +302,10 @@ class NewChatViewController: UITableViewController {
 
     private func askToDeleteContact(contactId: Int, context: DcContext) {
         let contact = DcContact(id: contactId)
-        let alert = UIAlertController(title: String.localized("delete"),
-                                      message: String.localizedStringWithFormat(String.localized("delete_contact"), contact.nameNAddr),
-                                      preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: { _ in
+        let alert = UIAlertController(title: String.localizedStringWithFormat(String.localized("delete_contact"), contact.nameNAddr),
+                                      message: nil,
+                                      preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { _ in
             self.dismiss(animated: true, completion: nil)
             if context.deleteContact(contactId: contactId) {
                 self.contactIds = Utils.getContactIds()
@@ -322,8 +322,8 @@ class NewChatViewController: UITableViewController {
         let dcContact = DcContact(id: contactId)
         let alert = UIAlertController(title: String.localizedStringWithFormat(String.localized("ask_start_chat_with"), dcContact.nameNAddr),
                                       message: nil,
-                                      preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: { _ in
+                                      preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { _ in
             self.dismiss(animated: true, completion: nil)
             self.coordinator?.showNewChat(contactId: contactId)
         }))

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -218,11 +218,11 @@ internal final class SettingsViewController: QuickTableViewController {
 
         let dbfile = appDelegate.dbfile()
         let dburl = URL(fileURLWithPath: dbfile, isDirectory: false)
-        let alert = UIAlertController(title: String.localized("delete_account"),
-                                      message: String.localized("delete_account_message"),
+        let alert = UIAlertController(title: String.localized("delete_account_message"),
+                                      message: nil,
                                       preferredStyle: .actionSheet)
 
-        alert.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { _ in
+        alert.addAction(UIAlertAction(title: String.localized("delete_account"), style: .destructive, handler: { _ in
             appDelegate.stop()
             appDelegate.close()
             do {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -341,7 +341,6 @@ class NewChatCoordinator: Coordinator {
 
     func showContactDetail(contactId: Int) {
         let contactDetailController = ContactDetailViewController(contactId: contactId)
-        contactDetailController.showChatCell = true
         let coordinator = ContactDetailCoordinator(dcContext: dcContext, navigationController: navigationController)
         childCoordinators.append(coordinator)
         contactDetailController.coordinator = coordinator
@@ -418,7 +417,6 @@ class ChatViewCoordinator: NSObject, Coordinator {
 
     func showContactDetail(of contactId: Int) {
         let contactDetailController = ContactDetailViewController(contactId: contactId)
-        contactDetailController.showChatCell = true
         //let nav = UINavigationController(rootViewController: contactDetailController)
         let coordinator = ContactDetailCoordinator(dcContext: dcContext, navigationController: navigationController)
         childCoordinators.append(coordinator)


### PR DESCRIPTION
this pr changes the `UIAlertController` to use `preferredStyle: .actionSheet` for user actions and confirmations, cmp. https://developer.apple.com/design/human-interface-guidelines/ios/views/action-sheets/

`preferredStyle: .alert` stays for showing system states errors etc., see https://developer.apple.com/design/human-interface-guidelines/ios/views/alerts/

nb: we're using the _title_ instead of the _message_ if text gets displayed - the latter shows the text in bold when only a message is given. for whatever reason.