### PR TITLE
marknoticed and update badge on entering chat

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -59,8 +59,6 @@ class ChatViewController: MessagesViewController {
     }
 
     override func viewDidLoad() {
-        dcContext.marknoticedChat(chatId: chatId)
-
         messagesCollectionView.register(CustomMessageCell.self)
         super.viewDidLoad()
         if !DcConfig.configured {
@@ -151,14 +149,21 @@ class ChatViewController: MessagesViewController {
         }
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // things that do not affect the chatview
+        // and are delayed after the view is displayed
+        dcContext.marknoticedChat(chatId: chatId)
+        let array = DcArray(arrayPointer: dc_get_fresh_msgs(mailboxPointer))
+        UIApplication.shared.applicationIconBadgeNumber = array.count
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
         // the navigationController will be used when chatDetail is pushed, so we have to remove that gestureRecognizer
         navigationController?.navigationBar.removeGestureRecognizer(navBarTap)
-
-        let array = DcArray(arrayPointer: dc_get_fresh_msgs(mailboxPointer))
-        UIApplication.shared.applicationIconBadgeNumber = array.count
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
this pr updates the app icon's badge-counter as soon a chat is entered and the messages are noticed - before, the counter was updated when the chat was left again.

moreover, the pr delays moves marknoticed call also to viewDidAppear to avoid the one being executed without the other and for performance reasons (no need to delay entering the view)