### PR TITLE
move contact-requests out of focus

### DIFF
--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -110,6 +110,9 @@ internal final class SettingsViewController: QuickTableViewController {
             Section(
                 title: String.localized("pref_communication"),
                 rows: [
+                    NavigationRow(text: String.localized("menu_deaddrop"),
+                              detailText: .none,
+                              action: { [weak self] in self?.showDeaddrop($0) }),
                     NavigationRow(text: String.localized("pref_show_emails"),
                                   detailText: .value1(SettingsClassicViewController.getValString(val: DcConfig.showEmails)),
                               action: { [weak self] in self?.showClassicMail($0) }),
@@ -204,6 +207,14 @@ internal final class SettingsViewController: QuickTableViewController {
         }))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         present(alert, animated: true, completion: nil)
+    }
+
+    private func showDeaddrop(_: Row) {
+        let deaddropViewController = MailboxViewController(dcContext: dcContext, chatId: Int(DC_CHAT_ID_DEADDROP))
+        let deaddropNavigationController = DcNavigationController(rootViewController: deaddropViewController)
+        let deaddropCoordinator = MailboxCoordinator(dcContext: dcContext, navigationController: deaddropNavigationController)
+        deaddropViewController.coordinator = deaddropCoordinator
+        self.coordinator?.navigationController.pushViewController(deaddropViewController, animated: true)
     }
 
     private func showClassicMail(_: Row) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -6,10 +6,9 @@ import MobileCoreServices
 class AppCoordinator: NSObject, Coordinator {
     private let window: UIWindow
     private let dcContext: DcContext
-    private let mailboxTab = 0
-    private let qrTab = 1
-    private let chatsTab = 2
-    private let settingsTab = 3
+    private let qrTab = 0
+    private let chatsTab = 1
+    private let settingsTab = 2
 
     var rootViewController: UIViewController {
         return tabBarController

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -19,25 +19,12 @@ class AppCoordinator: NSObject, Coordinator {
 
     private lazy var tabBarController: UITabBarController = {
         let tabBarController = UITabBarController()
-        tabBarController.viewControllers = [mailboxController, qrController, chatListController, settingsController]
-        // put viewControllers here
+        tabBarController.viewControllers = [qrController, chatListController, settingsController]
         tabBarController.tabBar.tintColor = DcColors.primary
-        tabBarController.tabBar.backgroundColor = .white
         return tabBarController
     }()
 
     // MARK: viewControllers
-
-    private lazy var mailboxController: UIViewController = {
-        let controller = MailboxViewController(dcContext: dcContext, chatId: Int(DC_CHAT_ID_DEADDROP))
-        let nav = DcNavigationController(rootViewController: controller)
-        let settingsImage = UIImage(named: "message")
-        nav.tabBarItem = UITabBarItem(title: String.localized("menu_deaddrop"), image: settingsImage, tag: mailboxTab)
-        let coordinator = MailboxCoordinator(dcContext: dcContext, navigationController: nav)
-        self.childCoordinators.append(coordinator)
-        controller.coordinator = coordinator
-        return nav
-    }()
 
     private lazy var qrController: UIViewController = {
         let controller = QrViewController(dcContext: dcContext)


### PR DESCRIPTION
the idea is that contact-requests pop up directly in the chatlist.
so, the contact-request-view is only needed
when the user discards a request and decides to come back to that later.
in a typical usage, there is often no need to open the contact requests,
therefore, a whole tab, at eye level of "chats" is overrated.

on android, contact-requests are used in the same way,
being not directly in the eyes of the user.

there are still some things to do on contact requests,
eg. they are still a bit ugly and not always refreshed in the chatlist
and the options show_emails=all should display all incoming mails
as contact-requests directly in the chatlist.

<img src=https://user-images.githubusercontent.com/9800740/65520998-cfb47580-dee8-11e9-9e25-e1bd1fe44a5d.png width=320>
