### PR TITLE
harden callback

### DIFF
--- a/deltachat-ios/DC/events.swift
+++ b/deltachat-ios/DC/events.swift
@@ -12,12 +12,12 @@ let dcNotificationContactChanged = Notification.Name(rawValue: "MrEventContactsC
 
 @_silgen_name("callbackSwift")
 
-public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLong, data1String: UnsafePointer<Int8>, data2String: UnsafePointer<Int8>) -> UnsafePointer<Int8>? {
+public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLong, data1String: UnsafePointer<Int8>, data2String: UnsafePointer<Int8>) {
     if event >= DC_EVENT_ERROR && event <= 499 {
         let s = String(cString: data2String)
         AppDelegate.lastErrorString = s
         logger.error("event: \(s)")
-        return nil
+        return
     }
 
     switch event {
@@ -171,6 +171,4 @@ public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLon
     default:
         logger.warning("unknown event: \(event)")
     }
-
-    return nil
 }

--- a/deltachat-ios/DC/wrapper.c
+++ b/deltachat-ios/DC/wrapper.c
@@ -1,8 +1,9 @@
 #include "wrapper.h"
 
-long callbackSwift(int, long, long, const char*, const char*);
+void callbackSwift(int, long, long, const char*, const char*);
 
 uintptr_t callback_ios(dc_context_t* mailbox, int event, uintptr_t data1, uintptr_t data2)
 {
-    return callbackSwift(event, data1, data2, (const char*)data1, (const char*)data2);
+    callbackSwift(event, data1, data2, (const char*)data1, (const char*)data2);
+    return 0;
 }

--- a/deltachat-ios/DC/wrapper.c
+++ b/deltachat-ios/DC/wrapper.c
@@ -4,6 +4,6 @@ void callbackSwift(int, long, long, const char*, const char*);
 
 uintptr_t callback_ios(dc_context_t* mailbox, int event, uintptr_t data1, uintptr_t data2)
 {
-    callbackSwift(event, data1, data2, (const char*)data1, (const char*)data2);
+    callbackSwift(event, data1, data2, data1? (const char*)data1 : "", data2? (const char*)data2 : "");
     return 0;
 }


### PR DESCRIPTION
this pr makes the swift-callback for receiving events from core more robust against NULL-pointers as a strings.

might already fix #373 