### PR TITLE
tweak login

### DIFF
--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -38,7 +38,9 @@ class AccountSetupController: UITableViewController {
         progressView.centerYAnchor.constraint(equalTo: alert.view.centerYAnchor, constant: 0).isActive = true
         progressView.heightAnchor.constraint(equalToConstant: 65).isActive = true
         progressView.widthAnchor.constraint(equalToConstant: 65).isActive = true
-        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: loginCancelled(_:)))
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
+            self.dcContext.stopOngoingProcess()
+        }))
         return alert
     }()
 
@@ -72,15 +74,6 @@ class AccountSetupController: UITableViewController {
             configProgressIndicator.value = CGFloat(value / 10)
         }
     }
-
-    private func loginCancelled(_ action: UIAlertAction) {
-        DcConfig.addr = nil
-        DcConfig.mailPw = nil
-        DispatchQueue.global(qos: .background).async {
-            dc_stop_ongoing_process(mailboxPointer)        // this function freezes UI so execute in background thread
-        }
-    }
-
 
     // account setup
 

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -6,6 +6,7 @@ class AccountSetupController: UITableViewController {
 
     weak var coordinator: AccountSetupCoordinator?
 
+    private let dcContext: DcContext
     private var skipOauth = false
     private var backupProgressObserver: Any?
     private var configureProgressObserver: Any?
@@ -225,7 +226,8 @@ class AccountSetupController: UITableViewController {
 
     private var advancedSectionShowing: Bool = false
 
-    init() {
+    init(dcContext: DcContext) {
+        self.dcContext = dcContext
         super.init(style: .grouped)
         hidesBottomBarWhenPushed = true
     }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -66,7 +66,7 @@ class AppCoordinator: NSObject, Coordinator {
         let nav = DcNavigationController(rootViewController: controller)
         let settingsImage = UIImage(named: "settings")
         nav.tabBarItem = UITabBarItem(title: String.localized("menu_settings"), image: settingsImage, tag: settingsTab)
-        let coordinator = SettingsCoordinator(navigationController: nav)
+        let coordinator = SettingsCoordinator(dcContext: dcContext, navigationController: nav)
         self.childCoordinators.append(coordinator)
         controller.coordinator = coordinator
         return nav
@@ -102,7 +102,7 @@ class AppCoordinator: NSObject, Coordinator {
     }
 
     func presentLoginController() {
-        let accountSetupController = AccountSetupController()
+        let accountSetupController = AccountSetupController(dcContext: dcContext)
         let accountSetupNav = DcNavigationController(rootViewController: accountSetupController)
         let coordinator = AccountSetupCoordinator(navigationController: accountSetupNav)
         childCoordinators.append(coordinator)
@@ -177,16 +177,18 @@ class ChatListCoordinator: Coordinator {
 }
 
 class SettingsCoordinator: Coordinator {
+    let dcContext: DcContext
     let navigationController: UINavigationController
 
     var childCoordinators: [Coordinator] = []
 
-    init(navigationController: UINavigationController) {
+    init(dcContext: DcContext, navigationController: UINavigationController) {
+        self.dcContext = dcContext
         self.navigationController = navigationController
     }
 
     func showAccountSetupController() {
-        let accountSetupVC = AccountSetupController()
+        let accountSetupVC = AccountSetupController(dcContext: dcContext)
         let coordinator = AccountSetupCoordinator(navigationController: navigationController)
         childCoordinators.append(coordinator)
         accountSetupVC.coordinator = coordinator
@@ -199,7 +201,7 @@ class SettingsCoordinator: Coordinator {
     }
 
     func showLoginController() {
-        let accountSetupVC = AccountSetupController()
+        let accountSetupVC = AccountSetupController(dcContext: dcContext)
         let coordinator = AccountSetupCoordinator(navigationController: navigationController)
         childCoordinators.append(coordinator)
         accountSetupVC.coordinator = coordinator


### PR DESCRIPTION
pass context to AccountSetupController and simplify the cancellation process.

in fact, it should have worked before, however, might be delayed by the unneeded async.

in any case, #90 is fixed, either by this or by previous chances in the rust-core.