### PR TITLE
Fix share dc context initialization

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -930,7 +930,7 @@ public class DcMsg {
         return nil
     }
 
-    public func setFile(filepath: String?, mimeType: String?) {
+    public func setFile(filepath: String?, mimeType: String? = nil) {
         dc_msg_set_file(messagePointer, filepath, mimeType)
     }
 

--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -57,9 +57,6 @@ class ShareViewController: SLComposeServiceViewController {
         }
         placeholder = String.localized("chat_input_placeholder")
 
-        DispatchQueue.global(qos: .background).async {
-            self.shareAttachment = ShareAttachment(dcContext: self.dcContext, inputItems: self.extensionContext?.inputItems, delegate: self)
-        }
     }
 
     override func presentationAnimationDidFinish() {
@@ -71,6 +68,9 @@ class ShareViewController: SLComposeServiceViewController {
                 selectedChatId = dcContext.getChatIdByContactId(contactId: Int(DC_CONTACT_ID_SELF))
                 if let chatId = selectedChatId {
                     selectedChat = dcContext.getChat(chatId: chatId)
+                }
+                DispatchQueue.global(qos: .background).async {
+                    self.shareAttachment = ShareAttachment(dcContext: self.dcContext, inputItems: self.extensionContext?.inputItems, delegate: self)
                 }
             }
             reloadConfigurationItems()

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -81,9 +81,7 @@ class ShareAttachment {
             if let result = result, let animatedImageData = result.animatedImageData {
                 let path = DcUtils.saveAnimatedImage(data: animatedImageData, suffix: "gif")
                 let msg = DcMsg(viewType: DC_MSG_GIF)
-                msg.setFile(filepath: path, mimeType: "image/gif")
-                let pixelSize = result.imageSizeInPixel()
-                msg.setDimension(width: pixelSize.width, height: pixelSize.height)
+                msg.setFile(filepath: path)
                 self.messages.append(msg)
                 self.delegate?.onAttachmentChanged()
                 if self.imageThumbnail == nil {
@@ -111,16 +109,14 @@ class ShareAttachment {
                 self.dcContext.logger?.debug("Unexpected data: \(type(of: data))")
                 result = nil
             }
-            if let result = result, let compressedImage = result.dcCompress() {
-                let pixelSize = compressedImage.imageSizeInPixel()
-                let path = DcUtils.saveImage(image: compressedImage)
+            if let result = result {
+                let path = DcUtils.saveImage(image: result)
                 let msg = DcMsg(viewType: DC_MSG_IMAGE)
-                msg.setFile(filepath: path, mimeType: "image/jpeg")
-                msg.setDimension(width: pixelSize.width, height: pixelSize.height)
+                msg.setFile(filepath: path)
                 self.delegate?.onAttachmentChanged()
                 self.messages.append(msg)
                 if self.imageThumbnail == nil {
-                    self.imageThumbnail = compressedImage.scaleDownImage(toMax: self.thumbnailSize)
+                    self.imageThumbnail = result.scaleDownImage(toMax: self.thumbnailSize)
                     self.delegate?.onThumbnailChanged()
                 }
             }
@@ -177,7 +173,7 @@ class ShareAttachment {
 
     private func addDcMsg(url: URL, viewType: Int32) {
         let msg = DcMsg(viewType: viewType)
-        msg.setFile(filepath: url.path, mimeType: DcUtils.getMimeTypeForPath(path: url.path))
+        msg.setFile(filepath: url.relativePath)
         self.messages.append(msg)
     }
 


### PR DESCRIPTION
fixes #756 

* sharing files, audio, images, videos works again \o/

* removal of dcCompress() in image message creation

* removal of mimetype and dimensions config during DcMsg creation

