### PR TITLE
use small/default titlebar everywhere

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/PortSettingsController.swift
+++ b/deltachat-ios/Controller/AccountSetup/PortSettingsController.swift
@@ -63,10 +63,6 @@ class PortSettingsController: UITableViewController {
         resetButton.isEnabled = false
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
-    }
-
     override func viewWillDisappear(_ animated: Bool) {
         onDismiss?("\(currentPort)")
     }

--- a/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
+++ b/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
@@ -43,10 +43,6 @@ class SecuritySettingsController: UITableViewController {
         navigationItem.rightBarButtonItem = resetButton
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
-    }
-
     override func viewWillDisappear(_ animated: Bool) {
         let selectedOption = options[selectedIndex]
         onDismiss?(selectedOption)

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -243,7 +243,6 @@ class AccountSetupController: UITableViewController {
         imapPortCell.detailTextLabel?.text = DcConfig.mailPort ?? DcConfig.configuredMailPort
         smtpSecurityCell.detailTextLabel?.text = SecurityConverter.convertHexToString(type: .SMTPSecurity, hex: DcConfig.getSmtpSecurity())
         imapSecurityCell.detailTextLabel?.text  = SecurityConverter.convertHexToString(type: .IMAPSecurity, hex: DcConfig.getImapSecurity())
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -33,7 +33,6 @@ class ChatListController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        NavBarUtils.setBigTitle(navigationController: navigationController)
         getChatList()
     }
 

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -76,7 +76,6 @@ class ChatViewController: MessagesViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
         // this will be removed in viewWillDisappear
         navigationController?.navigationBar.addGestureRecognizer(navBarTap)
 

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -41,10 +41,6 @@ class EditGroupViewController: UITableViewController {
         navigationItem.leftBarButtonItem = cancelButton
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
-    }
-
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         return groupNameCell
     }

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -39,7 +39,6 @@ class EditSettingsController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         displayNameBackup = DcConfig.displayname
         statusCellBackup = DcConfig.selfstatus
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -77,7 +77,6 @@ class GroupChatDetailViewController: UIViewController {
         updateGroupMembers()
         chatDetailTable.reloadData() // to display updates
         editBarButtonItem.isEnabled = currentUser != nil
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     private func updateGroupMembers() {

--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -16,7 +16,6 @@ class NewGroupViewController: GroupMembersViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     override func didReceiveMemoryWarning() {
@@ -119,7 +118,6 @@ class BlockedContactsViewController: GroupMembersViewController, GroupMemberSele
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     func selected(contactId: Int, selected: Bool) {

--- a/deltachat-ios/Controller/GroupNameController.swift
+++ b/deltachat-ios/Controller/GroupNameController.swift
@@ -31,10 +31,6 @@ class GroupNameController: UITableViewController {
         // setupSubviews()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
-    }
-
     @objc func doneButtonPressed() {
         let groupChatId = dc_create_group_chat(mailboxPointer, 0, groupName)
         for contactId in contactIdsForGroup {

--- a/deltachat-ios/Controller/MailboxViewController.swift
+++ b/deltachat-ios/Controller/MailboxViewController.swift
@@ -22,7 +22,6 @@ class MailboxViewController: ChatViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        NavBarUtils.setBigTitle(navigationController: navigationController)
     }
 
     override func didTapMessage(in cell: MessageCollectionViewCell) {

--- a/deltachat-ios/Controller/MessageInfoViewController.swift
+++ b/deltachat-ios/Controller/MessageInfoViewController.swift
@@ -19,10 +19,6 @@ class MessageInfoViewController: UITableViewController {
         title = String.localized("menu_message_details")
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
-    }
-
     // MARK: - Table view data source
 
     override func numberOfSections(in _: UITableView) -> Int {

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -81,7 +81,6 @@ class NewChatViewController: UITableViewController {
         // this will show the searchbar on launch -> will be set back to true on viewDidAppear
         if #available(iOS 11.0, *) {
             navigationItem.hidesSearchBarWhenScrolling = false
-            navigationController?.navigationBar.prefersLargeTitles = false
         }
     }
 

--- a/deltachat-ios/Controller/NewContactController.swift
+++ b/deltachat-ios/Controller/NewContactController.swift
@@ -60,7 +60,6 @@ class NewContactController: UITableViewController {
 
     override func viewWillAppear(_: Bool) {
         navigationController?.setNavigationBarHidden(false, animated: false)
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
 
     @objc func emailTextChanged() {

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -66,7 +66,6 @@ class QrCodeReaderController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         captureSession.startRunning()
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
     }
     override func viewWillDisappear(_ animated: Bool) {
         captureSession.stopRunning()

--- a/deltachat-ios/Controller/QrInviteViewController.swift
+++ b/deltachat-ios/Controller/QrInviteViewController.swift
@@ -36,10 +36,6 @@ class QrInviteViewController: UITableViewController {
         }
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        NavBarUtils.setSmallTitle(navigationController: navigationController)
-    }
-
     override func numberOfSections(in _: UITableView) -> Int {
         return 1
     }

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -48,10 +48,6 @@ class QrViewController: UITableViewController, QrCodeReaderDelegate {
         }
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        NavBarUtils.setBigTitle(navigationController: navigationController)
-    }
-
     override func numberOfSections(in _: UITableView) -> Int {
         return 1
     }

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -72,7 +72,6 @@ internal final class SettingsViewController: QuickTableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setTable()
-        NavBarUtils.setBigTitle(navigationController: navigationController)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -160,19 +160,6 @@ struct Utils {
     }
 }
 
-class NavBarUtils {
-    static func setBigTitle(navigationController: UINavigationController?) {
-        if #available(iOS 11.0, *) {
-            navigationController?.navigationBar.prefersLargeTitles = true
-        }
-    }
-    static func setSmallTitle(navigationController: UINavigationController?) {
-        if #available(iOS 11.0, *) {
-            navigationController?.navigationBar.prefersLargeTitles = false
-        }
-    }
-}
-
 class DateUtils {
     // TODO: refactor that, it's an improper way for localizations, use stringsdict instead
     // blocked by: converting androids plurals xml entries to stringsdict


### PR DESCRIPTION
the usage of large titles adds some additional maintainace effort
we do not want to spend currently.
but even if we would, due to the tabbar,
there would be some ugly switching between title sizes left,
eg. when settings and chats have different scrolling positions.
(one atop, the other somewhere else).

tackles https://github.com/deltachat/deltachat-ios/issues/232