### PR TITLE
Close item appearance condition fixed

### DIFF
--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -23,7 +23,7 @@ class PreviewController: QLPreviewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        if navigationController != nil && isBeingPresented {
+        if navigationController?.isBeingPresented ?? false {
             /* QLPreviewController comes with a done-button by default. But if is embedded in UINavigationContrller we need to set a done-button manually.
             */
             navigationItem.leftBarButtonItem = doneButtonItem

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -543,7 +543,7 @@ class ChatViewCoordinator: NSObject, Coordinator {
     func showMediaGallery(currentIndex: Int, mediaUrls urls: [URL]) {
         let betterPreviewController = PreviewController(currentIndex: currentIndex, urls: urls)
         let nav = UINavigationController(rootViewController: betterPreviewController)
-
+        nav.modalPresentationStyle = .fullScreen
         navigationController.present(nav, animated: true)
     }
 }


### PR DESCRIPTION
fixes #570 

The condition that determines the appearance of the close-item was wrong. Fixed that.

Not sure, what you mean with full-screen?
Since iOS13 a modally presented (animated from bottom) UIViewController is not fullscreen by default anymore.  But we do get this nice swipe-to-dismiss-feature which we use here.