### PR TITLE
Debug toolkit moved to Settings

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -1,5 +1,4 @@
 import AudioToolbox
-import DBDebugToolkit
 import Reachability
 import SwiftyBeaver
 import UIKit
@@ -47,8 +46,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        DBDebugToolkit.setup()
-        DBDebugToolkit.setupCrashReporting()
 
         let console = ConsoleDestination()
         logger.addDestination(console)
@@ -228,13 +225,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         } catch {
             logger.info("could not start reachability notifier")
         }
-
-        let info: [DBCustomVariable] = dcContext.getInfo().map { kv in
-            let value = kv.count > 1 ? kv[1] : ""
-            return DBCustomVariable(name: kv[0], value: value)
-        }
-
-        DBDebugToolkit.add(info)
     }
 
     @objc private func reachabilityChanged(note: Notification) {

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -413,6 +413,8 @@ internal final class SettingsViewController: UITableViewController {
             UserDefaults.standard.set(!locationStreaming, forKey: "location_streaming")
         }))
 
+        let logAction = UIAlertAction(title: String.localized("pref_view_log"), style: .default, handler: { [unowned self] _ in self.coordinator?.showDebugToolkit()})
+        alert.addAction(logAction)
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         present(alert, animated: true, completion: nil)
     }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -327,10 +327,14 @@ class SettingsCoordinator: Coordinator {
     }
 
     func showDebugToolkit() {
-
-        let vc = UIViewController()
-        vc.view.backgroundColor = .red
-        navigationController.present(vc, animated: true, completion: nil)
+        DBDebugToolkit.setup(with: [])  // emtpy array will override default device shake trigger
+        DBDebugToolkit.setupCrashReporting()
+        let info: [DBCustomVariable] = dcContext.getInfo().map { kv in
+            let value = kv.count > 1 ? kv[1] : ""
+            return DBCustomVariable(name: kv[0], value: value)
+        }
+        DBDebugToolkit.add(info)
+        DBDebugToolkit.showMenu()
     }
 }
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -3,7 +3,9 @@ import ALCameraViewController
 import Photos
 import MobileCoreServices
 import DcCore
+import DBDebugToolkit
 
+// MARK: - AppCoordinator
 class AppCoordinator: NSObject, Coordinator {
 
     private let window: UIWindow
@@ -160,6 +162,7 @@ class AppCoordinator: NSObject, Coordinator {
     }
 }
 
+// MARK: - WelcomeCoordinator
 extension AppCoordinator: WelcomeCoordinator {
 
     func showLogin() {
@@ -275,6 +278,7 @@ class ChatListCoordinator: Coordinator {
     }
 }
 
+// MARK: - SettingsCoordinator
 class SettingsCoordinator: Coordinator {
     let dcContext: DcContext
     let navigationController: UINavigationController
@@ -323,12 +327,14 @@ class SettingsCoordinator: Coordinator {
     }
 
     func showDebugToolkit() {
+
         let vc = UIViewController()
         vc.view.backgroundColor = .red
         navigationController.present(vc, animated: true, completion: nil)
     }
 }
 
+// MARK: - EditSettingsCoordinator
 class EditSettingsCoordinator: Coordinator {
     var dcContext: DcContext
     let navigationController: UINavigationController
@@ -349,7 +355,7 @@ class EditSettingsCoordinator: Coordinator {
     }
 }
 
-
+// MARK: - AccountSetupCoordinator
 class AccountSetupCoordinator: Coordinator {
     var dcContext: DcContext
     let navigationController: UINavigationController
@@ -388,6 +394,7 @@ class AccountSetupCoordinator: Coordinator {
     }
 }
 
+// MARK: - NewChatCoordinator
 class NewChatCoordinator: Coordinator {
     var dcContext: DcContext
     let navigationController: UINavigationController
@@ -441,6 +448,7 @@ class NewChatCoordinator: Coordinator {
     
 }
 
+// MARK: - GroupChatDetailCoordinator
 class GroupChatDetailCoordinator: Coordinator {
     var dcContext: DcContext
     let navigationController: UINavigationController
@@ -548,6 +556,7 @@ class GroupChatDetailCoordinator: Coordinator {
     }
 }
 
+// MARK: - ChatViewCoordinator
 class ChatViewCoordinator: NSObject, Coordinator {
     var dcContext: DcContext
     let navigationController: UINavigationController
@@ -631,6 +640,7 @@ class ChatViewCoordinator: NSObject, Coordinator {
     }
 }
 
+// MARK: - NewGroupAddMembersCoordinator
 class NewGroupAddMembersCoordinator: Coordinator {
     var dcContext: DcContext
     let navigationController: UINavigationController
@@ -643,6 +653,7 @@ class NewGroupAddMembersCoordinator: Coordinator {
     }
 }
 
+// MARK: - AddGroupMembersCoordinator
 class AddGroupMembersCoordinator: Coordinator {
     var dcContext: DcContext
     let navigationController: UINavigationController
@@ -664,6 +675,7 @@ class AddGroupMembersCoordinator: Coordinator {
     }
 }
 
+// MARK: - NewGroupCoordinator
 class NewGroupCoordinator: Coordinator {
     var dcContext: DcContext
     let navigationController: UINavigationController
@@ -724,6 +736,7 @@ class NewGroupCoordinator: Coordinator {
     }
 }
 
+// MARK: - ContactDetailCoordinator
 class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
     var dcContext: DcContext
     let navigationController: UINavigationController
@@ -817,6 +830,7 @@ class ContactDetailCoordinator: Coordinator, ContactDetailCoordinatorProtocol {
 
 }
 
+// MARK: - EditGroupCoordinator
 class EditGroupCoordinator: Coordinator {
     let navigationController: UINavigationController
     let dcContext: DcContext
@@ -841,6 +855,7 @@ class EditGroupCoordinator: Coordinator {
     }
 }
 
+// MARK: - EditContactCoordinator
 class EditContactCoordinator: Coordinator, EditContactCoordinatorProtocol {
     var dcContext: DcContext
     let navigationController: UINavigationController
@@ -870,6 +885,7 @@ class EditContactCoordinator: Coordinator, EditContactCoordinatorProtocol {
 /*
  boilerplate - I tend to remove that interface (cyberta)
  */
+// MARK: - coordinator protocols
 protocol ContactDetailCoordinatorProtocol: class {
     func showEditContact(contactId: Int)
     func showChat(chatId: Int)

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -321,6 +321,12 @@ class SettingsCoordinator: Coordinator {
         let helpViewController = HelpViewController()
         navigationController.pushViewController(helpViewController, animated: true)
     }
+
+    func showDebugToolkit() {
+        let vc = UIViewController()
+        vc.view.backgroundColor = .red
+        navigationController.present(vc, animated: true, completion: nil)
+    }
 }
 
 class EditSettingsCoordinator: Coordinator {


### PR DESCRIPTION
fixes #496 

The DBToolkit no longer can be triggered by shaking the device. 
Instead go to:
**Settings-Tab** -> **Advanced**->**View Log**

Basically moved all the DBToolkit from AppDelegate to SettingsCoordinator, so also the instantiation is setup there.

Unfortunately the DBDebugToolkit doesn't provide any presentation options at least not without forking the repo. At least on my device I don't see any animations when presenting the whole thing (even though internally it actually has animations turned on).