### PR TITLE
disable dark-mode partially

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -58,6 +58,12 @@ class ChatViewController: MessagesViewController {
     override func viewDidLoad() {
         messagesCollectionView.register(CustomMessageCell.self)
         super.viewDidLoad()
+
+        // TODO: support dark mode for this view, see https://github.com/deltachat/deltachat-ios/issues/163#issuecomment-533797080
+        if #available(iOS 13.0, *) {
+            overrideUserInterfaceStyle = .light
+        }
+
         view.backgroundColor = DcColors.chatBackgroundColor
         if !DcConfig.configured {
             // TODO: display message about nothing being configured


### PR DESCRIPTION
tackles #163 

we do not disable the darkmode for the whole app as the issues should be "in the face of the developers ;)"

however, to make the chatview usable, we disable it there.