### PR TITLE
lowered constraint priority to solve breaking conflict

### DIFF
--- a/deltachat-ios/View/Cell/ProfileCell.swift
+++ b/deltachat-ios/View/Cell/ProfileCell.swift
@@ -24,7 +24,9 @@ class ProfileCell: UITableViewCell {
         detailView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 0).isActive = true
         detailView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: 0).isActive = true
         detailView.trailingAnchor.constraint(equalTo: accessoryView?.trailingAnchor ?? contentView.trailingAnchor, constant: 0).isActive = true
-        detailView.heightAnchor.constraint(equalToConstant: ContactDetailHeader.headerHeight).isActive = true
+        let heightConstraint = detailView.heightAnchor.constraint(equalToConstant: ContactDetailHeader.headerHeight)
+        heightConstraint.priority = .defaultLow
+        heightConstraint.isActive = true
     }
 
     func update(contact: DcContact, displayName: String?, address: String?) {


### PR DESCRIPTION
fixes #662 

I don't know what exactly was causing this, but I could fix it by lowering the constraint's priority that was breaking. 

To reproduce:
launch App -> go to Settings-Tab -> in XCode Console you will see a message about nslayoutconstraint-conflicts (you will see it in the issue description).

With this PR this message should be gone.
