### PR TITLE
bugfix ios 12 - deallocation bug 

### DIFF
--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -43,6 +43,16 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        if #available(iOS 13, *) {}
+        else {
+            /*
+             for pre-iOS 13 versions there was an issue that welcomeView was not deallocated after login - reason unknown
+             */
+            welcomeView.removeFromSuperview()
+        }
+    }
+
     // MARK: - lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
fixes #686 

This bug **only happened for iOS12** or older devices. 

I realised that after logging in  manually via `WelcomeController` the `AccountSetupController`  was still behind or UIWindow, which is really strange. 
The first thing I did, I made the `AccountSetupController`-instance **optional** in `AppCoordinator`, and made sure it was set to nil after the user logged in.

Then things became even more weird:
Instead of the `AccountSetupController` there was now the `WelcomeContentView` behind `UIWindow`. `WelcomeViewController` was clearly deallocated, and there is no object in our code, that actually references `WelcomeContentView` except for `WelcomeViewController`. The fact that `WelcomeViewController` was clearly de-allocating implies also that there is no retain cycle.
Also on iOS13 this issue did not exist at all.

The solution now I found that worked:
I explicitly remove `WelcomeContentView` from superview during `WelcomeController.deinit` (on iOS 12).

To test:
To reproduce the issue **on Master**:
- use a simulator with iOS 12. Make sure delta chat is not installed. (Delete every time between tests). 
- on WelcomeScreen -> Login to your Server -> Login with credentials -> After redirect to TabBar -> Go to Qr-tab -> select Scan QR-Code -> You see AccountSetupController shine through


