### PR TITLE
trigger maybeNetwork() on getting to foreground

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -53,14 +53,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         reachability.whenReachable = { reachability in
             logger.info("network: reachable", reachability.connection.description)
-
-            // call dc_maybe_network() from a worker thread.
-            // normally, dc_maybe_network() can be called uncoditionally,
-            // however, in fact, it may halt things for some seconds.
-            // this pr is a workaround that make things usable for now.
-            DispatchQueue.global(qos: .background).async {
-               self.dcContext.maybeNetwork()
-           }
+            self.dcContext.maybeNetwork()
         }
 
         reachability.whenUnreachable = { _ in
@@ -110,6 +103,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.info("---- foreground ----")
         appIsInForeground = true
         startThreads()
+
+        if reachability.connection != .none {
+            self.dcContext.maybeNetwork()
+        }
     }
 
     func applicationDidEnterBackground(_: UIApplication) {


### PR DESCRIPTION
if there is some network available when the apps comes to foreground,
call maybeNetwork() to re-schedule jobs and to connect if connection
reconnected while being in background.