### PR TITLE
Streamline ui media messages

### DIFF
--- a/deltachat-ios/DC/DcMsg+Extension.swift
+++ b/deltachat-ios/DC/DcMsg+Extension.swift
@@ -52,7 +52,7 @@ extension DcMsg: MessageType {
         if text.isEmpty {
             return MessageKind.video(Media(url: fileURL, image: thumbnail))
         }
-        let attributedString = NSAttributedString(string: text, attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16.0),
+        let attributedString = NSAttributedString(string: text, attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
                                                                              NSAttributedString.Key.foregroundColor: DcColors.defaultTextColor])
         return MessageKind.videoText(Media(url: fileURL, image: thumbnail, text: [attributedString]))
     }
@@ -61,7 +61,7 @@ extension DcMsg: MessageType {
         if text.isEmpty {
             return MessageKind.photo(Media(image: image))
         }
-        let attributedString = NSAttributedString(string: text, attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16.0),
+        let attributedString = NSAttributedString(string: text, attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
                                                                              NSAttributedString.Key.foregroundColor: DcColors.defaultTextColor])
         return MessageKind.photoText(Media(image: image, text: [attributedString]))
     }
@@ -70,7 +70,7 @@ extension DcMsg: MessageType {
         if text.isEmpty {
             return MessageKind.animatedImageText(Media(url: fileURL, image: image))
         }
-        let attributedString = NSAttributedString(string: text, attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16.0),
+        let attributedString = NSAttributedString(string: text, attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
                                                                              NSAttributedString.Key.foregroundColor: DcColors.defaultTextColor])
         return MessageKind.animatedImageText(Media(url: fileURL, image: image, text: [attributedString]))
     }
@@ -79,7 +79,7 @@ extension DcMsg: MessageType {
         let audioAsset = AVURLAsset(url: fileURL!)
         let seconds = Float(CMTimeGetSeconds(audioAsset.duration))
         if !text.isEmpty {
-            let attributedString = NSAttributedString(string: text, attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16.0),
+            let attributedString = NSAttributedString(string: text, attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
                                                                                  NSAttributedString.Key.foregroundColor: DcColors.defaultTextColor])
             return MessageKind.audio(Audio(url: audioAsset.url, duration: seconds, text: attributedString))
         }
