### PR TITLE
handling received autocrypt-setup-messages

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -848,6 +848,7 @@ extension ChatViewController: MessageCellDelegate {
         inputDlg.addTextField(configurationHandler: { (textField) in
             textField.placeholder = msg.setupCodeBegin + ".."
             textField.text = orgText
+            textField.keyboardType = UIKeyboardType.numbersAndPunctuation // allows entering spaces; decimalPad would require a mask to keep things readable
         })
         inputDlg.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
 

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -69,6 +69,10 @@ class DcContext {
         }
         return nil
     }
+
+    func continueKeyTransfer(msgId: Int, setupCode: String) -> Bool {
+        return dc_continue_key_transfer(self.contextPointer, UInt32(msgId), setupCode) != 0
+    }
 }
 
 class DcConfig {
@@ -624,6 +628,17 @@ class DcMsg: MessageType {
 
     var isInfo: Bool {
         return dc_msg_is_info(messagePointer) == 1
+    }
+
+    var isSetupMessage: Bool {
+        return dc_msg_is_setupmessage(messagePointer) == 1
+    }
+
+    var setupCodeBegin: String {
+        guard let cString = dc_msg_get_setupcodebegin(messagePointer) else { return "" }
+        let swiftString = String(cString: cString)
+        free(cString)
+        return swiftString
     }
 
     func summary(chars: Int) -> String? {

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -457,6 +457,8 @@ class DcMsg: MessageType {
                 NSAttributedString.Key.foregroundColor: UIColor.darkGray,
                 ])
             return MessageKind.attributedText(text)
+        } else if isSetupMessage {
+            return MessageKind.text(String.localized("autocrypt_asm_click_body"))
         }
 
         let text = self.text ?? ""


### PR DESCRIPTION
the input field is very basic, a simple improvement might be to add a mask and insert a space or so every 4th character, doing so, we can also switch to UIKeyboardType. decimalPad.

an alternative would be to show the 3x3 input fields, not sure if this is possible in the UIAlertController (this would be my favourite) or in a separate view.

however, all in all, things are working, and the layout can be improved on an interation and should not prevent this pr from being merged :) 