### PR TITLE
Chat cells have archive tag

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -202,7 +202,7 @@ extension ChatListController: UITableViewDataSource, UITableViewDelegate {
         cell.setTimeLabel(summary.timestamp)
         cell.setUnreadMessageCounter(unreadMessages)
         cell.setDeliveryStatusIndicator(summary.state)
-
+        cell.setIsArchived(showArchive)
         return cell
     }
 

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -166,7 +166,7 @@ extension ChatListController: UITableViewDataSource, UITableViewDelegate {
         let summary = chatList.getSummary(index: row)
         let unreadMessages = dcContext.getUnreadMessages(chatId: chatId)
 
-        cell.nameLabel.attributedText = (unreadMessages > 0) ?
+        cell.titleLabel.attributedText = (unreadMessages > 0) ?
             NSAttributedString(string: chat.name, attributes: [ .font: UIFont.systemFont(ofSize: 16, weight: .bold) ]) :
             NSAttributedString(string: chat.name, attributes: [ .font: UIFont.systemFont(ofSize: 16, weight: .medium) ])
 
@@ -198,7 +198,7 @@ extension ChatListController: UITableViewDataSource, UITableViewDelegate {
             result = "\(result1)\(result2)"
         }
 
-        cell.emailLabel.text = result
+        cell.subtitleLabel.text = result
         cell.setTimeLabel(summary.timestamp)
         cell.setUnreadMessageCounter(unreadMessages)
         cell.setDeliveryStatusIndicator(summary.state)

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -186,8 +186,8 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 if let contactCell = cell as? ContactCell {
                     let contact = groupMembers[row - sectionMembersStaticRowCount]
                     let displayName = contact.displayName
-                    contactCell.nameLabel.text = displayName
-                    contactCell.emailLabel.text = contact.email
+                    contactCell.titleLabel.text = displayName
+                    contactCell.subtitleLabel.text = contact.email
                     contactCell.avatar.setName(displayName)
                     contactCell.avatar.setColor(contact.color)
                     if let profileImage = contact.profileImage {

--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -420,11 +420,11 @@ class GroupMembersViewController: UITableViewController, UISearchResultsUpdating
         let contact = contactWithHighlight.contact
         let displayName = contact.displayName
 
-        let emailLabelFontSize = cell.emailLabel.font.pointSize
-        let nameLabelFontSize = cell.nameLabel.font.pointSize
+        let emailLabelFontSize = cell.subtitleLabel.font.pointSize
+        let nameLabelFontSize = cell.titleLabel.font.pointSize
 
-        cell.nameLabel.text = displayName
-        cell.emailLabel.text = contact.email
+        cell.titleLabel.text = displayName
+        cell.subtitleLabel.text = contact.email
         cell.avatar.setName(displayName)
         cell.avatar.setColor(contact.color)
         if let profileImage = contact.profileImage {
@@ -434,15 +434,15 @@ class GroupMembersViewController: UITableViewController, UISearchResultsUpdating
 
         if let emailHighlightedIndexes = contactWithHighlight.indexesToHighlight.filter({ $0.contactDetail == .EMAIL }).first {
             // gets here when contact is a result of current search -> highlights relevant indexes
-            cell.emailLabel.attributedText = contact.email.boldAt(indexes: emailHighlightedIndexes.indexes, fontSize: emailLabelFontSize)
+            cell.subtitleLabel.attributedText = contact.email.boldAt(indexes: emailHighlightedIndexes.indexes, fontSize: emailLabelFontSize)
         } else {
-            cell.emailLabel.attributedText = contact.email.boldAt(indexes: [], fontSize: emailLabelFontSize)
+            cell.subtitleLabel.attributedText = contact.email.boldAt(indexes: [], fontSize: emailLabelFontSize)
         }
 
         if let nameHighlightedIndexes = contactWithHighlight.indexesToHighlight.filter({ $0.contactDetail == .NAME }).first {
-            cell.nameLabel.attributedText = displayName.boldAt(indexes: nameHighlightedIndexes.indexes, fontSize: nameLabelFontSize)
+            cell.titleLabel.attributedText = displayName.boldAt(indexes: nameHighlightedIndexes.indexes, fontSize: nameLabelFontSize)
         } else {
-            cell.nameLabel.attributedText = displayName.boldAt(indexes: [], fontSize: nameLabelFontSize)
+            cell.titleLabel.attributedText = displayName.boldAt(indexes: [], fontSize: nameLabelFontSize)
         }
     }
 

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -322,11 +322,11 @@ class NewChatViewController: UITableViewController {
         let contact = contactWithHighlight.contact
         let displayName = contact.displayName
 
-        let emailLabelFontSize = cell.emailLabel.font.pointSize
-        let nameLabelFontSize = cell.nameLabel.font.pointSize
+        let emailLabelFontSize = cell.subtitleLabel.font.pointSize
+        let nameLabelFontSize = cell.titleLabel.font.pointSize
 
-        cell.nameLabel.text = displayName
-        cell.emailLabel.text = contact.email
+        cell.titleLabel.text = displayName
+        cell.subtitleLabel.text = contact.email
         cell.avatar.setName(displayName)
         cell.avatar.setColor(contact.color)
         if let profileImage = contact.profileImage {
@@ -336,15 +336,15 @@ class NewChatViewController: UITableViewController {
 
         if let emailHighlightedIndexes = contactWithHighlight.indexesToHighlight.filter({ $0.contactDetail == .EMAIL }).first {
             // gets here when contact is a result of current search -> highlights relevant indexes
-            cell.emailLabel.attributedText = contact.email.boldAt(indexes: emailHighlightedIndexes.indexes, fontSize: emailLabelFontSize)
+            cell.subtitleLabel.attributedText = contact.email.boldAt(indexes: emailHighlightedIndexes.indexes, fontSize: emailLabelFontSize)
         } else {
-            cell.emailLabel.attributedText = contact.email.boldAt(indexes: [], fontSize: emailLabelFontSize)
+            cell.subtitleLabel.attributedText = contact.email.boldAt(indexes: [], fontSize: emailLabelFontSize)
         }
 
         if let nameHighlightedIndexes = contactWithHighlight.indexesToHighlight.filter({ $0.contactDetail == .NAME }).first {
-            cell.nameLabel.attributedText = displayName.boldAt(indexes: nameHighlightedIndexes.indexes, fontSize: nameLabelFontSize)
+            cell.titleLabel.attributedText = displayName.boldAt(indexes: nameHighlightedIndexes.indexes, fontSize: nameLabelFontSize)
         } else {
-            cell.nameLabel.attributedText = displayName.boldAt(indexes: [], fontSize: nameLabelFontSize)
+            cell.titleLabel.attributedText = displayName.boldAt(indexes: [], fontSize: nameLabelFontSize)
         }
     }
 

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -181,8 +181,8 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
             if let contactCell = cell as? ContactCell {
                 let contact = DcContact(id: groupContactIds[row])
                 let displayName = contact.displayName
-                contactCell.nameLabel.text = displayName
-                contactCell.emailLabel.text = contact.email
+                contactCell.titleLabel.text = displayName
+                contactCell.subtitleLabel.text = contact.email
                 contactCell.avatar.setName(displayName)
                 contactCell.avatar.setColor(contact.color)
                 if let profileImage = contact.profileImage {

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -496,6 +496,10 @@ class DcChat {
         return dc_chat_is_verified(chatPointer) > 0
     }
 
+    var isArchived: Bool {
+        return Int(dc_chat_get_archived(chatPointer)) == 1
+    }
+
     var contactIds: [Int] {
         return Utils.copyAndFreeArray(inputArray: dc_get_chat_contacts(mailboxPointer, UInt32(id)))
     }

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -242,7 +242,7 @@ class ContactCell: UITableViewCell {
             setTimeLabel(chatData.summary.timestamp)
             setUnreadMessageCounter(chatData.unreadMessages)
             setDeliveryStatusIndicator(chatData.summary.state)
-            setIsArchived(chatData.isArchived)
+            setIsArchived(chat.isArchived)
 
         case .CONTACT(let contactData):
             let contact = DcContact(id: contactData.contactId)

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -15,13 +15,13 @@ class ContactCell: UITableViewCell {
     private let imgSize: CGFloat = 20
 
     lazy var toplineStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [nameLabel, timeLabel])
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, timeLabel])
         stackView.axis = .horizontal
         return stackView
     }()
 
     lazy var bottomlineStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [emailLabel, deliveryStatusIndicator])
+        let stackView = UIStackView(arrangedSubviews: [subtitleLabel, deliveryStatusIndicator])
         stackView.axis = .horizontal
         stackView.spacing = 10
         return stackView
@@ -36,21 +36,12 @@ class ContactCell: UITableViewCell {
         return badge
     }()
 
-    let nameLabel: UILabel = {
+    let titleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 16, weight: .medium)
         label.lineBreakMode = .byTruncatingTail
         label.textColor = DcColors.defaultTextColor
         label.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1), for: NSLayoutConstraint.Axis.horizontal)
-        return label
-
-    }()
-
-    let emailLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 14)
-        label.textColor = UIColor(hexString: "848ba7")
-        label.lineBreakMode = .byTruncatingTail
         return label
     }()
 
