### PR TITLE
avoid direct calls to NSLocalizedString()

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -258,7 +258,7 @@ class ChatViewController: MessagesViewController {
         var subtitle = "ErrSubtitle"
         let chatContactIds = chat.contactIds
         if chat.isGroup {
-            subtitle = String.localizedStringWithFormat(NSLocalizedString("n_members", comment: ""), chatContactIds.count)
+            subtitle = String.localized(stringID: "n_members", count: chatContactIds.count)
         } else if chatContactIds.count >= 1 {
             if chat.isDeviceTalk {
                 subtitle = String.localized("device_talk_subtitle")

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -81,7 +81,7 @@ class ProfileInfoViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         let email = dcContext.addr ?? ""
         let footerTitle = String.localizedStringWithFormat(
-            NSLocalizedString("qraccount_success_enter_name", comment: ""), email
+            String.localized("qraccount_success_enter_name"), email
         )
         return footerTitle
     }

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -143,7 +143,7 @@ extension WelcomeViewController: QrCodeReaderDelegate {
     }
 
     private func confirmAccountCreationAlert(accountDomain domain: String, qrCode: String) {
-        let title = String.localizedStringWithFormat(NSLocalizedString("qraccount_ask_create_and_login", comment: ""), domain)
+        let title = String.localizedStringWithFormat(String.localized("qraccount_ask_create_and_login"), domain)
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
 
         let okAction = UIAlertAction(

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -129,7 +129,7 @@ class ChatListViewModel: NSObject, ChatListViewModelProtocol {
             case .messages:
                 title = "n_messages"
             }
-            return String.localizedStringWithFormat(NSLocalizedString(title, comment: ""), numberOfRowsIn(section: section))
+            return String.localized(stringID: title, count: numberOfRowsIn(section: section))
         }
         return nil
     }


### PR DESCRIPTION
instead of calling NSLocalizedString(), we should use String.localize() that falls back to english when a string is missing. 

this pr fixes that for a few calls, the vast majority of calls was already fine :)