### PR TITLE
clearer error message on login error if no internet connection available

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -22,6 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     var locationManager: LocationManager!
     private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
     var reachability = Reachability()!
+    var hasNetwork = false
     var window: UIWindow?
     var state = ApplicationState.stopped
 
@@ -226,6 +227,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         switch reachability.connection {
         case .wifi, .cellular:
             logger.info("network: reachable", reachability.connection.description)
+            hasNetwork = true
 
             // call dc_maybe_network() from a worker thread.
             // normally, dc_maybe_network() can be called uncoditionally,
@@ -236,6 +238,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             }
         case .none:
             logger.info("network: not reachable")
+            hasNetwork = false
         }
     }
 

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -51,6 +51,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         setStockTranslations()
 
         reachability.whenReachable = { reachability in
+            logger.info("network: reachable", reachability.connection.description)
+
             // call dc_maybe_network() from a worker thread.
             // normally, dc_maybe_network() can be called uncoditionally,
             // however, in fact, it may halt things for some seconds.

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -51,7 +51,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         setStockTranslations()
 
         reachability.whenReachable = { reachability in
-            logger.info("could not start reachability notifier")
             // call dc_maybe_network() from a worker thread.
             // normally, dc_maybe_network() can be called uncoditionally,
             // however, in fact, it may halt things for some seconds.

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -659,7 +659,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             if let ui = notification.userInfo {
                 if ui["error"] as! Bool {
                     var errorMessage = ui["errorMessage"] as? String
-                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate, !appDelegate.hasNetwork {
+                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate, appDelegate.reachability.connection == .none {
                         errorMessage = String.localized("login_error_no_internet_connection")
                     }
                     self.updateProgressAlert(error: errorMessage)

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -658,7 +658,11 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             notification in
             if let ui = notification.userInfo {
                 if ui["error"] as! Bool {
-                    self.updateProgressAlert(error: ui["errorMessage"] as? String)
+                    var errorMessage = ui["errorMessage"] as? String
+                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate, !appDelegate.hasNetwork {
+                        errorMessage = String.localized("login_error_no_internet_connection")
+                    }
+                    self.updateProgressAlert(error: errorMessage)
                 } else if ui["done"] as! Bool {
                     self.updateProgressAlertSuccess(completion: self.handleLoginSuccess)
                 } else {

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -650,3 +650,4 @@
 "import_contacts_message" = "To chat with contacts from your device open Settings and enable Contacts.";
 "stop_sharing_location" = "Stop sharing location";
 "a11y_voice_message_hint_ios" = "After recording double-tap to send. To discard the recording scrub left-right with two fingers.";
+"login_error_no_internet_connection" = "No internet connection, can\'t log in to your server.";

--- a/tools/untranslated.xml
+++ b/tools/untranslated.xml
@@ -6,4 +6,5 @@
     <string name="import_contacts_message">To chat with contacts from your device open Settings and enable Contacts.</string>
     <string name="stop_sharing_location">Stop sharing location</string>
     <string name="a11y_voice_message_hint_ios">After recording double-tap to send. To discard the recording scrub left-right with two fingers.</string>
+    <string name="login_error_no_internet_connection">No internet connection, can\'t log in to your server.</string>
 </resources>


### PR DESCRIPTION
closes #503

it also includes a fix for a potential bug where changing network connectivity is not recognized while the app is in the background leading to a wrong state when reentering the foreground.

The framework we're using has 2 event handling options: using a callback or notifications and I switched to the callback option while fixing the mentioned bug. 

