### PR TITLE
disable gallery/document links for profiles without a chat

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -641,7 +641,7 @@ class ChatViewController: MessagesViewController {
         switch chat.chatType {
         case .SINGLE:
             if let contactId = chat.contactIds.first {
-                let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId, chatId: chatId)
+                let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId)
                 navigationController?.pushViewController(contactDetailController, animated: true)
             }
         case .GROUP, .VERIFIEDGROUP:
@@ -651,7 +651,7 @@ class ChatViewController: MessagesViewController {
     }
 
     private func showContactDetail(of contactId: Int, in chatOfType: ChatType, chatId: Int?) {
-        let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId, chatId: chatId)
+        let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId)
         navigationController?.pushViewController(contactDetailController, animated: true)
     }
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -53,6 +53,10 @@ class ContactDetailViewController: UITableViewController {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.textLabel?.text = String.localized("gallery")
         cell.accessoryType = .disclosureIndicator
+        if viewModel.chatId == nil {
+            cell.isUserInteractionEnabled = false
+            cell.textLabel?.isEnabled = false
+        }
         return cell
     }()
 
@@ -60,12 +64,16 @@ class ContactDetailViewController: UITableViewController {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.textLabel?.text = String.localized("documents")
         cell.accessoryType = .disclosureIndicator
+        if viewModel.chatId == nil {
+            cell.isUserInteractionEnabled = false
+            cell.textLabel?.isEnabled = false
+        }
         return cell
     }()
 
 
-    init(dcContext: DcContext, contactId: Int, chatId: Int?) {
-        self.viewModel = ContactDetailViewModel(contactId: contactId, chatId: chatId, context: dcContext)
+    init(dcContext: DcContext, contactId: Int) {
+        self.viewModel = ContactDetailViewModel(dcContext: dcContext, contactId: contactId)
         super.init(style: .grouped)
     }
 
@@ -297,7 +305,7 @@ class ContactDetailViewController: UITableViewController {
     }
 
     private func presentPreview(for messageType: Int32, messageType2: Int32, messageType3: Int32) {
-        guard let chatId = viewModel.chatId ?? viewModel.context.getChatIdByContactId(viewModel.contactId) else { return }
+        guard let chatId = viewModel.chatId else { return }
         let messageIds = viewModel.context.getChatMedia(chatId: chatId, messageType: messageType, messageType2: messageType2, messageType3: messageType3)
         var mediaUrls: [URL] = []
         for messageId in messageIds {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -211,7 +211,7 @@ class GroupChatDetailViewController: UIViewController {
     }
 
     private func showContactDetail(of contactId: Int) {
-        let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId, chatId: nil)
+        let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId)
         navigationController?.pushViewController(contactDetailController, animated: true)
     }
 

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -352,7 +352,7 @@ class NewChatViewController: UITableViewController {
     }
 
     private func showContactDetail(contactId: Int) {
-        let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId, chatId: nil)
+        let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId)
         navigationController?.pushViewController(contactDetailController, animated: true)
     }
 }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -35,11 +35,10 @@ class ContactDetailViewModel {
     private var chatActions: [ChatAction] = [] // chatDetail: archive, block, delete - else: block
     private var attachmentActions: [AttachmentAction] = [.gallery, .documents]
 
-    /// if chatId is nil this is a contact detail with 'start chat'-option
-    init(contactId: Int, chatId: Int?, context: DcContext) {
-        self.context = context
+    init(dcContext: DcContext, contactId: Int) {
+        self.context = dcContext
         self.contactId = contactId
-        self.chatId = chatId
+        self.chatId = dcContext.getChatIdByContactId(contactId)
         self.sharedChats = context.getChatlist(flags: 0, queryString: nil, queryId: contactId)
 
         sections.append(.attachments)
@@ -70,7 +69,6 @@ class ContactDetailViewModel {
 
     var chatIsArchived: Bool {
         guard let chatId = chatId else {
-           // safe_fatalError("This is a ContactDetail view with no chat id")
             return false
         }
         return context.getChat(chatId: chatId).isArchived
@@ -91,7 +89,6 @@ class ContactDetailViewModel {
 
     func getSharedChatIdAt(indexPath: IndexPath) -> Int {
         let index = indexPath.row
-        // assert(sections[indexPath.section] == .sharedChats)
         return sharedChats.getChatId(index: index)
     }
 


### PR DESCRIPTION
this pr disables the gallery/document links for profiles without a chat (they can be opened from new chat -> swipe contact without a chat -> info)

already in the past, the gallery was only opened for context.getChatIdByContactId(), not for the given chatId, this pr always sets the used chatId to context.getChatIdByContactId() - and makes the chatId for the ContactDetailsViewController superfluous (the chat-details shown along with the contact always belong to the one-to-one-chat by nature, never to some group)

fixes #706