### PR TITLE
simplify getConfigInt()

### DIFF
--- a/deltachat-ios/DC/Wrapper.swift
+++ b/deltachat-ios/DC/Wrapper.swift
@@ -299,15 +299,11 @@ class DcContext {
     }
 
     func getConfigInt(_ key: String) -> Int {
-        let vStr = getConfig(key)
-        if vStr == nil {
+        if let str = getConfig(key) {
+            return Int(str) ?? 0
+        } else {
             return 0
         }
-        let vInt = Int(vStr!)
-        if vInt == nil {
-            return 0
-        }
-        return vInt!
     }
 
     private func setConfigInt(_ key: String, _ value: Int) {


### PR DESCRIPTION
we should avoid this force-unwrap.