### PR TITLE
email + pw forms are cleared after signout

### DIFF
--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -91,7 +91,6 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
         cell.tag = tagEmailCell
         cell.textField.addTarget(self, action: #selector(emailCellEdited), for: .editingChanged)
         cell.textField.tag = tagTextFieldEmail // will be used to eventually show oAuth-Dialogue when pressing return key
-        cell.setText(text: dcContext.addr ?? nil)
         cell.textField.delegate = self
         cell.textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         return cell
@@ -102,7 +101,6 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
         cell.tag = tagPasswordCell
         cell.textField.tag = tagTextFieldPassword  // will be used to eventually show oAuth-Dialogue when selecting
         cell.textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
-        cell.setText(text: dcContext.mailPw ?? nil)
         cell.textField.delegate = self
         return cell
     }()
@@ -370,7 +368,9 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         initSelectionCells()
+        updateCellData()
         handleLoginButton()
+
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -500,6 +500,12 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
         default:
             break
         }
+    }
+
+    // MARK: - updates
+    private func updateCellData() {
+        emailCell.setText(text: dcContext.addr ?? nil)
+        passwordCell.setText(text: dcContext.mailPw ?? nil)
     }
 
     // MARK: - actions
@@ -787,7 +793,6 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             DatabaseHelper().clearAccountData()
             appDelegate.open()
             appDelegate.start()
-
             appDelegate.appCoordinator.presentWelcomeController()
         }))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
@@ -851,7 +856,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
 
 }
 
-// MARK: -
+// MARK: - UITextFieldDelegate
 extension AccountSetupController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         let currentTag = textField.tag

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -19,7 +19,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         let view = WelcomeContentView()
         view.onLogin = {
             [unowned self] in
-            self.coordinator?.showLogin()
+            self.coordinator?.presentLogin()
         }
         view.onScanQRCode = {
             [unowned self] in

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -157,7 +157,7 @@ class AppCoordinator: NSObject, Coordinator {
 // MARK: - WelcomeCoordinator
 extension AppCoordinator: WelcomeCoordinator {
 
-    func showLogin() {
+    func presentLogin() {
         // add cancel button item to accountSetupController
         if let nav = loginController as? UINavigationController, let loginController = nav.topViewController as? AccountSetupController {
             loginController.navigationItem.leftBarButtonItem = UIBarButtonItem(
@@ -893,7 +893,7 @@ protocol EditContactCoordinatorProtocol: class {
 }
 
 protocol WelcomeCoordinator: class {
-    func showLogin()
+    func presentLogin()
     func handleLoginSuccess()
     func handleQRAccountCreationSuccess()
 }


### PR DESCRIPTION
fixes #615 

The password-cell and email-cell are now updated in `AccountSetupController.viewWillAppear`. 

 