### PR TITLE
improve accessibility of voice message recording, alternative

### DIFF
--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -150,6 +150,13 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         validateMicrophoneAccess()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .layoutChanged, argument: self.doneButton)
+        }
+     }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -1094,8 +1094,6 @@ extension ChatViewController: MessagesLayoutDelegate {
         let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
         let documentAction = UIAlertAction(title: String.localized("documents"), style: .default, handler: documentActionPressed(_:))
         let voiceMessageAction = UIAlertAction(title: String.localized("voice_message"), style: .default, handler: voiceMessageButtonPressed(_:))
-        voiceMessageAction.accessibilityLabel = String.localized("voice_message")
-        voiceMessageAction.accessibilityHint = String.localized("a11y_voice_message_hint_ios")
         let isLocationStreaming = dcContext.isSendingLocationsToChat(chatId: chatId)
         let locationStreamingAction = UIAlertAction(title: isLocationStreaming ? String.localized("stop_sharing_location") : String.localized("location"),
                                                     style: isLocationStreaming ? .destructive : .default,
@@ -1109,7 +1107,15 @@ extension ChatViewController: MessagesLayoutDelegate {
             alert.addAction(locationStreamingAction)
         }
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
-        self.present(alert, animated: true, completion: nil)
+        self.present(alert, animated: true, completion: {
+            // unfortunately, voiceMessageAction.accessibilityHint does not work,
+            // but this hack does the trick
+            if UIAccessibility.isVoiceOverRunning {
+                if let view = voiceMessageAction.value(forKey: "__representer") as? UIView {
+                    view.accessibilityHint = String.localized("a11y_voice_message_hint_ios")
+                }
+            }
+        })
     }
 
     private func documentActionPressed(_ action: UIAlertAction) {

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -1094,6 +1094,8 @@ extension ChatViewController: MessagesLayoutDelegate {
         let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
         let documentAction = UIAlertAction(title: String.localized("documents"), style: .default, handler: documentActionPressed(_:))
         let voiceMessageAction = UIAlertAction(title: String.localized("voice_message"), style: .default, handler: voiceMessageButtonPressed(_:))
+        voiceMessageAction.accessibilityLabel = String.localized("voice_message")
+        voiceMessageAction.accessibilityHint = String.localized("a11y_voice_message_hint_ios")
         let isLocationStreaming = dcContext.isSendingLocationsToChat(chatId: chatId)
         let locationStreamingAction = UIAlertAction(title: isLocationStreaming ? String.localized("stop_sharing_location") : String.localized("location"),
                                                     style: isLocationStreaming ? .destructive : .default,

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -649,3 +649,4 @@
 "import_contacts" = "Import device contacts";
 "import_contacts_message" = "To chat with contacts from your device open Settings and enable Contacts.";
 "stop_sharing_location" = "Stop sharing location";
+"a11y_voice_message_hint_ios" = "After recording double-tap to send. Or scrub left-right with two fingers to discard the recording.";

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -649,4 +649,4 @@
 "import_contacts" = "Import device contacts";
 "import_contacts_message" = "To chat with contacts from your device open Settings and enable Contacts.";
 "stop_sharing_location" = "Stop sharing location";
-"a11y_voice_message_hint_ios" = "After recording double-tap to send. Or scrub left-right with two fingers to discard the recording.";
+"a11y_voice_message_hint_ios" = "After recording double-tap to send. To discard the recording scrub left-right with two fingers.";

--- a/tools/untranslated.xml
+++ b/tools/untranslated.xml
@@ -5,5 +5,5 @@
     <string name="import_contacts">Import device contacts</string>
     <string name="import_contacts_message">To chat with contacts from your device open Settings and enable Contacts.</string>
     <string name="stop_sharing_location">Stop sharing location</string>
-    <string name="a11y_voice_message_hint_ios">After recording double-tap to send. Or scrub left-right with two fingers to discard the recording.</string>
+    <string name="a11y_voice_message_hint_ios">After recording double-tap to send. To discard the recording scrub left-right with two fingers.</string>
 </resources>

--- a/tools/untranslated.xml
+++ b/tools/untranslated.xml
@@ -5,4 +5,5 @@
     <string name="import_contacts">Import device contacts</string>
     <string name="import_contacts_message">To chat with contacts from your device open Settings and enable Contacts.</string>
     <string name="stop_sharing_location">Stop sharing location</string>
+    <string name="a11y_voice_message_hint_ios">After recording double-tap to send. Or scrub left-right with two fingers to discard the recording.</string>
 </resources>


### PR DESCRIPTION
fixes #493 

this is my suggestion from https://github.com/deltachat/deltachat-ios/pull/673#pullrequestreview-406569343

~~unfortunately, the `accessibilityHint` seems not to work for buttons in UIAlertController - i cannot really believe this, maybe i did sth. wrong?~~ EDIT: i found a solution

btw: i found the cancel-gesture at https://www.interactiveaccessibility.com/education/training/downloads/iOS-Cheatsheet.pdf  