### PR TITLE
mitigate some halts

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -233,10 +233,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         switch reachability.connection {
         case .wifi, .cellular:
-            dc_maybe_network(mailboxPointer)
+            logger.info("network: reachable", reachability.connection.description)
 
+            // call dc_maybe_network() from a worker thread.
+            // normally, dc_maybe_network() can be called uncoditionally,
+            // however, in fact, it may halt things for some seconds.
+            // this pr is a workaround that make things usable for now.
+            DispatchQueue.global(qos: .background).async {
+                dc_maybe_network(mailboxPointer)
+            }
         case .none:
-            break
+            logger.info("network: not reachable")
         }
     }
 

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -233,23 +233,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         switch reachability.connection {
         case .wifi, .cellular:
-            logger.info("network: reachable", reachability.connection.description)
             dc_maybe_network(mailboxPointer)
 
-            let nc = NotificationCenter.default
-            DispatchQueue.main.async {
-                nc.post(name: dcNotificationStateChanged,
-                        object: nil,
-                        userInfo: ["state": "online"])
-            }
         case .none:
-            logger.info("network: not reachable")
-            let nc = NotificationCenter.default
-            DispatchQueue.main.async {
-                nc.post(name: dcNotificationStateChanged,
-                        object: nil,
-                        userInfo: ["state": "offline"])
-            }
+            break
         }
     }
 

--- a/deltachat-ios/Controller/DcNavigationController.swift
+++ b/deltachat-ios/Controller/DcNavigationController.swift
@@ -2,7 +2,6 @@ import UIKit
 import Reachability
 
 final class DcNavigationController: UINavigationController {
-    var stateChangedObserver: Any?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -13,52 +12,6 @@ final class DcNavigationController: UINavigationController {
             //navigationBar.setBackgroundImage(UIImage(), for: .default)
         }
         //navigationBar.backgroundColor = .white
-        setShadow(nil)
-    }
-
-    private func setShadow(_ state: String?) {
-        /*
-        switch state {
-        case "offline":
-            navigationBar.shadowImage = Constants.defaultShadow
-        case "online":
-            navigationBar.shadowImage = Constants.onlineShadow
-        default:
-            navigationBar.shadowImage = Constants.defaultShadow
-        }
-        */
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        if let connection = Reachability()?.connection {
-            switch connection {
-            case Reachability.Connection.cellular, Reachability.Connection.wifi:
-                setShadow("online")
-            case Reachability.Connection.none:
-                setShadow("offline")
-            }
-        }
-
-        let nc = NotificationCenter.default
-        stateChangedObserver = nc.addObserver(
-            forName: dcNotificationStateChanged,
-            object: nil,
-            queue: nil
-        ) { notification in
-            if let state = notification.userInfo?["state"] {
-                self.setShadow(state as? String)
-            }
-        }
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        let nc = NotificationCenter.default
-        if let stateChangedObserver = self.stateChangedObserver {
-            nc.removeObserver(stateChangedObserver)
-        }
     }
 
 }

--- a/deltachat-ios/DC/events.swift
+++ b/deltachat-ios/DC/events.swift
@@ -2,7 +2,6 @@ import UIKit
 import UserNotifications
 
 let dcNotificationChanged = Notification.Name(rawValue: "MrEventMsgsChanged")
-let dcNotificationStateChanged = Notification.Name(rawValue: "MrEventStateChanged")
 let dcNotificationIncoming = Notification.Name(rawValue: "MrEventIncomingMsg")
 let dcNotificationImexProgress = Notification.Name(rawValue: "dcNotificationImexProgress")
 let dcNotificationConfigureProgress = Notification.Name(rawValue: "MrEventConfigureProgress")
@@ -77,24 +76,8 @@ public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLon
             logger.warning("network: \(msg)")
         }
 
-        let nc = NotificationCenter.default
-        DispatchQueue.main.async {
-            DispatchQueue.main.async {
-                nc.post(name: dcNotificationStateChanged,
-                        object: nil,
-                        userInfo: ["state": "offline"])
-            }
-        }
-
     case DC_EVENT_IMAP_CONNECTED, DC_EVENT_SMTP_CONNECTED:
         logger.warning("network: \(String(cString: data2String))")
-
-        let nc = NotificationCenter.default
-        DispatchQueue.main.async {
-            nc.post(name: dcNotificationStateChanged,
-                    object: nil,
-                    userInfo: ["state": "online"])
-        }
 
     case DC_EVENT_MSGS_CHANGED, DC_EVENT_MSG_READ, DC_EVENT_MSG_DELIVERED:
         logger.info("change: \(event)")


### PR DESCRIPTION
call dc_maybe_network() from a worker thread.
    
normally, dc_maybe_network() can be called unconditionally,
however, in fact, it may halt things for some seconds.
this pr is a workaround that make things usable for now.

moreover, this pr removes some currently unused code 
to make things less confusing.

tackles #100