### PR TITLE
add last chats to share suggestions

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -408,7 +408,6 @@ public class DcContext {
 
     public func sendLocationsToChat(chatId: Int, seconds: Int) {
         dc_send_locations_to_chat(contextPointer, UInt32(chatId), Int32(seconds))
-        //TODO: discuss if we want to omit the message intent donation here here
     }
 
     public func setLocation(latitude: Double, longitude: Double, accuracy: Double) {

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -93,7 +93,6 @@ public class DcContext {
 
     public func sendMsgSync(chatId: Int, msg: DcMsg) {
         dc_send_msg_sync(contextPointer, UInt32(chatId), msg.messagePointer)
-        DcUtils.donateSendMessageIntent(chatId: chatId)
     }
 
     public func getChatMedia(chatId: Int, messageType: Int32, messageType2: Int32, messageType3: Int32) -> [Int] {
@@ -270,12 +269,10 @@ public class DcContext {
 
     public func forwardMessage(with msgId: Int, to chat: Int) {
         dc_forward_msgs(contextPointer, [UInt32(msgId)], 1, UInt32(chat))
-        DcUtils.donateSendMessageIntent(chatId: chat)
     }
 
     public func sendTextInChat(id: Int, message: String) {
         dc_send_text_msg(contextPointer, UInt32(id), message)
-        DcUtils.donateSendMessageIntent(chatId: id)
     }
 
     public func initiateKeyTransfer() -> String? {
@@ -1018,7 +1015,6 @@ public class DcMsg {
 
     public func sendInChat(id: Int) {
         dc_send_msg(DcContext.shared.contextPointer, UInt32(id), messagePointer)
-        DcUtils.donateSendMessageIntent(chatId: chatId)
     }
 
     public func previousMediaURLs() -> [URL] {

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -586,13 +586,6 @@ public class DcContext {
     }
 }
 
-
-
-
-
-
-
-
 public class DcEventEmitter {
     private var eventEmitterPointer: OpaquePointer?
 

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -93,6 +93,7 @@ public class DcContext {
 
     public func sendMsgSync(chatId: Int, msg: DcMsg) {
         dc_send_msg_sync(contextPointer, UInt32(chatId), msg.messagePointer)
+        DcUtils.donateSendMessageIntent(chatId: chatId)
     }
 
     public func getChatMedia(chatId: Int, messageType: Int32, messageType2: Int32, messageType3: Int32) -> [Int] {
@@ -269,10 +270,12 @@ public class DcContext {
 
     public func forwardMessage(with msgId: Int, to chat: Int) {
         dc_forward_msgs(contextPointer, [UInt32(msgId)], 1, UInt32(chat))
+        DcUtils.donateSendMessageIntent(chatId: chat)
     }
 
     public func sendTextInChat(id: Int, message: String) {
         dc_send_text_msg(contextPointer, UInt32(id), message)
+        DcUtils.donateSendMessageIntent(chatId: id)
     }
 
     public func initiateKeyTransfer() -> String? {
@@ -408,6 +411,7 @@ public class DcContext {
 
     public func sendLocationsToChat(chatId: Int, seconds: Int) {
         dc_send_locations_to_chat(contextPointer, UInt32(chatId), Int32(seconds))
+        //TODO: discuss if we want to omit the message intent donation here here
     }
 
     public func setLocation(latitude: Double, longitude: Double, accuracy: Double) {
@@ -581,6 +585,13 @@ public class DcContext {
         return getConfigBool("configured")
     }
 }
+
+
+
+
+
+
+
 
 public class DcEventEmitter {
     private var eventEmitterPointer: OpaquePointer?
@@ -1014,6 +1025,7 @@ public class DcMsg {
 
     public func sendInChat(id: Int) {
         dc_send_msg(DcContext.shared.contextPointer, UInt32(id), messagePointer)
+        DcUtils.donateSendMessageIntent(chatId: chatId)
     }
 
     public func previousMediaURLs() -> [URL] {

--- a/DcCore/DcCore/Helper/DcUtils.swift
+++ b/DcCore/DcCore/Helper/DcUtils.swift
@@ -23,8 +23,8 @@ public struct DcUtils {
                                                         content: nil,
                                                         speakableGroupName: groupName,
                                                         conversationIdentifier: "\(chat.id)",
-                serviceName: nil,
-                sender: nil)
+                                                        serviceName: nil,
+                                                        sender: nil)
 
             // Add the user's avatar to the intent.
             if let imageData = chat.profileImage?.pngData() {

--- a/DcCore/DcCore/Helper/DcUtils.swift
+++ b/DcCore/DcCore/Helper/DcUtils.swift
@@ -15,35 +15,31 @@ public struct DcUtils {
     }
 
     public static func donateSendMessageIntent(chatId: Int) {
-       let chat = DcContext.shared.getChat(chatId: chatId)
-       let groupName = INSpeakableString(spokenPhrase: chat.name)
+        if #available(iOS 13.0, *) {
+            let chat = DcContext.shared.getChat(chatId: chatId)
+            let groupName = INSpeakableString(spokenPhrase: chat.name)
 
-       let sendMessageIntent = INSendMessageIntent(recipients: nil,
-                                                   content: nil,
-                                                   speakableGroupName: groupName,
-                                                   conversationIdentifier: "\(chat.id)",
-                                                   serviceName: nil,
-                                                   sender: nil)
+            let sendMessageIntent = INSendMessageIntent(recipients: nil,
+                                                        content: nil,
+                                                        speakableGroupName: groupName,
+                                                        conversationIdentifier: "\(chat.id)",
+                serviceName: nil,
+                sender: nil)
 
-       // Add the user's avatar to the intent.
-        if #available(iOS 12.0, *) {
+            // Add the user's avatar to the intent.
             if let imageData = chat.profileImage?.pngData() {
                 let image = INImage(imageData: imageData)
                 sendMessageIntent.setImage(image, forParameterNamed: \.speakableGroupName)
             }
-        }
 
-       // Donate the intent.
-       let interaction = INInteraction(intent: sendMessageIntent, response: nil)
-       interaction.donate(completion: { error in
-           if error != nil {
-               // Add error handling here.
-                DcContext.shared.logger?.error(error.debugDescription)
-           } else {
-               // Do something, e.g. send the content to a contact.
-                DcContext.shared.logger?.debug("donated message intent")
-           }
-       })
+            // Donate the intent.
+            let interaction = INInteraction(intent: sendMessageIntent, response: nil)
+            interaction.donate(completion: { error in
+                if error != nil {
+                    DcContext.shared.logger?.error(error.debugDescription)
+                }
+            })
+        }
     }
 
     static func copyAndFreeArray(inputArray: OpaquePointer?) -> [Int] {

--- a/DcShare/Controller/SendingController.swift
+++ b/DcShare/Controller/SendingController.swift
@@ -72,6 +72,10 @@ class SendingController: UIViewController {
             for dcMsg in self.dcMsgs {
                 self.dcContext.sendMsgSync(chatId: self.chatId, msg: dcMsg)
             }
+
+            if !self.dcContext.getChat(chatId: self.chatId).isSelfTalk {
+                DcUtils.donateSendMessageIntent(chatId: self.chatId)
+            }
             self.delegate?.onSendingAttemptFinished()
         }
     }

--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import Social
 import DcCore
 import MobileCoreServices
+import Intents
 
 
 class ShareViewController: SLComposeServiceViewController {
@@ -65,7 +66,15 @@ class ShareViewController: SLComposeServiceViewController {
             dcContext.openDatabase(dbFile: dbHelper.sharedDbFile)
             isAccountConfigured = dcContext.isConfigured()
             if isAccountConfigured {
-                selectedChatId = dcContext.getChatIdByContactId(contactId: Int(DC_CONTACT_ID_SELF))
+                if #available(iOSApplicationExtension 13.0, *) {
+                   if let intent = self.extensionContext?.intent as? INSendMessageIntent, let chatId = Int(intent.conversationIdentifier ?? "") {
+                       selectedChatId = chatId
+                   }
+                }
+
+                if selectedChatId == nil {
+                    selectedChatId = dcContext.getChatIdByContactId(contactId: Int(DC_CONTACT_ID_SELF))
+                }
                 if let chatId = selectedChatId {
                     selectedChat = dcContext.getChat(chatId: chatId)
                 }

--- a/DcShare/Info.plist
+++ b/DcShare/Info.plist
@@ -24,6 +24,10 @@
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
+			<key>IntentsSupported</key>
+			<array>
+				<string>INSendMessageIntent</string>
+			</array>
 			<key>NSExtensionActivationRule</key>
 			<string>SUBQUERY (
 extensionItems,

--- a/deltachat-ios/Info.plist
+++ b/deltachat-ios/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>INSendMessageIntent</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
closes #731 

we might want to have this feature optional. The documentation is quite very vague about the privacy implications of using SiriKit intents needed to implement the suggestion shortcuts. 

Wire and Signal don't have implemented this feature at all, whereas Telegram does. 
From what I understood, reading various third party articles is that at least anonymized data will be sent to Siri servers.

Another open discussion point is if we want to ignore location messages (as currently implemented) from being taken into account for the the share suggestion data aggregation. 

Also missing in this PR is a default image generation in case a user has no own user image set. In a subsequent PR the image generation could create an UIImage based on the InitialsBadge layout containing the users Initials and default background color. 