### PR TITLE
add simple layout to show forwarded messages

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -518,15 +518,33 @@ extension ChatViewController: MessagesDataSource {
     }
 
     func messageTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        var attributedString: NSMutableAttributedString?
         if !isPreviousMessageSameSender(at: indexPath) {
             let name = message.sender.displayName
             let m = messageList[indexPath.section]
-            return NSAttributedString(string: name, attributes: [
+            attributedString = NSMutableAttributedString(string: name, attributes: [
                 .font: UIFont.systemFont(ofSize: 14),
                 .foregroundColor: m.fromContact.color,
             ])
         }
-        return nil
+        if isMessageForwarded(at: indexPath) {
+            let forwardedString = NSMutableAttributedString(string: String.localized("forwarded_message"), attributes: [
+                .font: UIFont.systemFont(ofSize: 14),
+                .foregroundColor: UIColor.darkGray,
+            ])
+            if attributedString == nil {
+                attributedString = forwardedString
+            } else {
+                attributedString?.append(NSAttributedString(string: "\n", attributes: nil))
+                attributedString?.append(forwardedString)
+            }
+        }
+        return attributedString
+    }
+
+    func isMessageForwarded(at indexPath: IndexPath) -> Bool {
+        let m = messageList[indexPath.section]
+        return m.isForwarded
     }
 
     func isTimeLabelVisible(at indexPath: IndexPath) -> Bool {
@@ -794,7 +812,13 @@ extension ChatViewController: MessagesLayoutDelegate {
             return 0
         }
 
-        return !isPreviousMessageSameSender(at: indexPath) ? 40 : 0
+        if !isPreviousMessageSameSender(at: indexPath) {
+            return 40
+        } else if isMessageForwarded(at: indexPath) {
+            return 20
+        }
+
+        return 0
     }
 
     func messageBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in _: MessagesCollectionView) -> CGFloat {

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -568,6 +568,10 @@ class DcMsg: MessageType {
         return MessageKind.fileText(Media(text: attributedFileString))
     }
 
+    var isForwarded: Bool {
+        return dc_msg_is_forwarded(messagePointer) == 1
+    }
+
     var messageId: String {
         return "\(id)"
     }

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -569,7 +569,7 @@ class DcMsg: MessageType {
     }
 
     var isForwarded: Bool {
-        return dc_msg_is_forwarded(messagePointer) == 1
+        return dc_msg_is_forwarded(messagePointer) != 0
     }
 
     var messageId: String {


### PR DESCRIPTION
adds a line to the message top label, showing Forwarded Message if dc_msg_is_forwarded returns 1

There's a core bug though that prevents returning ever 1, tested with the current core on Android and on iOS. I'll file a bug for that. 

![Screen Shot 2019-10-16 at 16 08 36](https://user-images.githubusercontent.com/2614900/66927325-e5bcde00-f02f-11e9-837f-c855334ff747.png)


