### PR TITLE
fix app delegate

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -28,10 +28,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     var appIsInForeground = false
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // explicitly ignore SIGPIPE to avoid crashes, see https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/CommonPitfalls/CommonPitfalls.html
+        // setupCrashReporting() may create an additional handler, but we do not want to rely on that
+        signal(SIGPIPE, SIG_IGN)
+
         DBDebugToolkit.setup(with: []) // empty array will override default device shake trigger
         DBDebugToolkit.setupCrashReporting()
 
-        // main()
         let console = ConsoleDestination()
         logger.addDestination(console)
         dcContext.logger = DcLogger()

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -29,6 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         DBDebugToolkit.setup(with: []) // empty array will override default device shake trigger
+        DBDebugToolkit.setupCrashReporting()
 
         // main()
         let console = ConsoleDestination()

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -8,13 +8,6 @@ import DBDebugToolkit
 
 let logger = SwiftyBeaver.self
 
-enum ApplicationState {
-    case stopped
-    case running
-    case background
-    case backgroundFetch
-}
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     private let dcContext = DcContext.shared
@@ -24,7 +17,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
     var reachability = Reachability()!
     var window: UIWindow?
-    var state = ApplicationState.stopped
     var appIsInForeground = false
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
@@ -158,7 +150,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     func closeDatabase() {
-        state = .stopped
         dcContext.closeDatabase()
     }
 
@@ -213,17 +204,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func startThreads() {
         logger.info("---- start ----")
-
-        if state == .running {
-            return
-        }
-        state = .running
-
         dcContext.maybeStartIo()
     }
 
     func stopThreads() {
-        state = .background
         dcContext.stopIo()
     }
 

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -437,7 +437,6 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
     }
 
     private func showDebugToolkit() {
-        DBDebugToolkit.setupCrashReporting() // as this might cause issues on its own, we add this handler only on opening the debugToolkit the first time
         let info: [DBCustomVariable] = dcContext.getInfo().map { kv in
             let value = kv.count > 1 ? kv[1] : ""
             return DBCustomVariable(name: kv[0], value: value)


### PR DESCRIPTION
this pr calls `maybeStartIo()` without checking ApplicationState and removes the now unused application-quad-state completely; it was already replaced by `appIsInForeground` in #740 

moreover, according to [[1]](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/CommonPitfalls/CommonPitfalls.html), `SIGPIPE` exception is ignored unconditionally, afaik in the past it was ignored as a side-effect of `DBDebugToolkit.setupCrashReporting()`, not sure, though.

finally `DBDebugToolkit.setupCrashReporting()` is called on startup, not sure if and which problems this can/could cause, however, at least for the next testflight, this is seems to make some sense :)
