### PR TITLE
call maybeNetwork() unconditionally on coming to foreground; 

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -103,9 +103,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.info("---- foreground ----")
         appIsInForeground = true
         startThreads()
-        if reachability.connection != .none {
-            self.dcContext.maybeNetwork()
-        }
+        self.dcContext.maybeNetwork()
 
         if let userDefaults = UserDefaults.shared, userDefaults.bool(forKey: UserDefaults.hasExtensionAttemptedToSend) {
             userDefaults.removeObject(forKey: UserDefaults.hasExtensionAttemptedToSend)


### PR DESCRIPTION
the call is required when there is some network, so, it is called in the majority of cases anyway. skipping the check removes uncertainty in checking the network state.

counterpart of https://github.com/deltachat/deltachat-android/pull/1411