### PR TITLE
move account-edit to profile

### DIFF
--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -2,6 +2,7 @@ import UIKit
 
 class EditSettingsController: UITableViewController {
 
+    private let dcContext: DcContext
     private var displayNameBackup: String?
     private var statusCellBackup: String?
 
@@ -23,7 +24,8 @@ class EditSettingsController: UITableViewController {
         return cell
     }()
 
-    init() {
+    init(dcContext: DcContext) {
+        self.dcContext = dcContext
         super.init(style: .grouped)
     }
 

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -10,7 +10,12 @@ class EditSettingsController: UITableViewController {
     private let section1Name = 0
     private let section1Status = 1
     private let section1RowCount = 2
-    private let sectionCount = 1
+
+    private let section2 = 1
+    private let section2AccountSettings = 0
+    private let section2RowCount = 1
+
+    private let sectionCount = 2
 
     private lazy var displayNameCell: TextFieldCell = {
         let cell = TextFieldCell(description: String.localized("pref_your_name"), placeholder: String.localized("pref_your_name"))
@@ -21,6 +26,14 @@ class EditSettingsController: UITableViewController {
     private lazy var statusCell: TextFieldCell = {
         let cell = TextFieldCell(description: String.localized("pref_default_status_label"), placeholder: String.localized("pref_default_status_label"))
         cell.setText(text: DcConfig.selfstatus ?? nil)
+        return cell
+    }()
+
+    lazy var accountSettingsCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        cell.textLabel?.text = String.localized("pref_password_and_account_settings")
+        cell.accessoryType = .disclosureIndicator
+        cell.accessibilityIdentifier = "accountSettingsCell"
         return cell
     }()
 
@@ -58,14 +71,23 @@ class EditSettingsController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return section1RowCount
+        if section == section1 {
+            return section1RowCount
+        } else {
+            return section2RowCount
+        }
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.section == section1 && indexPath.row == section1Name {
-            return displayNameCell
+        if indexPath.section == section1 {
+            if indexPath.row == section1Name {
+                return displayNameCell
+            } else {
+                return statusCell
+            }
+        } else {
+            return accountSettingsCell
         }
-        return statusCell
     }
 
     override func tableView(_: UITableView, titleForFooterInSection section: Int) -> String? {
@@ -73,6 +95,12 @@ class EditSettingsController: UITableViewController {
             return String.localized("pref_who_can_see_profile_explain")
         } else {
             return nil
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) else { return }
+        if cell.accessibilityIdentifier == "accountSettingsCell" {
         }
     }
 }

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -101,6 +101,12 @@ class EditSettingsController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let cell = tableView.cellForRow(at: indexPath) else { return }
         if cell.accessibilityIdentifier == "accountSettingsCell" {
+            tableView.deselectRow(at: indexPath, animated: true)
+            guard let nc = navigationController else { return }
+            let accountSetupVC = AccountSetupController(dcContext: dcContext, editView: true)
+            let coordinator = AccountSetupCoordinator(dcContext: dcContext, navigationController: nc)
+            accountSetupVC.coordinator = coordinator
+            nc.pushViewController(accountSetupVC, animated: true)
         }
     }
 }

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -104,11 +104,6 @@ internal final class SettingsViewController: QuickTableViewController {
                         action: { _ in
                             self.coordinator?.showEditSettingsController()
                     }),
-                    NavigationRow(text: String.localized("pref_password_and_account_settings"),
-                        detailText: .none,
-                        action: { _ in
-                            self.coordinator?.showAccountSetupController()
-                    }),
                 ]
             ),
 

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -87,8 +87,13 @@ internal final class SettingsViewController: QuickTableViewController {
     }
 
     private func setTable() {
-        let subtitle = String.localized("pref_default_status_label") + ": "
-            + (DcConfig.selfstatus ?? "-")
+        let addr = (DcConfig.addr ?? "")
+        let status = (DcConfig.selfstatus ?? "-")
+        var subtitle = addr
+        if !addr.isEmpty && !status.isEmpty {
+            subtitle += ", " + String.localized("pref_default_status_label") + ": "
+        }
+        subtitle += status
 
         var appNameAndVersion = "Delta Chat"
         if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -182,7 +182,7 @@ class SettingsCoordinator: Coordinator {
     }
 
     func showEditSettingsController() {
-        let editController = EditSettingsController()
+        let editController = EditSettingsController(dcContext: dcContext)
         navigationController.pushViewController(editController, animated: true)
     }
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -173,14 +173,6 @@ class SettingsCoordinator: Coordinator {
         self.navigationController = navigationController
     }
 
-    func showAccountSetupController() {
-        let accountSetupVC = AccountSetupController(dcContext: dcContext, editView: true)
-        let coordinator = AccountSetupCoordinator(dcContext: dcContext, navigationController: navigationController)
-        childCoordinators.append(coordinator)
-        accountSetupVC.coordinator = coordinator
-        navigationController.pushViewController(accountSetupVC, animated: true)
-    }
-
     func showEditSettingsController() {
         let editController = EditSettingsController(dcContext: dcContext)
         navigationController.pushViewController(editController, animated: true)


### PR DESCRIPTION
this pr puts the "Password and account settings" navigation link into the profile info (as on android), it is typically not that important - when the user is logged in, he already managed the things to do there.

moreover, in the subtitle of the profile-info-link the email address is shown.