### PR TITLE
disable special drawings of the titlebar for now

### DIFF
--- a/deltachat-ios/Controller/DcNavigationController.swift
+++ b/deltachat-ios/Controller/DcNavigationController.swift
@@ -10,13 +10,14 @@ final class DcNavigationController: UINavigationController {
         if #available(iOS 11.0, *) {
             // preferred height of navigation bar title is configured in ViewControllers
         } else {
-            navigationBar.setBackgroundImage(UIImage(), for: .default)
+            //navigationBar.setBackgroundImage(UIImage(), for: .default)
         }
-        navigationBar.backgroundColor = .white
+        //navigationBar.backgroundColor = .white
         setShadow(nil)
     }
 
     private func setShadow(_ state: String?) {
+        /*
         switch state {
         case "offline":
             navigationBar.shadowImage = Constants.defaultShadow
@@ -25,6 +26,7 @@ final class DcNavigationController: UINavigationController {
         default:
             navigationBar.shadowImage = Constants.defaultShadow
         }
+        */
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
the online/offline "shadow" is not used in all viewcontrollers
and is not always in sync with the current state.
also onboarding is a bit weird.
so, if we really want to use such an indiactor,
this would require some more investigation.
also, with the commands commented out by this commit,
for some reasons, the opaque-look-n-feel is not ios-ish
and has additional problems in dark-mode.