### PR TITLE
Clear blobs folder on account deletion

### DIFF
--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -804,8 +804,6 @@ class AccountSetupController: UITableViewController {
             return
         }
 
-        let dbfile = DatabaseHelper().currentDatabaseLocation
-        let dburl = URL(fileURLWithPath: dbfile, isDirectory: false)
         let alert = UIAlertController(
             title: String.localized("delete_account_ask"),
             message: nil,
@@ -814,13 +812,7 @@ class AccountSetupController: UITableViewController {
         alert.addAction(UIAlertAction(title: String.localized("delete_account"), style: .destructive, handler: { _ in
             appDelegate.stop()
             appDelegate.close()
-            do {
-                //TODO: remove also blobs folder?!
-                try FileManager.default.removeItem(at: dburl)
-            } catch {
-                logger.error("failed to delete db: \(error)")
-            }
-
+            DatabaseHelper().clearAccountData()
             appDelegate.open()
             appDelegate.start()
 


### PR DESCRIPTION
deletes the database blobs folder including images and messages after the user tapped on delete account in the stettings. Depending on #612 which needs to me reviewed and merged first

This PR takes into account that the DB migration could have failed for whatever reasons and ensures to delete the blobs folder at the right path (either local storage or shared, depending on where the database has been found)