### PR TITLE
marknoticed chat on opening

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -59,6 +59,8 @@ class ChatViewController: MessagesViewController {
     }
 
     override func viewDidLoad() {
+        dcContext.marknoticedChat(chatId: chatId)
+
         messagesCollectionView.register(CustomMessageCell.self)
         super.viewDidLoad()
 

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -36,6 +36,10 @@ class DcContext {
         dc_archive_chat(self.contextPointer, UInt32(chatId), Int32(archive ? 1 : 0))
     }
 
+    func marknoticedChat(chatId: Int) {
+        dc_marknoticed_chat(self.contextPointer, UInt32(chatId))
+    }
+
     func getSecurejoinQr (chatId: Int) -> String? {
         if let cString = dc_get_securejoin_qr(self.contextPointer, UInt32(chatId)) {
             let swiftString = String(cString: cString)


### PR DESCRIPTION
this marks all messages in the chat as being notices
so that they do no longer appear as fresh
and are eg. not shown in the counter badges.

this does not send out an mdn;
this is done still only for the messages really shown on the display