### PR TITLE
Name and Avatar Selection after QR-Account-Creation

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		AE851AD0227DF50900ED86F0 /* GroupChatDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE851ACF227DF50900ED86F0 /* GroupChatDetailViewController.swift */; };
 		AE9DAF0D22C1215D004C9591 /* EditContactController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9DAF0C22C1215D004C9591 /* EditContactController.swift */; };
 		AE9DAF0F22C278C6004C9591 /* ChatTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9DAF0E22C278C6004C9591 /* ChatTitleView.swift */; };
+		AEA0F6A124474146009F887B /* ProfileInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA0F6A024474146009F887B /* ProfileInfoViewController.swift */; };
 		AEACE2DD1FB323CA00DCDD78 /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEACE2DC1FB323CA00DCDD78 /* ChatViewController.swift */; };
 		AEACE2DF1FB3246400DCDD78 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEACE2DE1FB3246400DCDD78 /* Message.swift */; };
 		AEACE2E31FB32B5C00DCDD78 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEACE2E21FB32B5C00DCDD78 /* Constants.swift */; };
@@ -394,6 +395,7 @@
 		AE851ACF227DF50900ED86F0 /* GroupChatDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupChatDetailViewController.swift; sourceTree = "<group>"; };
 		AE9DAF0C22C1215D004C9591 /* EditContactController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditContactController.swift; sourceTree = "<group>"; };
 		AE9DAF0E22C278C6004C9591 /* ChatTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTitleView.swift; sourceTree = "<group>"; };
+		AEA0F6A024474146009F887B /* ProfileInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInfoViewController.swift; sourceTree = "<group>"; };
 		AEACE2DC1FB323CA00DCDD78 /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
 		AEACE2DE1FB3246400DCDD78 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		AEACE2E21FB32B5C00DCDD78 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -791,6 +793,7 @@
 				7A0052C71FBE6CB40048C3BF /* NewContactController.swift */,
 				7070FB9A2101ECBB000DC258 /* NewGroupController.swift */,
 				AE4AEE3422B1030D000AA495 /* PreviewController.swift */,
+				AEA0F6A024474146009F887B /* ProfileInfoViewController.swift */,
 				789E879521D6CB58003ED1C5 /* QrCodeReaderController.swift */,
 				30A4D9AD2332672600544344 /* QrInviteViewController.swift */,
 				30149D9222F21129003C12B5 /* QrViewController.swift */,
@@ -1237,6 +1240,7 @@
 				305961FF2346125100C80F33 /* AvatarView.swift in Sources */,
 				3059620C2346125100C80F33 /* MessageSizeCalculator.swift in Sources */,
 				305962042346125100C80F33 /* MessagesCollectionViewLayoutAttributes.swift in Sources */,
+				AEA0F6A124474146009F887B /* ProfileInfoViewController.swift in Sources */,
 				305961D02346125100C80F33 /* NSAttributedString+Extensions.swift in Sources */,
 				302B84C72396770B001C261F /* RelayHelper.swift in Sources */,
 				305961CF2346125100C80F33 /* UIColor+Extensions.swift in Sources */,

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		7AE0A5491FC42F65005ECB4B /* NewChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE0A5481FC42F65005ECB4B /* NewChatViewController.swift */; };
 		8B6D425BC604F7C43B65D436 /* Pods_deltachat_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6241BE1534A653E79AD5D01D /* Pods_deltachat_ios.framework */; };
 		AE0D26FD1FB1FE88002FAFCE /* ChatListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0D26FC1FB1FE88002FAFCE /* ChatListController.swift */; };
+		AE13E5E32449AAC600FCD5D4 /* TextCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE13E5E22449AAC600FCD5D4 /* TextCell.swift */; };
 		AE18F294228C602A0007B1BE /* SecuritySettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18F293228C602A0007B1BE /* SecuritySettingsController.swift */; };
 		AE19887523EB264000B4CD5F /* HelpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE19887423EB264000B4CD5F /* HelpViewController.swift */; };
 		AE1988A523EB2FBA00B4CD5F /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1988A423EB2FBA00B4CD5F /* Errors.swift */; };
