### PR TITLE
Fix inputBar (without Rust-core changes).

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -65,7 +65,6 @@ class ChatViewController: MessagesViewController {
     private var showNamesAboveMessage: Bool
     var showCustomNavBar = true
     var previewView: UIView?
-    var previewController: PreviewController?
 
     var emptyStateView: PaddingLabel = {
         let view =  PaddingLabel()
@@ -1154,8 +1153,7 @@ extension ChatViewController: MessageCellDelegate {
 
                 // these are the files user will be able to swipe trough
                 let mediaUrls: [URL] = previousUrls + [url] + nextUrls
-                previewController = PreviewController(currentIndex: previousUrls.count, urls: mediaUrls)
-                present(previewController!.qlController, animated: true)
+                coordinator?.showMediaGallery(currentIndex: previousUrls.count, mediaUrls: mediaUrls)
             }
         }
     }

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -1,27 +1,7 @@
 import QuickLook
 import UIKit
 
-class PreviewController: QLPreviewControllerDataSource {
-    var urls: [URL]
-    var qlController: QLPreviewController
-
-    init(currentIndex: Int, urls: [URL]) {
-        self.urls = urls
-        qlController = QLPreviewController()
-        qlController.dataSource = self
-        qlController.currentPreviewItemIndex = currentIndex
-    }
-
-    func numberOfPreviewItems(in _: QLPreviewController) -> Int {
-        return urls.count
-    }
-
-    func previewController(_: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
-        return urls[index] as QLPreviewItem
-    }
-}
-
-class BetterPreviewController: QLPreviewController {
+class PreviewController: QLPreviewController {
 
     var urls: [URL]
 
@@ -43,8 +23,8 @@ class BetterPreviewController: QLPreviewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        if navigationController != nil {
-            /* QLPreviewController comes with a done-button by default. But if is embedded in UINavigationContrller we set a done-button manually.
+        if navigationController != nil && isBeingPresented {
+            /* QLPreviewController comes with a done-button by default. But if is embedded in UINavigationContrller we need to set a done-button manually.
             */
             navigationItem.leftBarButtonItem = doneButtonItem
         }
@@ -56,7 +36,7 @@ class BetterPreviewController: QLPreviewController {
     }
 }
 
-extension BetterPreviewController: QLPreviewControllerDataSource {
+extension PreviewController: QLPreviewControllerDataSource {
 
     func numberOfPreviewItems(in _: QLPreviewController) -> Int {
         return urls.count

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -20,3 +20,49 @@ class PreviewController: QLPreviewControllerDataSource {
         return urls[index] as QLPreviewItem
     }
 }
+
+class BetterPreviewController: QLPreviewController {
+
+    var urls: [URL]
+
+    private lazy var doneButtonItem: UIBarButtonItem = {
+        let button = UIBarButtonItem(title: String.localized("done"), style: .done, target: self, action: #selector(doneButtonPressed(_:)))
+        return button
+    }()
+
+    init(currentIndex: Int, urls: [URL]) {
+        self.urls = urls
+        super.init(nibName: nil, bundle: nil)
+        dataSource = self
+        currentPreviewItemIndex = currentIndex
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if navigationController != nil {
+            /* QLPreviewController comes with a done-button by default. But if is embedded in UINavigationContrller we set a done-button manually.
+            */
+            navigationItem.leftBarButtonItem = doneButtonItem
+        }
+    }
+
+    // MARK: - actions
+    @objc private func doneButtonPressed(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true, completion: nil)
+    }
+}
+
+extension BetterPreviewController: QLPreviewControllerDataSource {
+
+    func numberOfPreviewItems(in _: QLPreviewController) -> Int {
+        return urls.count
+    }
+
+    func previewController(_: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+        return urls[index] as QLPreviewItem
+    }
+}

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -523,6 +523,13 @@ class ChatViewCoordinator: NSObject, Coordinator {
     func showPhotoVideoLibrary(delegate: MediaPickerDelegate) {
         mediaPicker.showPhotoVideoLibrary(delegate: delegate)
     }
+
+    func showMediaGallery(currentIndex: Int, mediaUrls urls: [URL]) {
+        let betterPreviewController = BetterPreviewController(currentIndex: currentIndex, urls: urls)
+        let nav = UINavigationController(rootViewController: betterPreviewController)
+
+        navigationController.present(nav, animated: true)
+    }
 }
 
 class NewGroupAddMembersCoordinator: Coordinator {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -414,7 +414,7 @@ class GroupChatDetailCoordinator: Coordinator {
         }
         previewController = PreviewController(currentIndex: 0, urls: mediaUrls)
         if let previewController = previewController {
-            navigationController.pushViewController(previewController.qlController, animated: true)
+            navigationController.pushViewController(previewController, animated: true)
         }
     }
 
@@ -525,7 +525,7 @@ class ChatViewCoordinator: NSObject, Coordinator {
     }
 
     func showMediaGallery(currentIndex: Int, mediaUrls urls: [URL]) {
-        let betterPreviewController = BetterPreviewController(currentIndex: currentIndex, urls: urls)
+        let betterPreviewController = PreviewController(currentIndex: currentIndex, urls: urls)
         let nav = UINavigationController(rootViewController: betterPreviewController)
 
         navigationController.present(nav, animated: true)
@@ -677,7 +677,7 @@ class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
         }
         previewController = PreviewController(currentIndex: 0, urls: mediaUrls)
         if let previewController = previewController {
-            navigationController.pushViewController(previewController.qlController, animated: true)
+            navigationController.pushViewController(previewController, animated: true)
         }
     }
 


### PR DESCRIPTION
Got lost when attempting to extract Rust-core changes from #558, so I had to create a new branch.
closes #521 

PreviewController is now actually a QLPreviewController (before it was a object/class holding a QLPreviewController instance).

EDIT: fix link