### PR TITLE
Fixed truncated labels in ContactCell

### DIFF
--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -16,6 +16,7 @@ class ContactCell: UITableViewCell {
     lazy var toplineStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [titleLabel, pinnedIndicator, timeLabel, locationStreamingIndicator])
         stackView.axis = .horizontal
+        stackView.alignment = .firstBaseline
         stackView.spacing = 4
         return stackView
     }()


### PR DESCRIPTION
fixes #567 

Took me a while how to solve this. 
`stackView.alignment = .firstBaseline`
fixes the issue.
