### PR TITLE
Bugfix - qr reader no longer induces crashes on simulators

### DIFF
--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -13,13 +13,6 @@ class QrCodeReaderController: UIViewController {
         return videoPreviewLayer
     }()
 
-    private lazy var cameraAccessButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("Settings", for: .normal)
-        button.addTarget(self, action: #selector(cameraAccessButtonPressed(_:)), for: .touchUpInside)
-        return button
-    }()
-
     private var infoLabel: UILabel = {
         let label = UILabel()
            label.translatesAutoresizingMaskIntoConstraints = false

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -68,7 +68,7 @@ class QrCodeReaderController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        
+        startSession()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -82,7 +82,7 @@ class QrCodeReaderController: UIViewController {
     }
 
     override func viewWillDisappear(_ animated: Bool) {
-        captureSession.stopRunning()
+        stopSession()
     }
 
     // MARK: - setup
@@ -128,8 +128,12 @@ class QrCodeReaderController: UIViewController {
 
     // MARK: - actions
     func startSession() {
+        #if targetEnvironment(simulator)
+        // ignore if run from simulator
+        #else
         captureSession.startRunning()
-    }
+        #endif
+        }
 
     func stopSession() {
         captureSession.stopRunning()

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -15,13 +15,13 @@ class QrCodeReaderController: UIViewController {
 
     private var infoLabel: UILabel = {
         let label = UILabel()
-           label.translatesAutoresizingMaskIntoConstraints = false
-           label.text = String.localized("qrscan_hint")
-           label.lineBreakMode = .byWordWrapping
-           label.numberOfLines = 0
-           label.textAlignment = .center
-           label.textColor = .white
-           return label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = String.localized("qrscan_hint")
+        label.lineBreakMode = .byWordWrapping
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.textColor = .white
+        return label
     }()
 
     private let supportedCodeTypes = [
@@ -117,14 +117,10 @@ class QrCodeReaderController: UIViewController {
         #else
         captureSession.startRunning()
         #endif
-        }
+    }
 
     func stopSession() {
         captureSession.stopRunning()
-    }
-
-    @objc private func cameraAccessButtonPressed(_ sender: UIButton) {
-        print("Camera button pressed")
     }
 }
 

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -90,22 +90,14 @@ class QrCodeReaderController: UIViewController {
         view.bringSubviewToFront(infoLabel)
     }
 
-    private func handleCameraAutorizationState() {
-        if AVCaptureDevice.authorizationStatus(for: AVMediaType.video) == .authorized {
-            captureSession.startRunning()
-        }
-    }
-
     private func updateVideoOrientation() {
 
         guard let connection = videoPreviewLayer.connection else {
             return
         }
-
         guard connection.isVideoOrientationSupported else {
             return
         }
-
         let statusBarOrientation = UIApplication.shared.statusBarOrientation
         let videoOrientation: AVCaptureVideoOrientation =  statusBarOrientation.videoOrientation ?? .portrait
 
@@ -113,7 +105,6 @@ class QrCodeReaderController: UIViewController {
             print("no change to videoOrientation")
             return
         }
-
         videoPreviewLayer.frame = view.bounds
         connection.videoOrientation = videoOrientation
         videoPreviewLayer.removeAllAnimations()

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -13,6 +13,13 @@ class QrCodeReaderController: UIViewController {
         return videoPreviewLayer
     }()
 
+    private lazy var cameraAccessButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("Settings", for: .normal)
+        button.addTarget(self, action: #selector(cameraAccessButtonPressed(_:)), for: .touchUpInside)
+        return button
+    }()
+
     private var infoLabel: UILabel = {
         let label = UILabel()
            label.translatesAutoresizingMaskIntoConstraints = false
@@ -61,10 +68,10 @@ class QrCodeReaderController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        captureSession.startRunning()
+        
     }
 
-  override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
         coordinator.animate(alongsideTransition: nil, completion: { [weak self] _ in
@@ -88,6 +95,12 @@ class QrCodeReaderController: UIViewController {
         infoLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         infoLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -10).isActive = true
         view.bringSubviewToFront(infoLabel)
+    }
+
+    private func handleCameraAutorizationState() {
+        if AVCaptureDevice.authorizationStatus(for: AVMediaType.video) == .authorized {
+            captureSession.startRunning()
+        }
     }
 
     private func updateVideoOrientation() {
@@ -120,6 +133,10 @@ class QrCodeReaderController: UIViewController {
 
     func stopSession() {
         captureSession.stopRunning()
+    }
+
+    @objc private func cameraAccessButtonPressed(_ sender: UIButton) {
+        print("Camera button pressed")
     }
 }
 


### PR DESCRIPTION
fixes #688 

Easiest solution was just to not start the video capture session on simulators. 