### PR TITLE
AppStart also respects last active chat

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -147,7 +147,7 @@
 		AEACE2DF1FB3246400DCDD78 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEACE2DE1FB3246400DCDD78 /* Message.swift */; };
 		AEACE2E31FB32B5C00DCDD78 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEACE2E21FB32B5C00DCDD78 /* Constants.swift */; };
 		AEACE2E51FB32E1900DCDD78 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEACE2E41FB32E1900DCDD78 /* Utils.swift */; };
-		AEC67A1C241CE9E4007DDBE1 /* TabBarRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC67A1B241CE9E4007DDBE1 /* TabBarRestorer.swift */; };
+		AEC67A1C241CE9E4007DDBE1 /* AppStateRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC67A1B241CE9E4007DDBE1 /* AppStateRestorer.swift */; };
 		AEC67A1E241FCFE0007DDBE1 /* ChatListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC67A1D241FCFE0007DDBE1 /* ChatListViewModel.swift */; };
 		AEE56D762253431E007DC082 /* AccountSetupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE56D752253431E007DC082 /* AccountSetupController.swift */; };
 		AEE56D7D2253ADB4007DC082 /* HudHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE56D7C2253ADB4007DC082 /* HudHandler.swift */; };
@@ -381,7 +381,7 @@
 		AEACE2DE1FB3246400DCDD78 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		AEACE2E21FB32B5C00DCDD78 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		AEACE2E41FB32E1900DCDD78 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
