### PR TITLE
tweak support for device-chat

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -178,6 +178,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         dc_set_stock_translation(mailboxPointer, UInt32(DC_STR_SERVER_RESPONSE), String.localized("login_error_server_response"))
         dc_set_stock_translation(mailboxPointer, UInt32(DC_STR_MSGACTIONBYUSER), String.localized("systemmsg_action_by_user"))
         dc_set_stock_translation(mailboxPointer, UInt32(DC_STR_MSGACTIONBYME), String.localized("systemmsg_action_by_me"))
+        dc_set_stock_translation(mailboxPointer, UInt32(DC_STR_DEVICE_MESSAGES), String.localized("device_talk"))
     }
 
     func stop() {

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -35,7 +35,7 @@ class ChatViewController: MessagesViewController {
     /// The `BasicAudioController` controll the AVAudioPlayer state (play, pause, stop) and udpate audio cell UI accordingly.
     open lazy var audioController = BasicAudioController(messageCollectionView: messagesCollectionView)
 
-    var disableWriting = false
+    private var disableWriting: Bool
     var showCustomNavBar = true
     var previewView: UIView?
     var previewController: PreviewController?
@@ -50,6 +50,7 @@ class ChatViewController: MessagesViewController {
     init(dcContext: DcContext, chatId: Int) {
         self.dcContext = dcContext
         self.chatId = chatId
+        self.disableWriting = !DcChat(id: chatId).canSend
         super.init(nibName: nil, bundle: nil)
         hidesBottomBarWhenPushed = true
     }
@@ -90,7 +91,9 @@ class ChatViewController: MessagesViewController {
             if chat.isGroup {
                 subtitle = String.localizedStringWithFormat(NSLocalizedString("n_members", comment: ""), chatContactIds.count)
             } else if chatContactIds.count >= 1 {
-                if chat.isSelfTalk {
+                if chat.isDeviceTalk {
+                    subtitle = String.localized("device_talk_subtitle")
+                } else if chat.isSelfTalk {
                     subtitle = String.localized("chat_self_talk_subtitle")
                 } else {
                     subtitle = DcContact(id: chatContactIds[0]).email

--- a/deltachat-ios/Controller/MailboxViewController.swift
+++ b/deltachat-ios/Controller/MailboxViewController.swift
@@ -5,7 +5,6 @@ class MailboxViewController: ChatViewController {
     override init(dcContext: DcContext, chatId: Int) {
         super.init(dcContext: dcContext, chatId: chatId)
         hidesBottomBarWhenPushed = true
-        disableWriting = true
         showCustomNavBar = false
     }
 

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -440,6 +440,14 @@ class DcChat {
         return Int(dc_chat_is_self_talk(chatPointer)) != 0
     }
 
+    var isDeviceTalk: Bool {
+        return Int(dc_chat_is_device_talk(chatPointer)) != 0
+    }
+
+    var canSend: Bool {
+        return Int(dc_chat_can_send(chatPointer)) != 0
+    }
+
     var isVerified: Bool {
         return dc_chat_is_verified(chatPointer) > 0
     }


### PR DESCRIPTION
this pr removes the input-field depending on dc_chat_can_send() (false for device-chat and deaddrop currently).

moreover, it adds the correct subtitle for device-chats.

<img width="535" alt="Screen Shot 2019-11-10 at 14 11 04" src="https://user-images.githubusercontent.com/9800740/68544601-39b7aa00-03c5-11ea-8437-fad93957d992.png">