### PR TITLE
 Archive + Delete in GroupChatDetail and Archive in SingleChatDetail

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -159,11 +159,11 @@ class ContactDetailViewController: UITableViewController {
 
     private func toggleArchiveChat() {
         let archived = viewModel.toggleArchiveChat()
-        updateArchiveChatCell(archived: archived)
-    }
-
-    private func updateArchiveChatCell(archived: Bool) {
-        archiveChatCell.actionTitle = archived ? String.localized("menu_unarchive_chat") :  String.localized("menu_archive_chat")
+        if archived {
+            self.navigationController?.popToRootViewController(animated: false)
+        } else {
+            archiveChatCell.actionTitle = String.localized("menu_archive_chat")
+        }
     }
 
     private func updateBlockContactCell() {

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -143,7 +143,7 @@ class ContactDetailViewController: UITableViewController {
         return viewModel.titleFor(section: section)
     }
 
-    // MARK: -actions
+    // MARK: - actions
 
     private func handleCellAction(for index: Int) {
         let action = viewModel.actionFor(row: index)

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -222,5 +222,4 @@ class ContactDetailViewController: UITableViewController {
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         self.present(alert, animated: true, completion: nil)
     }
-
 }

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -147,29 +147,58 @@ class ContactDetailViewController: UITableViewController {
 
     private func handleCellAction(for index: Int) {
         if index == 0 {
-            coordinator?.archiveChat()
+            toggleArchiveChat()
         } else if index == 1 {
             toggleBlockContact()
         } else {
             safe_assert(index == 2)
             showDeleteChatConfirmationAlert()
         }
-
     }
-    private func askToChatWith(contactId: Int) {
-        let dcContact = DcContact(id: contactId)
-        let alert = UIAlertController(title: String.localizedStringWithFormat(String.localized("ask_start_chat_with"), dcContact.nameNAddr),
-                                      message: nil,
-                                      preferredStyle: .safeActionSheet)
-        alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { _ in
-            self.dismiss(animated: true, completion: nil)
-            let chatId = Int(dc_create_chat_by_contact_id(mailboxPointer, UInt32(contactId)))
-            self.coordinator?.showChat(chatId: chatId)
+
+    private func toggleArchiveChat() {
+        let archived = viewModel.toggleArchiveChat()
+        updateArchiveChatCell(archived: archived)
+    }
+
+    private func updateArchiveChatCell(archived: Bool) {
+        archiveChatCell.actionTitle = archived ? String.localized("menu_unarchive_chat") :  String.localized("menu_archive_chat")
+    }
+
+    private func updateBlockContactCell() {
+        blockContactCell.actionTitle = viewModel.contact.isBlocked ? String.localized("menu_unblock_contact") : String.localized("menu_block_contact")
+        blockContactCell.actionColor = viewModel.contact.isBlocked ? SystemColor.blue.uiColor : UIColor.red
+    }
+
+
+    @objc private func editButtonPressed() {
+        coordinator?.showEditContact(contactId: viewModel.contactId)
+    }
+}
+
+// MARK: alerts
+extension ContactDetailViewController {
+    private func showDeleteChatConfirmationAlert() {
+        let alert = UIAlertController(
+            title: nil,
+            message: String.localized("ask_delete_chat_desktop"),
+            preferredStyle: .safeActionSheet
+        )
+        alert.addAction(UIAlertAction(title: String.localized("menu_delete_chat"), style: .destructive, handler: { _ in
+            self.coordinator?.deleteChat()
         }))
-        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
-            self.dismiss(animated: true, completion: nil)
-        }))
-        present(alert, animated: true, completion: nil)
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+        self.present(alert, animated: true, completion: nil)
+    }
+
+    private func showNotificationSetup() {
+        let notificationSetupAlert = UIAlertController(
+            title: "Notifications Setup is not implemented yet",
+            message: "But you get an idea where this is going",
+            preferredStyle: .safeActionSheet)
+        let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil)
+        notificationSetupAlert.addAction(cancelAction)
+        present(notificationSetupAlert, animated: true, completion: nil)
     }
 
     private func toggleBlockContact() {
@@ -192,34 +221,21 @@ class ContactDetailViewController: UITableViewController {
         }
     }
 
-    private func updateBlockContactCell() {
-        blockContactCell.actionTitle = viewModel.contact.isBlocked ? String.localized("menu_unblock_contact") : String.localized("menu_block_contact")
-        blockContactCell.actionColor = viewModel.contact.isBlocked ? SystemColor.blue.uiColor : UIColor.red
-    }
-
-    private func showNotificationSetup() {
-        let notificationSetupAlert = UIAlertController(title: "Notifications Setup is not implemented yet",
-                                                       message: "But you get an idea where this is going",
-                                                       preferredStyle: .safeActionSheet)
-        let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil)
-        notificationSetupAlert.addAction(cancelAction)
-        present(notificationSetupAlert, animated: true, completion: nil)
-    }
-
-    @objc private func editButtonPressed() {
-        coordinator?.showEditContact(contactId: viewModel.contactId)
-    }
-
-    private func showDeleteChatConfirmationAlert() {
-        let alert = UIAlertController(
-            title: nil,
-            message: String.localized("ask_delete_chat_desktop"),
-            preferredStyle: .safeActionSheet
-        )
-        alert.addAction(UIAlertAction(title: String.localized("menu_delete_chat"), style: .destructive, handler: { _ in
-            self.coordinator?.deleteChat()
+    private func askToChatWith(contactId: Int) {
+        let dcContact = DcContact(id: contactId)
+        let alert = UIAlertController(title: String.localizedStringWithFormat(
+            String.localized("ask_start_chat_with"), dcContact.nameNAddr),
+                                      message: nil,
+                                      preferredStyle: .safeActionSheet)
+        alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { _ in
+            self.dismiss(animated: true, completion: nil)
+            let chatId = Int(dc_create_chat_by_contact_id(mailboxPointer, UInt32(contactId)))
+            self.coordinator?.showChat(chatId: chatId)
         }))
-        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
-        self.present(alert, animated: true, completion: nil)
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
+            self.dismiss(animated: true, completion: nil)
+        }))
+        present(alert, animated: true, completion: nil)
     }
