### PR TITLE
use dcContext.lastErrorString instead of AppDelegate.lastErrorString

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -22,7 +22,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     var locationManager: LocationManager!
     // static let appCoordinatorDeprecated = AppCoordinatorDeprecated()
     static var progress: Float = 0 // TODO: delete
-    static var lastErrorString: String?
     private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
 
     var reachability = Reachability()!

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -141,9 +141,9 @@ class QrViewController: UITableViewController {
             // execute blocking secure join in background
             DispatchQueue.global(qos: .background).async {
                 self.addSecureJoinProgressListener()
-                AppDelegate.lastErrorString = nil
+                self.dcContext.lastErrorString = nil
                 let chatId = self.dcContext.joinSecurejoin(qrCode: code)
-                let errorString = AppDelegate.lastErrorString
+                let errorString = self.dcContext.lastErrorString
                 self.removeSecureJoinProgressListener()
 
                 DispatchQueue.main.async {


### PR DESCRIPTION
use dcContext.lastErrorString instead of AppDelegate.lastErrorString; the latter is just never set, maybe it was used at some time in the past and was forgot on some refactoring