### PR TITLE
Fix retain cycles in ChatList and NewGroupController

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -82,22 +82,22 @@ class ChatListController: UITableViewController {
         msgChangedObserver = nc.addObserver(
             forName: dcNotificationChanged,
             object: nil,
-            queue: nil) { _ in
-                self.viewModel.refreshData()
+            queue: nil) { [weak self] _ in
+                self?.viewModel.refreshData()
 
         }
         incomingMsgObserver = nc.addObserver(
             forName: dcNotificationIncoming,
             object: nil,
-            queue: nil) { _ in
-                self.viewModel.refreshData()
+            queue: nil) { [weak self] _ in
+                self?.viewModel.refreshData()
         }
         viewChatObserver = nc.addObserver(
             forName: dcNotificationViewChat,
             object: nil,
-            queue: nil) { notification in
+            queue: nil) { [weak self] notification in
                 if let chatId = notification.userInfo?["chat_id"] as? Int {
-                    self.showChat(chatId: chatId)
+                    self?.showChat(chatId: chatId)
                 }
         }
     }

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -159,7 +159,8 @@ class ChatViewController: MessagesViewController {
             forName: dcNotificationChanged,
             object: nil,
             queue: OperationQueue.main
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             if let ui = notification.userInfo {
                 if self.disableWriting {
                     // always refresh, as we can't check currently

--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -109,7 +109,8 @@ class AddGroupMembersViewController: GroupMembersViewController {
             forName: dcNotificationContactChanged,
             object: nil,
             queue: nil
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             if let ui = notification.userInfo {
                 if let contactId = ui["contact_id"] as? Int {
                     if contactId == 0 {

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -96,7 +96,8 @@ class NewChatViewController: UITableViewController {
             forName: dcNotificationSecureJoinerProgress,
             object: nil,
             queue: nil
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             if let ui = notification.userInfo {
                 if ui["error"] as? Bool ?? false {
                     self.hud?.error(ui["errorMessage"] as? String)

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -74,7 +74,8 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
             forName: dcNotificationChatModified,
             object: nil,
             queue: nil
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             if let ui = notification.userInfo {
                 if let chatId = ui["chat_id"] as? Int {
                     if self.groupChatId == 0 || chatId != self.groupChatId {
@@ -90,7 +91,8 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
             forName: dcNotificationChanged,
             object: nil,
             queue: nil
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             if let ui = notification.userInfo {
                 if let chatId = ui["chat_id"] as? Int {
                     if self.groupChatId == 0 || chatId != self.groupChatId {

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -239,7 +239,8 @@ extension QrPageController: QrCodeReaderDelegate {
             forName: dcNotificationSecureJoinerProgress,
             object: nil,
             queue: nil
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             if let ui = notification.userInfo,
                 ui["progress"] as? Int == 400,
                 let contactId = ui["contact_id"] as? Int {

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -239,7 +239,8 @@ internal final class SettingsViewController: UITableViewController {
             forName: dcNotificationImexProgress,
             object: nil,
             queue: nil
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             if let ui = notification.userInfo {
                 if ui["error"] as? Bool ?? false {
                     self.hudHandler.setHudError(ui["errorMessage"] as? String)
@@ -254,7 +255,8 @@ internal final class SettingsViewController: UITableViewController {
             forName: dcNotificationConfigureProgress,
             object: nil,
             queue: nil
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             if let ui = notification.userInfo {
                 if ui["error"] as? Bool ?? false {
                     self.hudHandler.setHudError(ui["errorMessage"] as? String)

--- a/deltachat-ios/Handler/ProgressAlertHandler.swift
+++ b/deltachat-ios/Handler/ProgressAlertHandler.swift
@@ -64,7 +64,8 @@ extension ProgressAlertHandler {
             forName: dcNotificationConfigureProgress,
             object: nil,
             queue: nil
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             if let ui = notification.userInfo {
                 if ui["error"] as? Bool ?? false {
                     self.updateProgressAlert(error: ui["errorMessage"] as? String)


### PR DESCRIPTION
fixes #699 

We're adding/removing notification observers in most of our viewControllers. I realised the way we're adding these, we're creating a retain cycle.

Fixed this by declaring `weak self`.