### PR TITLE
avoid flashing up the welcome-screen between login-view and chatlist

### DIFF
--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -178,21 +178,17 @@ extension AppCoordinator: WelcomeCoordinator {
         welcomeController?.present(loginController, animated: true, completion: nil)
     }
 
-    func handleLoginSuccess() {
-        presentTabBarController()
-    }
-
     func handleQRAccountCreationSuccess() {
         let profileInfoController = ProfileInfoViewController(context: dcContext)
         let profileInfoNav = UINavigationController(rootViewController: profileInfoController)
         profileInfoNav.modalPresentationStyle = .fullScreen
         let coordinator = EditSettingsCoordinator(dcContext: dcContext, navigationController: profileInfoNav)
         profileInfoController.coordinator = coordinator
-        profileInfoController.onClose = handleProfileInfoClosed
+        profileInfoController.onClose = handleLoginSuccess
         welcomeController?.present(profileInfoNav, animated: true, completion: nil)
     }
 
-    private func handleProfileInfoClosed() {
+    func handleLoginSuccess() {
         presentTabBarController()
     }
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -179,11 +179,7 @@ extension AppCoordinator: WelcomeCoordinator {
     }
 
     func handleLoginSuccess() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            self.loginController.dismiss(animated: true) { // this is ignored if loginController is not shown
-                self.presentTabBarController()
-            }
-        }
+        presentTabBarController()
     }
 
     func handleQRAccountCreationSuccess() {


### PR DESCRIPTION
there was a short, annoying flashing of the welcome-screen (that was long left...) and the chatlist that is shown on login success.

this pr fixes that by removing a one-second-timeout and also by removing a probably superfluous dismiss (probably similar to the removing at https://github.com/deltachat/deltachat-ios/pull/654/commits/59aafeafafbed7787a30c20236d44ec9026002d9 )

the two account-created-functions handleLoginSuccess() and handleProfileInfoClosed() are exactly the same now, which looks quite correct to me :)