+
 }

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -96,12 +96,12 @@ class ContactDetailViewController: UITableViewController {
         let cellType = viewModel.typeFor(section: indexPath.section)
         switch cellType {
         case .chatActions:
-            if row == 0 {
+            switch viewModel.actionFor(row: row) {
+            case .archiveChat:
                 return archiveChatCell
-            } else if row == 1 {
+            case .blockChat:
                 return blockContactCell
-            } else {
-                safe_assert(row == 2)
+            case .deleteChat:
                 return deleteChatCell
             }
         case .startChat:
@@ -146,12 +146,13 @@ class ContactDetailViewController: UITableViewController {
     // MARK: -actions
 
     private func handleCellAction(for index: Int) {
-        if index == 0 {
+        let action = viewModel.actionFor(row: index)
+        switch action {
+        case .archiveChat:
             toggleArchiveChat()
-        } else if index == 1 {
+        case .blockChat:
             toggleBlockContact()
-        } else {
-            safe_assert(index == 2)
+        case .deleteChat:
             showDeleteChatConfirmationAlert()
         }
     }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -129,9 +129,15 @@ class GroupChatDetailViewController: UIViewController {
         coordinator?.showGroupChatEdit(chat: chat)
     }
 
-    func archiveChat() {
 
-    }
+    private func toggleArchiveChat() {
+        let archived = false
+         updateArchiveChatCell(archived: archived)
+     }
+
+     private func updateArchiveChatCell(archived: Bool) {
+         archiveChatCell.actionTitle = archived ? String.localized("menu_unarchive_chat") :  String.localized("menu_archive_chat")
+     }
 
     private func leaveGroup() {
         if let userId = currentUser?.id {
@@ -236,7 +242,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             coordinator?.showContactDetail(of: contact.id)
         case .chatActions:
             if row == 0 {
-                archiveChat()
+                toggleArchiveChat()
             } else if row == 1 {
                 leaveGroup()
             } else if row == 2 {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -134,25 +134,13 @@ class GroupChatDetailViewController: UIViewController {
     private func toggleArchiveChat() {
         let archivedBefore = chat.isArchived
          context.archiveChat(chatId: chat.id, archive: !archivedBefore)
-        updateArchiveChatCell(archived: chat.isArchived)
+        updateArchiveChatCell(archived: !archivedBefore)
+        self.chat = DcChat(id: chat.id)
      }
 
      private func updateArchiveChatCell(archived: Bool) {
          archiveChatCell.actionTitle = archived ? String.localized("menu_unarchive_chat") :  String.localized("menu_archive_chat")
      }
-
-    private func leaveGroup() {
-        if let userId = currentUser?.id {
-            let alert = UIAlertController(title: String.localized("ask_leave_group"), message: nil, preferredStyle: .safeActionSheet)
-            alert.addAction(UIAlertAction(title: String.localized("menu_leave_group"), style: .destructive, handler: { _ in
-                dc_remove_contact_from_chat(mailboxPointer, UInt32(self.chat.id), UInt32(userId))
-                self.editBarButtonItem.isEnabled = false
-                self.updateGroupMembers()
-            }))
-            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
-            present(alert, animated: true, completion: nil)
-        }
-    }
 }
 
 // MARK: -UITableViewDelegate, UITableViewDataSource
@@ -245,7 +233,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             if row == 0 {
                 toggleArchiveChat()
             } else if row == 1 {
-                leaveGroup()
+                showLeaveGroupConfirmationAlert()
             } else if row == 2 {
                 showDeleteChatConfirmationAlert()
             }
@@ -313,5 +301,18 @@ extension GroupChatDetailViewController {
         }))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         self.present(alert, animated: true, completion: nil)
+    }
+
+    private func showLeaveGroupConfirmationAlert() {
+        if let userId = currentUser?.id {
+            let alert = UIAlertController(title: String.localized("ask_leave_group"), message: nil, preferredStyle: .safeActionSheet)
+            alert.addAction(UIAlertAction(title: String.localized("menu_leave_group"), style: .destructive, handler: { _ in
+                dc_remove_contact_from_chat(mailboxPointer, UInt32(self.chat.id), UInt32(userId))
+                self.editBarButtonItem.isEnabled = false
+                self.updateGroupMembers()
+            }))
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+            present(alert, animated: true, completion: nil)
+        }
     }
 }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -142,13 +142,13 @@ class GroupChatDetailViewController: UIViewController {
 
     private func toggleArchiveChat() {
         let archivedBefore = chat.isArchived
-         context.archiveChat(chatId: chat.id, archive: !archivedBefore)
-        updateArchiveChatCell(archived: !archivedBefore)
+        context.archiveChat(chatId: chat.id, archive: !archivedBefore)
+        if archivedBefore {
+            archiveChatCell.actionTitle = String.localized("menu_archive_chat")
+        } else {
+            self.navigationController?.popToRootViewController(animated: false)
+        }
         self.chat = DcChat(id: chat.id)
-     }
-
-     private func updateArchiveChatCell(archived: Bool) {
-         archiveChatCell.actionTitle = archived ? String.localized("menu_unarchive_chat") :  String.localized("menu_archive_chat")
      }
 }
 

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -116,6 +116,7 @@ class GroupChatDetailViewController: UIViewController {
         updateGroupMembers()
         tableView.reloadData() // to display updates
         editBarButtonItem.isEnabled = currentUser != nil
+        updateHeader()
         //update chat object, maybe chat name was edited
         chat = DcChat(id: chat.id)
     }
@@ -124,6 +125,13 @@ class GroupChatDetailViewController: UIViewController {
     private func updateGroupMembers() {
         groupMemberIds = chat.contactIds
         tableView.reloadData()
+    }
+
+    private func updateHeader() {
+        headerCell.updateDetails(
+            title: chat.name,
+            subtitle: String.localizedStringWithFormat(String.localized("n_members"), chat.contactIds.count)
+        )
     }
 
     // MARK: -actions
@@ -227,8 +235,8 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 coordinator?.showQrCodeInvite(chatId: chat.id)
             }
         case .members:
-            let contact = getGroupMember(at: row)
-            coordinator?.showContactDetail(of: contact.id)
+            let member = getGroupMember(at: row)
+            coordinator?.showContactDetail(of: member.id)
         case .chatActions:
             if row == 0 {
                 toggleArchiveChat()
@@ -268,14 +276,13 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 alert.addAction(UIAlertAction(title: String.localized("remove_desktop"), style: .destructive, handler: { _ in
                     let success = dc_remove_contact_from_chat(mailboxPointer, UInt32(self.chat.id), UInt32(contact.id))
                     if success == 1 {
-                        self.groupMemberIds.remove(at: row)
-                        tableView.deleteRows(at: [indexPath], with: .fade)
-                        tableView.reloadData()
+                        self.removeGroupeMemberFromTableAt(indexPath)
                     }
                 }))
                 alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
                 self.present(alert, animated: true, completion: nil)
-            }
+
+ }
             delete.backgroundColor = UIColor.red
             return [delete]
         }
@@ -286,6 +293,11 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         return DcContact(id: groupMemberIds[row])
     }
 
+    func removeGroupeMemberFromTableAt(_ indexPath: IndexPath) {
+        self.groupMemberIds.remove(at: indexPath.row)
+        self.tableView.deleteRows(at: [indexPath], with: .automatic)
+        updateHeader()  // to display correct group size
+    }
 }
 
 // MARK: -alerts

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -129,6 +129,10 @@ class GroupChatDetailViewController: UIViewController {
         coordinator?.showGroupChatEdit(chat: chat)
     }
 
+    func archiveChat() {
+
+    }
+
     private func leaveGroup() {
         if let userId = currentUser?.id {
             let alert = UIAlertController(title: String.localized("ask_leave_group"), message: nil, preferredStyle: .safeActionSheet)
@@ -232,13 +236,12 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             coordinator?.showContactDetail(of: contact.id)
         case .chatActions:
             if row == 0 {
-
+                archiveChat()
             } else if row == 1 {
                 leaveGroup()
             } else if row == 2 {
-
+                showDeleteChatConfirmationAlert()
             }
-
         }
     }
 
@@ -288,4 +291,20 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         return DcContact(id: groupMemberIds[row])
     }
 
