### PR TITLE
WIP: SearchBar in ChatList (2nd Attempt)

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		AEACE2E31FB32B5C00DCDD78 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEACE2E21FB32B5C00DCDD78 /* Constants.swift */; };
 		AEACE2E51FB32E1900DCDD78 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEACE2E41FB32E1900DCDD78 /* Utils.swift */; };
 		AEC67A1C241CE9E4007DDBE1 /* TabBarRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC67A1B241CE9E4007DDBE1 /* TabBarRestorer.swift */; };
+		AEC67A1E241FCFE0007DDBE1 /* ChatListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC67A1D241FCFE0007DDBE1 /* ChatListViewModel.swift */; };
 		AEE56D762253431E007DC082 /* AccountSetupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE56D752253431E007DC082 /* AccountSetupController.swift */; };
 		AEE56D7D2253ADB4007DC082 /* HudHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE56D7C2253ADB4007DC082 /* HudHandler.swift */; };
 		AEE56D80225504DB007DC082 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE56D7F225504DB007DC082 /* Extensions.swift */; };
@@ -379,6 +380,7 @@
 		AEACE2E21FB32B5C00DCDD78 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		AEACE2E41FB32E1900DCDD78 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		AEC67A1B241CE9E4007DDBE1 /* TabBarRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarRestorer.swift; sourceTree = "<group>"; };
+		AEC67A1D241FCFE0007DDBE1 /* ChatListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListViewModel.swift; sourceTree = "<group>"; };
 		AEE56D752253431E007DC082 /* AccountSetupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSetupController.swift; sourceTree = "<group>"; tabWidth = 4; };
 		AEE56D7C2253ADB4007DC082 /* HudHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HudHandler.swift; sourceTree = "<group>"; };
 		AEE56D7F225504DB007DC082 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -710,6 +712,7 @@
 			children = (
 				AE77838C23E32ED20093EABD /* ContactDetailViewModel.swift */,
 				AE77838E23E4276D0093EABD /* ContactCellViewModel.swift */,
+				AEC67A1D241FCFE0007DDBE1 /* ChatListViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1204,6 +1207,7 @@
 				302B84C72396770B001C261F /* RelayHelper.swift in Sources */,
 				305961CF2346125100C80F33 /* UIColor+Extensions.swift in Sources */,
 				AEACE2E51FB32E1900DCDD78 /* Utils.swift in Sources */,