@@ -368,6 +369,7 @@
 		8DE110C607A0E4485C43B5FA /* Pods-deltachat-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-deltachat-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-deltachat-ios/Pods-deltachat-ios.debug.xcconfig"; sourceTree = "<group>"; };
 		A8615D4600859851E53CAA9C /* Pods-deltachat-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-deltachat-ios.release.xcconfig"; path = "Pods/Target Support Files/Pods-deltachat-ios/Pods-deltachat-ios.release.xcconfig"; sourceTree = "<group>"; };
 		AE0D26FC1FB1FE88002FAFCE /* ChatListController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ChatListController.swift; sourceTree = "<group>"; tabWidth = 4; };
+		AE13E5E22449AAC600FCD5D4 /* TextCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCell.swift; sourceTree = "<group>"; };
 		AE18F293228C602A0007B1BE /* SecuritySettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecuritySettingsController.swift; sourceTree = "<group>"; };
 		AE19887423EB264000B4CD5F /* HelpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpViewController.swift; sourceTree = "<group>"; };
 		AE1988A423EB2FBA00B4CD5F /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
@@ -738,6 +740,7 @@
 			isa = PBXGroup;
 			children = (
 				AE406EEF240FF8FF005F7022 /* ProfileCell.swift */,
+				AE13E5E22449AAC600FCD5D4 /* TextCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -1231,6 +1234,7 @@
 				AEE6EC412282DF5700EDC689 /* MailboxViewController.swift in Sources */,
 				AEE6EC482283045D00EDC689 /* EditSettingsController.swift in Sources */,
 				305961DF2346125100C80F33 /* MessageCellDelegate.swift in Sources */,
+				AE13E5E32449AAC600FCD5D4 /* TextCell.swift in Sources */,
 				302B84CE2397F6CD001C261F /* URL+Extension.swift in Sources */,
 				305961CC2346125100C80F33 /* UIView+Extensions.swift in Sources */,
 				7A9FB1441FB061E2001FEA36 /* AppDelegate.swift in Sources */,

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -68,7 +68,7 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if indexPath.row == rowAvatar {
-            return AvatarSelectionCell.cellSize
+            return AvatarSelectionCell.cellHeight
         }
         return Constants.defaultCellHeight
     }

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -107,7 +107,7 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
         if indexPath.section == section1 {
             switch indexPath.row {
             case section1Avatar:
-                return AvatarSelectionCell.cellSize
+                return AvatarSelectionCell.cellHeight
             case section1Status:
                 return MultilineTextFieldCell.cellHeight
             default:

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -189,3 +189,5 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
     }
 
 }
+
+

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -8,8 +8,6 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
     private var displayNameBackup: String?
     private var statusCellBackup: String?
 
