### PR TITLE
chat list scrolls up on search input + cancel actions

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -356,5 +356,13 @@ extension ChatListController: UISearchBarDelegate {
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         viewModel.endSearch()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+           self.tableView.scrollToTop()
+        }
+    }
+
+    func searchBar(_ searchBar: UISearchBar, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        tableView.scrollToTop()
+        return true
     }
 }


### PR DESCRIPTION
fixes #584 

In PR #585 I added a quitSearch-method. I possibly have add a `tableView.scrollToTop()` there too.