### PR TITLE
Tweak member list screens

### DIFF
--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -147,10 +147,9 @@ class AddGroupMembersViewController: GroupMembersViewController {
     }
 
     func loadMemberCandidates() -> [Int] {
-        var contactIds = Set(Utils.getContactIds()) // turn into set to speed up search
-        for member in chatMemberIds {
-            contactIds.remove(member)
-        }
+        var contactIds = Utils.getContactIds()
+        let memberSet = Set(chatMemberIds)
+        contactIds.removeAll(where: { memberSet.contains($0)})
         return Array(contactIds)
     }
 

--- a/deltachat-ios/Controller/GroupNameController.swift
+++ b/deltachat-ios/Controller/GroupNameController.swift
@@ -38,8 +38,7 @@ class GroupNameController: UITableViewController {
             if success == 1 {
                 logger.info("successfully added \(contactId) to group \(groupName)")
             } else {
-                // FIXME:
-                fatalError("failed to add \(contactId) to group \(groupName)")
+                logger.error("failed to add \(contactId) to group \(groupName)")
             }
         }
 


### PR DESCRIPTION
closes #355 
could not reproduce that issue:

> avatar color not updated on edit-name. if this is not easily fixable, we can remove the avatar in the edit-name screen at all

when changing the name of a group, also the avatar color changed. There might be collisions though as there are a limited amount of colors. Sometimes 2 different strings will result in the same color.