### PR TITLE
Image and document gallery

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -49,19 +49,17 @@ class ContactDetailViewController: UITableViewController {
         return cell
     }()
 
-    private lazy var galleryCell: ActionCell = {
-        let cell = ActionCell()
-        cell.actionTitle = String.localized("gallery")
-        cell.actionColor = SystemColor.blue.uiColor
-        cell.selectionStyle = .none
+    private lazy var galleryCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        cell.textLabel?.text = String.localized("gallery")
+        cell.accessoryType = .disclosureIndicator
         return cell
     }()
 
-    private lazy var documentsCell: ActionCell = {
-        let cell = ActionCell()
-        cell.actionTitle = String.localized("documents")
-        cell.actionColor = SystemColor.blue.uiColor
-        cell.selectionStyle = .none
+    private lazy var documentsCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        cell.textLabel?.text = String.localized("documents")
+        cell.accessoryType = .disclosureIndicator
         return cell
     }()
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -49,6 +49,23 @@ class ContactDetailViewController: UITableViewController {
         return cell
     }()
 
+    private lazy var galleryCell: ActionCell = {
+        let cell = ActionCell()
+        cell.actionTitle = String.localized("gallery")
+        cell.actionColor = SystemColor.blue.uiColor
+        cell.selectionStyle = .none
+        return cell
+    }()
+
+    private lazy var documentsCell: ActionCell = {
+        let cell = ActionCell()
+        cell.actionTitle = String.localized("documents")
+        cell.actionColor = SystemColor.blue.uiColor
+        cell.selectionStyle = .none
+        return cell
+    }()
+
+
     init(viewModel: ContactDetailViewModelProtocol) {
         self.viewModel = viewModel
         super.init(style: .grouped)
@@ -95,8 +112,15 @@ class ContactDetailViewController: UITableViewController {
         let row = indexPath.row
         let cellType = viewModel.typeFor(section: indexPath.section)
         switch cellType {
+        case .attachments:
+            switch viewModel.attachmentActionFor(row: row) {
+            case .documents:
+                return documentsCell
+            case .gallery:
+                return galleryCell
+            }
         case .chatActions:
-            switch viewModel.actionFor(row: row) {
+            switch viewModel.chatActionFor(row: row) {
             case .archiveChat:
                 return archiveChatCell
             case .blockChat:
@@ -118,6 +142,8 @@ class ContactDetailViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let type = viewModel.typeFor(section: indexPath.section)
         switch type {
+        case .attachments:
+            handleAttachmentAction(for: indexPath.row)
         case .chatActions:
             handleCellAction(for: indexPath.row)
         case .startChat:
@@ -132,8 +158,8 @@ class ContactDetailViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let type = viewModel.typeFor(section: indexPath.section)
         switch type {
-        case .chatActions, .startChat:
-            return 44
+        case .chatActions, .startChat, .attachments:
+            return Constants.defaultCellHeight
         case .sharedChats:
             return ContactCell.cellHeight
         }
@@ -143,10 +169,14 @@ class ContactDetailViewController: UITableViewController {
         return viewModel.titleFor(section: section)
     }
 
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return Constants.defaultHeaderHeight
+    }
+
     // MARK: - actions
 
     private func handleCellAction(for index: Int) {
-        let action = viewModel.actionFor(row: index)
+        let action = viewModel.chatActionFor(row: index)
         switch action {
         case .archiveChat:
             toggleArchiveChat()
@@ -154,6 +184,16 @@ class ContactDetailViewController: UITableViewController {
             toggleBlockContact()
         case .deleteChat:
             showDeleteChatConfirmationAlert()
+        }
+    }
+
+    private func handleAttachmentAction(for index: Int) {
+        let action = viewModel.attachmentActionFor(row: index)
+        switch action {
+        case .documents:
+            coordinator?.showDocuments()
+        case .gallery:
+            coordinator?.showGallery()
         }
     }
 

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -8,6 +8,12 @@ class GroupChatDetailViewController: UIViewController {
         case chatActions // archive, leave, delete
     }
 
+    private let memberManagementRowAddMembers = 0
+    private let memberManagementRowQrInvite = 1
+    private let chatActionsRowArchiveChat = 0
+    private let chatActionsRowLeaveGroup = 1
+    private let chatActionsRowDeleteChat = 2
+
     private let context: DcContext
     weak var coordinator: GroupChatDetailCoordinator?
 
@@ -192,11 +198,11 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 safe_fatalError("could not dequeu action cell")
                 break
             }
-            if row == 0 {
+            if row == memberManagementRowAddMembers {
                 actionCell.actionTitle = String.localized("group_add_members")
                 actionCell.actionColor = UIColor.systemBlue
 
-            } else {
+            } else if row == memberManagementRowQrInvite {
                 actionCell.actionTitle = String.localized("qrshow_join_group_title")
                 actionCell.actionColor = UIColor.systemBlue
             }
@@ -212,11 +218,11 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             contactCell.updateCell(cellViewModel: cellViewModel)
             return contactCell
         case .chatActions:
-            if row == 0 {
+            if row == chatActionsRowArchiveChat {
                 return archiveChatCell
-            } else if row == 1 {
+            } else if row == chatActionsRowLeaveGroup {
                 return leaveGroupCell
-            } else if row == 2 {
+            } else if row == chatActionsRowDeleteChat {
                 return deleteChatCell
             }
         }
@@ -230,20 +236,20 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
 
         switch sectionType {
         case .memberManagement:
-            if row == 0 {
+            if row == memberManagementRowAddMembers {
                 coordinator?.showAddGroupMember(chatId: chat.id)
-            } else if row == 1 {
+            } else if row == memberManagementRowQrInvite {
                 coordinator?.showQrCodeInvite(chatId: chat.id)
             }
         case .members:
             let member = getGroupMember(at: row)
             coordinator?.showContactDetail(of: member.id)
         case .chatActions:
-            if row == 0 {
+            if row == chatActionsRowArchiveChat {
                 toggleArchiveChat()
-            } else if row == 1 {
+            } else if row == chatActionsRowLeaveGroup {
                 showLeaveGroupConfirmationAlert()
-            } else if row == 2 {
+            } else if row == chatActionsRowDeleteChat {
                 showDeleteChatConfirmationAlert()
             }
         }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -3,11 +3,14 @@ import UIKit
 class GroupChatDetailViewController: UIViewController {
 
     enum ProfileSections {
+        case attachments
         case memberManagement // add member, qr invideCode
         case members // contactCells
         case chatActions // archive, leave, delete
     }
 
+    private let attachmentsRowGallery = 0
+    private let attachmentsRowDocuments = 1
     private let memberManagementRowAddMembers = 0
     private let memberManagementRowQrInvite = 1
     private let chatActionsRowArchiveChat = 0
@@ -17,7 +20,7 @@ class GroupChatDetailViewController: UIViewController {
     private let context: DcContext
     weak var coordinator: GroupChatDetailCoordinator?
 
-    private let sections: [ProfileSections] = [.memberManagement, .members, .chatActions]
+    private let sections: [ProfileSections] = [.attachments, .memberManagement, .members, .chatActions]
 
     private var currentUser: DcContact? {
         let myId = groupMemberIds.filter { DcContact(id: $0).email == DcConfig.addr }.first
@@ -168,6 +171,8 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
     func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
         let sectionType = sections[section]
         switch sectionType {
+        case .attachments:
+            return 2
         case .memberManagement:
             return 2
         case .members:
@@ -180,12 +185,10 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let sectionType = sections[indexPath.section]
         switch sectionType {
-        case .memberManagement:
+        case .attachments, .memberManagement, .chatActions:
             return Constants.defaultCellHeight
         case .members:
             return ContactCell.cellHeight
-        case .chatActions:
-            return Constants.defaultCellHeight
         }
     }
 
@@ -193,6 +196,18 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         let row = indexPath.row
         let sectionType = sections[indexPath.section]
         switch sectionType {
+        case .attachments:
+            guard let actionCell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath) as? ActionCell else {
+                safe_fatalError("could not dequeue action cell")
+                break
+            }
+            if row == attachmentsRowGallery {
+                actionCell.actionTitle = String.localized("gallery")
+                actionCell.actionColor = UIColor.systemBlue
+            } else if row == attachmentsRowDocuments {
+                actionCell.actionTitle = String.localized("documents")
+                actionCell.actionColor = UIColor.systemBlue
+            }
         case .memberManagement:
             guard let actionCell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath) as? ActionCell else {
                 safe_fatalError("could not dequeu action cell")
@@ -235,6 +250,12 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         let row = indexPath.row
 
         switch sectionType {
+        case .attachments:
+            if row == attachmentsRowGallery {
+                coordinator?.showGallery(chatId: chat.id)
+            } else if row == attachmentsRowDocuments {
+                coordinator?.showDocuments(chatId: chat.id)
+            }
         case .memberManagement:
             if row == memberManagementRowAddMembers {
                 coordinator?.showAddGroupMember(chatId: chat.id)

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -93,19 +93,17 @@ class GroupChatDetailViewController: UIViewController {
         return cell
     }()
 
-    private lazy var galleryCell: ActionCell = {
-        let cell = ActionCell()
-        cell.actionTitle = String.localized("gallery")
-        cell.actionColor = UIColor.systemBlue
-        cell.selectionStyle = .none
+    private lazy var galleryCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        cell.textLabel?.text = String.localized("gallery")
+        cell.accessoryType = .disclosureIndicator
         return cell
     }()
 
-    private lazy var documentsCell: ActionCell = {
-        let cell = ActionCell()
-        cell.actionTitle = String.localized("documents")
-        cell.actionColor = UIColor.systemBlue
-        cell.selectionStyle = .none
+    private lazy var documentsCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        cell.textLabel?.text = String.localized("documents")
+        cell.accessoryType = .disclosureIndicator
         return cell
     }()
 

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -252,9 +252,9 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         switch sectionType {
         case .attachments:
             if row == attachmentsRowGallery {
-                coordinator?.showGallery(chatId: chat.id)
+                coordinator?.showGallery()
             } else if row == attachmentsRowDocuments {
-                coordinator?.showDocuments(chatId: chat.id)
+                coordinator?.showDocuments()
             }
         case .memberManagement:
             if row == memberManagementRowAddMembers {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -210,7 +210,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             }
         case .memberManagement:
             guard let actionCell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath) as? ActionCell else {
-                safe_fatalError("could not dequeu action cell")
+                safe_fatalError("could not dequeue action cell")
                 break
             }
             if row == memberManagementRowAddMembers {
@@ -224,7 +224,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             return actionCell
         case .members:
             guard let contactCell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath) as? ContactCell else {
-                safe_fatalError("could not dequeu contactCell cell")
+                safe_fatalError("could not dequeue contactCell cell")
                 break
 
             }
@@ -311,7 +311,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 alert.addAction(UIAlertAction(title: String.localized("remove_desktop"), style: .destructive, handler: { _ in
                     let success = dc_remove_contact_from_chat(mailboxPointer, UInt32(self.chat.id), UInt32(contact.id))
                     if success == 1 {
-                        self.removeGroupeMemberFromTableAt(indexPath)
+                        self.removeGroupMemberFromTableAt(indexPath)
                     }
                 }))
                 alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
@@ -328,7 +328,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         return DcContact(id: groupMemberIds[row])
     }
 
-    private func removeGroupeMemberFromTableAt(_ indexPath: IndexPath) {
+    private func removeGroupMemberFromTableAt(_ indexPath: IndexPath) {
         self.groupMemberIds.remove(at: indexPath.row)
         self.tableView.deleteRows(at: [indexPath], with: .automatic)
         updateHeader()  // to display correct group size

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -20,7 +20,7 @@ class GroupChatDetailViewController: UIViewController {
     private let context: DcContext
     weak var coordinator: GroupChatDetailCoordinator?
 
-    private let sections: [ProfileSections] = [.attachments, .memberManagement, .members, .chatActions]
+    private let sections: [ProfileSections] = [.memberManagement, .attachments, .members, .chatActions]
 
     private var currentUser: DcContact? {
         let myId = groupMemberIds.filter { DcContact(id: $0).email == DcConfig.addr }.first
@@ -71,7 +71,7 @@ class GroupChatDetailViewController: UIViewController {
     private lazy var archiveChatCell: ActionCell = {
         let cell = ActionCell()
         cell.actionTitle = chat.isArchived ? String.localized("menu_unarchive_chat") :  String.localized("menu_archive_chat")
-        cell.actionColor = SystemColor.blue.uiColor
+        cell.actionColor = UIColor.systemBlue
         cell.selectionStyle = .none
         return cell
     }()
@@ -88,6 +88,22 @@ class GroupChatDetailViewController: UIViewController {
         let cell = ActionCell()
         cell.actionTitle = String.localized("menu_delete_chat")
         cell.actionColor = UIColor.red
+        cell.selectionStyle = .none
+        return cell
+    }()
+
+    private lazy var galleryCell: ActionCell = {
+        let cell = ActionCell()
+        cell.actionTitle = String.localized("gallery")
+        cell.actionColor = UIColor.systemBlue
+        cell.selectionStyle = .none
+        return cell
+    }()
+
+    private lazy var documentsCell: ActionCell = {
+        let cell = ActionCell()
+        cell.actionTitle = String.localized("documents")
+        cell.actionColor = UIColor.systemBlue
         cell.selectionStyle = .none
         return cell
     }()
@@ -197,16 +213,10 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         let sectionType = sections[indexPath.section]
         switch sectionType {
         case .attachments:
-            guard let actionCell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath) as? ActionCell else {
-                safe_fatalError("could not dequeue action cell")
-                break
-            }
             if row == attachmentsRowGallery {
-                actionCell.actionTitle = String.localized("gallery")
-                actionCell.actionColor = UIColor.systemBlue
+                return galleryCell
             } else if row == attachmentsRowDocuments {
-                actionCell.actionTitle = String.localized("documents")
-                actionCell.actionColor = UIColor.systemBlue
+                return documentsCell
             }
         case .memberManagement:
             guard let actionCell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath) as? ActionCell else {
@@ -279,8 +289,14 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         if sections[section] == .members {
             return String.localized("tab_members")
+        } else if sections[section] == .attachments {
+            return String.localized("media")
         }
         return nil
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return Constants.defaultHeaderHeight
     }
 
     func tableView(_: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -4,9 +4,8 @@ class GroupChatDetailViewController: UIViewController {
 
     enum ProfileSections {
         case attachments
-        //case memberManagement // add member, qr invideCode
-        case members // contactCells
-        case chatActions // archive, leave, delete
+        case members
+        case chatActions
     }
 
     private let attachmentsRowGallery = 0

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -620,9 +620,9 @@ class NewGroupCoordinator: Coordinator {
 }
 
 class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
-
     var dcContext: DcContext
     let navigationController: UINavigationController
+    var previewController: PreviewController?
     let chatId: Int?
 
     private var childCoordinators: [Coordinator] = []
@@ -649,6 +649,31 @@ class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
         editContactController.coordinator = coordinator
         navigationController.pushViewController(editContactController, animated: true)
     }
+
+    func showDocuments() {
+        presentPreview(for: DC_MSG_FILE, messageType2: DC_MSG_AUDIO, messageType3: 0)
+    }
+
+    func showGallery() {
+        presentPreview(for: DC_MSG_IMAGE, messageType2: DC_MSG_GIF, messageType3: DC_MSG_VIDEO)
+    }
+
+    private func presentPreview(for messageType: Int32, messageType2: Int32, messageType3: Int32) {
+        guard let chatId = self.chatId else { return }
+        let messageIds = dcContext.getChatMedia(chatId: chatId, messageType: messageType, messageType2: messageType2, messageType3: messageType3)
+        var mediaUrls: [URL] = []
+        for messageId in messageIds {
+            let message = DcMsg.init(id: messageId)
+            if let url = message.fileURL {
+                mediaUrls.insert(url, at: 0)
+            }
+        }
+        previewController = PreviewController(currentIndex: 0, urls: mediaUrls)
+        if let previewController = previewController {
+            navigationController.pushViewController(previewController.qlController, animated: true)
+        }
+    }
+
 
     func deleteChat() {
         guard let chatId = chatId else {
@@ -736,10 +761,16 @@ class EditContactCoordinator: Coordinator, EditContactCoordinatorProtocol {
     }
 }
 
+
+/*
+ boilerplate - I tend to remove that interface (cyberta)
+ */
 protocol ContactDetailCoordinatorProtocol: class {
     func showEditContact(contactId: Int)
     func showChat(chatId: Int)
     func deleteChat()
+    func showDocuments()
+    func showGallery()
 }
 
 protocol EditContactCoordinatorProtocol: class {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -349,6 +349,7 @@ class GroupChatDetailCoordinator: Coordinator {
     let chatId: Int
 
     private var childCoordinators: [Coordinator] = []
+    private var previewController: PreviewController?
 
     init(dcContext: DcContext, chatId: Int, navigationController: UINavigationController) {
         self.dcContext = dcContext
@@ -394,23 +395,16 @@ class GroupChatDetailCoordinator: Coordinator {
         navigationController.pushViewController(contactDetailController, animated: true)
     }
 
-    func showDocuments(chatId: Int) {
-        let messageIds = dcContext.getChatMedia(chatId: chatId, messageType: DC_MSG_FILE, messageType2: DC_MSG_AUDIO, messageType3: 0)
-        var mediaUrls: [URL] = []
-        for messageId in messageIds {
-            let message = DcMsg.init(id: messageId)
-            if let url = message.fileURL {
-                logger.debug("add file url: \(url.absoluteString)")
-                mediaUrls.insert(url, at: 0)
-            }
-        }
-        // these are the files user will be able to swipe trough
-        let previewController = PreviewController(currentIndex: 0, urls: mediaUrls)
-        navigationController.present(previewController.qlController, animated: true, completion: nil)
+    func showDocuments() {
+        presentPreview(for: DC_MSG_FILE, messageType2: DC_MSG_AUDIO, messageType3: 0)
     }
 
-    func showGallery(chatId: Int) {
-        let messageIds = dcContext.getChatMedia(chatId: chatId, messageType: DC_MSG_GIF, messageType2: DC_MSG_IMAGE, messageType3: DC_MSG_VIDEO)
+    func showGallery() {
+        presentPreview(for: DC_MSG_IMAGE, messageType2: DC_MSG_GIF, messageType3: DC_MSG_VIDEO)
+    }
+
+    private func presentPreview(for messageType: Int32, messageType2: Int32, messageType3: Int32) {
+        let messageIds = dcContext.getChatMedia(chatId: chatId, messageType: messageType, messageType2: messageType2, messageType3: messageType3)
         var mediaUrls: [URL] = []
         for messageId in messageIds {
             let message = DcMsg.init(id: messageId)
@@ -418,9 +412,10 @@ class GroupChatDetailCoordinator: Coordinator {
                 mediaUrls.insert(url, at: 0)
             }
         }
-        // these are the files user will be able to swipe trough
-        let previewController = PreviewController(currentIndex: 0, urls: mediaUrls)
-        navigationController.present(previewController.qlController, animated: true, completion: nil)
+        previewController = PreviewController(currentIndex: 0, urls: mediaUrls)
+        if let previewController = previewController {
+            navigationController.pushViewController(previewController.qlController, animated: true)
+        }
     }
 
     func deleteChat() {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -394,6 +394,35 @@ class GroupChatDetailCoordinator: Coordinator {
         navigationController.pushViewController(contactDetailController, animated: true)
     }
 
+    func showDocuments(chatId: Int) {
+        let messageIds = dcContext.getChatMedia(chatId: chatId, messageType: DC_MSG_FILE, messageType2: DC_MSG_AUDIO, messageType3: 0)
+        var mediaUrls: [URL] = []
+        for messageId in messageIds {
+            let message = DcMsg.init(id: messageId)
+            if let url = message.fileURL {
+                logger.debug("add file url: \(url.absoluteString)")
+                mediaUrls.insert(url, at: 0)
+            }
+        }
+        // these are the files user will be able to swipe trough
+        let previewController = PreviewController(currentIndex: 0, urls: mediaUrls)
+        navigationController.present(previewController.qlController, animated: true, completion: nil)
+    }
+
+    func showGallery(chatId: Int) {
+        let messageIds = dcContext.getChatMedia(chatId: chatId, messageType: DC_MSG_GIF, messageType2: DC_MSG_IMAGE, messageType3: DC_MSG_VIDEO)
+        var mediaUrls: [URL] = []
+        for messageId in messageIds {
+            let message = DcMsg.init(id: messageId)
+            if let url = message.fileURL {
+                mediaUrls.insert(url, at: 0)
+            }
+        }
+        // these are the files user will be able to swipe trough
+        let previewController = PreviewController(currentIndex: 0, urls: mediaUrls)
+        navigationController.present(previewController.qlController, animated: true, completion: nil)
+    }
+
     func deleteChat() {
         /*
         app will navigate to chatlist or archive and delete the chat there

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -49,11 +49,8 @@ class DcContext {
         guard let messagesPointer = dc_get_chat_media(contextPointer, UInt32(chatId), messageType, messageType2, messageType3) else {
             return []
         }
-        let array = DcArray(arrayPointer: messagesPointer)
-        var messageIds: [Int] = []
-        for index in 0..<array.count {
-            messageIds.append(array.getId(at: index))
-        }
+
+        let messageIds: [Int] =  Utils.copyAndFreeArray(inputArray: messagesPointer)
         return messageIds
     }
 
@@ -566,10 +563,6 @@ class DcArray {
 
     var count: Int {
        return Int(dc_array_get_cnt(dcArrayPointer))
-    }
-
-    func getId(at index: Int) -> Int {
-        return Int(dc_array_get_id(dcArrayPointer, index))
     }
 
     ///TODO: add missing methods here

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -45,6 +45,18 @@ class DcContext {
         return chatlist
     }
 
+    func getChatMedia(chatId: Int, messageType: Int32, messageType2: Int32, messageType3: Int32) -> [Int] {
+        guard let messagesPointer = dc_get_chat_media(contextPointer, UInt32(chatId), messageType, messageType2, messageType3) else {
+            return []
+        }
+        let array = DcArray(arrayPointer: messagesPointer)
+        var messageIds: [Int] = []
+        for index in 0..<array.count {
+            messageIds.append(array.getId(at: index))
+        }
+        return messageIds
+    }
+
     @discardableResult
     func createChat(contactId: Int) -> Int {
         return Int(dc_create_chat_by_contact_id(contextPointer, UInt32(contactId)))
@@ -554,6 +566,10 @@ class DcArray {
 
     var count: Int {
        return Int(dc_array_get_cnt(dcArrayPointer))
+    }
+
+    func getId(at index: Int) -> Int {
+        return Int(dc_array_get_id(dcArrayPointer, index))
     }
 
     ///TODO: add missing methods here

--- a/deltachat-ios/Helper/Constants.swift
+++ b/deltachat-ios/Helper/Constants.swift
@@ -17,4 +17,5 @@ struct Constants {
     static let notificationIdentifier = "deltachat-ios-local-notifications"
 
     static let defaultCellHeight: CGFloat = 48
+    static let defaultHeaderHeight: CGFloat = 20
 }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -53,8 +53,8 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
         self.contact = DcContact(id: contactId)
         self.sharedChats = context.getChatlist(flags: 0, queryString: nil, queryId: contactId)
 
-        sections.append(.startChat)
         sections.append(.attachments)
+        sections.append(.startChat)
         if sharedChats.length > 0 {
             sections.append(.sharedChats)
         }
@@ -119,8 +119,6 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
     func titleFor(section: Int) -> String? {
         if sections[section] == .sharedChats {
             return String.localized("profile_shared_chats")
-        } else if sections[section] == .attachments {
-            return String.localized("media")
         }
         return nil
     }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -7,7 +7,8 @@ protocol ContactDetailViewModelProtocol {
     var chatIsArchived: Bool { get }
     func numberOfRowsInSection(_ : Int) -> Int
     func typeFor(section: Int) -> ContactDetailViewModel.ProfileSections
-    func actionFor(row: Int) -> ContactDetailViewModel.ChatAction
+    func chatActionFor(row: Int) -> ContactDetailViewModel.ChatAction
+    func attachmentActionFor(row: Int) -> ContactDetailViewModel.AttachmentAction
     func update(sharedChatCell: ContactCell, row index: Int)
     func getSharedChatIdAt(indexPath: IndexPath) -> Int
     func titleFor(section: Int) -> String?
@@ -19,6 +20,7 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
     let context: DcContext
     enum ProfileSections {
         case startChat
+        case attachments
         case sharedChats
         case chatActions //  archive chat, block chat, delete chats
     }
@@ -29,13 +31,19 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
         case deleteChat
     }
 
+    enum AttachmentAction {
+        case gallery
+        case documents
+    }
+
     var contactId: Int
 
     var contact: DcContact
     private let chatId: Int?
     private let sharedChats: DcChatlist
     private var sections: [ProfileSections] = []
-    private var actions: [ChatAction] = [] // chatDetail: archive, block, delete - else: block
+    private var chatActions: [ChatAction] = [] // chatDetail: archive, block, delete - else: block
+    private var attachmentActions: [AttachmentAction] = [.gallery, .documents]
 
     /// if chatId is nil this is a contact detail with 'start chat'-option
     init(contactId: Int, chatId: Int?, context: DcContext) {
@@ -46,15 +54,16 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
         self.sharedChats = context.getChatlist(flags: 0, queryString: nil, queryId: contactId)
 
         sections.append(.startChat)
+        sections.append(.attachments)
         if sharedChats.length > 0 {
             sections.append(.sharedChats)
         }
         sections.append(.chatActions)
 
         if chatId != nil {
-            actions = [.archiveChat, .blockChat, .deleteChat]
+            chatActions = [.archiveChat, .blockChat, .deleteChat]
         } else {
-            actions = [.blockChat]
+            chatActions = [.blockChat]
         }
     }
 
@@ -62,8 +71,12 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
         return sections[section]
     }
 
-    func actionFor(row: Int) -> ContactDetailViewModel.ChatAction {
-        return actions[row]
+    func chatActionFor(row: Int) -> ContactDetailViewModel.ChatAction {
+        return chatActions[row]
+    }
+
+    func attachmentActionFor(row: Int) -> ContactDetailViewModel.AttachmentAction {
+        return attachmentActions[row]
     }
 
     var chatIsArchived: Bool {
@@ -80,9 +93,10 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
 
     func numberOfRowsInSection(_ section: Int) -> Int {
         switch sections[section] {
+        case .attachments: return 2
         case .sharedChats: return sharedChats.length
         case .startChat: return 1
-        case .chatActions: return actions.count
+        case .chatActions: return chatActions.count
         }
     }
 
@@ -105,6 +119,8 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
     func titleFor(section: Int) -> String? {
         if sections[section] == .sharedChats {
             return String.localized("profile_shared_chats")
+        } else if sections[section] == .attachments {
+            return String.localized("media")
         }
         return nil
     }

--- a/deltachat-ios/ViewModel/GroupDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/GroupDetailViewModel.swift
@@ -1,9 +1,0 @@
-//
-//  GroupDetailViewModel.swift
-//  deltachat-ios
-//
-//  Created by Macci on 06.03.20.
-//  Copyright © 2020 Jonas Reinsch. All rights reserved.
-//
-
-import Foundation

--- a/deltachat-ios/ViewModel/GroupDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/GroupDetailViewModel.swift
@@ -1,0 +1,9 @@
+//
+//  GroupDetailViewModel.swift
+//  deltachat-ios
+//
+//  Created by Macci on 06.03.20.
+//  Copyright © 2020 Jonas Reinsch. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
* implements a media section in contact and group profiles
* closes #546 
* drawback for now using existing components: tapping on gallery/documents opens the single preview first, a second tap on the list icon opens the item overview, there's no api to change that behavior of QLPreviewController (a native iOS component), thus custom views should be implemented in another PR

![Screen Shot 2020-03-05 at 13 19 03](https://user-images.githubusercontent.com/2614900/75981704-55e7d580-5ee5-11ea-94d6-2feb05db93b7.png)
![Screen Shot 2020-03-05 at 13 19 29](https://user-images.githubusercontent.com/2614900/75981708-56806c00-5ee5-11ea-8d28-08070613b228.png)
![Screen Shot 2020-03-05 at 13 19 41](https://user-images.githubusercontent.com/2614900/75981713-57b19900-5ee5-11ea-8e12-f372a6c6355c.png)

