### PR TITLE
load all messages in ChatView

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -41,6 +41,12 @@ public class DcContext {
         return ids
     }
 
+	public func getMessageIds(chatId: Int) -> [Int] {
+		let cMessageIds = getChatMessages(chatId: chatId)
+		let ids: [Int] = DcUtils.copyAndFreeArray(inputArray: cMessageIds)
+		return ids
+	}
+
     public func createContact(name: String, email: String) -> Int {
         return Int(dc_create_contact(contextPointer, name, email))
     }
@@ -249,10 +255,10 @@ public class DcContext {
         dc_markseen_msgs(contextPointer, ptr, Int32(count))
     }
 
-    public func getChatMessages(chatId: Int) -> OpaquePointer {
+	private func getChatMessages(chatId: Int) -> OpaquePointer {
         return dc_get_chat_msgs(contextPointer, UInt32(chatId), 0, 0)
     }
-    
+
     public func getMsgInfo(msgId: Int) -> String {
         if let cString = dc_get_msg_info(self.contextPointer, UInt32(msgId)) {
             let swiftString = String(cString: cString)

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -95,6 +95,7 @@ class ChatViewController: MessagesViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - lifecycle
     override func viewDidLoad() {
         messagesCollectionView.register(InfoMessageCell.self)
         super.viewDidLoad()
@@ -252,6 +253,7 @@ class ChatViewController: MessagesViewController {
         super.viewWillTransition(to: size, with: coordinator)
     }
 
+    // MARK - update
     private func updateTitle(chat: DcChat) {
         let titleView =  ChatTitleView()
 
@@ -284,8 +286,7 @@ class ChatViewController: MessagesViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: badge)
     }
 
-    @objc
-    private func loadMoreMessages() {
+    @objc private func loadMoreMessages() {
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
             DispatchQueue.main.async {
                 self.messageList = self.getMessageIds(self.loadCount, from: self.messageList.count) + self.messageList
@@ -295,8 +296,7 @@ class ChatViewController: MessagesViewController {
         }
     }
 
-    @objc
-    private func refreshMessages() {
+    @objc private func refreshMessages() {
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
             DispatchQueue.main.async {
                 self.messageList = self.getMessageIds(self.messageList.count)
@@ -352,6 +352,15 @@ class ChatViewController: MessagesViewController {
 
     private var textDraft: String? {
         return dcContext.getDraft(chatId: chatId)
+    }
+
+    private func getMessageIds() -> [DcMsg] {
+        let ids = dcContext.getMessageIds(chatId: chatId)
+        let markIds: [UInt32] = ids.map { UInt32($0) }
+        dcContext.markSeenMessages(messageIds: markIds, count: ids.count)
+        return ids.map {
+            DcMsg(id: $0)
+        }
     }
 
     private func getMessageIds(_ count: Int, from: Int? = nil) -> [DcMsg] {

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -44,7 +44,6 @@ class ChatViewController: MessagesViewController {
     weak var coordinator: ChatViewCoordinator?
 
     let outgoingAvatarOverlap: CGFloat = 17.5
-    let loadCount = 30
 
     let chatId: Int
     let refreshControl = UIRefreshControl()
@@ -125,7 +124,7 @@ class ChatViewController: MessagesViewController {
             //reload table
             DispatchQueue.main.async {
                 guard let self = self else { return }
-                self.messageList = self.getMessageIds(self.messageList.count)
+                self.messageList = self.getMessageIds()
                 self.messagesCollectionView.reloadDataAndKeepOffset()
                 self.refreshControl.endRefreshing()
             }
@@ -289,7 +288,7 @@ class ChatViewController: MessagesViewController {
     @objc private func loadMoreMessages() {
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
             DispatchQueue.main.async {
-                self.messageList = self.getMessageIds(self.loadCount, from: self.messageList.count) + self.messageList
+                self.messageList = self.getMessageIds()
                 self.messagesCollectionView.reloadDataAndKeepOffset()
                 self.refreshControl.endRefreshing()
             }
@@ -299,7 +298,7 @@ class ChatViewController: MessagesViewController {
     @objc private func refreshMessages() {
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
             DispatchQueue.main.async {
-                self.messageList = self.getMessageIds(self.messageList.count)
+                self.messageList = self.getMessageIds()
                 self.messagesCollectionView.reloadDataAndKeepOffset()
                 self.refreshControl.endRefreshing()
                 if self.isLastSectionVisible() {
@@ -313,7 +312,7 @@ class ChatViewController: MessagesViewController {
     private func loadFirstMessages() {
         DispatchQueue.global(qos: .userInitiated).async {
             DispatchQueue.main.async {
-                self.messageList = self.getMessageIds(self.loadCount)
+                self.messageList = self.getMessageIds()
                 self.messagesCollectionView.reloadData()
                 self.refreshControl.endRefreshing()
                 self.messagesCollectionView.scrollToBottom(animated: false)
@@ -363,6 +362,7 @@ class ChatViewController: MessagesViewController {
         }
     }
 
+    /*
     private func getMessageIds(_ count: Int, from: Int? = nil) -> [DcMsg] {
         let ids = dcContext.getMessageIds(chatId: chatId, count: count, from: from)
         let markIds: [UInt32] = ids.map { UInt32($0) }
@@ -372,6 +372,7 @@ class ChatViewController: MessagesViewController {
             DcMsg(id: $0)
         }
     }
+    */
 
     @objc private func setTextDraft() {
         if let text = self.messageInputBar.inputTextView.text {

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -191,7 +191,7 @@ class ChatViewController: MessagesViewController {
             }
         }
 
-        loadFirstMessages()
+        loadMessages()
 
         if RelayHelper.sharedInstance.isForwarding() {
             askToForwardMessage()
@@ -296,7 +296,7 @@ class ChatViewController: MessagesViewController {
         }
     }
 
-    private func loadFirstMessages() {
+    private func loadMessages() {
         DispatchQueue.global(qos: .userInitiated).async {
             DispatchQueue.main.async {
                 self.messageList = self.getMessageIds()
@@ -417,8 +417,10 @@ class ChatViewController: MessagesViewController {
         messageInputBar.inputTextView.placeholderTextColor = DcColors.placeholderColor
         messageInputBar.inputTextView.textContainerInset = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 38)
         messageInputBar.inputTextView.placeholderLabelInsets = UIEdgeInsets(top: 8, left: 20, bottom: 8, right: 38)
-        messageInputBar.inputTextView.layer.borderColor = UIColor.themeColor(light: UIColor(red: 200 / 255, green: 200 / 255, blue: 200 / 255, alpha: 1),
-                                                                             dark: UIColor(red: 55 / 255, green: 55/255, blue: 55/255, alpha: 1)).cgColor
+        messageInputBar.inputTextView.layer.borderColor = UIColor.themeColor(
+            light: UIColor(red: 200 / 255, green: 200 / 255, blue: 200 / 255, alpha: 1),
+            dark: UIColor(red: 55 / 255, green: 55/255, blue: 55/255, alpha: 1)
+        ).cgColor
         messageInputBar.inputTextView.layer.borderWidth = 1.0
         messageInputBar.inputTextView.layer.cornerRadius = 13.0
         messageInputBar.inputTextView.layer.masksToBounds = true
@@ -430,7 +432,6 @@ class ChatViewController: MessagesViewController {
 
         messageInputBar.setLeftStackViewWidthConstant(to: 40, animated: false)
         messageInputBar.setRightStackViewWidthConstant(to: 40, animated: false)
-
 
         let sendButtonImage = UIImage(named: "paper_plane")?.withRenderingMode(.alwaysTemplate)
         messageInputBar.sendButton.image = sendButtonImage

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -46,7 +46,6 @@ class ChatViewController: MessagesViewController {
     let outgoingAvatarOverlap: CGFloat = 17.5
 
     let chatId: Int
-    let refreshControl = UIRefreshControl()
     var messageList: [DcMsg] = []
 
     var msgChangedObserver: Any?
@@ -126,7 +125,6 @@ class ChatViewController: MessagesViewController {
                 guard let self = self else { return }
                 self.messageList = self.getMessageIds()
                 self.messagesCollectionView.reloadDataAndKeepOffset()
-                self.refreshControl.endRefreshing()
             }
         }
     }
@@ -290,7 +288,6 @@ class ChatViewController: MessagesViewController {
             DispatchQueue.main.async {
                 self.messageList = self.getMessageIds()
                 self.messagesCollectionView.reloadDataAndKeepOffset()
-                self.refreshControl.endRefreshing()
             }
         }
     }
@@ -300,7 +297,6 @@ class ChatViewController: MessagesViewController {
             DispatchQueue.main.async {
                 self.messageList = self.getMessageIds()
                 self.messagesCollectionView.reloadDataAndKeepOffset()
-                self.refreshControl.endRefreshing()
                 if self.isLastSectionVisible() {
                     self.messagesCollectionView.scrollToBottom(animated: true)
                 }
@@ -314,7 +310,6 @@ class ChatViewController: MessagesViewController {
             DispatchQueue.main.async {
                 self.messageList = self.getMessageIds()
                 self.messagesCollectionView.reloadData()
-                self.refreshControl.endRefreshing()
                 self.messagesCollectionView.scrollToBottom(animated: false)
                 self.showEmptyStateView(self.messageList.isEmpty)
             }
@@ -399,8 +394,6 @@ class ChatViewController: MessagesViewController {
         scrollsToBottomOnKeyboardBeginsEditing = true // default false
         maintainPositionOnKeyboardFrameChanged = true // default false
         messagesCollectionView.backgroundColor = DcColors.chatBackgroundColor
-        messagesCollectionView.addSubview(refreshControl)
-        refreshControl.addTarget(self, action: #selector(loadMoreMessages), for: .valueChanged)
 
         let layout = messagesCollectionView.collectionViewLayout as? MessagesCollectionViewFlowLayout
         layout?.sectionInset = UIEdgeInsets(top: 0, left: 8, bottom: 2, right: 8)

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -283,15 +283,6 @@ class ChatViewController: MessagesViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: badge)
     }
 
-    @objc private func loadMoreMessages() {
-        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
-            DispatchQueue.main.async {
-                self.messageList = self.getMessageIds()
-                self.messagesCollectionView.reloadDataAndKeepOffset()
-            }
-        }
-    }
-
     @objc private func refreshMessages() {
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
             DispatchQueue.main.async {
@@ -356,18 +347,6 @@ class ChatViewController: MessagesViewController {
             DcMsg(id: $0)
         }
     }
-
-    /*
-    private func getMessageIds(_ count: Int, from: Int? = nil) -> [DcMsg] {
-        let ids = dcContext.getMessageIds(chatId: chatId, count: count, from: from)
-        let markIds: [UInt32] = ids.map { UInt32($0) }
-        dcContext.markSeenMessages(messageIds: markIds, count: ids.count)
-
-        return ids.map {
-            DcMsg(id: $0)
-        }
-    }
-    */
 
     @objc private func setTextDraft() {
         if let text = self.messageInputBar.inputTextView.text {


### PR DESCRIPTION
fixes #614 

- created method that loads all messages of chat
in `ChatViewController`:
- removed `refreshControl` + target
- all messages are fetched at once.