-    private let groupBadgeSize: CGFloat = 72
-
     private let section1 = 0
     private let section1Avatar = 0
     private let section1Name = 1

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -207,7 +207,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
         switch section {
         case sectionGroupDetails:
             if row == sectionGroupDetailsRowAvatar {
-                return AvatarSelectionCell.cellSize
+                return AvatarSelectionCell.cellHeight
             } else {
                 return Constants.defaultCellHeight
             }

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -1,22 +1,107 @@
 import UIKit
 import DcCore
 
-class ProfileInfoViewController: UIViewController {
+class ProfileInfoViewController: UITableViewController {
+
+    private lazy var headerCell: TextCell = {
+        let cell = TextCell(style: .default, reuseIdentifier: nil)
+        cell.textLabel?.text = String.localized("qraccount_success_enter_name")
+        cell.textLabel?.numberOfLines = 0
+        return cell
+    }()
+
+    private lazy var emailCell: TextFieldCell = {
+        let cell = TextFieldCell(description: "Meine Email Adresse", placeholder: "Meine Email")
+        cell.setText(text: dcContext.addr)
+        return cell
+    }()
+
+    private lazy var avatarCell: UITableViewCell = {
+        let cell = AvatarSelectionCell(context: self.dcContext)
+        cell.onAvatarTapped = avatarTapped
+        return cell
+    }()
+
+    private lazy var nameCell: TextFieldCell = {
+        let cell = TextFieldCell(description: String.localized("pref_your_name"), placeholder: String.localized("pref_your_name"))
+        cell.setText(text: dcContext.displayname)
+        return cell
+    }()
+
+    private lazy var cells = [headerCell, avatarCell, nameCell]
 
     private let dcContext: DcContext
 
     init(context: DcContext) {
         self.dcContext = context
-        super.init(nibName: nil, bundle: nil)
+        super.init(style: .grouped)
+        tableView.estimatedRowHeight = Constants.defaultCellHeight
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         title = String.localized("pref_profile_info_headline")
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return cells.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        return cells[indexPath.row]
+    }
+
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+
+        let cell = cells[indexPath.row]
+
+        if let textCell = cell as? TextCell {
+            return textCell.intrinsicCellHeight
+        }
+
+        if cell is AvatarSelectionCell {
+            return AvatarSelectionCell.cellHeight
+        }
+
+        return Constants.defaultCellHeight
+    }
+
+    private func avatarTapped() {
+
+    }
+
+}
+
+class TextCell: UITableViewCell {
+
+    var intrinsicCellHeight: CGFloat {
+        return intrinsicContentSize.height
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupSubviews()
+        textLabel?.numberOfLines = 0
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupSubviews() {
+        guard let textLabel = self.textLabel else {
+            return
+        }
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        textLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor, constant: 0).isActive = true
+        textLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor, constant: 0).isActive = true
+        textLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor, constant: 0).isActive = true
+        textLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor, constant: 0).isActive = true
     }
 
 }

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -3,6 +3,17 @@ import DcCore
 
 class ProfileInfoViewController: UITableViewController {
 
+    var displayName: String?
+
+    private lazy var doneButtonItem: UIBarButtonItem = {
+        return UIBarButtonItem(
+            title: String.localized("done"),
+            style: .done,
+            target: self,
+            action: #selector(doneButtonPressed(_:))
+        )
+    }()
+
     private lazy var headerCell: TextCell = {
         let cell = TextCell(style: .default, reuseIdentifier: nil)
         let email = dcContext.addr ?? ""
@@ -23,8 +34,12 @@ class ProfileInfoViewController: UITableViewController {
     }()
 
     private lazy var nameCell: TextFieldCell = {
-        let cell = TextFieldCell(description: String.localized("pref_your_name"), placeholder: String.localized("pref_your_name"))
+        let cell =  TextFieldCell.makeNameCell()
+        cell.placeholder = String.localized("pref_your_name")
         cell.setText(text: dcContext.displayname)
+        cell.onTextFieldChange = {[unowned self] textField in
+            self.displayName = textField.text
+        }
         return cell
     }()
 
@@ -46,6 +61,7 @@ class ProfileInfoViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = String.localized("pref_profile_info_headline")
+        navigationItem.rightBarButtonItem = doneButtonItem
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -75,5 +91,9 @@ class ProfileInfoViewController: UITableViewController {
 
     }
 
-}
+    @objc private func doneButtonPressed(_ sender: UIBarButtonItem) {
+        dcContext.displayname = displayName
+        self.dismiss(animated: true, completion: nil)
+    }
 
+}

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -1,0 +1,22 @@
+import UIKit
+import DcCore
+
+class ProfileInfoViewController: UIViewController {
+
+    private let dcContext: DcContext
+
+    init(context: DcContext) {
+        self.dcContext = context
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = String.localized("pref_profile_info_headline")
+    }
+
+}

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -3,6 +3,8 @@ import DcCore
 
 class ProfileInfoViewController: UITableViewController {
 
+    weak var coordinator: EditSettingsCoordinator?
+
     var displayName: String?
 
     private lazy var doneButtonItem: UIBarButtonItem = {
@@ -64,6 +66,7 @@ class ProfileInfoViewController: UITableViewController {
         navigationItem.rightBarButtonItem = doneButtonItem
     }
 
+    // MARK: - tableviewDelegate
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return cells.count
     }
@@ -87,8 +90,37 @@ class ProfileInfoViewController: UITableViewController {
         return Constants.defaultCellHeight
     }
 
-    private func avatarTapped() {
+    // MARK: - updates
+    private func updateAvatarCell() {
+        self.tableView.beginUpdates()
+        let indexPath = IndexPath(row: 1, section: 0)
+        self.tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.none)
+        self.tableView.endUpdates()
+    }
 
+    // MARK: - actions
+    private func avatarTapped() {
+        let alert = UIAlertController(
+            title: String.localized("pref_profile_photo"),
+            message: nil,
+            preferredStyle: .safeActionSheet
+        )
+
+        let photoAction = PhotoPickerAlertAction(
+            title: String.localized("gallery"),
+            style: .default,
+            handler: galleryButtonPressed(_:)
+        )
+        let videoAction = PhotoPickerAlertAction(
+            title: String.localized("camera"),
+            style: .default,
+            handler: cameraButtonPressed(_:)
+        )
+
+        alert.addAction(photoAction)
+        alert.addAction(videoAction)
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+        self.present(alert, animated: true, completion: nil)
     }
 
     @objc private func doneButtonPressed(_ sender: UIBarButtonItem) {
@@ -96,4 +128,18 @@ class ProfileInfoViewController: UITableViewController {
         self.dismiss(animated: true, completion: nil)
     }
 
+    private func galleryButtonPressed(_ action: UIAlertAction) {
+        coordinator?.showPhotoPicker(delegate: self)
+    }
+
+    private func cameraButtonPressed(_ action: UIAlertAction) {
+        coordinator?.showCamera(delegate: self)
+    }
+}
+
+extension ProfileInfoViewController: MediaPickerDelegate {
+  func onImageSelected(image: UIImage) {
+    AvatarHelper.saveSelfAvatarImage(dcContext: dcContext, image: image)
+    updateAvatarCell()
+  }
 }

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -5,8 +5,8 @@ class ProfileInfoViewController: UITableViewController {
 
     private lazy var headerCell: TextCell = {
         let cell = TextCell(style: .default, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("qraccount_success_enter_name")
-        cell.textLabel?.numberOfLines = 0
+        let email = dcContext.addr ?? ""
+        cell.content = String.localizedStringWithFormat(NSLocalizedString("qraccount_success_enter_name", comment: ""), email)
         return cell
     }()
 
@@ -77,31 +77,3 @@ class ProfileInfoViewController: UITableViewController {
 
 }
 
-class TextCell: UITableViewCell {
-
-    var intrinsicCellHeight: CGFloat {
-        return intrinsicContentSize.height
-    }
-
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupSubviews()
-        textLabel?.numberOfLines = 0
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    private func setupSubviews() {
-        guard let textLabel = self.textLabel else {
-            return
-        }
-        textLabel.translatesAutoresizingMaskIntoConstraints = false
-        textLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor, constant: 0).isActive = true
-        textLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor, constant: 0).isActive = true
-        textLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor, constant: 0).isActive = true
-        textLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor, constant: 0).isActive = true
-    }
-
-}

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -99,10 +99,11 @@ class ProfileInfoViewController: UITableViewController {
 
     // MARK: - actions
     private func avatarTapped() {
+        let sender = avatarCell.badge
         let alert = UIAlertController(
             title: String.localized("pref_profile_photo"),
             message: nil,
-            preferredStyle: .safeActionSheet
+            preferredStyle: .actionSheet
         )
         let photoAction = PhotoPickerAlertAction(
             title: String.localized("gallery"),
@@ -117,6 +118,15 @@ class ProfileInfoViewController: UITableViewController {
         alert.addAction(photoAction)
         alert.addAction(videoAction)
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+        if let popoverController = alert.popoverPresentationController {
+            popoverController.sourceView = self.avatarCell
+            popoverController.sourceRect = CGRect(
+                x: sender.frame.minX - 10,
+                y: sender.frame.minY,
+                width: sender.frame.width,
+                height: sender.frame.height
+            )
+         }
         self.present(alert, animated: true, completion: nil)
     }
 

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -4,8 +4,9 @@ import DcCore
 class ProfileInfoViewController: UITableViewController {
 
     weak var coordinator: EditSettingsCoordinator?
+    private let dcContext: DcContext
 
-    var displayName: String?
+    private var displayName: String?
 
     private lazy var doneButtonItem: UIBarButtonItem = {
         return UIBarButtonItem(
@@ -29,7 +30,7 @@ class ProfileInfoViewController: UITableViewController {
         return cell
     }()
 
-    private lazy var avatarCell: UITableViewCell = {
+    private lazy var avatarCell: AvatarSelectionCell = {
         let cell = AvatarSelectionCell(context: self.dcContext)
         cell.onAvatarTapped = avatarTapped
         return cell
@@ -46,8 +47,6 @@ class ProfileInfoViewController: UITableViewController {
     }()
 
     private lazy var cells = [headerCell, avatarCell, nameCell]
-
-    private let dcContext: DcContext
 
     init(context: DcContext) {
         self.dcContext = context
@@ -78,20 +77,20 @@ class ProfileInfoViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
 
         let cell = cells[indexPath.row]
-
         if let textCell = cell as? TextCell {
             return textCell.intrinsicCellHeight
         }
-
         if cell is AvatarSelectionCell {
             return AvatarSelectionCell.cellHeight
         }
-
         return Constants.defaultCellHeight
     }
 
     // MARK: - updates
     private func updateAvatarCell() {
+        if let avatarImage = dcContext.getSelfAvatarImage() {
+            avatarCell.updateAvatar(image: avatarImage)
+        }
         self.tableView.beginUpdates()
         let indexPath = IndexPath(row: 1, section: 0)
         self.tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.none)
@@ -105,7 +104,6 @@ class ProfileInfoViewController: UITableViewController {
             message: nil,
             preferredStyle: .safeActionSheet
         )
-
         let photoAction = PhotoPickerAlertAction(
             title: String.localized("gallery"),
             style: .default,
@@ -116,7 +114,6 @@ class ProfileInfoViewController: UITableViewController {
             style: .default,
             handler: cameraButtonPressed(_:)
         )
-
         alert.addAction(photoAction)
         alert.addAction(videoAction)
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
@@ -138,8 +135,8 @@ class ProfileInfoViewController: UITableViewController {
 }
 
 extension ProfileInfoViewController: MediaPickerDelegate {
-  func onImageSelected(image: UIImage) {
-    AvatarHelper.saveSelfAvatarImage(dcContext: dcContext, image: image)
-    updateAvatarCell()
-  }
+    func onImageSelected(image: UIImage) {
+        AvatarHelper.saveSelfAvatarImage(dcContext: dcContext, image: image)
+        updateAvatarCell()
+    }
 }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -83,6 +83,8 @@ class AppCoordinator: NSObject, Coordinator {
         return nav
     }()
 
+    private var profileInfoNavigationController: UINavigationController?
+
     init(window: UIWindow, dcContext: DcContext) {
         self.window = window
         self.dcContext = dcContext

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -112,8 +112,6 @@ class AppCoordinator: NSObject, Coordinator {
 
     func showTab(index: Int) {
         tabBarController.selectedIndex = index
-        // TODO: make sure to delete this before submitting PR
-        showProfileInfo()
     }
 
     func showChat(chatId: Int, animated: Bool = true) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -180,6 +180,14 @@ extension AppCoordinator: WelcomeCoordinator {
 
     func handleQRAccountCreationSuccess() {
         self.presentTabBarController()
+        showTab(index: 1)
+        let profileInfoController = ProfileInfoViewController(context: dcContext)
+        let profileInfoNav = UINavigationController(rootViewController: profileInfoController)
+        profileInfoNav.modalPresentationStyle = .fullScreen
+        let coordinator = EditSettingsCoordinator(dcContext: dcContext, navigationController: profileInfoNav)
+        profileInfoController.coordinator = coordinator
+        childCoordinators.append(coordinator)
+        tabBarController.present(profileInfoNav, animated: false, completion: nil)
     }
 
     @objc private func cancelButtonPressed(_ sender: UIBarButtonItem) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -112,6 +112,8 @@ class AppCoordinator: NSObject, Coordinator {
 
     func showTab(index: Int) {
         tabBarController.selectedIndex = index
+        // TODO: make sure to delete this before submitting PR
+        showProfileInfo()
     }
 
     func showChat(chatId: Int, animated: Bool = true) {

--- a/deltachat-ios/Helper/TypeAlias.swift
+++ b/deltachat-ios/Helper/TypeAlias.swift
@@ -1,3 +1,3 @@
-import Foundation
+import UIKit
 
 typealias VoidFunction = () -> Void

--- a/deltachat-ios/View/Alerts.swift
+++ b/deltachat-ios/View/Alerts.swift
@@ -1,0 +1,9 @@
+//
+//  Alerts.swift
+//  deltachat-ios
+//
+//  Created by Bastian van de Wetering on 17.04.20.
+//  Copyright © 2020 Jonas Reinsch. All rights reserved.
+//
+
+import Foundation

--- a/deltachat-ios/View/Alerts.swift
+++ b/deltachat-ios/View/Alerts.swift
@@ -1,9 +1,0 @@
-//
-//  Alerts.swift
-//  deltachat-ios
-//
-//  Created by Bastian van de Wetering on 17.04.20.
-//  Copyright © 2020 Jonas Reinsch. All rights reserved.
-//
-
-import Foundation

--- a/deltachat-ios/View/AvatarSelectionCell.swift
+++ b/deltachat-ios/View/AvatarSelectionCell.swift
@@ -3,7 +3,7 @@ import DcCore
 
 class AvatarSelectionCell: UITableViewCell {
     let badgeSize: CGFloat = 72
-    static let cellSize: CGFloat = 98
+    static let cellHeight: CGFloat = 98
 
     var onAvatarTapped: (() -> Void)?
 

--- a/deltachat-ios/View/AvatarSelectionCell.swift
+++ b/deltachat-ios/View/AvatarSelectionCell.swift
@@ -87,6 +87,7 @@ class AvatarSelectionCell: UITableViewCell {
         }
     }
 
+    // I think this is no good, we should rather update badge than overwriting it.
     func setAvatar(for chat: DcChat) {
         if let image = chat.profileImage {
             badge = InitialsBadge(image: image, size: badgeSize)
@@ -96,6 +97,7 @@ class AvatarSelectionCell: UITableViewCell {
         badge.setVerified(chat.isVerified)
     }
 
+    // I think this is no good, we should rather update badge than overwriting it.
     func setAvatar(image: UIImage?, with defaultImage: UIImage?) {
         if let image = image {
             badge = InitialsBadge(image: image, size: badgeSize)
@@ -103,5 +105,9 @@ class AvatarSelectionCell: UITableViewCell {
             badge = InitialsBadge(image: defaultImage, size: badgeSize)
             badge.backgroundColor = DcColors.grayTextColor
         }
+    }
+
+    func updateAvatar(image: UIImage) {
+        badge.setImage(image)
     }
 }

--- a/deltachat-ios/View/Cell/TextCell.swift
+++ b/deltachat-ios/View/Cell/TextCell.swift
@@ -1,0 +1,42 @@
+import UIKit
+
+/*
+ cell that displays text and grows in size
+*/
+
+class TextCell: UITableViewCell {
+
+    var content: String? {
+        set {
+            textLabel?.text = newValue
+        }
+        get {
+            return textLabel?.text
+        }
+    }
+
+    var intrinsicCellHeight: CGFloat {
+        return intrinsicContentSize.height
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupSubviews()
+        textLabel?.numberOfLines = 0
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupSubviews() {
+        guard let textLabel = self.textLabel else {
+            return
+        }
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        textLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor, constant: 0).isActive = true
+        textLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor, constant: 0).isActive = true
+        textLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor, constant: 0).isActive = true
+        textLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor, constant: 0).isActive = true
+    }
+}

--- a/deltachat-ios/View/TextFieldCell.swift
+++ b/deltachat-ios/View/TextFieldCell.swift
@@ -1,7 +1,15 @@
 import UIKit
 
 class TextFieldCell: UITableViewCell {
-    private let placeholder: String
+
+    var placeholder: String? {
+        set {
+            textField.placeholder = newValue
+        }
+        get {
+            return textField.placeholder
+        }
+    }
 
     var onTextFieldChange:((_:UITextField) -> Void)?	// set this from outside to get notified about textfield changes
 
@@ -9,13 +17,11 @@ class TextFieldCell: UITableViewCell {
         let textField = UITextField()
         textField.textAlignment = .right
         // textField.enablesReturnKeyAutomatically = true
-        textField.placeholder = self.placeholder
         textField.addTarget(self, action: #selector(textFieldChanged), for: .editingChanged)
         return textField
     }()
 
     init(description: String, placeholder: String, delegate: UITextFieldDelegate? = nil) {
-        self.placeholder = placeholder
         super.init(style: .value1, reuseIdentifier: nil)
         textLabel?.text = "\(description):"
 
@@ -25,6 +31,7 @@ class TextFieldCell: UITableViewCell {
         selectionStyle = .none
         setupViews()
         textField.delegate = delegate
+        textField.placeholder = placeholder
     }
 
     convenience init(descriptionID: String, placeholder: String, delegate: UITextFieldDelegate? = nil) {


### PR DESCRIPTION
fixes #609

No issues, but ....

... I am not too happy with the transition from our WelcomeScreen to the MainScreen (TabBar).
Since we're switching the UIWindow when we navigate from WelcomeScreen to MainScreen  there is no chance to add nice animations to the login flow. 

For example after the account creation is completed, I had to switch windows first, before I could present the Avatar/NamePicker. So there are a few milliseconds where the user can actually see the MainScreen. So this makes the login flow a bit wonky from the animation perspective. 

Also keep in mind, that this PR is based on master, there is another PR  #632 which also fix minor things. I suggest to merge #632 first. I can do a rebase after. 

Also have a look on Ipad when selecting an Avatar how the UIAlertController is presented. If this is preferred, I would do the same on other occasions, because that's how it is usually implemented on Ipad. 