### PR TITLE
avoid flashing up the chatlist between qr-scan and enter-name

### DIFF
--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -132,7 +132,6 @@ class ProfileInfoViewController: UITableViewController {
 
     @objc private func doneButtonPressed(_ sender: UIBarButtonItem) {
         dcContext.displayname = displayName
-        self.dismiss(animated: false, completion: nil) // not sure if this is needed
         onClose?()
     }
 

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -131,6 +131,10 @@ class ProfileInfoViewController: UITableViewController {
     @objc private func doneButtonPressed(_ sender: UIBarButtonItem) {
         dcContext.displayname = displayName
         self.dismiss(animated: true, completion: nil)
+
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.appCoordinator.presentTabBarController()
+        }
     }
 
     private func galleryButtonPressed(_ action: UIAlertAction) {

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -4,6 +4,8 @@ import DcCore
 class ProfileInfoViewController: UITableViewController {
 
     weak var coordinator: EditSettingsCoordinator?
+    var onClose: VoidFunction?
+
     private let dcContext: DcContext
 
     private var displayName: String?
@@ -130,11 +132,8 @@ class ProfileInfoViewController: UITableViewController {
 
     @objc private func doneButtonPressed(_ sender: UIBarButtonItem) {
         dcContext.displayname = displayName
-        self.dismiss(animated: true, completion: nil)
-
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            appDelegate.appCoordinator.presentTabBarController()
-        }
+        self.dismiss(animated: false, completion: nil) // not sure if this is needed
+        onClose?()
     }
 
     private func galleryButtonPressed(_ action: UIAlertAction) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -187,19 +187,12 @@ extension AppCoordinator: WelcomeCoordinator {
     }
 
     func handleQRAccountCreationSuccess() {
-        self.presentTabBarController()
-        showTab(index: 1)
-        presentProfileInfoController()
-    }
-
-    private func presentProfileInfoController() {
         let profileInfoController = ProfileInfoViewController(context: dcContext)
         let profileInfoNav = UINavigationController(rootViewController: profileInfoController)
         profileInfoNav.modalPresentationStyle = .fullScreen
         let coordinator = EditSettingsCoordinator(dcContext: dcContext, navigationController: profileInfoNav)
         profileInfoController.coordinator = coordinator
-        childCoordinators.append(coordinator)
-        tabBarController.present(profileInfoNav, animated: false, completion: nil)
+        welcomeController.present(profileInfoNav, animated: true, completion: nil)
     }
 
     @objc private func cancelButtonPressed(_ sender: UIBarButtonItem) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -192,7 +192,12 @@ extension AppCoordinator: WelcomeCoordinator {
         profileInfoNav.modalPresentationStyle = .fullScreen
         let coordinator = EditSettingsCoordinator(dcContext: dcContext, navigationController: profileInfoNav)
         profileInfoController.coordinator = coordinator
+        profileInfoController.onClose = handleProfileInfoClosed
         welcomeController.present(profileInfoNav, animated: true, completion: nil)
+    }
+
+    private func handleProfileInfoClosed() {
+        presentTabBarController()
     }
 
     @objc private func cancelButtonPressed(_ sender: UIBarButtonItem) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -193,7 +193,7 @@ extension AppCoordinator: WelcomeCoordinator {
         let coordinator = EditSettingsCoordinator(dcContext: dcContext, navigationController: profileInfoNav)
         profileInfoController.coordinator = coordinator
         profileInfoController.onClose = handleProfileInfoClosed
-        welcomeController.present(profileInfoNav, animated: true, completion: nil)
+        welcomeController?.present(profileInfoNav, animated: true, completion: nil)
     }
 
     private func handleProfileInfoClosed() {


### PR DESCRIPTION
targets https://github.com/deltachat/deltachat-ios/pull/642#pullrequestreview-397728054:

instead of directly creating the tab-view-controller with enter-name opend (which led to flashing the chatlist shortly), go from the welcome-screen to the enter-name-view-controller and when "done" is pressed there, finally go to the tab-view-controller.

@nayooti i tested it and it works, however, i am not that familiar with all these coordinator, can you please check if this is not terribly wrong in the model-logic :)