### PR TITLE
qr-Account creation enhancements

### DIFF
--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -136,6 +136,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
             if let loginCompletion = self.onProgressSuccess {
                 addProgressAlertListener(onSuccess: loginCompletion)
                 showProgressAlert(title: String.localized("login_header"))
+                activateSpinner(false)
             }
             dcContext.configure()
         } else {
@@ -192,7 +193,8 @@ extension WelcomeViewController: QrCodeReaderDelegate {
             title: String.localized("ok"),
             style: .default,
             handler: { [unowned self] _ in
-                self.qrCodeReaderNav.dismiss(animated: true) {
+                self.activateSpinner(true)
+                self.qrCodeReaderNav.dismiss(animated: false) {
                     self.createAccountFromQRCode()
                 }
             }

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -133,15 +133,17 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         let success = dcContext.configureAccountFromQR(qrCode: code)
         scannedQrCode = nil
         if success {
-            if let loginCompletion = self.onProgressSuccess {
-                addProgressAlertListener(onSuccess: loginCompletion)
-                showProgressAlert(title: String.localized("login_header"))
-                activateSpinner(false)
-            }
+            addProgressAlertListener(onSuccess: handleLoginSuccess)
+            showProgressAlert(title: String.localized("login_header"))
+            activateSpinner(false)
             dcContext.configure()
         } else {
             accountCreationErrorAlert()
         }
+    }
+
+    private func handleLoginSuccess() {
+        onProgressSuccess?()
     }
 
     private func accountCreationErrorAlert() {
@@ -171,6 +173,10 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         alert.addAction(okAction)
         alert.addAction(repeatAction)
         present(alert, animated: true)
+    }
+
+    func progressAlertWillDismiss() {
+        activateSpinner(true)
     }
 }
 

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -135,10 +135,9 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         if success {
             if let loginCompletion = self.onProgressSuccess {
                 addProgressAlertListener(onSuccess: loginCompletion)
-                showProgressAlert(title: String.localized("qraccount_use_on_new_install"))
+                showProgressAlert(title: String.localized("login_header"))
             }
             dcContext.configure()
-
         } else {
             accountCreationErrorAlert()
         }
@@ -151,7 +150,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
             })
         }
 
-        let title = String.localized("qraccount_creation_failed")
+        let title = AppDelegate.lastErrorString ?? String.localized("error")
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
         let okAction = UIAlertAction(
             title: String.localized("ok"),

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -147,31 +147,10 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
     }
 
     private func accountCreationErrorAlert() {
-        func handleRepeat() {
-            showQRReader(completion: { [unowned self] in
-                self.activateSpinner(false)
-            })
-        }
-
-        let title = AppDelegate.lastErrorString ?? String.localized("error")
+        activateSpinner(false)
+        let title = DcContext.shared.lastErrorString ?? String.localized("error")
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-        let okAction = UIAlertAction(
-            title: String.localized("ok"),
-            style: .default,
-            handler: { [unowned self] _ in
-                self.activateSpinner(false)
-            }
-        )
-
-        let repeatAction = UIAlertAction(
-            title: String.localized("global_menu_edit_redo_desktop"),
-            style: .default,
-            handler: { _ in
-                handleRepeat()
-            }
-        )
-        alert.addAction(okAction)
-        alert.addAction(repeatAction)
+        alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default))
         present(alert, animated: true)
     }
 

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -138,6 +138,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
                 showProgressAlert(title: String.localized("qraccount_use_on_new_install"))
             }
             dcContext.configure()
+
         } else {
             accountCreationErrorAlert()
         }
@@ -192,7 +193,6 @@ extension WelcomeViewController: QrCodeReaderDelegate {
             title: String.localized("ok"),
             style: .default,
             handler: { [unowned self] _ in
-                self.activateSpinner(true)
                 self.qrCodeReaderNav.dismiss(animated: true) {
                     self.createAccountFromQRCode()
                 }

--- a/deltachat-ios/Handler/ProgressAlertHandler.swift
+++ b/deltachat-ios/Handler/ProgressAlertHandler.swift
@@ -4,12 +4,12 @@ import DcCore
 protocol ProgressAlertHandler: UIViewController {
     var progressAlert: UIAlertController { get }
     var configureProgressObserver: Any? { get set }
-    var onProgressSuccess: VoidFunction? { get set }
     func showProgressAlert(title: String)
     func updateProgressAlertValue(value: Int?)
     func updateProgressAlert(error: String?)
     func updateProgressAlertSuccess(completion: VoidFunction?)
     func addProgressAlertListener(onSuccess: @escaping VoidFunction)
+    func progressAlertWillDismiss()
 }
 
 extension ProgressAlertHandler {
@@ -38,6 +38,8 @@ extension ProgressAlertHandler {
 
     func updateProgressAlertSuccess(completion onComplete: VoidFunction?) {
         updateProgressAlertValue(value: 1000)
+        progressAlertWillDismiss()
+        // delay so the user has time to read the success message
         DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
             self.progressAlert.dismiss(animated: true) {
                 onComplete?()
@@ -62,6 +64,10 @@ extension ProgressAlertHandler {
                 }
             }
         }
+    }
+
+    func progressAlertWillDismiss() {
+        // can be overwritten if needed
     }
 }
 

--- a/tools/untranslated.xml
+++ b/tools/untranslated.xml
@@ -5,5 +5,4 @@
     <string name="import_contacts">Import device contacts</string>
     <string name="import_contacts_message">To chat with contacts from your device open Settings and enable Contacts.</string>
     <string name="stop_sharing_location">Stop sharing location</string>
-    <string  name="qraccount_config_failed">Account creation failed.</string>
 </resources>


### PR DESCRIPTION
fixes #631

I removed the spinner during the account creation.

There is nothing really I can do about the delay of the alert presentation. The action is triggered when the qr-reader is showing so I have to dismiss this first, and once the dismissal is completed I present the alert. 
I can't present the alert and exchange underlying viewcontrollers AFAIK.

The only thing I can do is to remove dismiss-animation, but there will still be a noticeable delay, and I personally I prefer having present+dismiss-animations. 

I am now showing the spinner during the delay before the alert is showing, so the user can't press any buttons. The spinner will be hidden once the alert is being presented.