### PR TITLE
[wip] update memberlist on qr-scan

### DIFF
--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -24,6 +24,8 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     private lazy var countSectionInvite: Int = 2
     private let sectionGroupMembers = 2
 
+    private var chatModifiedObserver: Any?
+
     lazy var groupNameCell: TextFieldCell = {
         let cell = TextFieldCell(description: String.localized("group_name"), placeholder: String.localized("group_name"))
         cell.onTextFieldChange = self.updateGroupName
@@ -67,6 +69,25 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
         if groupChatId != 0 {
             let chat = DcChat.init(id: groupChatId)
             updateGroupContactIds(Set(chat.contactIds))
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        let nc = NotificationCenter.default
+        chatModifiedObserver = nc.addObserver(forName: dcNotificationChatModified, object: nil, queue: nil) { _ in
+            if self.groupChatId != 0 {
+                let chat = DcChat.init(id: self.groupChatId)
+                self.updateGroupContactIds(Set(chat.contactIds))
+            }
+        }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        let nc = NotificationCenter.default
+        if let chatModifiedObserver = self.chatModifiedObserver {
+            nc.removeObserver(chatModifiedObserver)
         }
     }
 

--- a/deltachat-ios/DC/events.swift
+++ b/deltachat-ios/DC/events.swift
@@ -9,6 +9,7 @@ let dcNotificationSecureJoinerProgress = Notification.Name(rawValue: "MrEventSec
 let dcNotificationSecureInviterProgress = Notification.Name(rawValue: "MrEventSecureInviterProgress")
 let dcNotificationViewChat = Notification.Name(rawValue: "MrEventViewChat")
 let dcNotificationContactChanged = Notification.Name(rawValue: "MrEventContactsChanged")
+let dcNotificationChatModified = Notification.Name(rawValue: "DC_EVENT_CHAT_MODIFIED")
 
 @_silgen_name("callbackSwift")
 
@@ -166,6 +167,18 @@ public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLon
                 object: nil,
                 userInfo: [
                     "contact_id": Int(data1)
+                ]
+            )
+        }
+
+    case DC_EVENT_CHAT_MODIFIED:
+        let nc = NotificationCenter.default
+        DispatchQueue.main.async {
+            nc.post(
+                name: dcNotificationChatModified,
+                object: nil,
+                userInfo: [
+                    "chat_id": Int(data1)
                 ]
             )
         }


### PR DESCRIPTION
on group creation, when a qr-code was show at some point, the memberlist may change at any time (https://github.com/deltachat/deltachat-ios/pull/464/commits/c91d67576e731ab98fca953dbd2dd2507afe0d54 is needed, but not sufficient), in these cases, we get the event [DC_EVENT_CHAT_MODIFIED](https://c.delta.chat/group__DC__EVENT.html#ga27512e465c573fcf295014f8e0075adf) and we have to update the list.

there is still a bug in this pr, however, in theory, it should work like this. checked android, there it works as expected and the list is updated, so this seems to be no core bug.  
i will dive into the details at a later point.