### PR TITLE
setup DBDebugToolkit on startup

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -4,6 +4,7 @@ import SwiftyBeaver
 import UIKit
 import UserNotifications
 import DcCore
+import DBDebugToolkit
 
 let logger = SwiftyBeaver.self
 
@@ -27,6 +28,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     var appIsInForeground = false
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        DBDebugToolkit.setup(with: []) // empty array will override default device shake trigger
+
         // main()
         let console = ConsoleDestination()
         logger.addDestination(console)

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -437,8 +437,7 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
     }
 
     private func showDebugToolkit() {
-        DBDebugToolkit.setup(with: [])  // emtpy array will override default device shake trigger
-        DBDebugToolkit.setupCrashReporting()
+        DBDebugToolkit.setupCrashReporting() // as this might cause issues on its own, we add this handler only on opening the debugToolkit the first time
         let info: [DBCustomVariable] = dcContext.getInfo().map { kv in
             let value = kv.count > 1 ? kv[1] : ""
             return DBCustomVariable(name: kv[0], value: value)


### PR DESCRIPTION
currently, the log shown at "Settings / Advanced Log" is started only at the moment, the log is opened the first time.

this pr starts log collecting from startup, however, still without adding some handlers as shake or tripple-tap.


this partly reverts https://github.com/deltachat/deltachat-ios/pull/634