+}
+
+// MARK: -alerts
+extension GroupChatDetailViewController {
+    private func showDeleteChatConfirmationAlert() {
+        let alert = UIAlertController(
+            title: nil,
+            message: String.localized("ask_delete_chat_desktop"),
+            preferredStyle: .safeActionSheet
+        )
+        alert.addAction(UIAlertAction(title: String.localized("menu_delete_chat"), style: .destructive, handler: { _ in
+            self.coordinator?.deleteChat()
+        }))
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+        self.present(alert, animated: true, completion: nil)
+    }
 }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -2,7 +2,15 @@ import UIKit
 
 class GroupChatDetailViewController: UIViewController {
 
+    enum ProfileSections {
+        case memberManagement // add member, qr invideCode
+        case members // contactCells
+        case chatActions // archive, leave, delete
+    }
+
     weak var coordinator: GroupChatDetailCoordinator?
+
+    let sections: [ProfileSections] = [.memberManagement, .members, .chatActions]
 
     private let sectionMembers = 0
     private let sectionMembersRowAddMember = 0
@@ -15,7 +23,11 @@ class GroupChatDetailViewController: UIViewController {
     private let sectionCount = 2
 
     private var currentUser: DcContact? {
-        return groupMembers.filter { $0.email == DcConfig.addr }.first
+        let myId = groupMemberIds.filter { DcContact(id: $0).email == DcConfig.addr }.first
+        guard let currentUserId = myId else {
+            return nil
+        }
+        return DcContact(id: currentUserId)
     }
 
     fileprivate var chat: DcChat
@@ -56,6 +68,14 @@ class GroupChatDetailViewController: UIViewController {
         return cell
     }()
 
+    private lazy var leaveGroupCell: ActionCell = {
+        let cell = ActionCell()
+        cell.actionTitle = String.localized("menu_leave_group")
+        cell.actionColor = UIColor.red
+        return cell
+    }()
+
+
     private lazy var deleteChatCell: ActionCell = {
         let cell = ActionCell()
         cell.actionTitle = String.localized("menu_delete_chat")
@@ -88,7 +108,8 @@ class GroupChatDetailViewController: UIViewController {
         UIBarButtonItem(title: String.localized("global_menu_edit_desktop"), style: .plain, target: self, action: #selector(editButtonPressed))
     }()
 
-    private var groupMembers: [DcContact] = []
+    // stores contactIds
+    private var groupMemberIds: [Int] = []
 
     // MARK: -lifecycle
     override func viewDidLoad() {
@@ -109,8 +130,7 @@ class GroupChatDetailViewController: UIViewController {
 
     // MARK: -update
     private func updateGroupMembers() {
-        let ids = chat.contactIds
-        groupMembers = ids.map { DcContact(id: $0) }
+        groupMemberIds = chat.contactIds
         tableView.reloadData()
     }
 
@@ -144,89 +164,120 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
     }
 
     func numberOfSections(in _: UITableView) -> Int {
-        if currentUser == nil {
-            return sectionCount-1 // leave out last section (leaveSection)
-        }
-        return sectionCount
+        return sections.count
     }
 
     func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch section {
-        case sectionMembers:
-            return sectionMembersStaticRowCount + groupMembers.count
-        case sectionLeaveGroup:
-            return sectionLeaveGroupRowCount
-        default:
-            return 0
+        let sectionType = sections[section]
+        switch sectionType {
+        case .memberManagement:
+            return 2
+        case .members:
+            return groupMemberIds.count
+        case .chatActions:
+            return 3
         }
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        let section = indexPath.section
-        let row = indexPath.row
-        switch section {
-        case sectionMembers:
-            switch row {
-            case sectionMembersRowAddMember:
-                return Constants.defaultCellHeight
-            case sectionMembersRowJoinQR:
-                return Constants.defaultCellHeight
-            default:
-                return ContactCell.cellHeight
-            }
-        case sectionLeaveGroup:
+        let sectionType = sections[indexPath.section]
+        switch sectionType {
+        case .memberManagement:
             return Constants.defaultCellHeight
-        default:
-            return 0
+        case .members:
+            return ContactCell.cellHeight
+        case .chatActions:
+            return Constants.defaultCellHeight
         }
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let section = indexPath.section
         let row = indexPath.row
-        switch section {
-        case sectionMembers:
-            switch row {
-            case sectionMembersRowAddMember:
-                let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
-                if let actionCell = cell as? ActionCell {
-                    actionCell.actionTitle = String.localized("group_add_members")
-                    actionCell.actionColor = UIColor.systemBlue
-                }
-                return cell
-            case sectionMembersRowJoinQR:
-                let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
-                if let actionCell = cell as? ActionCell {
-                    actionCell.actionTitle = String.localized("qrshow_join_group_title")
-                    actionCell.actionColor = UIColor.systemBlue
-                }
-                return cell
-            default:
-                let cell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath)
-                if let contactCell = cell as? ContactCell {
-                    let contact = groupMembers[row - sectionMembersStaticRowCount]
-                    let displayName = contact.displayName
-                    contactCell.titleLabel.text = displayName
-                    contactCell.subtitleLabel.text = contact.email
-                    contactCell.avatar.setName(displayName)
-                    contactCell.avatar.setColor(contact.color)
-                    if let profileImage = contact.profileImage {
-                        contactCell.avatar.setImage(profileImage)
-                    }
-                    contactCell.setVerified(isVerified: contact.isVerified)
-                }
-                return cell
+        let sectionType = sections[indexPath.section]
+        switch sectionType {
+        case .memberManagement:
+            guard let actionCell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath) as? ActionCell else {
+                safe_fatalError("could not dequeu action cell")
+                break
             }
-        case sectionLeaveGroup:
-            let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
-            if let actionCell = cell as? ActionCell {
-                actionCell.actionTitle = String.localized("menu_leave_group")
-                actionCell.actionColor = UIColor.red
+            if row == 0 {
+                actionCell.actionTitle = String.localized("group_add_members")
+                actionCell.actionColor = UIColor.systemBlue
+
+            } else {
+                actionCell.actionTitle = String.localized("qrshow_join_group_title")
+                actionCell.actionColor = UIColor.systemBlue
+
             }
-            return cell
-        default:
-            return UITableViewCell(frame: .zero)
+            return actionCell
+        case .members:
+            guard let contactCell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath) as? ContactCell else {
+                safe_fatalError("could not dequeu contactCell cell")
+                break
+
+            }
+            let cellData = ContactCellData(contactId: groupMemberIds[row])
+            let cellViewModel = ContactCellViewModel(contactData: cellData)
+            contactCell.updateCell(cellViewModel: cellViewModel)
+            return contactCell
+        case .chatActions:
+            if row == 0 {
+                return archiveChatCell
+            } else if row == 1 {
+                return leaveGroupCell
+            } else if row == 2 {
+                return deleteChatCell
+            }
         }
+        // should never get here
+        return UITableViewCell(frame: .zero)
+        /*
+         let section = indexPath.section
+         let row = indexPath.row
+         switch section {
+         case sectionMembers:
+         switch row {
+         case sectionMembersRowAddMember:
+         let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
+         if let actionCell = cell as? ActionCell {
+         actionCell.actionTitle = String.localized("group_add_members")
+         actionCell.actionColor = UIColor.systemBlue
+         }
+         return cell
+         case sectionMembersRowJoinQR:
+         let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
+         if let actionCell = cell as? ActionCell {
+         actionCell.actionTitle = String.localized("qrshow_join_group_title")
+         actionCell.actionColor = UIColor.systemBlue
+         }
+         return cell
+         default:
+         let cell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath)
+         if let contactCell = cell as? ContactCell {
+         let contact = groupMembers[row - sectionMembersStaticRowCount]
+         let displayName = contact.displayName
+         contactCell.titleLabel.text = displayName
+         contactCell.subtitleLabel.text = contact.email
+         contactCell.avatar.setName(displayName)
+         contactCell.avatar.setColor(contact.color)
+         if let profileImage = contact.profileImage {
+         contactCell.avatar.setImage(profileImage)
+         }
+         contactCell.setVerified(isVerified: contact.isVerified)
+         }
+         return cell
+         }
+         case sectionLeaveGroup:
+         let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
+         if let actionCell = cell as? ActionCell {
+         actionCell.actionTitle = String.localized("menu_leave_group")
+         actionCell.actionColor = UIColor.red
+         }
+         return cell
+         default:
+         return UITableViewCell(frame: .zero)
+         }
+         */
     }
 
     func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -247,20 +298,48 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
     }
 
     func tableView(_: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        let section = indexPath.section
+        guard let currentUser = self.currentUser else {
+            return false
+        }
         let row = indexPath.row
-
-        if let currentUser = currentUser {
-            if section == sectionMembers, row >= sectionMembersStaticRowCount, groupMembers[row - sectionMembersStaticRowCount].id != currentUser.id {
-                return true
-            }
+        let sectionType = sections[indexPath.section]
+        if sectionType == .members && groupMemberIds[row] != currentUser.id {
+            return true
         }
         return false
     }
 
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        let section = indexPath.section
+        guard let currentUser = self.currentUser else {
+            return nil
+        }
         let row = indexPath.row
+        let sectionType = sections[indexPath.section]
+        if sectionType == .members && groupMemberIds[row] != currentUser.id {
+            // action set for members except for current user
+            let delete = UITableViewRowAction(style: .destructive, title: String.localized("remove_desktop")) { [unowned self] _, indexPath in
+
+                let contact = self.getGroupMember(at: row)
+                let title = String.localizedStringWithFormat(String.localized("ask_remove_members"), contact.nameNAddr)
+                let alert = UIAlertController(title: title, message: nil, preferredStyle: .safeActionSheet)
+                alert.addAction(UIAlertAction(title: String.localized("remove_desktop"), style: .destructive, handler: { _ in
+                    let success = dc_remove_contact_from_chat(mailboxPointer, UInt32(self.chat.id), UInt32(contact.id))
+                    if success == 1 {
+                        self.groupMemberIds.remove(at: row)
+                        tableView.deleteRows(at: [indexPath], with: .fade)
+                        tableView.reloadData()
+                    }
+                }))
+                alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+                self.present(alert, animated: true, completion: nil)
+            }
+            delete.backgroundColor = UIColor.red
+            return [delete]
+        }
+        return nil
+
+        /*
+
 
         // assigning swipe by delete to members (except for current user)
         if section == sectionMembers, row >= sectionMembersStaticRowCount, groupMembers[row - sectionMembersStaticRowCount].id != currentUser?.id {
@@ -272,7 +351,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 alert.addAction(UIAlertAction(title: String.localized("remove_desktop"), style: .destructive, handler: { _ in
                     let success = dc_remove_contact_from_chat(mailboxPointer, UInt32(self.chat.id), UInt32(contact.id))
                     if success == 1 {
-                        self.groupMembers.remove(at: row - self.sectionMembersStaticRowCount)
+                        self.groupMemberIds.remove(at: row - self.sectionMembersStaticRowCount)
                         tableView.deleteRows(at: [indexPath], with: .fade)
                         tableView.reloadData()
                     }
@@ -285,11 +364,11 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         } else {
             return nil
         }
+        */
     }
 
     func getGroupMember(at row: Int) -> DcContact {
-        let memberId = self.groupMembers[row - self.sectionMembersStaticRowCount].id
-        return DcContact(id: memberId)
+        return DcContact(id: groupMemberIds[row])
     }
 
 }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -12,16 +12,6 @@ class GroupChatDetailViewController: UIViewController {
 
     let sections: [ProfileSections] = [.memberManagement, .members, .chatActions]
 
-    private let sectionMembers = 0
-    private let sectionMembersRowAddMember = 0
-    private let sectionMembersRowJoinQR = 1
-    private let sectionMembersStaticRowCount = 2 // followed by one row per member
-
-    private let sectionLeaveGroup = 1
-    private let sectionLeaveGroupRowCount = 1
-
-    private let sectionCount = 2
-
     private var currentUser: DcContact? {
         let myId = groupMemberIds.filter { DcContact(id: $0).email == DcConfig.addr }.first
         guard let currentUserId = myId else {
@@ -156,13 +146,6 @@ class GroupChatDetailViewController: UIViewController {
 // MARK: -UITableViewDelegate, UITableViewDataSource
 extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSource {
 
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if section == sectionMembers {
-            return ContactDetailHeader.cellHeight
-        }
-        return 0
-    }
-
     func numberOfSections(in _: UITableView) -> Int {
         return sections.count
     }
@@ -231,69 +214,31 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         }
         // should never get here
         return UITableViewCell(frame: .zero)
-        /*
-         let section = indexPath.section
-         let row = indexPath.row
-         switch section {
-         case sectionMembers:
-         switch row {
-         case sectionMembersRowAddMember:
-         let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
-         if let actionCell = cell as? ActionCell {
-         actionCell.actionTitle = String.localized("group_add_members")
-         actionCell.actionColor = UIColor.systemBlue
-         }
-         return cell
-         case sectionMembersRowJoinQR:
-         let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
-         if let actionCell = cell as? ActionCell {
-         actionCell.actionTitle = String.localized("qrshow_join_group_title")
-         actionCell.actionColor = UIColor.systemBlue
-         }
-         return cell
-         default:
-         let cell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath)
-         if let contactCell = cell as? ContactCell {
-         let contact = groupMembers[row - sectionMembersStaticRowCount]
-         let displayName = contact.displayName
-         contactCell.titleLabel.text = displayName
-         contactCell.subtitleLabel.text = contact.email
-         contactCell.avatar.setName(displayName)
-         contactCell.avatar.setColor(contact.color)
-         if let profileImage = contact.profileImage {
-         contactCell.avatar.setImage(profileImage)
-         }
-         contactCell.setVerified(isVerified: contact.isVerified)
-         }
-         return cell
-         }
-         case sectionLeaveGroup:
-         let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
-         if let actionCell = cell as? ActionCell {
-         actionCell.actionTitle = String.localized("menu_leave_group")
-         actionCell.actionColor = UIColor.red
-         }
-         return cell
-         default:
-         return UITableViewCell(frame: .zero)
-         }
-         */
     }
 
     func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let section = indexPath.section
+        let sectionType = sections[indexPath.section]
         let row = indexPath.row
-        if section == sectionMembers {
-            if row == sectionMembersRowAddMember {
+
+        switch sectionType {
+        case .memberManagement:
+            if row == 0 {
                 coordinator?.showAddGroupMember(chatId: chat.id)
-            } else if row == sectionMembersRowJoinQR {
+            } else if row == 1 {
                 coordinator?.showQrCodeInvite(chatId: chat.id)
-            } else {
-                let contact = getGroupMember(at: row)
-                coordinator?.showContactDetail(of: contact.id)
             }
-        } else if section == sectionLeaveGroup {
-            leaveGroup()
+        case .members:
+            let contact = getGroupMember(at: row)
+            coordinator?.showContactDetail(of: contact.id)
+        case .chatActions:
+            if row == 0 {
+
+            } else if row == 1 {
+                leaveGroup()
+            } else if row == 2 {
+
+            }
+
         }
     }
 
@@ -337,34 +282,6 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             return [delete]
         }
         return nil
-
-        /*
-
-
-        // assigning swipe by delete to members (except for current user)
-        if section == sectionMembers, row >= sectionMembersStaticRowCount, groupMembers[row - sectionMembersStaticRowCount].id != currentUser?.id {
-            let delete = UITableViewRowAction(style: .destructive, title: String.localized("remove_desktop")) { [unowned self] _, indexPath in
-
-                let contact = self.getGroupMember(at: row)
-                let title = String.localizedStringWithFormat(String.localized("ask_remove_members"), contact.nameNAddr)
-                let alert = UIAlertController(title: title, message: nil, preferredStyle: .safeActionSheet)
-                alert.addAction(UIAlertAction(title: String.localized("remove_desktop"), style: .destructive, handler: { _ in
-                    let success = dc_remove_contact_from_chat(mailboxPointer, UInt32(self.chat.id), UInt32(contact.id))
-                    if success == 1 {
-                        self.groupMemberIds.remove(at: row - self.sectionMembersStaticRowCount)
-                        tableView.deleteRows(at: [indexPath], with: .fade)
-                        tableView.reloadData()
-                    }
-                }))
-                alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
-                self.present(alert, animated: true, completion: nil)
-            }
-            delete.backgroundColor = UIColor.red
-            return [delete]
-        } else {
-            return nil
-        }
-        */
     }
 
     func getGroupMember(at row: Int) -> DcContact {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -20,7 +20,8 @@ class GroupChatDetailViewController: UIViewController {
 
     fileprivate var chat: DcChat
 
-    lazy var chatDetailTable: UITableView = {
+    // MARK: -subviews
+    lazy var tableView: UITableView = {
         let table = UITableView(frame: .zero, style: .grouped)
         table.bounces = false
         table.register(UITableViewCell.self, forCellReuseIdentifier: "tableCell")
@@ -28,7 +29,23 @@ class GroupChatDetailViewController: UIViewController {
         table.register(ContactCell.self, forCellReuseIdentifier: "contactCell")
         table.delegate = self
         table.dataSource = self
+        table.tableHeaderView = headerCell
         return table
+    }()
+
+    private lazy var headerCell: ContactDetailHeader = {
+        let header = ContactDetailHeader()
+        header.updateDetails(
+            title: chat.name,
+            subtitle: String.localizedStringWithFormat(String.localized("n_members"), chat.contactIds.count)
+        )
+        if let img = chat.profileImage {
+            header.setImage(img)
+        } else {
+            header.setBackupImage(name: chat.name, color: chat.color)
+        }
+        header.setVerified(isVerified: chat.isVerified)
+        return header
     }()
 
     private lazy var archiveChatCell: ActionCell = {
@@ -58,13 +75,13 @@ class GroupChatDetailViewController: UIViewController {
     }
 
     private func setupSubviews() {
-        view.addSubview(chatDetailTable)
-        chatDetailTable.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
 
-        chatDetailTable.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
-        chatDetailTable.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-        chatDetailTable.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-        chatDetailTable.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        tableView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
     }
 
     private lazy var editBarButtonItem: UIBarButtonItem = {
@@ -78,12 +95,13 @@ class GroupChatDetailViewController: UIViewController {
         super.viewDidLoad()
         title = String.localized("tab_group")
         navigationItem.rightBarButtonItem = editBarButtonItem
+        headerCell.frame = CGRect(0, 0, tableView.frame.width, ContactCell.cellHeight)
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateGroupMembers()
-        chatDetailTable.reloadData() // to display updates
+        tableView.reloadData() // to display updates
         editBarButtonItem.isEnabled = currentUser != nil
         //update chat object, maybe chat name was edited
         chat = DcChat(id: chat.id)
@@ -93,7 +111,7 @@ class GroupChatDetailViewController: UIViewController {
     private func updateGroupMembers() {
         let ids = chat.contactIds
         groupMembers = ids.map { DcContact(id: $0) }
-        chatDetailTable.reloadData()
+        tableView.reloadData()
     }
 
     // MARK: -actions
@@ -123,23 +141,6 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             return ContactDetailHeader.cellHeight
         }
         return 0
-    }
-    
-    func tableView(_: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        if section == sectionMembers {
-            let header = ContactDetailHeader()
-            header.updateDetails(title: chat.name,
-                                 subtitle: String.localizedStringWithFormat(String.localized("n_members"), chat.contactIds.count))
-            if let img = chat.profileImage {
-                header.setImage(img)
-            } else {
-                header.setBackupImage(name: chat.name, color: chat.color)
-            }
-            header.setVerified(isVerified: chat.isVerified)
-            return header
-        } else {
-            return nil
-        }
     }
 
     func numberOfSections(in _: UITableView) -> Int {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -8,9 +8,10 @@ class GroupChatDetailViewController: UIViewController {
         case chatActions // archive, leave, delete
     }
 
+    private let context: DcContext
     weak var coordinator: GroupChatDetailCoordinator?
 
-    let sections: [ProfileSections] = [.memberManagement, .members, .chatActions]
+    private let sections: [ProfileSections] = [.memberManagement, .members, .chatActions]
 
     private var currentUser: DcContact? {
         let myId = groupMemberIds.filter { DcContact(id: $0).email == DcConfig.addr }.first
@@ -74,7 +75,8 @@ class GroupChatDetailViewController: UIViewController {
         return cell
     }()
 
-    init(chatId: Int) {
+    init(chatId: Int, context: DcContext) {
+        self.context = context
         chat = DcChat(id: chatId)
         super.init(nibName: nil, bundle: nil)
         setupSubviews()
@@ -129,10 +131,10 @@ class GroupChatDetailViewController: UIViewController {
         coordinator?.showGroupChatEdit(chat: chat)
     }
 
-
     private func toggleArchiveChat() {
-        let archived = false
-         updateArchiveChatCell(archived: archived)
+        let archivedBefore = chat.isArchived
+         context.archiveChat(chatId: chat.id, archive: !archivedBefore)
+        updateArchiveChatCell(archived: chat.isArchived)
      }
 
      private func updateArchiveChatCell(archived: Bool) {
@@ -200,7 +202,6 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             } else {
                 actionCell.actionTitle = String.localized("qrshow_join_group_title")
                 actionCell.actionColor = UIColor.systemBlue
-
             }
             return actionCell
         case .members:

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -104,7 +104,7 @@ class GroupChatDetailViewController: UIViewController {
         tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
     }
 
-    // MARK: -lifecycle
+    // MARK: - lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         title = String.localized("tab_group")
@@ -122,7 +122,7 @@ class GroupChatDetailViewController: UIViewController {
         chat = DcChat(id: chat.id)
     }
 
-    // MARK: -update
+    // MARK: - update
     private func updateGroupMembers() {
         groupMemberIds = chat.contactIds
         tableView.reloadData()
@@ -135,7 +135,7 @@ class GroupChatDetailViewController: UIViewController {
         )
     }
 
-    // MARK: -actions
+    // MARK: - actions
     @objc func editButtonPressed() {
         coordinator?.showGroupChatEdit(chat: chat)
     }
@@ -152,7 +152,7 @@ class GroupChatDetailViewController: UIViewController {
      }
 }
 
-// MARK: -UITableViewDelegate, UITableViewDataSource
+// MARK: - UITableViewDelegate, UITableViewDataSource
 extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSource {
 
     func numberOfSections(in _: UITableView) -> Int {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -23,7 +23,15 @@ class GroupChatDetailViewController: UIViewController {
 
     fileprivate var chat: DcChat
 
+    // stores contactIds
+    private var groupMemberIds: [Int] = []
+
     // MARK: -subviews
+
+    private lazy var editBarButtonItem: UIBarButtonItem = {
+        UIBarButtonItem(title: String.localized("global_menu_edit_desktop"), style: .plain, target: self, action: #selector(editButtonPressed))
+    }()
+
     lazy var tableView: UITableView = {
         let table = UITableView(frame: .zero, style: .grouped)
         table.bounces = false
@@ -32,11 +40,11 @@ class GroupChatDetailViewController: UIViewController {
         table.register(ContactCell.self, forCellReuseIdentifier: "contactCell")
         table.delegate = self
         table.dataSource = self
-        table.tableHeaderView = headerCell
+        table.tableHeaderView = groupHeader
         return table
     }()
 
-    private lazy var headerCell: ContactDetailHeader = {
+    private lazy var groupHeader: ContactDetailHeader = {
         let header = ContactDetailHeader()
         header.updateDetails(
             title: chat.name,
@@ -96,19 +104,12 @@ class GroupChatDetailViewController: UIViewController {
         tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
     }
 
-    private lazy var editBarButtonItem: UIBarButtonItem = {
-        UIBarButtonItem(title: String.localized("global_menu_edit_desktop"), style: .plain, target: self, action: #selector(editButtonPressed))
-    }()
-
-    // stores contactIds
-    private var groupMemberIds: [Int] = []
-
     // MARK: -lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         title = String.localized("tab_group")
         navigationItem.rightBarButtonItem = editBarButtonItem
-        headerCell.frame = CGRect(0, 0, tableView.frame.width, ContactCell.cellHeight)
+        groupHeader.frame = CGRect(0, 0, tableView.frame.width, ContactCell.cellHeight)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -128,7 +129,7 @@ class GroupChatDetailViewController: UIViewController {
     }
 
     private func updateHeader() {
-        headerCell.updateDetails(
+        groupHeader.updateDetails(
             title: chat.name,
             subtitle: String.localizedStringWithFormat(String.localized("n_members"), chat.contactIds.count)
         )
@@ -248,6 +249,13 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         }
     }
 
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        if sections[section] == .members {
+            return String.localized("tab_members")
+        }
+        return nil
+    }
+
     func tableView(_: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         guard let currentUser = self.currentUser else {
             return false
@@ -289,11 +297,11 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         return nil
     }
 
-    func getGroupMember(at row: Int) -> DcContact {
+    private func getGroupMember(at row: Int) -> DcContact {
         return DcContact(id: groupMemberIds[row])
     }
 
-    func removeGroupeMemberFromTableAt(_ indexPath: IndexPath) {
+    private func removeGroupeMemberFromTableAt(_ indexPath: IndexPath) {
         self.groupMemberIds.remove(at: indexPath.row)
         self.tableView.deleteRows(at: [indexPath], with: .automatic)
         updateHeader()  // to display correct group size

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -390,18 +390,34 @@ class GroupChatDetailCoordinator: Coordinator {
     }
 
     func deleteChat() {
+        /*
+        app will navigate to chatlist or archive and delete the chat there
+        notify chatList/archiveList to delete chat AFTER is is visible
+        */
         func notifyToDeleteChat() {
-            NotificationCenter.default.post(name: dcNotificationChatDeletedInChatDetail, object: nil, userInfo: ["chat_id": chatId])
+            NotificationCenter.default.post(name: dcNotificationChatDeletedInChatDetail, object: nil, userInfo: ["chat_id": self.chatId])
         }
 
-        // we want to notify chatList to delete chat AFTER is is visible
+        func showArchive() {
+            self.navigationController.popToRootViewController(animated: false) // in main ChatList now
+            let controller = ChatListController(dcContext: dcContext, showArchive: true)
+            let coordinator = ChatListCoordinator(dcContext: dcContext, navigationController: navigationController)
+            childCoordinators.append(coordinator)
+            controller.coordinator = coordinator
+            navigationController.pushViewController(controller, animated: false)
+        }
+
         CATransaction.begin()
-        CATransaction.setAnimationDuration(2)
         CATransaction.setCompletionBlock(notifyToDeleteChat)
-        self.navigationController.popToRootViewController(animated: true)
+
+        let chat = DcChat(id: chatId)
+        if chat.isArchived {
+            showArchive()
+        } else {
+            self.navigationController.popToRootViewController(animated: true) // in main ChatList now
+        }
         CATransaction.commit()
     }
-
 }
 
 class ChatViewCoordinator: NSObject, Coordinator {
@@ -617,17 +633,37 @@ class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
             return
         }
 
+        /*
+        app will navigate to chatlist or archive and delete the chat there
+        notify chatList/archiveList to delete chat AFTER is is visible
+        */
         func notifyToDeleteChat() {
-            NotificationCenter.default.post(name: dcNotificationChatDeletedInChatDetail, object: nil, userInfo: ["chat_id": chatId])
+            NotificationCenter.default.post(name: dcNotificationChatDeletedInChatDetail, object: nil, userInfo: ["chat_id": self.chatId])
         }
 
-        // we want to notify chatList to delete chat AFTER is is visible
+        func showArchive() {
+            self.navigationController.popToRootViewController(animated: false) // in main ChatList now
+            let controller = ChatListController(dcContext: dcContext, showArchive: true)
+            let coordinator = ChatListCoordinator(dcContext: dcContext, navigationController: navigationController)
+            childCoordinators.append(coordinator)
+            controller.coordinator = coordinator
+            navigationController.pushViewController(controller, animated: false)
+        }
+
         CATransaction.begin()
-        CATransaction.setAnimationDuration(2)
         CATransaction.setCompletionBlock(notifyToDeleteChat)
-        self.navigationController.popToRootViewController(animated: true)
+
+        let chat = DcChat(id: chatId)
+        if chat.isArchived {
+            showArchive()
+        } else {
+            self.navigationController.popToRootViewController(animated: true) // in main ChatList now
+        }
         CATransaction.commit()
     }
+
+
+
 }
 
 class EditGroupCoordinator: Coordinator {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -638,7 +638,7 @@ class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
         notify chatList/archiveList to delete chat AFTER is is visible
         */
         func notifyToDeleteChat() {
-            NotificationCenter.default.post(name: dcNotificationChatDeletedInChatDetail, object: nil, userInfo: ["chat_id": self.chatId])
+            NotificationCenter.default.post(name: dcNotificationChatDeletedInChatDetail, object: nil, userInfo: ["chat_id": chatId])
         }
 
         func showArchive() {
@@ -661,8 +661,6 @@ class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
         }
         CATransaction.commit()
     }
-
-
 
 }
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -437,7 +437,7 @@ class ChatViewCoordinator: NSObject, Coordinator {
                 navigationController.pushViewController(contactDetailController, animated: true)
             }
         case .GROUP, .VERYFIEDGROUP:
-            let groupChatDetailViewController = GroupChatDetailViewController(chatId: chatId) // inherits from ChatDetailViewController
+            let groupChatDetailViewController = GroupChatDetailViewController(chatId: chatId, context: dcContext) // inherits from ChatDetailViewController
             let coordinator = GroupChatDetailCoordinator(dcContext: dcContext, chatId: chatId, navigationController: navigationController)
             childCoordinators.append(coordinator)
             groupChatDetailViewController.coordinator = coordinator

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -628,11 +628,6 @@ class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
         self.navigationController.popToRootViewController(animated: true)
         CATransaction.commit()
     }
-
-    func archiveChat() {
-        print("archive chat")
-    }
-
 }
 
 class EditGroupCoordinator: Coordinator {
@@ -689,7 +684,6 @@ protocol ContactDetailCoordinatorProtocol: class {
     func showEditContact(contactId: Int)
     func showChat(chatId: Int)
     func deleteChat()
-    func archiveChat()
 }
 
 protocol EditContactCoordinatorProtocol: class {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -341,11 +341,13 @@ class NewChatCoordinator: Coordinator {
 class GroupChatDetailCoordinator: Coordinator {
     var dcContext: DcContext
     let navigationController: UINavigationController
+    let chatId: Int
 
     private var childCoordinators: [Coordinator] = []
 
-    init(dcContext: DcContext, navigationController: UINavigationController) {
+    init(dcContext: DcContext, chatId: Int, navigationController: UINavigationController) {
         self.dcContext = dcContext
+        self.chatId = chatId
         self.navigationController = navigationController
     }
 
@@ -387,6 +389,19 @@ class GroupChatDetailCoordinator: Coordinator {
         navigationController.pushViewController(contactDetailController, animated: true)
     }
 
+    func deleteChat() {
+        func notifyToDeleteChat() {
+            NotificationCenter.default.post(name: dcNotificationChatDeletedInChatDetail, object: nil, userInfo: ["chat_id": chatId])
+        }
+
+        // we want to notify chatList to delete chat AFTER is is visible
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(2)
+        CATransaction.setCompletionBlock(notifyToDeleteChat)
+        self.navigationController.popToRootViewController(animated: true)
+        CATransaction.commit()
+    }
+
 }
 
 class ChatViewCoordinator: NSObject, Coordinator {
@@ -423,7 +438,7 @@ class ChatViewCoordinator: NSObject, Coordinator {
             }
         case .GROUP, .VERYFIEDGROUP:
             let groupChatDetailViewController = GroupChatDetailViewController(chatId: chatId) // inherits from ChatDetailViewController
-            let coordinator = GroupChatDetailCoordinator(dcContext: dcContext, navigationController: navigationController)
+            let coordinator = GroupChatDetailCoordinator(dcContext: dcContext, chatId: chatId, navigationController: navigationController)
             childCoordinators.append(coordinator)
             groupChatDetailViewController.coordinator = coordinator
             navigationController.pushViewController(groupChatDetailViewController, animated: true)

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -67,7 +67,7 @@ class DcContext {
     }
 
     func archiveChat(chatId: Int, archive: Bool) {
-        dc_archive_chat(contextPointer, UInt32(chatId), Int32(archive ? 1 : 0))
+        dc_set_chat_visibility(contextPointer, UInt32(chatId), Int32(archive ? DC_CHAT_VISIBILITY_ARCHIVED : DC_CHAT_VISIBILITY_NORMAL))
     }
 
     func marknoticedChat(chatId: Int) {
@@ -472,7 +472,7 @@ class DcChat {
     }
 
     var isArchived: Bool {
-        return Int(dc_chat_get_archived(chatPointer)) == 1
+        return Int(dc_chat_get_visibility(chatPointer)) == DC_CHAT_VISIBILITY_ARCHIVED
     }
 
     var isUnpromoted: Bool {

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -500,10 +500,6 @@ class DcChat {
         return dc_chat_is_verified(chatPointer) > 0
     }
 
-    var isArchived: Bool {
-        return Int(dc_chat_get_archived(chatPointer)) == 1
-    }
-
     var contactIds: [Int] {
         return Utils.copyAndFreeArray(inputArray: dc_get_chat_contacts(mailboxPointer, UInt32(id)))
     }

--- a/deltachat-ios/Handler/DeviceContactsHandler.swift
+++ b/deltachat-ios/Handler/DeviceContactsHandler.swift
@@ -23,7 +23,7 @@ class DeviceContactsHandler {
     }
 
     private func addContactsToCore() {
-        fetchContactsWithEmailFromDevice() { contacts in
+        fetchContactsWithEmailFromDevice { contacts in
             DispatchQueue.main.async {
                 let contactString = self.makeContactString(contacts: contacts)
                 self.dcContext.addContacts(contactString: contactString)
@@ -32,7 +32,7 @@ class DeviceContactsHandler {
         }
     }
 
-    private func fetchContactsWithEmailFromDevice(completionHandler: @escaping ([CNContact])->Void) {
+    private func fetchContactsWithEmailFromDevice(completionHandler: @escaping ([CNContact]) -> Void) {
 
         DispatchQueue.global(qos: .background).async {
             let keys = [CNContactFamilyNameKey, CNContactGivenNameKey, CNContactEmailAddressesKey]

--- a/deltachat-ios/View/ContactDetailHeader.swift
+++ b/deltachat-ios/View/ContactDetailHeader.swift
@@ -1,19 +1,91 @@
 import UIKit
 
-class ContactDetailHeader: ContactCell {
+class ContactDetailHeader: UIView {
+
+    public static let headerHeight: CGFloat = 74.5
+
+    let badgeSize: CGFloat = 54
+
+    private lazy var avatar: InitialsBadge = {
+        let badge = InitialsBadge(size: badgeSize)
+        badge.setColor(UIColor.lightGray)
+        badge.isAccessibilityElement = false
+        return badge
+    }()
+
+    private var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+        label.lineBreakMode = .byTruncatingTail
+        label.textColor = DcColors.defaultTextColor
+        label.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1), for: NSLayoutConstraint.Axis.horizontal)
+        return label
+    }()
+
+    private var subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = UIColor(hexString: "848ba7")
+        label.lineBreakMode = .byTruncatingTail
+        return label
+    }()
+
     init() {
-        super.init(style: .default, reuseIdentifier: nil)
+        super.init(frame: .zero)
         let bg = UIColor(red: 248 / 255, green: 248 / 255, blue: 255 / 255, alpha: 1.0)
         backgroundColor = bg
-        selectionStyle = .none
+        setupSubviews()
     }
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
+    private func setupSubviews() {
+        let margin: CGFloat = 10
+        let verticalStackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+
+        addSubview(avatar)
+        addSubview(verticalStackView)
+
+        avatar.translatesAutoresizingMaskIntoConstraints = false
+        verticalStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        addConstraints([
+            avatar.constraintWidthTo(badgeSize),
+            avatar.constraintHeightTo(badgeSize),
+            avatar.constraintAlignLeadingTo(self, paddingLeading: badgeSize / 4),
+            avatar.constraintCenterYTo(self),
+        ])
+
+
+        verticalStackView.clipsToBounds = true
+        verticalStackView.leadingAnchor.constraint(equalTo: avatar.trailingAnchor, constant: margin).isActive = true
+        verticalStackView.centerYAnchor.constraint(equalTo: avatar.centerYAnchor).isActive = true
+        verticalStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -margin).isActive = true
+        verticalStackView.axis = .vertical
+    }
+
     func updateDetails(title: String?, subtitle: String?) {
         titleLabel.text = title
         subtitleLabel.text = subtitle
+    }
+
+    func setImage(_ image: UIImage) {
+        avatar.setImage(image)
+    }
+
+    func resetBackupImage() {
+        avatar.setColor(UIColor.clear)
+        avatar.setName("")
+    }
+
+    func setBackupImage(name: String, color: UIColor) {
+        avatar.setColor(color)
+        avatar.setName(name)
+    }
+
+    func setVerified(isVerified: Bool) {
+        avatar.setVerified(isVerified)
     }
 }

--- a/deltachat-ios/ViewModel/ContactCellViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactCellViewModel.swift
@@ -54,7 +54,7 @@ class ContactCellViewModel: AvatarCellViewModel {
     }
 }
 
-class ChatCellViewModel: AvatarCellViewModel{
+class ChatCellViewModel: AvatarCellViewModel {
 
     private let chat: DcChat
     private let summary: DcLot

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -7,6 +7,7 @@ protocol ContactDetailViewModelProtocol {
     var chatIsArchived: Bool { get }
     func numberOfRowsInSection(_ : Int) -> Int
     func typeFor(section: Int) -> ContactDetailViewModel.ProfileSections
+    func actionFor(row: Int) -> ContactDetailViewModel.ChatAction
     func update(sharedChatCell: ContactCell, row index: Int)
     func getSharedChatIdAt(indexPath: IndexPath) -> Int
     func titleFor(section: Int) -> String?
@@ -22,6 +23,12 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
         case chatActions //  archive chat, block chat, delete chats
     }
 
+    enum ChatAction {
+        case archiveChat
+        case blockChat
+        case deleteChat
+    }
+
     var contactId: Int
 
     var contact: DcContact
@@ -29,6 +36,7 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
     private let sharedChats: DcChatlist
     private let startChatOption: Bool
     private var sections: [ProfileSections] = []
+    private var actions: [ChatAction] = [] // chatDetail: archive, block, delete - else: block
 
     /// if chatId is nil this is a contact detail with 'start chat'-option
     init(contactId: Int, chatId: Int?, context: DcContext) {
@@ -46,15 +54,26 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
             sections.append(.sharedChats)
         }
         sections.append(.chatActions)
+
+        if chatId != nil {
+            actions = [.archiveChat, .blockChat, .deleteChat]
+        } else {
+            actions = [.blockChat]
+        }
+
     }
 
     func typeFor(section: Int) -> ContactDetailViewModel.ProfileSections {
         return sections[section]
     }
 
+    func actionFor(row: Int) -> ContactDetailViewModel.ChatAction {
+        return actions[row]
+    }
+
     var chatIsArchived: Bool {
         guard let chatId = chatId else {
-            safe_fatalError("This is a ContactDetail view with no chat id")
+           // safe_fatalError("This is a ContactDetail view with no chat id")
             return false
         }
         return DcChat(id: chatId).isArchived
@@ -68,7 +87,7 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
         switch sections[section] {
         case .sharedChats: return sharedChats.length
         case .startChat: return 1
-        case .chatActions: return 3
+        case .chatActions: return actions.count
         }
     }
 

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -116,7 +116,7 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
 
     func toggleArchiveChat() -> Bool {
         guard let chatId = chatId else {
-            safe_fatalError("there is now chatId- you are probably are calling this from ContactDetail - this should be only called from ChatDetail")
+            safe_fatalError("there is no chatId - you are probably are calling this from ContactDetail - this should be only called from ChatDetail")
             return false
         }
         context.archiveChat(chatId: chatId, archive: !chatIsArchived)

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -10,6 +10,7 @@ protocol ContactDetailViewModelProtocol {
     func update(sharedChatCell: ContactCell, row index: Int)
     func getSharedChatIdAt(indexPath: IndexPath) -> Int
     func titleFor(section: Int) -> String?
+    func toggleArchiveChat() -> Bool // returns true if chat is archived after action
 }
 
 class ContactDetailViewModel: ContactDetailViewModelProtocol {
@@ -89,8 +90,17 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
 
     func titleFor(section: Int) -> String? {
         if sections[section] == .sharedChats {
-           return String.localized("profile_shared_chats")
+            return String.localized("profile_shared_chats")
         }
         return nil
-      }
+    }
+
+    func toggleArchiveChat() -> Bool {
+        guard let chatId = chatId else {
+            safe_fatalError("there is now chatId- you are probably are calling this from ContactDetail - this should be only called from ChatDetail")
+            return false
+        }
+        context.archiveChat(chatId: chatId, archive: !chatIsArchived)
+        return chatIsArchived
+    }
 }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -6,7 +6,7 @@ protocol ContactDetailViewModelProtocol {
     var numberOfSections: Int { get }
     var chatIsArchived: Bool { get }
     func numberOfRowsInSection(_ : Int) -> Int
-    func typeFor(section: Int) -> ContactDetailViewModel.SectionType
+    func typeFor(section: Int) -> ContactDetailViewModel.ProfileSections
     func update(sharedChatCell: ContactCell, row index: Int)
     func getSharedChatIdAt(indexPath: IndexPath) -> Int
     func titleFor(section: Int) -> String?
@@ -15,7 +15,7 @@ protocol ContactDetailViewModelProtocol {
 class ContactDetailViewModel: ContactDetailViewModelProtocol {
 
     let context: DcContext
-    enum SectionType {
+    enum ProfileSections {
         case startChat
         case sharedChats
         case chatActions //  archive chat, block chat, delete chats
@@ -27,7 +27,7 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
     private let chatId: Int?
     private let sharedChats: DcChatlist
     private let startChatOption: Bool
-    private var sections: [SectionType] = []
+    private var sections: [ProfileSections] = []
 
     /// if chatId is nil this is a contact detail with 'start chat'-option
     init(contactId: Int, chatId: Int?, context: DcContext) {
@@ -47,7 +47,7 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
         sections.append(.chatActions)
     }
 
-    func typeFor(section: Int) -> ContactDetailViewModel.SectionType {
+    func typeFor(section: Int) -> ContactDetailViewModel.ProfileSections {
         return sections[section]
     }
 


### PR DESCRIPTION
closes #490

Archiving Group + Single Chat Cells 

If user deletes Chat from Group- or SingleChatDetailScreen it triggers an confirmation alert - the app navigates to the ChatList (or the ArchivedChatList) and animates the cell deletion. 

The cleaned up the GroupDetailViewController a bit. The member section has a "Members"-title now. 