### PR TITLE
Revert "call maybeNetwork() unconditionally on coming to foreground; "

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -103,7 +103,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.info("---- foreground ----")
         appIsInForeground = true
         startThreads()
-        self.dcContext.maybeNetwork()
+        if reachability.connection != .none {
+            self.dcContext.maybeNetwork()
+        }
 
         if let userDefaults = UserDefaults.shared, userDefaults.bool(forKey: UserDefaults.hasExtensionAttemptedToSend) {
             userDefaults.removeObject(forKey: UserDefaults.hasExtensionAttemptedToSend)


### PR DESCRIPTION
Reverts deltachat/deltachat-ios#784

as @Hocuri pointed out at https://github.com/deltachat/deltachat-android/pull/1411#issuecomment-643785972 calling maybeNetwork() when there is actually no network will led to jobs fail faster and to interfere with the internal backoff timings. so, better leave this as is.

i tried to be a bit more concrete in the docs at https://github.com/deltachat/deltachat-core-rust/pull/1620/files