### PR TITLE
Tweak large titles

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/PortSettingsController.swift
+++ b/deltachat-ios/Controller/AccountSetup/PortSettingsController.swift
@@ -63,6 +63,10 @@ class PortSettingsController: UITableViewController {
         resetButton.isEnabled = false
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         onDismiss?("\(currentPort)")
     }

--- a/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
+++ b/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
@@ -43,6 +43,10 @@ class SecuritySettingsController: UITableViewController {
         navigationItem.rightBarButtonItem = resetButton
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         let selectedOption = options[selectedIndex]
         onDismiss?(selectedOption)

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -248,6 +248,7 @@ class AccountSetupController: UITableViewController {
         imapPortCell.detailTextLabel?.text = DcConfig.mailPort ?? DcConfig.configuredMailPort
         smtpSecurityCell.detailTextLabel?.text = SecurityConverter.convertHexToString(type: .SMTPSecurity, hex: DcConfig.getSmtpSecurity())
         imapSecurityCell.detailTextLabel?.text  = SecurityConverter.convertHexToString(type: .IMAPSecurity, hex: DcConfig.getImapSecurity())
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -33,19 +33,8 @@ class ChatListController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
-        if #available(iOS 11.0, *) {
-            navigationController?.navigationBar.prefersLargeTitles = true
-            navigationItem.largeTitleDisplayMode = .always
-        }
+        NavBarUtils.setBigTitle(navigationController: navigationController)
         getChatList()
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        if #available(iOS 11.0, *) {
-            navigationController?.navigationBar.prefersLargeTitles = false
-        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -89,8 +78,6 @@ class ChatListController: UIViewController {
         if showArchive {
             title = String.localized("chat_archived_chats_title")
         }
-
-        navigationController?.navigationBar.prefersLargeTitles = true
 
         newButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.compose, target: self, action: #selector(didPressNewChat))
         newButton.tintColor = DcColors.primary

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -76,7 +76,7 @@ class ChatViewController: MessagesViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
         // this will be removed in viewWillDisappear
         navigationController?.navigationBar.addGestureRecognizer(navBarTap)
 
@@ -96,12 +96,6 @@ class ChatViewController: MessagesViewController {
         }
 
         configureMessageMenu()
-
-        if #available(iOS 11.0, *) {
-            if disableWriting {
-                navigationController?.navigationBar.prefersLargeTitles = true
-            }
-        }
 
         let nc = NotificationCenter.default
         msgChangedObserver = nc.addObserver(
@@ -146,12 +140,6 @@ class ChatViewController: MessagesViewController {
         let cnt = Int(dc_get_fresh_msg_cnt(mailboxPointer, UInt32(chatId)))
         logger.info("updating count for chat \(cnt)")
         UIApplication.shared.applicationIconBadgeNumber = cnt
-
-        if #available(iOS 11.0, *) {
-            if disableWriting {
-                navigationController?.navigationBar.prefersLargeTitles = false
-            }
-        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/deltachat-ios/Controller/DcNavigationController.swift
+++ b/deltachat-ios/Controller/DcNavigationController.swift
@@ -8,7 +8,7 @@ final class DcNavigationController: UINavigationController {
         super.viewDidLoad()
 
         if #available(iOS 11.0, *) {
-            navigationBar.prefersLargeTitles = true
+            // preferred height of navigation bar title is configured in ViewControllers
         } else {
             navigationBar.setBackgroundImage(UIImage(), for: .default)
         }

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -41,6 +41,10 @@ class EditGroupViewController: UITableViewController {
         navigationItem.leftBarButtonItem = cancelButton
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
+    }
+
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         return groupNameCell
     }

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -39,6 +39,7 @@ class EditSettingsController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         displayNameBackup = DcConfig.displayname
         statusCellBackup = DcConfig.selfstatus
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -69,6 +69,7 @@ class GroupChatDetailViewController: UIViewController {
         updateGroupMembers()
         chatDetailTable.reloadData() // to display updates
         editBarButtonItem.isEnabled = currentUser != nil
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     private func updateGroupMembers() {

--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -6,13 +6,17 @@ class NewGroupViewController: GroupMembersViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = String.localized("menu_new_group")
-        navigationController?.navigationBar.prefersLargeTitles = false
         let groupCreationNextButton = UIBarButtonItem(title: String.localized("next"),
                                                       style: .done,
                                                       target: self,
                                                       action: #selector(nextButtonPressed))
         navigationItem.rightBarButtonItem = groupCreationNextButton
         contactIds = Utils.getContactIds()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     override func didReceiveMemoryWarning() {

--- a/deltachat-ios/Controller/GroupNameController.swift
+++ b/deltachat-ios/Controller/GroupNameController.swift
@@ -31,6 +31,10 @@ class GroupNameController: UITableViewController {
         // setupSubviews()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
+    }
+
     @objc func doneButtonPressed() {
         let groupChatId = dc_create_group_chat(mailboxPointer, 0, groupName)
         for contactId in contactIdsForGroup {

--- a/deltachat-ios/Controller/MailboxViewController.swift
+++ b/deltachat-ios/Controller/MailboxViewController.swift
@@ -16,9 +16,12 @@ class MailboxViewController: ChatViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = String.localized("menu_deaddrop")
-        if #available(iOS 11.0, *) {
-            navigationController?.navigationBar.prefersLargeTitles = true
-        }
+
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        NavBarUtils.setBigTitle(navigationController: navigationController)
     }
 
 }

--- a/deltachat-ios/Controller/MessageInfoViewController.swift
+++ b/deltachat-ios/Controller/MessageInfoViewController.swift
@@ -19,6 +19,10 @@ class MessageInfoViewController: UITableViewController {
         title = String.localized("menu_message_details")
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
+    }
+
     // MARK: - Table view data source
 
     override func numberOfSections(in _: UITableView) -> Int {

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -81,6 +81,7 @@ class NewChatViewController: UITableViewController {
         // this will show the searchbar on launch -> will be set back to true on viewDidAppear
         if #available(iOS 11.0, *) {
             navigationItem.hidesSearchBarWhenScrolling = false
+            navigationController?.navigationBar.prefersLargeTitles = false
         }
     }
 

--- a/deltachat-ios/Controller/NewContactController.swift
+++ b/deltachat-ios/Controller/NewContactController.swift
@@ -60,7 +60,7 @@ class NewContactController: UITableViewController {
 
     override func viewWillAppear(_: Bool) {
         navigationController?.setNavigationBarHidden(false, animated: false)
-        navigationController?.navigationBar.prefersLargeTitles = false
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     @objc func emailTextChanged() {
@@ -85,12 +85,6 @@ class NewContactController: UITableViewController {
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        navigationController?.navigationBar.prefersLargeTitles = true
     }
 
     override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -66,6 +66,7 @@ class QrCodeReaderController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         captureSession.startRunning()
+        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
     override func viewWillDisappear(_ animated: Bool) {
         captureSession.stopRunning()

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -48,10 +48,8 @@ class QrViewController: UITableViewController, QrCodeReaderDelegate {
         }
     }
 
-    override func viewWillAppear(_: Bool) {
-        if #available(iOS 11.0, *) {
-            navigationController?.navigationBar.prefersLargeTitles = true
-        }
+    override func viewWillAppear(_ animated: Bool) {
+        NavBarUtils.setBigTitle(navigationController: navigationController)
     }
 
     override func numberOfSections(in _: UITableView) -> Int {

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -67,16 +67,7 @@ internal final class SettingsViewController: QuickTableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setTable()
-        if #available(iOS 11.0, *) {
-            navigationController?.navigationBar.prefersLargeTitles = true
-        }
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        if #available(iOS 11.0, *) {
-            navigationController?.navigationBar.prefersLargeTitles = false
-        }
+        NavBarUtils.setBigTitle(navigationController: navigationController)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -21,7 +21,6 @@ class AppCoordinator: NSObject, Coordinator {
         let tabBarController = UITabBarController()
         tabBarController.viewControllers = [mailboxController, qrController, chatListController, settingsController]
         // put viewControllers here
-        tabBarController.delegate = self
         tabBarController.tabBar.tintColor = DcColors.primary
         tabBarController.tabBar.backgroundColor = .white
         return tabBarController
@@ -109,22 +108,6 @@ class AppCoordinator: NSObject, Coordinator {
         childCoordinators.append(coordinator)
         accountSetupController.coordinator = coordinator
         rootViewController.present(accountSetupNav, animated: false, completion: nil)
-    }
-}
-
-extension AppCoordinator: UITabBarControllerDelegate {
-    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        if let dcNav = viewController as? DcNavigationController {
-            switch tabBarController.selectedIndex {
-            case chatsTab, settingsTab:
-                dcNav.navigationBar.prefersLargeTitles = true
-            case mailboxTab, qrTab:
-                dcNav.navigationBar.prefersLargeTitles = false
-            default:
-                // should never get here
-                dcNav.navigationBar.prefersLargeTitles = false
-            }
-        }
     }
 }
 

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -155,6 +155,19 @@ struct Utils {
     }
 }
 
+class NavBarUtils {
+    static func setBigTitle(navigationController: UINavigationController?) {
+        if #available(iOS 11.0, *) {
+            navigationController?.navigationBar.prefersLargeTitles = true
+        }
+    }
+    static func setSmallTitle(navigationController: UINavigationController?) {
+        if #available(iOS 11.0, *) {
+            navigationController?.navigationBar.prefersLargeTitles = false
+        }
+    }
+}
+
 class DateUtils {
     // TODO: refactor that, it's an improper way for localizations, use stringsdict instead
     // blocked by: converting androids plurals xml entries to stringsdict


### PR DESCRIPTION
targets #232 

I first tried to set big titles in onViewWillAppear and small ones in onViewWillDisappear for the main viewcontrollers, but the result was not as I expected. After switching between the tabs and returning to a previosly visited tab, the titled appeard small, even though onViewWillAppear was called again in the corresponding view controller. 
That's why I've set the title's size of each viewcontroller individually by using a static helper method. 
With these changes, the Title of Contact requests is still small, if the list of contact requests is longer than the screen and the list scrolls to the bottom. There are workarounds, but I'm not sure if we really want them: https://stackoverflow.com/questions/46506401/how-to-turn-off-adjusting-large-titles-by-uitableview-in-ios-11?answertab=votes#tab-top

@r10s what do you think?