@@ -60,6 +51,14 @@ class ContactCell: UITableViewCell {
         label.textColor = UIColor(hexString: "848ba7")
         label.textAlignment = .right
         label.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 2), for: NSLayoutConstraint.Axis.horizontal)
+        return label
+    }()
+
+    let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = UIColor(hexString: "848ba7")
+        label.lineBreakMode = .byTruncatingTail
         return label
     }()
 
@@ -220,7 +219,7 @@ class ContactCell: UITableViewCell {
 
     func updateCell(cellViewModel: AvatarCellViewModel) {
         // subtitle
-        emailLabel.attributedText = cellViewModel.subtitle.boldAt(indexes: cellViewModel.subtitleHighlightIndexes, fontSize: emailLabel.font.pointSize)
+        subtitleLabel.attributedText = cellViewModel.subtitle.boldAt(indexes: cellViewModel.subtitleHighlightIndexes, fontSize: subtitleLabel.font.pointSize)
 
         switch cellViewModel.type {
         case .CHAT(let chatData):
@@ -228,9 +227,9 @@ class ContactCell: UITableViewCell {
 
             // text bold if chat contains unread messages - otherwise hightlight search results if needed
             if chatData.unreadMessages > 0 {
-                nameLabel.attributedText = NSAttributedString(string: cellViewModel.title, attributes: [ .font: UIFont.systemFont(ofSize: 16, weight: .bold) ])
+                titleLabel.attributedText = NSAttributedString(string: cellViewModel.title, attributes: [ .font: UIFont.systemFont(ofSize: 16, weight: .bold) ])
             } else {
-                nameLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: nameLabel.font.pointSize)
+                titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)
             }
 
             if let img = chat.profileImage {
@@ -247,7 +246,7 @@ class ContactCell: UITableViewCell {
 
         case .CONTACT(let contactData):
             let contact = DcContact(id: contactData.contactId)
-            nameLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: nameLabel.font.pointSize)
+            titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)
             avatar.setName(cellViewModel.title)
             avatar.setColor(contact.color)
         }

--- a/deltachat-ios/View/ContactDetailHeader.swift
+++ b/deltachat-ios/View/ContactDetailHeader.swift
@@ -13,7 +13,7 @@ class ContactDetailHeader: ContactCell {
     }
 
     func updateDetails(title: String?, subtitle: String?) {
-        nameLabel.text = title
-        emailLabel.text = subtitle
+        titleLabel.text = title
+        subtitleLabel.text = subtitle
     }
 }

