### PR TITLE
fix content validation for shared images

### DIFF
--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -113,8 +113,8 @@ class ShareAttachment {
                 let path = DcUtils.saveImage(image: result)
                 let msg = DcMsg(viewType: DC_MSG_IMAGE)
                 msg.setFile(filepath: path)
-                self.delegate?.onAttachmentChanged()
                 self.messages.append(msg)
+                self.delegate?.onAttachmentChanged()
                 if self.imageThumbnail == nil {
                     self.imageThumbnail = result.scaleDownImage(toMax: self.thumbnailSize)
                     self.delegate?.onThumbnailChanged()


### PR DESCRIPTION
* sometimes the send button doesn't gets enabled, because the content validation returns false
* fixing the order - first attaching new DcMsg objects containing images, then calling the callback - solves the issue 