### PR TITLE
move folder-settings to account settings

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		AEE6EC412282DF5700EDC689 /* MailboxViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE6EC402282DF5700EDC689 /* MailboxViewController.swift */; };
 		AEE6EC482283045D00EDC689 /* EditSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE6EC472283045D00EDC689 /* EditSettingsController.swift */; };
 		B21005DB23383664004C70C5 /* SettingsClassicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21005DA23383664004C70C5 /* SettingsClassicViewController.swift */; };
+		B26B3BC7236DC3DC008ED35A /* SwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26B3BC6236DC3DC008ED35A /* SwitchCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -361,6 +362,7 @@
 		B253ED9C2336E79A004DD215 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B253ED9D2336E79A004DD215 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B253ED9E2336E79A004DD215 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = hu; path = hu.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		B26B3BC6236DC3DC008ED35A /* SwitchCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCell.swift; sourceTree = "<group>"; };
 		FECB35E2B04CD5F5D02C157A /* Pods-deltachat-iosTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-deltachat-iosTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-deltachat-iosTests/Pods-deltachat-iosTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -695,6 +697,7 @@
 		AE851AC3227C695900ED86F0 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				B26B3BC6236DC3DC008ED35A /* SwitchCell.swift */,
 				78E45E4B21D404AE00D4B15E /* CustomMessageCell.swift */,
 				70B8882D2091B8550074812E /* ContactCell.swift */,
 				78ED839321D5AF8A00243125 /* QrCodeView.swift */,
@@ -1054,6 +1057,7 @@
 				AE25F09022807AD800CDEA66 /* GroupNameCell.swift in Sources */,
 				305961E62346125100C80F33 /* LocationMessageSnapshotOptions.swift in Sources */,
 				AEE6EC3F2282C59C00EDC689 /* GroupMembersViewController.swift in Sources */,
+				B26B3BC7236DC3DC008ED35A /* SwitchCell.swift in Sources */,
 				78E45E3A21D3CFBC00D4B15E /* SettingsController.swift in Sources */,
 				AE8519EA2272FDCA00ED86F0 /* DeviceContactsHandler.swift in Sources */,
 				3059620B2346125100C80F33 /* LocationMessageSizeCalculator.swift in Sources */,

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -78,7 +78,7 @@ class AccountSetupController: UITableViewController {
         }
     }
 
