### PR TITLE
streamline getChatIdByContactId()

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -66,7 +66,12 @@ public class DcContext {
         return DcChat(chatPointer: chatPointer)
     }
 
-    public func getChatIdByContactId(_ contactId: Int) -> Int? {
+    public func getChatIdByContactId(contactId: Int) -> Int {
+        return Int(dc_get_chat_id_by_contact_id(contextPointer, UInt32(contactId)))
+    }
+
+    public func getChatIdByContactIdOld(_ contactId: Int) -> Int? {
+        // deprecated function, use getChatIdByContactId() and check for != 0 as for all other places IDs are used
         let chatId = dc_get_chat_id_by_contact_id(contextPointer, UInt32(contactId))
         if chatId == 0 {
             return nil
@@ -102,10 +107,6 @@ public class DcContext {
     @discardableResult
     public func createChatByContactId(contactId: Int) -> Int {
         return Int(dc_create_chat_by_contact_id(contextPointer, UInt32(contactId)))
-    }
-
-    public func getChatIdByContactId(contactId: Int) -> Int {
-        return Int(dc_get_chat_id_by_contact_id(contextPointer, UInt32(contactId)))
     }
 
     public func createGroupChat(verified: Bool, name: String) -> Int {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -316,7 +316,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             let contactId: Int = getGroupMemberIdFor(row)
             let cellData = ContactCellData(
                 contactId: contactId,
-                chatId: dcContext.getChatIdByContactId(contactId)
+                chatId: dcContext.getChatIdByContactIdOld(contactId)
             )
             let cellViewModel = ContactCellViewModel(contactData: cellData)
             contactCell.updateCell(cellViewModel: cellViewModel)

--- a/deltachat-ios/ViewModel/ContactCellViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactCellViewModel.swift
@@ -107,7 +107,7 @@ extension ContactCellViewModel {
         let contact = DcContact(id: contactId)
         let nameIndexes = contact.displayName.containsExact(subSequence: searchText)
         let emailIndexes = contact.email.containsExact(subSequence: searchText)
-        let chatId: Int? = dcContext.getChatIdByContactId(contactId)
+        let chatId: Int? = dcContext.getChatIdByContactIdOld(contactId)
             // contact contains searchText
         let viewModel = ContactCellViewModel(
             contactData: ContactCellData(

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -38,7 +38,7 @@ class ContactDetailViewModel {
     init(dcContext: DcContext, contactId: Int) {
         self.context = dcContext
         self.contactId = contactId
-        self.chatId = dcContext.getChatIdByContactId(contactId)
+        self.chatId = dcContext.getChatIdByContactIdOld(contactId)
         self.sharedChats = context.getChatlist(flags: 0, queryString: nil, queryId: contactId)
 
         sections.append(.attachments)


### PR DESCRIPTION
there were two getChatIdByContactId() functions,
probably by accident as they were at differed places in the code.

this pr marks the one returning an optional as being deprecated
and brings in-line with the rest of the wrapper and the ffi,
where we do not use options for integer-ids (0 equals "none" instead)