### PR TITLE
scroll to top if filtering of contact list changed

### DIFF
--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -414,6 +414,7 @@ class GroupMembersViewController: UITableViewController, UISearchResultsUpdating
 
         filteredContacts = contactsWithHighlights.filter { !$0.indexesToHighlight.isEmpty }
         tableView.reloadData()
+        tableView.scrollToTop()
     }
 
     private func updateContactCell(cell: ContactCell, contactWithHighlight: ContactWithSearchResults) {

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -371,6 +371,7 @@ class NewChatViewController: UITableViewController {
 
         filteredContacts = contactsWithHighlights.filter { !$0.indexesToHighlight.isEmpty }
         tableView.reloadData()
+        tableView.scrollToTop()
     }
 }
 


### PR DESCRIPTION
closes #588 
I don't like the resulting UX though. What I at least sometimes do is entering some characters, scrolling a little and entering more characters if I don't see contact in question yet. In this case jumping again to the beginning of the list feels unsatisfying as I need to orientate newly.
@r10s @nayooti what do you think?