### PR TITLE
name "add member" view as such

### DIFF
--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -5,7 +5,7 @@ class NewGroupViewController: GroupMembersViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = String.localized("menu_new_group")
+        title = String.localized("group_add_members")
         let groupCreationNextButton = UIBarButtonItem(title: String.localized("next"),
                                                       style: .done,
                                                       target: self,


### PR DESCRIPTION
the old name "new group" was a bit misleading
as it was unclear what the user had to do on the view.
also, the next screen was also name "new group"
which adds some extra confusion
as the back-button was names same as the view then.

in general, we might refactor the whole stuff sooner or later
and allow entering the name first which allows showing a qr-code to join then.
however, this is a bit more work ;)