### PR TITLE
Remove ios image compression

### DIFF
--- a/DcCore/DcCore/Extensions/UIImage+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UIImage+Extensions.swift
@@ -37,36 +37,12 @@ public extension UIImage {
         return newImage
     }
 
-    func dcCompress(toMax target: Float = 1280) -> UIImage? {
-        return scaleDownAndCompress(toMax: target)
-    }
-
     func imageSizeInPixel() -> CGSize {
         let heightInPoints = size.height
         let heightInPixels = heightInPoints * scale
         let widthInPoints = size.width
         let widthInPixels = widthInPoints * scale
         return CGSize(width: widthInPixels, height: heightInPixels)
-    }
-    
-    // if an image has an alpha channel we try to keep it, using PNG formatting instead of JPEG
-    // PNGs are less compressed than JPEGs - to keep the message sizes small,
-    // the size of PNG imgaes will be scaled down
-    func scaleDownAndCompress(toMax: Float) -> UIImage? {
-        let rect = getResizedRectangle(toMax: self.isTransparent() ?
-            min(Float(self.size.width) / 2, toMax / 2) :
-            toMax)
-
-        UIGraphicsBeginImageContextWithOptions(rect.size, !self.isTransparent(), 0.0)
-        draw(in: rect)
-        let img = UIGraphicsGetImageFromCurrentImageContext()
-
-        let imageData = self.isTransparent() ?
-            img?.pngData() :
-            img?.jpegData(compressionQuality: 0.85)
-
-        UIGraphicsEndImageContext()
-        return UIImage(data: imageData!)
     }
 
     func isTransparent() -> Bool {

--- a/DcCore/DcCore/Helper/DcUtils.swift
+++ b/DcCore/DcCore/Helper/DcUtils.swift
@@ -61,7 +61,6 @@ public struct DcUtils {
         return acc
     }
 
-    // compression needs to be done before in UIImage.dcCompress()
     public static func saveImage(image: UIImage) -> String? {
         let timestamp = Double(Date().timeIntervalSince1970)
         guard let directory = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask,

--- a/DcCore/DcCore/Helper/DcUtils.swift
+++ b/DcCore/DcCore/Helper/DcUtils.swift
@@ -62,23 +62,15 @@ public struct DcUtils {
     }
 
     public static func saveImage(image: UIImage) -> String? {
-        let timestamp = Double(Date().timeIntervalSince1970)
-        guard let directory = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask,
-                                                           appropriateFor: nil, create: false) as NSURL,
-            let data = image.isTransparent() ? image.pngData() : image.jpegData(compressionQuality: 1.0),
-            let path = directory.appendingPathComponent("\(timestamp).jpg")
-            else { return nil }
-
-        do {
-            try data.write(to: path)
-            return path.relativePath
-        } catch {
-            DcContext.shared.logger?.info(error.localizedDescription)
+        let suffix = image.isTransparent() ? "png" : "jpg"
+        guard let data = image.isTransparent() ? image.pngData() : image.jpegData(compressionQuality: 1.0) else {
             return nil
         }
+
+        return saveImage(data: data, suffix: suffix)
     }
 
-    public static func saveAnimatedImage(data: Data, suffix: String) -> String? {
+    public static func saveImage(data: Data, suffix: String) -> String? {
         let timestamp = Double(Date().timeIntervalSince1970)
         guard let directory = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask,
                                                            appropriateFor: nil, create: false) as NSURL,

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -79,7 +79,7 @@ class ShareAttachment {
                 self.dcContext.logger?.debug("Unexpected data: \(type(of: data))")
             }
             if let result = result, let animatedImageData = result.animatedImageData {
-                let path = DcUtils.saveAnimatedImage(data: animatedImageData, suffix: "gif")
+                let path = DcUtils.saveImage(data: animatedImageData, suffix: "gif")
                 let msg = DcMsg(viewType: DC_MSG_GIF)
                 msg.setFile(filepath: path)
                 self.messages.append(msg)

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -1010,17 +1010,15 @@ extension ChatViewController: MessagesDataSource {
             let result = SDAnimatedImage(contentsOfFile: path)
             if let result = result,
                let animatedImageData = result.animatedImageData,
-               let pathInDocDir = DcUtils.saveAnimatedImage(data: animatedImageData, suffix: "gif") {
+               let pathInDocDir = DcUtils.saveImage(data: animatedImageData, suffix: "gif") {
                 self.sendImageMessage(viewType: DC_MSG_GIF, image: result, filePath: pathInDocDir)
             }
         }
     }
 
     private func sendImageMessage(viewType: Int32, image: UIImage, filePath: String, message: String? = nil) {
-        let pixelSize = image.imageSizeInPixel()
         let msg = DcMsg(viewType: viewType)
-        msg.setFile(filepath: filePath, mimeType: viewType == DC_MSG_GIF ? "image/gif" : "image/jpeg")
-        msg.setDimension(width: pixelSize.width, height: pixelSize.height)
+        msg.setFile(filepath: filePath)
         msg.text = (message ?? "").isEmpty ? nil : message
         msg.sendInChat(id: self.chatId)
     }


### PR DESCRIPTION
closes #773 
* includes a minor fix for saving png images with the correct suffix
* minor refactoring to reduce duplicated code