### PR TITLE
remove delay after dismissing qr-scan-viewcontroller, cleanup

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -154,13 +154,8 @@ public class DcContext {
         return DcLot(dc_check_qr(contextPointer, qrCode))
     }
 
-    public func configureAccountFromQR(qrCode: String) -> Bool {
-        let state = checkQR(qrCode: qrCode).state
-        if state != DC_QR_ACCOUNT {
-            return false
-        }
-        let success = dc_set_config_from_qr(contextPointer, qrCode)
-        return success == 1
+    public func setConfigFromQR(qrCode: String) -> Bool {
+        return dc_set_config_from_qr(contextPointer, qrCode) != 0
     }
 
     public func stopOngoingProcess() {

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -788,7 +788,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             appDelegate.open()
             appDelegate.start()
 
-            appDelegate.appCoordinator.presentWelcomeController(animated: true)
+            appDelegate.appCoordinator.presentWelcomeController()
         }))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
         present(alert, animated: true, completion: nil)

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -179,9 +179,8 @@ extension WelcomeViewController: QrCodeReaderDelegate {
             style: .default,
             handler: { [unowned self] _ in
                 self.activateSpinner(true)
-                self.qrCodeReaderNav.dismiss(animated: false) {
-                    self.createAccountFromQRCode()
-                }
+                self.qrCodeReaderNav.dismiss(animated: false)
+                self.createAccountFromQRCode()
             }
         )
 

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -113,11 +113,6 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         frameGuide.widthAnchor.constraint(equalTo: contentGuide.widthAnchor).isActive = true
     }
 
-    /// if active the welcomeViewController will show nothing but a centered activity indicator
-    func activateSpinner(_ active: Bool) {
-        welcomeView.showSpinner(active)
-    }
-
     // MARK: - actions
 
     private func showQRReader(completion onComplete: VoidFunction? = nil) {
@@ -135,7 +130,6 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         if success {
             addProgressAlertListener(onSuccess: handleLoginSuccess)
             showProgressAlert(title: String.localized("login_header"))
-            activateSpinner(false)
             dcContext.configure()
         } else {
             accountCreationErrorAlert()
@@ -147,15 +141,10 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
     }
 
     private func accountCreationErrorAlert() {
-        activateSpinner(false)
         let title = DcContext.shared.lastErrorString ?? String.localized("error")
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default))
         present(alert, animated: true)
-    }
-
-    func progressAlertWillDismiss() {
-        activateSpinner(true)
     }
 }
 
@@ -178,7 +167,6 @@ extension WelcomeViewController: QrCodeReaderDelegate {
             title: String.localized("ok"),
             style: .default,
             handler: { [unowned self] _ in
-                self.activateSpinner(true)
                 self.qrCodeReaderNav.dismiss(animated: false)
                 self.createAccountFromQRCode()
             }
@@ -314,18 +302,6 @@ class WelcomeContentView: UIView {
         return button
     }()
 
-    private var activityIndicator: UIActivityIndicatorView = {
-        let view: UIActivityIndicatorView
-        if #available(iOS 13, *) {
-             view = UIActivityIndicatorView(style: .large)
-        } else {
-            view = UIActivityIndicatorView(style: .whiteLarge)
-            view.color = UIColor.gray
-        }
-        view.isHidden = true
-        return view
-    }()
-
     private let defaultSpacing: CGFloat = 20
 
     init() {
@@ -400,11 +376,6 @@ class WelcomeContentView: UIView {
             $0.priority = .defaultLow
             $0.isActive = true
         }
-
-        addSubview(activityIndicator)
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-        activityIndicator.centerYAnchor.constraint(equalTo: buttonContainerGuide.centerYAnchor).isActive = true
-        activityIndicator.centerXAnchor.constraint(equalTo: container.centerXAnchor).isActive = true
     }
 
     private func calculateLogoHeight() -> CGFloat {
@@ -427,14 +398,4 @@ class WelcomeContentView: UIView {
      @objc private func importBackupButtonPressed(_ sender: UIButton) {
          onImportBackup?()
      }
-
-    func showSpinner(_ show: Bool) {
-        if show {
-            activityIndicator.startAnimating()
-        } else {
-            activityIndicator.stopAnimating()
-        }
-        activityIndicator.isHidden = !show
-        buttonStack.isHidden = show
-    }
 }

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -125,7 +125,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         guard let code = scannedQrCode else {
             return
         }
-        let success = dcContext.configureAccountFromQR(qrCode: code)
+        let success = dcContext.setConfigFromQR(qrCode: code)
         scannedQrCode = nil
         if success {
             addProgressAlertListener(onSuccess: handleLoginSuccess)
@@ -197,17 +197,7 @@ extension WelcomeViewController: QrCodeReaderDelegate {
                 self.qrCordeReader.startSession()
             }
         )
-        let qrCancelAction = UIAlertAction(
-             title: String.localized("cancel"),
-             style: .cancel,
-             handler: { [unowned self] _ in
-                 self.qrCodeReaderNav.dismiss(animated: true) {
-                     self.scannedQrCode = nil
-                 }
-             }
-         )
         alert.addAction(okAction)
-        alert.addAction(qrCancelAction)
         qrCodeReaderNav.present(alert, animated: true, completion: nil)
     }
 }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -91,7 +91,7 @@ class AppCoordinator: NSObject, Coordinator {
         if dcContext.isConfigured() {
             presentTabBarController()
         } else {
-            showWelcomeController()
+            presentWelcomeController()
         }
     }
 
@@ -133,19 +133,7 @@ class AppCoordinator: NSObject, Coordinator {
         }
     }
 
-    func presentWelcomeController(animated: Bool) {
-        if animated {
-            welcomeController.activateSpinner(true)
-            showWelcomeController()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                self.welcomeController.activateSpinner(false)
-            }
-        } else {
-            showWelcomeController()
-        }
-    }
-
-    private func showWelcomeController() {
+    func presentWelcomeController() {
         // the applicationIconBadgeNumber is remembered by the system even on reinstalls (just tested on ios 13.3.1),
         // to avoid appearing an old number of a previous installation, we reset the counter manually.
         // but even when this changes in ios, we need the reset as we allow account-deletion also in-app.
@@ -181,18 +169,15 @@ extension AppCoordinator: WelcomeCoordinator {
     
 
     func handleLoginSuccess() {
-        welcomeController.activateSpinner(true) // this will hide welcomeController's content
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             self.loginController.dismiss(animated: true) { // this is ignored if loginController is not shown
                 self.presentTabBarController()
-                self.welcomeController.activateSpinner(false)
             }
         }
     }
 
     func handleQRAccountCreationSuccess() {
         self.presentTabBarController()
-        self.welcomeController.activateSpinner(false)
     }
 
     @objc private func cancelButtonPressed(_ sender: UIBarButtonItem) {


### PR DESCRIPTION
UIKit seems to be pretty slow in updating underlaying view sometimes,
a quick search for "viewcontroller dismiss completion delayed"
shows several issues.

we ignore this issue by not waiting until the controller is really dismissed.
afaik, there is no need to do so. this is what the **first commit** is about.

the **second commit** removes the spinner, that was introduced to mitigate the effect of having a stale view for some seconds. the spinner is weird, there are several lines that show/hide it and it is not clear what happens there at all, also the spinner shows/hide too often. 

successor of #632, targets #631