-    // account setup
+    // cells
 
     private lazy var emailCell: TextFieldCell = {
         let cell = TextFieldCell.makeEmailCell(delegate: self)
@@ -219,17 +219,60 @@ class AccountSetupController: UITableViewController {
         return cell
     }()
 
-    // this loginButton can be enabled and disabled
+    lazy var inboxWatchCell: SwitchCell = {
+        return SwitchCell(textLabel: String.localized("pref_watch_inbox_folder"),
+                          on: dcContext.getConfigBool("inbox_watch"),
+                          action: { cell in
+                              self.dcContext.setConfigBool("inbox_watch", cell.isOn)
+                          })
+    }()
+
+    lazy var sentboxWatchCell: SwitchCell = {
+        return SwitchCell(textLabel: String.localized("pref_watch_sent_folder"),
+                          on: dcContext.getConfigBool("sentbox_watch"),
+                          action: { cell in
+                              self.dcContext.setConfigBool("sentbox_watch", cell.isOn)
+                          })
+    }()
+
+    lazy var mvboxWatchCell: SwitchCell = {
+        return SwitchCell(textLabel: String.localized("pref_watch_mvbox_folder"),
+                          on: dcContext.getConfigBool("mvbox_watch"),
+                          action: { cell in
+                              self.dcContext.setConfigBool("mvbox_watch", cell.isOn)
+                          })
+    }()
+
+    lazy var sendCopyToSelfCell: SwitchCell = {
+        return SwitchCell(textLabel: String.localized("pref_send_copy_to_self"),
+                          on: dcContext.getConfigBool("bcc_self"),
+                          action: { cell in
+                              self.dcContext.setConfigBool("bcc_self", cell.isOn)
+                          })
+    }()
+
+    lazy var mvboxMoveCell: SwitchCell = {
+        return SwitchCell(textLabel: String.localized("pref_auto_folder_moves"),
+                          on: dcContext.getConfigBool("mvbox_move"),
+                          action: { cell in
+                              self.dcContext.setConfigBool("mvbox_move", cell.isOn)
+                          })
+    }()
+
     private lazy var loginButton: UIBarButtonItem = {
         let button = UIBarButtonItem(title: String.localized("login_title"), style: .done, target: self, action: #selector(loginButtonPressed))
         button.isEnabled = dc_is_configured(mailboxPointer) == 0
         return button
     }()
 
-    let basicSection = 0
-    let restoreSection = 1
-    let advancedSection = 2
-    let dangerSection = 3
+
+    // add cells to sections
+
+    let basicSection = 100
+    let advancedSection = 200
+    let restoreSection = 300
+    let folderSection = 400
+    let dangerSection = 500
     private var sections = [Int]()
 
     private lazy var basicSectionCells: [UITableViewCell] = [emailCell, passwordCell]
@@ -246,6 +289,7 @@ class AccountSetupController: UITableViewController {
         smtpPasswordCell,
         smtpSecurityCell
     ]
+    private lazy var folderCells: [UITableViewCell] = [inboxWatchCell, sentboxWatchCell, mvboxWatchCell, sendCopyToSelfCell, mvboxMoveCell]
     private lazy var dangerCells: [UITableViewCell] = [emptyServerCell, deleteAccountCell]
 
     private let editView: Bool
@@ -258,6 +302,7 @@ class AccountSetupController: UITableViewController {
         self.sections.append(basicSection)
         self.sections.append(advancedSection)
         if editView {
+            self.sections.append(folderSection)
             self.sections.append(dangerSection)
         } else {
             self.sections.append(restoreSection)
@@ -324,6 +369,8 @@ class AccountSetupController: UITableViewController {
             return basicSectionCells.count
         } else if sections[section] == restoreSection {
             return restoreCells.count
+        } else if sections[section] == folderSection {
+            return folderCells.count
         } else if sections[section] == dangerSection {
             return dangerCells.count
         } else {
@@ -334,6 +381,8 @@ class AccountSetupController: UITableViewController {
     override func tableView(_: UITableView, titleForHeaderInSection section: Int) -> String? {
         if sections[section] == basicSection && editView {
             return String.localized("login_header")
+        } else if sections[section] == folderSection {
+            return String.localized("pref_imap_folder_handling")
         } else if sections[section] == dangerSection {
             return String.localized("danger")
         } else {
@@ -346,6 +395,8 @@ class AccountSetupController: UITableViewController {
             return String.localized("login_no_servers_hint")
         } else if sections[section] == advancedSection {
             return String.localized("login_subheader")
+        } else if sections[section] == folderSection {
+            return String.localized("pref_auto_folder_moves_explain")
         } else {
             return nil
         }
@@ -359,6 +410,8 @@ class AccountSetupController: UITableViewController {
             return basicSectionCells[row]
         } else if sections[section] == restoreSection {
             return restoreCells[row]
+        } else if sections[section] == folderSection {
+            return folderCells[row]
         } else if sections[section] == dangerSection {
             return dangerCells[row]
         } else {

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -303,9 +303,4 @@ internal final class SettingsViewController: QuickTableViewController {
         askAlert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         present(askAlert, animated: true, completion: nil)
     }
-
-    private func configure(_: Row) {
-        hudHandler.showHud(String.localized("configuring_account"))
-        dc_configure(mailboxPointer)
-    }
 }

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -200,48 +200,6 @@ internal final class SettingsViewController: QuickTableViewController {
             ),
 
             Section(
-                title: String.localized("pref_imap_folder_handling"),
-                rows: [
-                    SwitchRow(text: String.localized("pref_watch_inbox_folder"),
-                              switchValue: DcConfig.inboxWatch,
-                              action: { row in
-                                if let row = row as? SwitchRow {
-                                    DcConfig.inboxWatch = row.switchValue
-                                }
-                    }),
-                    SwitchRow(text: String.localized("pref_watch_sent_folder"),
-                              switchValue: DcConfig.sentboxWatch,
-                              action: { row in
-                                if let row = row as? SwitchRow {
-                                    DcConfig.sentboxWatch = row.switchValue
-                                }
-                    }),
-                    SwitchRow(text: String.localized("pref_watch_mvbox_folder"),
-                              switchValue: DcConfig.mvboxWatch,
-                              action: { row in
-                                if let row = row as? SwitchRow {
-                                    DcConfig.mvboxWatch = row.switchValue
-                                }
-                    }),
-                    SwitchRow(text: String.localized("pref_send_copy_to_self"),
-                              switchValue: dcContext.getConfigBool("bcc_self"),
-                              action: { row in
-                                if let row = row as? SwitchRow {
-                                    self.dcContext.setConfigBool("bcc_self", row.switchValue)
-                                }
-                    }),
-                    SwitchRow(text: String.localized("pref_auto_folder_moves"),
-                              switchValue: DcConfig.mvboxMove,
-                              action: { row in
-                                if let row = row as? SwitchRow {
-                                    DcConfig.mvboxMove = row.switchValue
-                                }
-                    }),
-                ],
-                footer: String.localized("pref_auto_folder_moves_explain")
-            ),
-
-            Section(
                 title: String.localized("autocrypt"),
                 rows: [
                     SwitchRow(text: String.localized("autocrypt_prefer_e2ee"),

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -309,27 +309,7 @@ class DcConfig {
         set { setConfigBool("mdns_enabled", newValue) }
         get { return getConfigBool("mdns_enabled") }
     }
-
-    class var inboxWatch: Bool {
-        set { setConfigBool("inbox_watch", newValue) }
-        get { return getConfigBool("inbox_watch") }
-    }
-
-    class var sentboxWatch: Bool {
-        set { setConfigBool("sentbox_watch", newValue) }
-        get { return getConfigBool("sentbox_watch") }
-    }
-
-    class var mvboxWatch: Bool {
-        set { setConfigBool("mvbox_watch", newValue) }
-        get { return getConfigBool("mvbox_watch") }
-    }
-
-    class var mvboxMove: Bool {
-        set { setConfigBool("mvbox_move", newValue) }
-        get { return getConfigBool("mvbox_move") }
-    }
-
+    
     class var showEmails: Int {
         // one of DC_SHOW_EMAILS_*
         set { setConfigInt("show_emails", newValue) }

--- a/deltachat-ios/View/SwitchCell.swift
+++ b/deltachat-ios/View/SwitchCell.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+class SwitchCell: UITableViewCell {
+
+    var uiSwitch: UISwitch
+    var action: ((SwitchCell) -> Void)?
+
+    var isOn: Bool {
+        return uiSwitch.isOn
+    }
+
+    init(textLabel: String, on: Bool, action: ((SwitchCell) -> Void)?) {
+        self.uiSwitch = UISwitch()
+        self.action = action
+        super.init(style: .value1, reuseIdentifier: nil)
+
+        self.uiSwitch.setOn(on, animated: false)
+        self.uiSwitch.addTarget(self, action: #selector(SwitchCell.didToggleSwitch(_:)), for: .valueChanged)
+        self.textLabel?.text = textLabel
+        self.accessoryView = uiSwitch
+        self.selectionStyle = .none
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc
+    private func didToggleSwitch(_ sender: UISwitch) {
+        action?(self)
+    }
+}


### PR DESCRIPTION
this pr moves the folder settings (watch inbox, move messages, bcc-self etc) from the main settings page to the account settings - now at the account-modify settings view.

i think the folder-settings belong directly to the account, and this way, all the account-releated settings are together.

the new account settings:

![Screen Shot 2019-11-02 at 16 13 08](https://user-images.githubusercontent.com/9800740/68073001-4f591e00-fd8c-11e9-8755-c6a9e8df5bc8.png)

the now more clear main settings view:

![Screen Shot 2019-11-02 at 16 13 00](https://user-images.githubusercontent.com/9800740/68073014-7c0d3580-fd8c-11e9-9273-343265beb8ad.png)