+				AEC67A1E241FCFE0007DDBE1 /* ChatListViewModel.swift in Sources */,
 				300C509D234B551900F8AE22 /* TextMediaMessageCell.swift in Sources */,
 				305961E92346125100C80F33 /* MessageKind.swift in Sources */,
 				305962022346125100C80F33 /* BubbleCircle.swift in Sources */,

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -66,7 +66,7 @@ class ChatListController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateTitle()
-        viewModel.refreshData()
+        // viewModel.refreshData()
         let nc = NotificationCenter.default
         msgChangedObserver = nc.addObserver(
             forName: dcNotificationChanged,

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -36,6 +36,7 @@ class ChatListController: UITableViewController {
     private lazy var archiveCell: UITableViewCell = {
         let cell = UITableViewCell()
         cell.textLabel?.textColor = .systemBlue
+        cell.textLabel?.textAlignment = .center
         return cell
     }()
 

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -66,7 +66,7 @@ class ChatListController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateTitle()
-        // viewModel.refreshData()
+        viewModel.refreshData()
         let nc = NotificationCenter.default
         msgChangedObserver = nc.addObserver(
             forName: dcNotificationChanged,

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -8,6 +8,11 @@ class ChatListController: UITableViewController {
     private let deadDropCellReuseIdentifier = "deaddrop_cell"
     private let contactCellReuseIdentifier = "contact_cell"
 
+    private var msgChangedObserver: Any?
+    private var incomingMsgObserver: Any?
+    private var viewChatObserver: Any?
+    private var deleteChatObserver: Any?
+
     private lazy var searchController: UISearchController = {
         let searchController = UISearchController(searchResultsController: nil)
         searchController.searchResultsUpdater = viewModel
@@ -16,11 +21,6 @@ class ChatListController: UITableViewController {
         searchController.searchBar.delegate = self
         return searchController
     }()
-
-    private var msgChangedObserver: Any?
-    private var incomingMsgObserver: Any?
-    private var viewChatObserver: Any?
-    private var deleteChatObserver: Any?
 
     private lazy var newButton: UIBarButtonItem = {
         let button = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.compose, target: self, action: #selector(didPressNewChat))
@@ -126,18 +126,7 @@ class ChatListController: UITableViewController {
         tableView.rowHeight = 80
     }
 
-    // MARK: - actions
-    @objc func didPressNewChat() {
-        coordinator?.showNewChatController()
-    }
-
-    @objc func cancelButtonPressed() {
-        RelayHelper.sharedInstance.cancel()
-        updateTitle()
-    }
-
     // MARK: - uitableviewdelegate, uitableviewdatasource
-
     override func numberOfSections(in tableView: UITableView) -> Int {
         return viewModel.numberOfSections
     }
@@ -215,6 +204,7 @@ class ChatListController: UITableViewController {
     override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
 
         if viewModel.searchActive {
+            // no swipe actions during search
             return []
         }
 
@@ -230,7 +220,7 @@ class ChatListController: UITableViewController {
         let archiveActionTitle: String = String.localized(viewModel.isArchive ? "unarchive" : "archive")
 
         let archiveAction = UITableViewRowAction(style: .destructive, title: archiveActionTitle) { [unowned self] _, _ in
-            self.viewModel.archiveChat(chatId: chatId)
+            self.viewModel.archiveChatToggle(chatId: chatId)
             self.updateArchivedCell()
         }
         archiveAction.backgroundColor = UIColor.lightGray
@@ -238,7 +228,7 @@ class ChatListController: UITableViewController {
         let chat = DcChat(id: chatId)
         let pinned = chat.visibility==DC_CHAT_VISIBILITY_PINNED
         let pinAction = UITableViewRowAction(style: .destructive, title: String.localized(pinned ? "unpin" : "pin")) { [unowned self] _, _ in
-            self.viewModel.pinChat(chatId: chat.id)
+            self.viewModel.pinChatToggle(chatId: chat.id)
         }
         pinAction.backgroundColor = UIColor.systemGreen
 
@@ -251,7 +241,6 @@ class ChatListController: UITableViewController {
     }
 
     // MARK: updates
-
     private func updateTitle() {
         if RelayHelper.sharedInstance.isForwarding() {
             title = String.localized("forward_to")
@@ -329,8 +318,17 @@ class ChatListController: UITableViewController {
         self.present(alert, animated: true, completion: nil)
     }
 
-    private func deleteChat(chatId: Int, animated: Bool) {
+    // MARK: - actions
+    @objc func didPressNewChat() {
+        coordinator?.showNewChatController()
+    }
 
+    @objc func cancelButtonPressed() {
+        RelayHelper.sharedInstance.cancel()
+        updateTitle()
+    }
+
+    private func deleteChat(chatId: Int, animated: Bool) {
         if !animated {
             _ = viewModel.deleteChat(chatId: chatId)
             viewModel.refreshData()
@@ -342,15 +340,14 @@ class ChatListController: UITableViewController {
     }
 }
 
-
-// MARK
+// MARK: - uisearchbardelegate
 extension ChatListController: UISearchBarDelegate {
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
-        viewModel.beginFiltering()
+        viewModel.beginSearch()
         return true
     }
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        viewModel.endFiltering()
+        viewModel.endSearch()
     }
 }

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -147,17 +147,18 @@ class ChatListController: UITableViewController {
                 return archiveCell
             } else if
                 chatId == DC_CHAT_ID_DEADDROP,
-                let msgId = viewModel.msgIdFor(row: indexPath.row),
                 let deaddropCell = tableView.dequeueReusableCell(withIdentifier: deadDropCellReuseIdentifier, for: indexPath) as? ContactCell {
                 deaddropCell.updateCell(cellViewModel: cellData)
                 deaddropCell.backgroundColor = DcColors.deaddropBackground
                 deaddropCell.contentView.backgroundColor = DcColors.deaddropBackground
-                let contact = DcContact(id: DcMsg(id: msgId).fromContactId)
-                if let img = contact.profileImage {
-                    deaddropCell.resetBackupImage()
-                    deaddropCell.setImage(img)
-                } else {
-                    deaddropCell.setBackupImage(name: contact.name, color: contact.color)
+                if let msgId = viewModel.msgIdFor(row: indexPath.row) {
+                    let contact = DcContact(id: DcMsg(id: msgId).fromContactId)
+                    if let img = contact.profileImage {
+                        deaddropCell.resetBackupImage()
+                        deaddropCell.setImage(img)
+                    } else {
+                        deaddropCell.setBackupImage(name: contact.nameNAddr, color: contact.color)
+                    }
                 }
                 return deaddropCell
             } else if let chatCell = tableView.dequeueReusableCell(withIdentifier: chatCellReuseIdentifier, for: indexPath) as? ContactCell {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -197,7 +197,11 @@ class ChatListController: UITableViewController {
             }
         case .CONTACT(let contactData):
             let contactId = contactData.contactId
-            self.askToChatWith(contactId: contactId)
+            if let chatId = contactData.chatId {
+                coordinator?.showChat(chatId: chatId)
+            } else {
+                self.askToChatWith(contactId: contactId)
+            }
         }
     }
 

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -41,7 +41,7 @@ class ChatListController: UITableViewController {
 
     init(viewModel: ChatListViewModelProtocol) {
         self.viewModel = viewModel
-        super.init(nibName: nil, bundle: nil)
+        super.init(style: .grouped)
         viewModel.onChatListUpdate = handleChatListUpdate // register listener
     }
 
@@ -179,6 +179,10 @@ class ChatListController: UITableViewController {
         }
         safe_fatalError("Could not find/dequeue or recycle UITableViewCell.")
         return UITableViewCell()
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return viewModel.titleForHeaderIn(section: section)
     }
 
     override func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -219,25 +219,25 @@ class ChatListController: UITableViewController {
         }
         let archiveActionTitle: String = String.localized(viewModel.isArchive ? "unarchive" : "archive")
 
-        let archive = UITableViewRowAction(style: .destructive, title: archiveActionTitle) { [unowned self] _, _ in
+        let archiveAction = UITableViewRowAction(style: .destructive, title: archiveActionTitle) { [unowned self] _, _ in
             self.viewModel.archiveChat(chatId: chatId)
             self.updateArchivedCell()
         }
-        archive.backgroundColor = UIColor.lightGray
+        archiveAction.backgroundColor = UIColor.lightGray
 
         let chat = DcChat(id: chatId)
         let pinned = chat.visibility==DC_CHAT_VISIBILITY_PINNED
-        let pin = UITableViewRowAction(style: .destructive, title: String.localized(pinned ? "unpin" : "pin")) { [unowned self] _, _ in
+        let pinAction = UITableViewRowAction(style: .destructive, title: String.localized(pinned ? "unpin" : "pin")) { [unowned self] _, _ in
             self.viewModel.pinChat(chatId: chat.id)
         }
-        pin.backgroundColor = UIColor.systemGreen
+        pinAction.backgroundColor = UIColor.systemGreen
 
-        let delete = UITableViewRowAction(style: .normal, title: String.localized("delete")) { [unowned self] _, _ in
+        let deleteAction = UITableViewRowAction(style: .normal, title: String.localized("delete")) { [unowned self] _, _ in
             self.showDeleteChatConfirmationAlert(chatId: chatId)
         }
-        delete.backgroundColor = UIColor.systemRed
+        deleteAction.backgroundColor = UIColor.systemRed
 
-        return [archive, pin, delete]
+        return [archiveAction, pinAction, deleteAction]
     }
 
     // MARK: updates

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -41,7 +41,11 @@ class ChatListController: UITableViewController {
 
     init(viewModel: ChatListViewModelProtocol) {
         self.viewModel = viewModel
-        super.init(style: .grouped)
+        if viewModel.isArchive {
+            super.init(nibName: nil, bundle: nil)
+        } else {
+            super.init(style: .grouped)
+        }
         viewModel.onChatListUpdate = handleChatListUpdate // register listener
     }
 
@@ -53,7 +57,9 @@ class ChatListController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.rightBarButtonItem = newButton
-        navigationItem.searchController = searchController
+        if !viewModel.isArchive {
+            navigationItem.searchController = searchController
+        }
         configureTableView()
     }
 

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -248,7 +248,11 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 safe_fatalError("could not dequeue contactCell cell")
                 break
             }
-            let cellData = ContactCellData(contactId: getGroupMemberIdFor(row))
+            let contactId: Int = getGroupMemberIdFor(row)
+            let cellData = ContactCellData(
+                contactId: contactId,
+                chatId: context.getChatIdByContactId(contactId)
+            )
             let cellViewModel = ContactCellViewModel(contactData: cellData)
             contactCell.updateCell(cellViewModel: cellViewModel)
             return contactCell

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -47,7 +47,7 @@ class AppCoordinator: NSObject, Coordinator {
 
     private lazy var chatListController: UIViewController = {
         let viewModel = ChatListViewModel(dcContext: dcContext, isArchive: false)
-        let controller = ChatListController(viewModel: viewModel, dcContext: dcContext, showArchive: false)
+        let controller = ChatListController(viewModel: viewModel)
         let nav = UINavigationController(rootViewController: controller)
         let settingsImage = UIImage(named: "ic_chat")
         nav.tabBarItem = UITabBarItem(title: String.localized("pref_chats"), image: settingsImage, tag: chatsTab)
@@ -192,7 +192,7 @@ class ChatListCoordinator: Coordinator {
 
     func showArchive() {
         let viewModel = ChatListViewModel(dcContext: dcContext, isArchive: true)
-        let controller = ChatListController(viewModel: viewModel, dcContext: dcContext, showArchive: true)
+        let controller = ChatListController(viewModel: viewModel)
         let coordinator = ChatListCoordinator(dcContext: dcContext, navigationController: navigationController)
         childCoordinators.append(coordinator)
         controller.coordinator = coordinator
@@ -440,7 +440,7 @@ class GroupChatDetailCoordinator: Coordinator {
         func showArchive() {
             self.navigationController.popToRootViewController(animated: false) // in main ChatList now
             let viewModel = ChatListViewModel(dcContext: dcContext, isArchive: true)
-            let controller = ChatListController(viewModel: viewModel, dcContext: dcContext, showArchive: true)
+            let controller = ChatListController(viewModel: viewModel)
             let coordinator = ChatListCoordinator(dcContext: dcContext, navigationController: navigationController)
             childCoordinators.append(coordinator)
             controller.coordinator = coordinator
@@ -709,7 +709,7 @@ class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
         func showArchive() {
             self.navigationController.popToRootViewController(animated: false) // in main ChatList now
             let viewModel = ChatListViewModel(dcContext: dcContext, isArchive: true)
-            let controller = ChatListController(viewModel: viewModel, dcContext: dcContext, showArchive: true)
+            let controller = ChatListController(viewModel: viewModel)
             let coordinator = ChatListCoordinator(dcContext: dcContext, navigationController: navigationController)
             childCoordinators.append(coordinator)
             controller.coordinator = coordinator

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -198,6 +198,11 @@ class ChatListCoordinator: Coordinator {
         controller.coordinator = coordinator
         navigationController.pushViewController(controller, animated: true)
     }
+
+    func showNewChat(contactId: Int) {
+        let chatId = dc_create_chat_by_contact_id(mailboxPointer, UInt32(contactId))
+        showChat(chatId: Int(chatId))
+    }
 }
 
 class SettingsCoordinator: Coordinator {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -46,7 +46,8 @@ class AppCoordinator: NSObject, Coordinator {
     }()
 
     private lazy var chatListController: UIViewController = {
-        let controller = ChatListController(dcContext: dcContext, showArchive: false)
+        let viewModel = ChatListViewModel(dcContext: dcContext, isArchive: false)
+        let controller = ChatListController(viewModel: viewModel, dcContext: dcContext, showArchive: false)
         let nav = UINavigationController(rootViewController: controller)
         let settingsImage = UIImage(named: "ic_chat")
         nav.tabBarItem = UITabBarItem(title: String.localized("pref_chats"), image: settingsImage, tag: chatsTab)
@@ -190,7 +191,8 @@ class ChatListCoordinator: Coordinator {
     }
 
     func showArchive() {
-        let controller = ChatListController(dcContext: dcContext, showArchive: true)
+        let viewModel = ChatListViewModel(dcContext: dcContext, isArchive: true)
+        let controller = ChatListController(viewModel: viewModel, dcContext: dcContext, showArchive: true)
         let coordinator = ChatListCoordinator(dcContext: dcContext, navigationController: navigationController)
         childCoordinators.append(coordinator)
         controller.coordinator = coordinator
@@ -437,7 +439,8 @@ class GroupChatDetailCoordinator: Coordinator {
 
         func showArchive() {
             self.navigationController.popToRootViewController(animated: false) // in main ChatList now
-            let controller = ChatListController(dcContext: dcContext, showArchive: true)
+            let viewModel = ChatListViewModel(dcContext: dcContext, isArchive: true)
+            let controller = ChatListController(viewModel: viewModel, dcContext: dcContext, showArchive: true)
             let coordinator = ChatListCoordinator(dcContext: dcContext, navigationController: navigationController)
             childCoordinators.append(coordinator)
             controller.coordinator = coordinator
@@ -705,7 +708,8 @@ class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
 
         func showArchive() {
             self.navigationController.popToRootViewController(animated: false) // in main ChatList now
-            let controller = ChatListController(dcContext: dcContext, showArchive: true)
+            let viewModel = ChatListViewModel(dcContext: dcContext, isArchive: true)
+            let controller = ChatListController(viewModel: viewModel, dcContext: dcContext, showArchive: true)
             let coordinator = ChatListCoordinator(dcContext: dcContext, navigationController: navigationController)
             childCoordinators.append(coordinator)
             controller.coordinator = coordinator

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -26,8 +26,8 @@ class DcContext {
         return dc_delete_contact(self.contextPointer, UInt32(contactId)) == 1
     }
 
-    func getContacts(flags: Int32) -> [Int] {
-        let cContacts = dc_get_contacts(self.contextPointer, UInt32(flags), nil)
+    func getContacts(flags: Int32, queryString: String? = nil) -> [Int] {
+        let cContacts = dc_get_contacts(self.contextPointer, UInt32(flags), queryString)
         return Utils.copyAndFreeArray(inputArray: cContacts)
     }
 

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -39,6 +39,15 @@ class DcContext {
         return DcChat(id: chatId)
     }
 
+    func getChatIdByContactId(_ contactId: Int) -> Int? {
+        let chatId = dc_get_chat_id_by_contact_id(self.contextPointer, UInt32(contactId))
+        if chatId == 0 {
+            return nil
+        } else {
+            return Int(chatId)
+        }
+    }
+
     func getChatlist(flags: Int32, queryString: String?, queryId: Int) -> DcChatlist {
         let chatlistPointer = dc_get_chatlist(contextPointer, flags, queryString, UInt32(queryId))
         let chatlist = DcChatlist(chatListPointer: chatlistPointer)

--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -221,6 +221,14 @@ class DcContext {
     func imex(what: Int32, directory: String) {
         dc_imex(contextPointer, what, directory, nil)
     }
+
+    func searchMessages(chatId: Int = 0, searchText: String) -> [Int] {
+        guard let arrayPointer = dc_search_msgs(contextPointer, UInt32(chatId), searchText) else {
+            return []
+        }
+        let messageIds = Utils.copyAndFreeArray(inputArray: arrayPointer)
+        return messageIds
+    }
 }
 
 class DcConfig {
@@ -866,6 +874,16 @@ class DcMsg: MessageType {
         let swiftString = String(cString: cString)
         dc_str_unref(cString)
         return swiftString
+    }
+
+    func summary(chat: DcChat) -> DcLot {
+        guard let chatPointer = chat.chatPointer else {
+            fatalError()
+        }
+        guard let dcLotPointer = dc_msg_get_summary(messagePointer, chatPointer) else {
+            fatalError()
+        }
+        return DcLot(dcLotPointer)
     }
 
     func showPadlock() -> Bool {

--- a/deltachat-ios/Extensions/String+Extension.swift
+++ b/deltachat-ios/Extensions/String+Extension.swift
@@ -13,6 +13,22 @@ extension String {
         return !trimmingCharacters(in: [" "]).isEmpty
     }
 
+    func containsExact(subSequence: String) -> [Int] {
+        if subSequence.count > count {
+            return []
+        }
+
+        if let range = range(of: subSequence, options: .caseInsensitive) {
+            let index: Int = distance(from: startIndex, to: range.lowerBound)
+            var indexes: [Int] = []
+            for i in index..<(index + subSequence.count) {
+                indexes.append(i)
+            }
+            return indexes
+        }
+        return []
+    }
+
     // O(n) - returns indexes of subsequences -> can be used to highlight subsequence within string
     func contains(subSequence: String) -> [Int] {
         if subSequence.count > count {

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -5,35 +5,35 @@ protocol ContactCellDelegate: class {
 }
 
 class ContactCell: UITableViewCell {
-
+    
     static let reuseIdentifier = "contact_cell_reuse_identifier"
     static let cellHeight: CGFloat = 74.5
-
+    
     weak var delegate: ContactCellDelegate?
     private let badgeSize: CGFloat = 54
     private let imgSize: CGFloat = 20
-
+    
     lazy var toplineStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [titleLabel, pinnedIndicator, timeLabel])
         stackView.axis = .horizontal
         stackView.spacing = 4
         return stackView
     }()
-
+    
     lazy var bottomlineStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [subtitleLabel, deliveryStatusIndicator, archivedIndicator, unreadMessageCounter])
         stackView.axis = .horizontal
         stackView.spacing = 10
         return stackView
     }()
-
+    
     lazy var avatar: InitialsBadge = {
         let badge = InitialsBadge(size: badgeSize)
         badge.setColor(UIColor.lightGray)
         badge.isAccessibilityElement = false
         return badge
     }()
-
+    
     let titleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 16, weight: .medium)
@@ -42,7 +42,7 @@ class ContactCell: UITableViewCell {
         label.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1), for: NSLayoutConstraint.Axis.horizontal)
         return label
     }()
-
+    
     private let pinnedIndicator: UIImageView = {
         let view = UIImageView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -53,7 +53,7 @@ class ContactCell: UITableViewCell {
         view.isHidden = true
         return view
     }()
-
+    
     private let timeLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 14)
@@ -62,7 +62,7 @@ class ContactCell: UITableViewCell {
         label.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 2), for: NSLayoutConstraint.Axis.horizontal)
         return label
     }()
-
+    
     let subtitleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 14)
@@ -71,14 +71,14 @@ class ContactCell: UITableViewCell {
         label.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1), for: NSLayoutConstraint.Axis.horizontal)
         return label
     }()
-
+    
     private let deliveryStatusIndicator: UIImageView = {
         let view = UIImageView()
         view.tintColor = UIColor.green
         view.isHidden = true
         return view
     }()
-
+    
     private let archivedIndicator: UIView = {
         let tintColor = UIColor(hexString: "848ba7")
         let label = UILabel()
@@ -92,7 +92,7 @@ class ContactCell: UITableViewCell {
         view.layer.borderWidth = 1
         view.layer.cornerRadius = 2
         view.isHidden = true
-
+        
         label.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(label)
         label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 4).isActive = true
@@ -101,13 +101,13 @@ class ContactCell: UITableViewCell {
         label.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0).isActive = true
         return view
     }()
-
+    
     private let unreadMessageCounter: MessageCounter = {
         let view = MessageCounter(count: 0, size: 20)
         view.isHidden = true
         return view
     }()
-
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         selectionStyle = .none
@@ -115,32 +115,32 @@ class ContactCell: UITableViewCell {
         contentView.backgroundColor = DcColors.contactCellBackgroundColor
         setupSubviews()
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     private func setupSubviews() {
         let margin: CGFloat = 10
-
+        
         avatar.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(avatar)
-
+        
         contentView.addConstraints([
             avatar.constraintWidthTo(badgeSize),
             avatar.constraintHeightTo(badgeSize),
             avatar.constraintAlignLeadingTo(contentView, paddingLeading: badgeSize / 4),
             avatar.constraintCenterYTo(contentView),
         ])
-
+        
         deliveryStatusIndicator.translatesAutoresizingMaskIntoConstraints = false
         deliveryStatusIndicator.heightAnchor.constraint(equalToConstant: 20).isActive = true
         deliveryStatusIndicator.widthAnchor.constraint(equalToConstant: 20).isActive = true
-
+        
         let verticalStackView = UIStackView()
         verticalStackView.translatesAutoresizingMaskIntoConstraints = false
         verticalStackView.clipsToBounds = true
-
+        
         contentView.addSubview(verticalStackView)
         verticalStackView.leadingAnchor.constraint(equalTo: avatar.trailingAnchor, constant: margin).isActive = true
         verticalStackView.centerYAnchor.constraint(equalTo: avatar.centerYAnchor).isActive = true
@@ -149,25 +149,25 @@ class ContactCell: UITableViewCell {
         verticalStackView.addArrangedSubview(toplineStackView)
         verticalStackView.addArrangedSubview(bottomlineStackView)
     }
-
+    
     func setVerified(isVerified: Bool) {
         avatar.setVerified(isVerified)
     }
-
+    
     func setImage(_ img: UIImage) {
         avatar.setImage(img)
     }
-
+    
     func resetBackupImage() {
         avatar.setColor(UIColor.clear)
         avatar.setName("")
     }
-
+    
     func setBackupImage(name: String, color: UIColor) {
         avatar.setColor(color)
         avatar.setName(name)
     }
-
+    
     func setStatusIndicators(unreadCount: Int, status: Int, visibility: Int32) {
         if visibility==DC_CHAT_VISIBILITY_ARCHIVED {
             pinnedIndicator.isHidden = true
@@ -176,7 +176,7 @@ class ContactCell: UITableViewCell {
             archivedIndicator.isHidden = false
         } else if unreadCount > 0 {
             unreadMessageCounter.setCount(unreadCount)
-
+            
             pinnedIndicator.isHidden = !(visibility==DC_CHAT_VISIBILITY_PINNED)
             unreadMessageCounter.isHidden = false
             deliveryStatusIndicator.isHidden = true
@@ -194,14 +194,14 @@ class ContactCell: UITableViewCell {
             default:
                 deliveryStatusIndicator.image = nil
             }
-
+            
             pinnedIndicator.isHidden = !(visibility==DC_CHAT_VISIBILITY_PINNED)
             unreadMessageCounter.isHidden = true
             deliveryStatusIndicator.isHidden = deliveryStatusIndicator.image == nil ? true : false
             archivedIndicator.isHidden = true
         }
     }
-
+    
     func setTimeLabel(_ timestamp: Int64?) {
         let timestamp = timestamp ?? 0
         if timestamp != 0 {
@@ -212,17 +212,17 @@ class ContactCell: UITableViewCell {
             timeLabel.text = nil
         }
     }
-
+    
     func setColor(_ color: UIColor) {
         avatar.setColor(color)
     }
-
+    
     // use this update-method to update cell in cellForRowAt whenever it is possible - other set-methods will be set private in progress
     func updateCell(cellViewModel: AvatarCellViewModel) {
-
+        
         // subtitle
         subtitleLabel.attributedText = cellViewModel.subtitle.boldAt(indexes: cellViewModel.subtitleHighlightIndexes, fontSize: subtitleLabel.font.pointSize)
-
+        
         switch cellViewModel.type {
         case .deaddrop(let deaddropData):
             safe_assert(deaddropData.chatId == DC_CHAT_ID_DEADDROP)
@@ -236,15 +236,22 @@ class ContactCell: UITableViewCell {
                 setBackupImage(name: contact.nameNAddr, color: contact.color)
             }
             titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)
-
+            
         case .chat(let chatData):
             let chat = DcChat(id: chatData.chatId)
-
+            
             // text bold if chat contains unread messages - otherwise hightlight search results if needed
             if chatData.unreadMessages > 0 {
                 titleLabel.attributedText = NSAttributedString(string: cellViewModel.title, attributes: [ .font: UIFont.systemFont(ofSize: 16, weight: .bold) ])
             } else {
                 titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)
+            }
+            if chat.visibility == DC_CHAT_VISIBILITY_PINNED {
+                backgroundColor = DcColors.deaddropBackground
+                contentView.backgroundColor = DcColors.deaddropBackground
+            } else {
+                backgroundColor = DcColors.contactCellBackgroundColor
+                contentView.backgroundColor = DcColors.contactCellBackgroundColor
             }
             setVerified(isVerified: chat.isVerified)
             setTimeLabel(chatData.summary.timestamp)

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -37,6 +37,7 @@ class ChatListViewModel: NSObject, ChatListViewModelProtocol {
     private var chatList: DcChatlist!
 
     init(dcContext: DcContext, isArchive: Bool) {
+        dcContext.updateDeviceChats()
         self.isArchive = isArchive
         self.dcContext = dcContext
         super.init()

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -153,7 +153,7 @@ class ChatListViewModel: NSObject, ChatListViewModelProtocol {
     }
 
     func msgIdFor(row: Int) -> Int? {
-        if searchActive {
+        if showSearchResults {
             return nil
         }
         return chatList.getMsgId(index: row)

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -1,0 +1,9 @@
+//
+//  ChatListViewModel.swift
+//  deltachat-ios
+//
+//  Created by Bastian van de Wetering on 16.03.20.
+//  Copyright © 2020 Jonas Reinsch. All rights reserved.
+//
+
+import Foundation

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -11,7 +11,8 @@ protocol ChatListViewModelProtocol: class, UISearchResultsUpdating {
     func cellDataFor(section: Int, row: Int) -> AvatarCellViewModel
 
     func msgIdFor(row: Int) -> Int?
-    func chatIdFor(section: Int, row: Int) -> Int? // to differentiate betweeen deaddrop / archive / default
+    func chatIdFor(section: Int, row: Int) -> Int? // needed to differentiate betweeen deaddrop / archive / default
+
     // search related
     var searchActive: Bool { get }
     func beginFiltering()

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -188,7 +188,7 @@ class ChatListViewModel: NSObject, ChatListViewModelProtocol {
     }
 
     func pinChatToggle(chatId: Int) {
-        let chat = DcChat(id: chatId)
+        let chat: DcChat = dcContext.getChat(chatId: chatId)
         let pinned = chat.visibility==DC_CHAT_VISIBILITY_PINNED
         self.dcContext.setChatVisibility(chatId: chatId, visibility: pinned ? DC_CHAT_VISIBILITY_NORMAL : DC_CHAT_VISIBILITY_PINNED)
         updateChatList(notifyListener: false)
@@ -208,7 +208,7 @@ private extension ChatListViewModel {
         let list: DcChatlist = searchResultChatList ?? chatList
 
         let chatId = list.getChatId(index: index)
-        let chat = DcChat(id: chatId)
+        let chat = dcContext.getChat(chatId: chatId)
         let summary = chatList.getSummary(index: index)
         let unreadMessages = dcContext.getUnreadMessages(chatId: chatId)
 

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -1,9 +1,114 @@
-//
-//  ChatListViewModel.swift
-//  deltachat-ios
-//
-//  Created by Bastian van de Wetering on 16.03.20.
-//  Copyright © 2020 Jonas Reinsch. All rights reserved.
-//
+import UIKit
 
-import Foundation
+protocol ChatListViewModelProtocol: class, UISearchResultsUpdating {
+
+    var onChatListUpdate: VoidFunction? { get set }
+
+    var isArchive: Bool { get }
+
+    var numberOfSections: Int { get }
+    func numberOfRowsIn(section: Int) -> Int
+    func cellDataFor(section: Int, row: Int) -> AvatarCellViewModel
+
+    // search related
+    var searchActive: Bool { get }
+    func beginFiltering()
+    func endFiltering()
+
+    func deleteChat(chatId: Int)
+    func archiveChat(chatId: Int)
+    func refreshData()
+
+    var numberOfArchivedChats: Int { get }
+}
+
+class ChatListViewModel: NSObject, ChatListViewModelProtocol {
+
+    var onChatListUpdate: VoidFunction?
+
+    var isArchive: Bool
+    private let dcContext: DcContext
+
+    var searchActive: Bool = false
+
+    private var chatList: DcChatlist!
+
+    init(dcContext: DcContext, isArchive: Bool) {
+        self.isArchive = isArchive
+        self.dcContext = dcContext
+        super.init()
+        updateChatList()
+    }
+
+    private func updateChatList() {
+        var gclFlags: Int32 = 0
+        if isArchive {
+            gclFlags |= DC_GCL_ARCHIVED_ONLY
+        }
+        self.chatList = dcContext.getChatlist(flags: gclFlags, queryString: nil, queryId: 0)
+        onChatListUpdate?()
+    }
+
+    var numberOfSections: Int {
+        return 1
+    }
+
+    func numberOfRowsIn(section: Int) -> Int {
+        return chatList.length
+    }
+
+    func cellDataFor(section: Int, row: Int) -> AvatarCellViewModel {
+        let chatId = chatList.getChatId(index: row)
+        let summary = chatList.getSummary(index: row)
+        let unreadMessages = dcContext.getUnreadMessages(chatId: chatId)
+        let viewModel = ChatCellViewModel(
+            chatData: ChatCellData(
+                chatId: chatId,
+                summary: summary,
+                unreadMessages: unreadMessages
+            )
+        )
+        return viewModel
+    }
+
+    func refreshData() {
+        updateChatList()
+    }
+
+    func beginFiltering() {
+
+    }
+
+    func endFiltering() {
+
+    }
+
+    func deleteChat(chatId: Int) {
+
+    }
+
+    func archiveChat(chatId: Int) {
+
+    }
+
+    var numberOfArchivedChats: Int {
+        return 0
+    }
+
+}
+
+// MARK: UISearchResultUpdating
+extension ChatListViewModel: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        if let searchText = searchController.searchBar.text {
+            filterContentForSearchText(searchText)
+        }
+    }
+
+    private func filterContentForSearchText(_ text: String) {
+
+    }
+
+
+}
+

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -145,9 +145,11 @@ class ChatListViewModel: NSObject, ChatListViewModelProtocol {
     func chatIdFor(section: Int, row: Int) -> Int? {
         let cellData = cellDataFor(section: section, row: row)
         switch cellData.type {
-        case .CHAT(let data):
+        case .deaddrop(let data):
             return data.chatId
-        case .CONTACT:
+        case .chat(let data):
+            return data.chatId
+        case .contact:
             return nil
         }
     }
@@ -206,10 +208,15 @@ private extension ChatListViewModel {
     func makeChatCellViewModel(index: Int, searchText: String) -> AvatarCellViewModel {
 
         let list: DcChatlist = searchResultChatList ?? chatList
-
         let chatId = list.getChatId(index: index)
+        let summary = list.getSummary(index: index)
+
+
+        if let msgId = msgIdFor(row: index), chatId == DC_CHAT_ID_DEADDROP {
+            return ChatCellViewModel(dearddropCellData: DeaddropCellData(chatId: chatId, msgId: msgId, summary: summary))
+        }
+
         let chat = dcContext.getChat(chatId: chatId)
-        let summary = chatList.getSummary(index: index)
         let unreadMessages = dcContext.getUnreadMessages(chatId: chatId)
 
         var chatTitleIndexes: [Int] = []

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -19,7 +19,7 @@ protocol ChatListViewModelProtocol: class, UISearchResultsUpdating {
     func beginSearch()
     func endSearch()
     func titleForHeaderIn(section: Int) -> String? // only visible on search results
-
+    
     /// returns ROW of table
     func deleteChat(chatId: Int) -> Int
     func archiveChatToggle(chatId: Int)
@@ -233,11 +233,12 @@ private extension ChatListViewModel {
         let contact = DcContact(id: contactId)
         let nameIndexes = contact.displayName.containsExact(subSequence: searchText)
         let emailIndexes = contact.email.containsExact(subSequence: searchText)
-
+        let chatId: Int? = dcContext.getChatIdByContactId(contactId)
         // contact contains searchText
         let viewModel = ContactCellViewModel(
             contactData: ContactCellData(
-                contactId: contact.id
+                contactId: contact.id,
+                chatId: chatId
             ),
             titleHighlightIndexes: nameIndexes,
             subtitleHighlightIndexes: emailIndexes

--- a/deltachat-ios/ViewModel/ContactCellViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactCellViewModel.swift
@@ -1,7 +1,3 @@
-/*
- this file and the containing classes are manually imported from searchBarContactList-branch which has not been merged into master at this time. Once it has been merged, this file can be deleted.
- */
-
 import Foundation
 
 protocol AvatarCellViewModel {
@@ -13,8 +9,9 @@ protocol AvatarCellViewModel {
 }
 
 enum CellModel {
-    case CONTACT(ContactCellData)
-    case CHAT(ChatCellData)
+    case contact(ContactCellData)
+    case chat(ChatCellData)
+    case deaddrop(DeaddropCellData)
 }
 
 struct ContactCellData {
@@ -26,6 +23,12 @@ struct ChatCellData {
     let chatId: Int
     let summary: DcLot
     let unreadMessages: Int
+}
+
+struct DeaddropCellData {
+    let chatId: Int
+    let msgId: Int
+    let summary: DcLot
 }
 
 class ContactCellViewModel: AvatarCellViewModel {
@@ -48,7 +51,7 @@ class ContactCellViewModel: AvatarCellViewModel {
     var subtitleHighlightIndexes: [Int]
 
     init(contactData: ContactCellData, titleHighlightIndexes: [Int] = [], subtitleHighlightIndexes: [Int] = []) {
-        type = CellModel.CONTACT(contactData)
+        type = CellModel.contact(contactData)
         self.titleHighlightIndexes = titleHighlightIndexes
         self.subtitleHighlightIndexes = subtitleHighlightIndexes
         self.contact = DcContact(id: contactData.contactId)
@@ -58,7 +61,8 @@ class ContactCellViewModel: AvatarCellViewModel {
 class ChatCellViewModel: AvatarCellViewModel {
 
     private let chat: DcChat
-    private let summary: DcLot
+
+    private var summary: DcLot
 
     var type: CellModel
     var title: String {
@@ -81,10 +85,18 @@ class ChatCellViewModel: AvatarCellViewModel {
     var subtitleHighlightIndexes: [Int]
 
     init(chatData: ChatCellData, titleHighlightIndexes: [Int] = [], subtitleHighlightIndexes: [Int] = []) {
-        self.type = CellModel.CHAT(chatData)
+        self.type = CellModel.chat(chatData)
         self.titleHighlightIndexes = titleHighlightIndexes
         self.subtitleHighlightIndexes = subtitleHighlightIndexes
         self.summary = chatData.summary
         self.chat = DcChat(id: chatData.chatId)
+    }
+
+    init(dearddropCellData cellData: DeaddropCellData) {
+        self.type = CellModel.deaddrop(cellData)
+        self.titleHighlightIndexes = []
+        self.subtitleHighlightIndexes = []
+        self.chat = DcChat(id: cellData.chatId)
+        self.summary = cellData.summary
     }
 }

--- a/deltachat-ios/ViewModel/ContactCellViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactCellViewModel.swift
@@ -19,6 +19,7 @@ enum CellModel {
 
 struct ContactCellData {
     let contactId: Int
+    let chatId: Int?
 }
 
 struct ChatCellData {


### PR DESCRIPTION
fixes #500 

ChatList is now managed by ChatListViewModel.

ChatList registers on ViewModel to listen to changes (such changes occur during search/filtering).
ChatList also can trigger a table reload by calling `viewModel.refreshData`.

The ViewModel holds:
- chatList 
or 3 sections with SearchResults (updated as the user types):
- chats
- contacts
- messages

The ViewModel provides all relevant data to make `UITableViewDelegate/Datasource` happy.
The cell's data is stored in a class called `AvatarCellViewModel` which can be used for contacts and chats. 

Before this PR ChatListController was a normal `UIViewController` with a `tableView` as subview. I turned ChatListController into a `UITableViewController`, because the scrolling reacts better to Keyboard-events.

Also since SearchResults are grouped in sections, I changed the UITableView-style to `.grouped`, because it looks a lot better.

I did see no reason to add a SearchBar to ArchivedChatsList, because Archived Chats will appear in the normal search results, and it would have complicated things a lot. Therefor the ArchivedChatList's style is not `.grouped`.

**Issues:**
* when active search, tap search result, navigate back, there is a scroll-glitch. (edit: caused by KeyBoard-reapperance).