@@ -91,7 +91,7 @@ extension DcMsg: MessageType {
         let fileSizeString = getPrettyFileSize()
         let attributedMediaMessageString =
                    NSAttributedString(string: text,
-                                             attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16.0),
+                                             attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
                                                           NSAttributedString.Key.foregroundColor: DcColors.defaultTextColor])
         let attributedFileString = NSAttributedString(string: fileString,
                                                              attributes: [NSAttributedString.Key.font: UIFont.italicSystemFont(ofSize: 13.0),

--- a/deltachat-ios/MessageKit/Layout/FileMessageSizeCalculator.swift
+++ b/deltachat-ios/MessageKit/Layout/FileMessageSizeCalculator.swift
@@ -14,11 +14,11 @@ open class FileMessageSizeCalculator: MessageSizeCalculator {
 
     private var incomingMessageLabelInsets = UIEdgeInsets(top: 0,
                                                          left: FileMessageCell.insetHorizontalBig,
-                                                         bottom: FileMessageCell.insetBottom,
+                                                         bottom: FileMessageCell.insetVertical,
                                                          right: FileMessageCell.insetHorizontalSmall)
     private var outgoingMessageLabelInsets = UIEdgeInsets(top: 0,
                                                          left: FileMessageCell.insetHorizontalSmall,
-                                                         bottom: FileMessageCell.insetBottom,
+                                                         bottom: FileMessageCell.insetVertical,
                                                          right: FileMessageCell.insetHorizontalBig)
 
     private var messageLabelFont = UIFont.preferredFont(forTextStyle: .body)

--- a/deltachat-ios/MessageKit/Views/Cells/AnimatedImageMessageCell.swift
+++ b/deltachat-ios/MessageKit/Views/Cells/AnimatedImageMessageCell.swift
@@ -8,8 +8,8 @@ open class AnimatedImageMessageCell: MessageContentCell {
 
     public static let insetTop: CGFloat = 12
     public static let insetBottom: CGFloat = 12
-    public static let insetHorizontalBig: CGFloat = 23
-    public static let insetHorizontalSmall: CGFloat = 12
+    public static let insetHorizontalBig: CGFloat = 18
+    public static let insetHorizontalSmall: CGFloat = 14
 
 
     // MARK: - Properties

--- a/deltachat-ios/MessageKit/Views/Cells/AudioMessageCell.swift
+++ b/deltachat-ios/MessageKit/Views/Cells/AudioMessageCell.swift
@@ -30,8 +30,8 @@ open class AudioMessageCell: MessageContentCell {
 
     public static let insetTop: CGFloat = 12
     public static let insetBottom: CGFloat = 12
-    public static let insetHorizontalBig: CGFloat = 23
-    public static let insetHorizontalSmall: CGFloat = 12
+    public static let insetHorizontalBig: CGFloat = 18
+    public static let insetHorizontalSmall: CGFloat = 14
 
     // MARK: - Properties
     /// The `MessageCellDelegate` for the cell.

--- a/deltachat-ios/MessageKit/Views/Cells/FileMessageCell.swift
+++ b/deltachat-ios/MessageKit/Views/Cells/FileMessageCell.swift
@@ -3,9 +3,9 @@ import UIKit
 // A subclass of `MessageContentCell` used to display mixed media messages.
 open class FileMessageCell: MessageContentCell {
 
-    static let insetBottom: CGFloat = 12
-    static let insetHorizontalBig: CGFloat = 23
-    static let insetHorizontalSmall: CGFloat = 12
+    static let insetVertical: CGFloat = 12
+    static let insetHorizontalBig: CGFloat = 18
+    static let insetHorizontalSmall: CGFloat = 14
 
     // MARK: - Properties
     var fileViewLeadingPadding: CGFloat = 0 {
@@ -29,9 +29,9 @@ open class FileMessageCell: MessageContentCell {
     open var messageLabel = MessageLabel()
 
     private lazy var fileView: FileView = {
-        let marginInsets = NSDirectionalEdgeInsets(top: FileMessageCell.insetHorizontalSmall,
+        let marginInsets = NSDirectionalEdgeInsets(top: FileMessageCell.insetVertical,
                                                    leading: FileMessageCell.insetHorizontalSmall,
-                                                   bottom: FileMessageCell.insetHorizontalSmall,
+                                                   bottom: FileMessageCell.insetVertical,
                                                    trailing: FileMessageCell.insetHorizontalSmall)
         let fileView = FileView(directionalLayoutMargins: marginInsets)
         fileView.translatesAutoresizingMaskIntoConstraints = false
@@ -63,7 +63,7 @@ open class FileMessageCell: MessageContentCell {
                 messageContainerView.frame.width -
                     FileMessageCell.insetHorizontalSmall -
                     FileMessageCell.insetHorizontalBig))
-            return height + FileMessageCell.insetBottom
+            return height + FileMessageCell.insetVertical
         }
         return 0
     }

--- a/deltachat-ios/MessageKit/Views/Cells/TextMediaMessageCell.swift
+++ b/deltachat-ios/MessageKit/Views/Cells/TextMediaMessageCell.swift
@@ -5,8 +5,8 @@ open class TextMediaMessageCell: MessageContentCell {
 
     static let insetTop: CGFloat = 12
     static let insetBottom: CGFloat = 12
-    static let insetHorizontalBig: CGFloat = 23
-    static let insetHorizontalSmall: CGFloat = 12
+    static let insetHorizontalBig: CGFloat = 18
+    static let insetHorizontalSmall: CGFloat = 14
 
 
     // MARK: - Properties


### PR DESCRIPTION
closes #768 
* it also increases the accessibility by implementing the system's preferred text size which can be changed in the system settings
* this was already implemented in MessageKit's default message cell