### PR TITLE
use textLabel for selected autodel-value

### DIFF
--- a/deltachat-ios/Controller/SettingsAutodelOverviewController.swift
+++ b/deltachat-ios/Controller/SettingsAutodelOverviewController.swift
@@ -20,31 +20,29 @@ class SettingsAutodelOverviewController: UITableViewController {
     }
 
     private lazy var autodelDeviceCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: nil)
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.tag = CellTags.autodelDevice.rawValue
-        cell.textLabel?.text = String.localized("autodel_device_title")
         cell.accessoryType = .disclosureIndicator
-        cell.detailTextLabel?.text = SettingsAutodelSetController.getSummary(dcContext, fromServer: false)
+        cell.textLabel?.text = SettingsAutodelSetController.getSummary(dcContext, fromServer: false)
         return cell
     }()
 
     private lazy var autodelServerCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: nil)
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.tag = CellTags.autodelServer.rawValue
-        cell.textLabel?.text = String.localized("autodel_server_title")
         cell.accessoryType = .disclosureIndicator
-        cell.detailTextLabel?.text = SettingsAutodelSetController.getSummary(dcContext, fromServer: true)
+        cell.textLabel?.text = SettingsAutodelSetController.getSummary(dcContext, fromServer: true)
         return cell
     }()
 
     private lazy var sections: [SectionConfigs] = {
         let autodelSection = SectionConfigs(
-            headerTitle: nil,
+            headerTitle: String.localized("autodel_device_title"),
             footerTitle: nil,
             cells: [autodelDeviceCell]
         )
         let autodelSection2 = SectionConfigs(
-            headerTitle: nil,
+            headerTitle: String.localized("autodel_server_title"),
             footerTitle: nil,
             cells: [autodelServerCell]
         )
@@ -68,8 +66,8 @@ class SettingsAutodelOverviewController: UITableViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        autodelDeviceCell.detailTextLabel?.text = SettingsAutodelSetController.getSummary(dcContext, fromServer: false)
-        autodelServerCell.detailTextLabel?.text = SettingsAutodelSetController.getSummary(dcContext, fromServer: true)
+        autodelDeviceCell.textLabel?.text = SettingsAutodelSetController.getSummary(dcContext, fromServer: false)
+        autodelServerCell.textLabel?.text = SettingsAutodelSetController.getSummary(dcContext, fromServer: true)
     }
 
     // MARK: - Table view data source


### PR DESCRIPTION
use textLabel for selected autodel-value, the field-name goes to the headline.

this suggestion might not be 100% the intended way of using the cell, however this results in a much clearer view, without truncated values or labels, especially on smaller screens.  
and, in an radio-view, the textLabel is used for values as well.

an alternative might be UITableViewCell with "style: .subtitle", however, this looks bad and brings the value out of focus - and is not the intended way as well.

<img width="350" alt="Screen Shot 2020-04-11 at 22 45 05" src="https://user-images.githubusercontent.com/9800740/79054660-09f82100-7c47-11ea-9584-b680448e4241.png">
