### PR TITLE
remove unused calls to dc_configure()

### DIFF
--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -71,7 +71,6 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
     override func viewWillDisappear(_ animated: Bool) {
         dcContext.selfstatus = statusCell.getText()
         dcContext.displayname = nameCell.getText()
-        dcContext.configure()
     }
 
     // MARK: - Table view data source

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -344,12 +344,10 @@ internal final class SettingsViewController: UITableViewController {
 
     @objc private func handleReceiptConfirmationToggle(_ sender: UISwitch) {
         dcContext.mdnsEnabled = sender.isOn
-        dcContext.configure()
     }
 
     @objc private func handleAutocryptPreferencesToggle(_ sender: UISwitch) {
         dcContext.e2eeEnabled = sender.isOn
-        dcContext.configure()
     }
 
     private func sendAutocryptSetupMessage() {


### PR DESCRIPTION
dc_configure() resp. dcContext.configure() should be called only when
server-related settings are changes or should be found out
(the ones from the setup-screens)

unless stated otherwise, once, Delta Chat is configured,
there is no need to call dc_configure() again.