-		AEC67A1B241CE9E4007DDBE1 /* TabBarRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarRestorer.swift; sourceTree = "<group>"; };
+		AEC67A1B241CE9E4007DDBE1 /* AppStateRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRestorer.swift; sourceTree = "<group>"; };
 		AEC67A1D241FCFE0007DDBE1 /* ChatListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListViewModel.swift; sourceTree = "<group>"; };
 		AEE56D752253431E007DC082 /* AccountSetupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSetupController.swift; sourceTree = "<group>"; tabWidth = 4; };
 		AEE56D7C2253ADB4007DC082 /* HudHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HudHandler.swift; sourceTree = "<group>"; };
@@ -833,7 +833,7 @@
 		AE851ACB227C7A5000ED86F0 /* Handler */ = {
 			isa = PBXGroup;
 			children = (
-				AEC67A1B241CE9E4007DDBE1 /* TabBarRestorer.swift */,
+				AEC67A1B241CE9E4007DDBE1 /* AppStateRestorer.swift */,
 				AEE56D7C2253ADB4007DC082 /* HudHandler.swift */,
 				AE8519E92272FDCA00ED86F0 /* DeviceContactsHandler.swift */,
 			);
@@ -1158,7 +1158,7 @@
 				B21005DB23383664004C70C5 /* SettingsClassicViewController.swift in Sources */,
 				305961F62346125100C80F33 /* MessageContentCell.swift in Sources */,
 				305961E42346125100C80F33 /* MessageKitDateFormatter.swift in Sources */,
-				AEC67A1C241CE9E4007DDBE1 /* TabBarRestorer.swift in Sources */,
+				AEC67A1C241CE9E4007DDBE1 /* AppStateRestorer.swift in Sources */,
 				305961D32346125100C80F33 /* MessagesViewController+Keyboard.swift in Sources */,
 				305961EF2346125100C80F33 /* HorizontalEdgeInsets.swift in Sources */,
 				30A4D9AE2332672700544344 /* QrInviteViewController.swift in Sources */,

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -201,7 +201,7 @@ class ChatViewController: MessagesViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
+        AppStateRestorer.shared.storeLastActiveChat(chatId: chatId)
         // things that do not affect the chatview
         // and are delayed after the view is displayed
         dcContext.marknoticedChat(chatId: chatId)
@@ -219,7 +219,7 @@ class ChatViewController: MessagesViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-
+        AppStateRestorer.shared.resetLastActiveChat()
         setTextDraft()
         let nc = NotificationCenter.default
         if let msgChangedObserver = self.msgChangedObserver {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -88,7 +88,7 @@ class AppCoordinator: NSObject, Coordinator {
         } else {
             showTab(index: lastActiveTab)
             if let lastActiveChatId = appStateRestorer.restoreLastActiveChatId(), lastActiveTab == 1 {
-                showChat(chatId: lastActiveChatId)
+                showChat(chatId: lastActiveChatId, animated: false)
             }
         }
     }
@@ -97,7 +97,7 @@ class AppCoordinator: NSObject, Coordinator {
         tabBarController.selectedIndex = index
     }
 
-    func showChat(chatId: Int) {
+    func showChat(chatId: Int, animated: Bool = true) {
         showTab(index: chatsTab)
         guard let navController = self.chatListController as? UINavigationController else {
             assertionFailure("huh? why no nav controller?")
@@ -106,7 +106,7 @@ class AppCoordinator: NSObject, Coordinator {
         let chatVC = ChatViewController(dcContext: dcContext, chatId: chatId)
         let coordinator = ChatViewCoordinator(dcContext: dcContext, navigationController: navController, chatId: chatId)
         chatVC.coordinator = coordinator
-        navController.pushViewController(chatVC, animated: true)
+        navController.pushViewController(chatVC, animated: animated)
     }
 
     func handleQRCode(_ code: String) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -10,13 +10,13 @@ class AppCoordinator: NSObject, Coordinator {
     private let chatsTab = 1
     private let settingsTab = 2
 
-    private let tabBarRestorer = TabBarRestorer()
+    private let appStateRestorer = AppStateRestorer.shared
 
     private var childCoordinators: [Coordinator] = []
 
     private lazy var tabBarController: UITabBarController = {
         let tabBarController = UITabBarController()
-        tabBarController.delegate = tabBarRestorer
+        tabBarController.delegate = appStateRestorer
         tabBarController.viewControllers = [qrController, chatListController, settingsController]
         tabBarController.tabBar.tintColor = DcColors.primary
         return tabBarController
@@ -81,12 +81,15 @@ class AppCoordinator: NSObject, Coordinator {
     }
 
     public func start() {
-        let lastActiveTab = tabBarRestorer.restoreLastActiveTab()
+        let lastActiveTab = appStateRestorer.restoreLastActiveTab()
         if lastActiveTab == -1 {
             // no stored tab
             showTab(index: chatsTab)
         } else {
             showTab(index: lastActiveTab)
+            if let lastActiveChatId = appStateRestorer.restoreLastActiveChatId(), lastActiveTab == 1 {
+                showChat(chatId: lastActiveChatId)
+            }
         }
     }
 

--- a/deltachat-ios/Handler/AppStateRestorer.swift
+++ b/deltachat-ios/Handler/AppStateRestorer.swift
@@ -40,10 +40,8 @@ class AppStateRestorer: NSObject, UITabBarControllerDelegate {
         let activeTab = tabBarController.selectedIndex + offsetKey
 
         if let tab = Tab(rawValue: activeTab), tab != .chatTab {
-            // reset last active chat
             resetLastActiveChat()
         }
-
 
         UserDefaults.standard.set(activeTab, forKey: lastActiveTabKey)
         UserDefaults.standard.synchronize()

--- a/deltachat-ios/Handler/AppStateRestorer.swift
+++ b/deltachat-ios/Handler/AppStateRestorer.swift
@@ -44,13 +44,11 @@ class AppStateRestorer: NSObject, UITabBarControllerDelegate {
         }
 
         UserDefaults.standard.set(activeTab, forKey: lastActiveTabKey)
-        UserDefaults.standard.synchronize()
     }
 
     private func storeChat(chatId: Int?) {
         let value = chatId ?? -1
         UserDefaults.standard.set(value, forKey: lastActiveChatId)
-        UserDefaults.standard.synchronize()
     }
 
     func storeLastActiveChat(chatId: Int) {

--- a/deltachat-ios/Handler/AppStateRestorer.swift
+++ b/deltachat-ios/Handler/AppStateRestorer.swift
@@ -1,8 +1,9 @@
 import UIKit
 
-class TabBarRestorer: NSObject, UITabBarControllerDelegate {
+class AppStateRestorer: NSObject, UITabBarControllerDelegate {
 
     private let lastActiveTabKey = "last_active_tab"
+    private let lastActiveChatId = "last_active_chat_id"
     private let offsetKey = 10
 
     // UserDefaults returns 0 by default which conflicts with tab 0 -> therefore we map our tab indexes by adding an offsetKey
@@ -13,6 +14,10 @@ class TabBarRestorer: NSObject, UITabBarControllerDelegate {
         case settingsTab = 12
         case firstLaunch = 0
     }
+
+    private override init() {}
+
+    static let shared: AppStateRestorer = AppStateRestorer()
 
     func restoreLastActiveTab() -> Int {
 
@@ -33,9 +38,36 @@ class TabBarRestorer: NSObject, UITabBarControllerDelegate {
 
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
         let activeTab = tabBarController.selectedIndex + offsetKey
+
+        if let tab = Tab(rawValue: activeTab), tab != .chatTab {
+            // reset last active chat
+            resetLastActiveChat()
+        }
+
+
         UserDefaults.standard.set(activeTab, forKey: lastActiveTabKey)
         UserDefaults.standard.synchronize()
     }
 
+    private func storeChat(chatId: Int?) {
+        let value = chatId ?? -1
+        UserDefaults.standard.set(value, forKey: lastActiveChatId)
+        UserDefaults.standard.synchronize()
+    }
 
+    func storeLastActiveChat(chatId: Int) {
+        storeChat(chatId: chatId)
+    }
+
+    func resetLastActiveChat() {
+        storeChat(chatId: nil)
+    }
+
+    func restoreLastActiveChatId() -> Int? {
+        let restoredChatId = UserDefaults.standard.integer(forKey: lastActiveChatId)
+        if restoredChatId == -1 || restoredChatId == 0 {
+            return nil
+        }
+        return restoredChatId
+    }
 }


### PR DESCRIPTION
fixes #541 

* renamed `TabBarRestorer` to `AppStateRestorer`
* `AppStateRestorer` is now a singleton, so it can be accessed from everywhere 
* added methods to store and restore chatIds (will be set/reset in ChatView-lifecycle-delegate-methods).
* AppCoordinator.start restores chat if possible
* `AppCoordinator.showChat` can be run without animation (otherwise the user would see the animation from `chatList` to `chatView` right at app start).