### PR TITLE
streamline creation of ViewControllers

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -641,8 +641,7 @@ class ChatViewController: MessagesViewController {
         switch chat.chatType {
         case .SINGLE:
             if let contactId = chat.contactIds.first {
-                let viewModel = ContactDetailViewModel(contactId: contactId, chatId: chatId, context: dcContext)
-                let contactDetailController = ContactDetailViewController(viewModel: viewModel)
+                let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId, chatId: chatId)
                 navigationController?.pushViewController(contactDetailController, animated: true)
             }
         case .GROUP, .VERIFIEDGROUP:
@@ -652,8 +651,7 @@ class ChatViewController: MessagesViewController {
     }
 
     private func showContactDetail(of contactId: Int, in chatOfType: ChatType, chatId: Int?) {
-        let viewModel = ContactDetailViewModel(contactId: contactId, chatId: chatId, context: dcContext )
-        let contactDetailController = ContactDetailViewController(viewModel: viewModel)
+        let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId, chatId: chatId)
         navigationController?.pushViewController(contactDetailController, animated: true)
     }
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -3,7 +3,7 @@ import DcCore
 
 // this is also used as ChatDetail for SingleChats
 class ContactDetailViewController: UITableViewController {
-    private let viewModel: ContactDetailViewModelProtocol
+    private let viewModel: ContactDetailViewModel
 
     private lazy var headerCell: ContactDetailHeader = {
         let cell = ContactDetailHeader()
@@ -64,8 +64,8 @@ class ContactDetailViewController: UITableViewController {
     }()
 
 
-    init(viewModel: ContactDetailViewModelProtocol) {
-        self.viewModel = viewModel
+    init(dcContext: DcContext, contactId: Int, chatId: Int?) {
+        self.viewModel = ContactDetailViewModel(contactId: contactId, chatId: chatId, context: dcContext)
         super.init(style: .grouped)
     }
 

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -211,8 +211,7 @@ class GroupChatDetailViewController: UIViewController {
     }
 
     private func showContactDetail(of contactId: Int) {
-        let viewModel = ContactDetailViewModel(contactId: contactId, chatId: nil, context: dcContext)
-        let contactDetailController = ContactDetailViewController(viewModel: viewModel)
+        let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId, chatId: nil)
         navigationController?.pushViewController(contactDetailController, animated: true)
     }
 

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -352,8 +352,7 @@ class NewChatViewController: UITableViewController {
     }
 
     private func showContactDetail(contactId: Int) {
-        let viewModel = ContactDetailViewModel(contactId: contactId, chatId: nil, context: dcContext)
-        let contactDetailController = ContactDetailViewController(viewModel: viewModel)
+        let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId, chatId: nil)
         navigationController?.pushViewController(contactDetailController, animated: true)
     }
 }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -1,24 +1,7 @@
 import UIKit
 import DcCore
 
-protocol ContactDetailViewModelProtocol {
-    var context: DcContext { get }
-    var contactId: Int { get }
-    var chatId: Int? { get }
-    var contact: DcContact { get }
-    var numberOfSections: Int { get }
-    var chatIsArchived: Bool { get }
-    func numberOfRowsInSection(_ : Int) -> Int
-    func typeFor(section: Int) -> ContactDetailViewModel.ProfileSections
-    func chatActionFor(row: Int) -> ContactDetailViewModel.ChatAction
-    func attachmentActionFor(row: Int) -> ContactDetailViewModel.AttachmentAction
-    func update(sharedChatCell: ContactCell, row index: Int)
-    func getSharedChatIdAt(indexPath: IndexPath) -> Int
-    func titleFor(section: Int) -> String?
-    func toggleArchiveChat() -> Bool // returns true if chat is archived after action
-}
-
-class ContactDetailViewModel: ContactDetailViewModelProtocol {
+class ContactDetailViewModel {
 
     let context: DcContext
 
@@ -129,6 +112,7 @@ class ContactDetailViewModel: ContactDetailViewModelProtocol {
         return nil
     }
 
+    // returns true if chat is archived after action
     func toggleArchiveChat() -> Bool {
         guard let chatId = chatId else {
             safe_fatalError("there is no chatId - you are probably are calling this from ContactDetail - this should be only called from ChatDetail")


### PR DESCRIPTION
most ViewControllers just take the chatId or the contactId in their constructor, the ContactDetailViewController was an exception here.

this pr streamlines this and hides the ViewModel from the ContactDetailViewController user.

if needed, we can change that, but this is not foreseeable, so we should just go the simple way.

(came over that when trying to fix/hide/disable the gallery/document links when there is no chat for a contact https://github.com/deltachat/deltachat-ios/issues/706)