### PR TITLE
Paste images, fix compression

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -883,7 +883,7 @@ extension ChatViewController: MessagesDataSource {
     private func sendImage(_ image: UIImage, message: String? = nil) {
         DispatchQueue.global().async {
             if let compressedImage = image.dcCompress() {
-                // at this point image is compressed by 85% by default
+                // at this point image is compressed by 50% by default
                 let pixelSize = compressedImage.imageSizeInPixel()
                 let path = Utils.saveImage(image: compressedImage)
                 let msg = DcMsg(viewType: DC_MSG_IMAGE)

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -883,7 +883,7 @@ extension ChatViewController: MessagesDataSource {
     private func sendImage(_ image: UIImage, message: String? = nil) {
         DispatchQueue.global().async {
             if let compressedImage = image.dcCompress() {
-                // at this point image is compressed by 50% by default
+                // at this point image is compressed by 85% by default
                 let pixelSize = compressedImage.imageSizeInPixel()
                 let path = Utils.saveImage(image: compressedImage)
                 let msg = DcMsg(viewType: DC_MSG_IMAGE)

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -112,6 +112,10 @@ class DcContext {
         dc_forward_msgs(contextPointer, [UInt32(msgId)], 1, UInt32(chat))
     }
 
+    func sendTextInChat(id: Int, message: String) {
+        dc_send_text_msg(contextPointer, UInt32(id), message)
+    }
+
     func initiateKeyTransfer() -> String? {
         if let cString = dc_initiate_key_transfer(self.contextPointer) {
             let swiftString = String(cString: cString)

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -789,7 +789,7 @@ class DcMsg: MessageType {
     }
 
     func setDimension(width: CGFloat, height: CGFloat) {
-        dc_msg_set_dimension(messagePointer, Int32(exactly: width)!, Int32(exactly: height)!)
+        dc_msg_set_dimension(messagePointer, Int32(width), Int32(height))
     }
 
     var filesize: Int {

--- a/deltachat-ios/Extensions/UIImage+Extension.swift
+++ b/deltachat-ios/Extensions/UIImage+Extension.swift
@@ -76,7 +76,7 @@ extension UIImage {
     // the size of PNG imgaes will be scaled down
     func scaleDownAndCompress(toMax: Float) -> UIImage? {
         let rect = getResizedRectangle(toMax: self.isTransparent() ?
-            Float(min(self.size.width / 2, CGFloat(toMax / 2))) :
+            min(Float(self.size.width) / 2, toMax / 2) :
             toMax)
 
         UIGraphicsBeginImageContextWithOptions(rect.size, !self.isTransparent(), 0.0)

--- a/deltachat-ios/Extensions/UIImage+Extension.swift
+++ b/deltachat-ios/Extensions/UIImage+Extension.swift
@@ -71,15 +71,22 @@ extension UIImage {
         return newImage
     }
 
-    // source: https://stackoverflow.com/questions/29137488/how-do-i-resize-the-uiimage-to-reduce-upload-image-size // slightly changed
+    // if an image has an alpha channel we try to keep it, using PNG formatting instead of JPEG
+    // PNGs are less compressed than JPEGs - to keep the message sizes small,
+    // the size of PNG imgaes will be scaled down
     func scaleDownAndCompress(toMax: Float) -> UIImage? {
-        let rect = getResizedRectangle(toMax: toMax)
-        //50 percent compression
-        let compressionQuality: Float = 0.5
-        UIGraphicsBeginImageContextWithOptions(rect.size, self.isTransparent(), 0.0)
+        let rect = getResizedRectangle(toMax: self.isTransparent() ?
+            Float(min(self.size.width / 2, CGFloat(toMax / 2))) :
+            toMax)
+
+        UIGraphicsBeginImageContextWithOptions(rect.size, !self.isTransparent(), 0.0)
         draw(in: rect)
         let img = UIGraphicsGetImageFromCurrentImageContext()
-        let imageData = img?.jpegData(compressionQuality: CGFloat(compressionQuality))
+
+        let imageData = self.isTransparent() ?
+            img?.pngData() :
+            img?.jpegData(compressionQuality: 0.5)
+
         UIGraphicsEndImageContext()
         return UIImage(data: imageData!)
     }

--- a/deltachat-ios/Extensions/UIImage+Extension.swift
+++ b/deltachat-ios/Extensions/UIImage+Extension.swift
@@ -76,13 +76,19 @@ extension UIImage {
         let rect = getResizedRectangle(toMax: toMax)
         //50 percent compression
         let compressionQuality: Float = 0.5
-        UIGraphicsBeginImageContext(rect.size)
+        UIGraphicsBeginImageContextWithOptions(rect.size, self.isTransparent(), 0.0)
         draw(in: rect)
         let img = UIGraphicsGetImageFromCurrentImageContext()
         let imageData = img?.jpegData(compressionQuality: CGFloat(compressionQuality))
         UIGraphicsEndImageContext()
         return UIImage(data: imageData!)
     }
+
+    public func isTransparent() -> Bool {
+        guard let alpha: CGImageAlphaInfo = self.cgImage?.alphaInfo else { return false }
+        return alpha == .first || alpha == .last || alpha == .premultipliedFirst || alpha == .premultipliedLast
+      }
+
 }
 
 public enum ImageType: String {

--- a/deltachat-ios/Extensions/UIImage+Extension.swift
+++ b/deltachat-ios/Extensions/UIImage+Extension.swift
@@ -85,7 +85,7 @@ extension UIImage {
 
         let imageData = self.isTransparent() ?
             img?.pngData() :
-            img?.jpegData(compressionQuality: 0.5)
+            img?.jpegData(compressionQuality: 0.85)
 
         UIGraphicsEndImageContext()
         return UIImage(data: imageData!)

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -126,7 +126,7 @@ struct Utils {
             return nil
         }
 
-        guard let data = image.jpegData(compressionQuality: 1.0) else {
+        guard let data = image.isTransparent() ? image.pngData() : image.jpegData(compressionQuality: 1.0) else {
             return nil
         }
 

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -119,27 +119,14 @@ struct Utils {
         return addressParts.joined(separator: ", ")
     }
 
+    // compression needs to be done before in UIImage.dcCompress()
     static func saveImage(image: UIImage) -> String? {
         guard let directory = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask,
             appropriateFor: nil, create: false) as NSURL else {
             return nil
         }
 
-        let size = image.size.applying(CGAffineTransform(scaleX: 0.2, y: 0.2))
-        let hasAlpha = false
-        let scale: CGFloat = 0.0
-
-        UIGraphicsBeginImageContextWithOptions(size, !hasAlpha, scale)
-        image.draw(in: CGRect(origin: CGPoint.zero, size: size))
-
-        let scaledImageI = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        guard let scaledImage = scaledImageI else {
-            return nil
-        }
-
-        guard let data = scaledImage.jpegData(compressionQuality: 0.9) else {
+        guard let data = image.jpegData(compressionQuality: 1.0) else {
             return nil
         }
 


### PR DESCRIPTION
- closes #418 

- refactoring compression and scaling: it was done multiple times before sending an image, resulting in too small and blurry images, now the compression 50% and the maximum size is 1280x1280px

- fixes app crash related to Float->Int32 conversion in the context of image sending

- images can be pasted from the clipboard
- Memoji-Sticker can be sent <3

- alpha channels are kept (using pngs)