### PR TITLE
Tweak share extension

### DIFF
--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -91,7 +91,6 @@ class ShareViewController: SLComposeServiceViewController {
             target: self,
             action: #selector(appendPostTapped))
         item.rightBarButtonItem? = button
-        item.titleView = UIImageView(image: UIImage(named: "ic_chat")?.scaleDownImage(toMax: 26))
     }
 
     /// Invoked when the user wants to post.

--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -54,6 +54,7 @@ class ShareViewController: SLComposeServiceViewController {
                 }
             }
         }
+        placeholder = String.localized("chat_input_placeholder")
 
         DispatchQueue.global(qos: .background).async {
             self.shareAttachment = ShareAttachment(dcContext: self.dcContext, inputItems: self.extensionContext?.inputItems, delegate: self)


### PR DESCRIPTION
related to #722 
* only removes the title icon and adds a placeholder

* the little space above the half-transparent background is part if the presentation mode which cannot be tweaked (at least by me) without replacing the whole default UIViewController. Telegram shows the same gap there. 

![gap](https://user-images.githubusercontent.com/2614900/82225509-991ee580-9925-11ea-9b47-a82b0b7b9528.png)

* I think implementing a custom view controller is the way to go for further improvement, also wrt the jumping window. It is not caused by the implemented workaround, removing almost all of our code still leads to the jumping behavior. 
