### PR TITLE
Bugfix for contact list search sync issue

### DIFF
--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -39,7 +39,7 @@ class NewChatViewController: UITableViewController {
 
     // searchBar active?
     func isFiltering() -> Bool {
-        return searchController.isActive && !searchBarIsEmpty()
+        return !searchBarIsEmpty()
     }
 
     // weak var chatDisplayer: ChatDisplayer?
@@ -300,9 +300,15 @@ class NewChatViewController: UITableViewController {
             self.coordinator?.showNewChat(contactId: contactId)
         }))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
-            self.dismiss(animated: true, completion: nil)
+            self.reactivateSearchBarIfNeeded()
         }))
         present(alert, animated: true, completion: nil)
+    }
+
+    private func reactivateSearchBarIfNeeded() {
+        if !searchBarIsEmpty() {
+            searchController.isActive = true
+        }
     }
 
     private func showChatAt(row: Int) {


### PR DESCRIPTION
fixes #557 

Short explanation:
To present this Ask-To-Chat-With-Alert we have to close / deactivate the searchbar first.
Now when hitting cancel there was nothing that re-activated the searchbar.
This solved the issue.

There was still one problem. When deactivating the searchBar the chatList reloaded (showing all contacts). To fix this I had to change the `isFiltering`-Condition. 