### PR TITLE
set voiceover text on chat avatar

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -274,9 +274,9 @@ class ChatViewController: MessagesViewController {
 
         let badge: InitialsBadge
         if let image = chat.profileImage {
-            badge =  InitialsBadge(image: image, size: 28, accessibilityLabelText: chat.name)
+            badge =  InitialsBadge(image: image, size: 28, accessibilityLabel: String.localized("menu_view_profile"))
         } else {
-            badge =  InitialsBadge(name: chat.name, color: chat.color, size: 28)
+            badge =  InitialsBadge(name: chat.name, color: chat.color, size: 28, accessibilityLabel: String.localized("menu_view_profile"))
             badge.setLabelFont(UIFont.systemFont(ofSize: 14))
         }
         badge.setVerified(chat.isVerified)

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -274,7 +274,7 @@ class ChatViewController: MessagesViewController {
 
         let badge: InitialsBadge
         if let image = chat.profileImage {
-            badge =  InitialsBadge(image: image, size: 28)
+            badge =  InitialsBadge(image: image, size: 28, accessibilityLabelText: chat.name)
         } else {
             badge =  InitialsBadge(name: chat.name, color: chat.color, size: 28)
             badge.setLabelFont(UIFont.systemFont(ofSize: 14))

--- a/deltachat-ios/View/InitialsBadge.swift
+++ b/deltachat-ios/View/InitialsBadge.swift
@@ -31,20 +31,21 @@ class InitialsBadge: UIView {
         return imageViewContainer
     }()
 
-    convenience init(name: String, color: UIColor, size: CGFloat) {
-        self.init(size: size)
+    convenience init(name: String, color: UIColor, size: CGFloat, accessibilityLabel: String? = nil) {
+        self.init(size: size, accessibilityLabel: accessibilityLabel)
         setName(name)
         setColor(color)
     }
 
-    convenience init (image: UIImage, size: CGFloat, accessibilityLabelText: String? = nil) {
-        self.init(size: size)
-        setImage(image, accessibilityLabelText)
+    convenience init (image: UIImage, size: CGFloat, accessibilityLabel: String? = nil) {
+        self.init(size: size, accessibilityLabel: accessibilityLabel)
+        setImage(image)
     }
 
-    init(size: CGFloat) {
+    init(size: CGFloat, accessibilityLabel: String? = nil) {
         self.size = size
         super.init(frame: CGRect(x: 0, y: 0, width: size, height: size))
+        self.accessibilityLabel = accessibilityLabel
         let radius = size / 2
         layer.cornerRadius = radius
         translatesAutoresizingMaskIntoConstraints = false
@@ -83,21 +84,17 @@ class InitialsBadge: UIView {
         label.text = Utils.getInitials(inputName: name)
         label.isHidden = name.isEmpty
         imageView.isHidden = !name.isEmpty
-        accessibilityLabel = "avatar \(name)"
     }
 
     func setLabelFont(_ font: UIFont) {
         label.font = font
     }
 
-    func setImage(_ image: UIImage, _ accessibilityLabelText: String? = nil) {
+    func setImage(_ image: UIImage) {
         self.imageView.image = image
         self.imageView.contentMode = UIView.ContentMode.scaleAspectFill
         self.imageView.isHidden = false
         self.label.isHidden = true
-        if let text = accessibilityLabelText {
-            accessibilityLabel = text
-        }
     }
 
     func showsInitials() -> Bool {

--- a/deltachat-ios/View/InitialsBadge.swift
+++ b/deltachat-ios/View/InitialsBadge.swift
@@ -37,9 +37,9 @@ class InitialsBadge: UIView {
         setColor(color)
     }
 
-    convenience init (image: UIImage, size: CGFloat) {
+    convenience init (image: UIImage, size: CGFloat, accessibilityLabelText: String? = nil) {
         self.init(size: size)
-        setImage(image)
+        setImage(image, accessibilityLabelText)
     }
 
     init(size: CGFloat) {
@@ -90,11 +90,14 @@ class InitialsBadge: UIView {
         label.font = font
     }
 
-    func setImage(_ image: UIImage) {
+    func setImage(_ image: UIImage, _ accessibilityLabelText: String? = nil) {
         self.imageView.image = image
         self.imageView.contentMode = UIView.ContentMode.scaleAspectFill
         self.imageView.isHidden = false
         self.label.isHidden = true
+        if let text = accessibilityLabelText {
+            accessibilityLabel = "avatar \(text)"
+        }
     }
 
     func showsInitials() -> Bool {

--- a/deltachat-ios/View/InitialsBadge.swift
+++ b/deltachat-ios/View/InitialsBadge.swift
@@ -96,7 +96,7 @@ class InitialsBadge: UIView {
         self.imageView.isHidden = false
         self.label.isHidden = true
         if let text = accessibilityLabelText {
-            accessibilityLabel = "avatar \(text)"
+            accessibilityLabel = text
         }
     }
 


### PR DESCRIPTION
fixes #629

There was no accessibilityLabel set when using an image as avatar.
Fixed. The text is pure optional and can be omitted (so it does not affect cell-avatars).