--- a/deltachat-ios/ViewModel/ContactCellViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactCellViewModel.swift
@@ -25,7 +25,6 @@ struct ChatCellData {
     let chatId: Int
     let summary: DcLot
     let unreadMessages: Int
-    let isArchived: Bool
 }
 
 class ContactCellViewModel: AvatarCellViewModel {

--- a/deltachat-ios/ViewModel/ContactCellViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactCellViewModel.swift
@@ -25,6 +25,7 @@ struct ChatCellData {
     let chatId: Int
     let summary: DcLot
     let unreadMessages: Int
+    let isArchived: Bool
 }
 
 class ContactCellViewModel: AvatarCellViewModel {

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -70,7 +70,7 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
         let summary = sharedChats.getSummary(index: index)
         let unreadMessages = context.getUnreadMessages(chatId: chatId)
 
-        let cellData = ChatCellData(chatId: chatId, summary: summary, unreadMessages: unreadMessages)
+        let cellData = ChatCellData(chatId: chatId, summary: summary, unreadMessages: unreadMessages, isArchived: false)
         let cellViewModel = ChatCellViewModel(chatData: cellData)
         cell.updateCell(cellViewModel: cellViewModel)
     }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -70,7 +70,7 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
         let summary = sharedChats.getSummary(index: index)
         let unreadMessages = context.getUnreadMessages(chatId: chatId)
 
-        let cellData = ChatCellData(chatId: chatId, summary: summary, unreadMessages: unreadMessages, isArchived: false)
+        let cellData = ChatCellData(chatId: chatId, summary: summary, unreadMessages: unreadMessages)
         let cellViewModel = ChatCellViewModel(chatData: cellData)
         cell.updateCell(cellViewModel: cellViewModel)
     }


### PR DESCRIPTION
Implementation for #502 

In `ContactCell`:

- designed `archivedIndicator`
- wrapper `DcChat` now has `isArchived`
- to access and manage the stackviews I had to make them cell attributes `toplineStackView`, `bottomlineStackView`
- the method `setIsArchived` now either removes or adds the needed indicators to the `bottomLineStackView`
- `setIsArchived` is called in ChatList (if it is the archive list)  and in  `ContactCell.updateCell` currently for updating the SharedChats section.