### PR TITLE
Fix dc event chat modified

### DIFF
--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -74,8 +74,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
         ) { notification in
             if let ui = notification.userInfo {
                 if let chatId = ui["chat_id"] as? Int {
-                    logger.warning("new created group chat id: \(self.groupChatId) vs. DC_EVENT_CHAT_MODIFIED chat Id: \(chatId)")
-                    if self.groupChatId == 0 /*|| chatId != self.groupChatId*/ {
+                    if self.groupChatId == 0 || chatId != self.groupChatId {
                         return
                     }
                     self.updateGroupContactIdsOnQRCodeInvite()

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -14,6 +14,8 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     let isVerifiedGroup: Bool
     let dcContext: DcContext
     private var contactAddedObserver: NSObjectProtocol?
+    ///TODO: remove the the line below as soon as deltachat-core 4b7b6d6cb3c26d817e3f3eeb6a20d8e8c66a4578 was released
+    private var workaroundObserver: NSObjectProtocol?
 
     private let sectionGroupDetails = 0
     private let sectionGroupDetailsRowAvatar = 0
@@ -81,11 +83,32 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
                 }
             }
         }
+
+        ///TODO: remove the the lines below as soon as deltachat-core 4b7b6d6cb3c26d817e3f3eeb6a20d8e8c66a4578 was released
+        workaroundObserver = nc.addObserver(
+            forName: dcNotificationChanged,
+            object: nil,
+            queue: nil
+        ) { notification in
+            if let ui = notification.userInfo {
+                if let chatId = ui["chat_id"] as? Int {
+                    if self.groupChatId == 0 || chatId != self.groupChatId {
+                        return
+                    }
+                    self.updateGroupContactIdsOnQRCodeInvite()
+                }
+            }
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         if let observer = self.contactAddedObserver {
             NotificationCenter.default.removeObserver(observer)
+        }
+
+        ///TODO: remove the the lines below as soon as deltachat-core 4b7b6d6cb3c26d817e3f3eeb6a20d8e8c66a4578 was released
+        if let workaroundObserver = self.workaroundObserver {
+            NotificationCenter.default.removeObserver(workaroundObserver)
         }
     }
 

--- a/deltachat-ios/DC/events.swift
+++ b/deltachat-ios/DC/events.swift
@@ -9,6 +9,7 @@ let dcNotificationSecureJoinerProgress = Notification.Name(rawValue: "MrEventSec
 let dcNotificationSecureInviterProgress = Notification.Name(rawValue: "MrEventSecureInviterProgress")
 let dcNotificationViewChat = Notification.Name(rawValue: "MrEventViewChat")
 let dcNotificationContactChanged = Notification.Name(rawValue: "MrEventContactsChanged")
+let dcNotificationChatModified = Notification.Name(rawValue: "dcNotificationChatModified")
 
 @_silgen_name("callbackSwift")
 
@@ -85,6 +86,19 @@ public func callbackSwift(event: CInt, data1: CUnsignedLong, data2: CUnsignedLon
                     "message_id": Int(data2),
                     "chat_id": Int(data1),
                     "date": Date(),
+                ]
+            )
+        }
+
+    case DC_EVENT_CHAT_MODIFIED:
+        logger.info("chat modified: \(event)")
+        let nc = NotificationCenter.default
+        DispatchQueue.main.async {
+            nc.post(
+                name: dcNotificationChatModified,
+                object: nil,
+                userInfo: [
+                    "chat_id": Int(data1),
                 ]
             )
         }


### PR DESCRIPTION
This PR only demonstrates a core bug (in case I understood the general qr code group join process correctly):

steps to reproduce:
* on device A: tap on new chat -> new group or new verified group 
* enter a group name
* tap on QR invite code
* on device B: scan QR code
* on device A: move back to new group / new verified group
* on device B: confirm alert "do you want to join group <XYZ>?"
* grep logs for "new created group chat id"

it will show that the chat id sent by DC_EVENT_CHAT_MODIFIED always stays 40. Instead the chat id should be the same as the return value of `dc_create_group_chat`