### PR TITLE
Async thumbnail loading in chatView

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -602,11 +602,8 @@
 				3059620D234614E700C80F33 /* DcContact+Extension.swift */,
 				3059620F2346154D00C80F33 /* String+Extension.swift */,
 				302B84CD2397F6CD001C261F /* URL+Extension.swift */,
-<<<<<<< HEAD
 				AE0AA957247834A400D42A7F /* Date+Extension.swift */,
-=======
 				AE6EC5232497663200A400E4 /* UIImageView+Extensions.swift */,
->>>>>>> thumbnails are generated on background thread + cached and restored from cache
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -947,11 +944,8 @@
 				AE1988A423EB2FBA00B4CD5F /* Errors.swift */,
 				AEFBE23023FF09B20045327A /* TypeAlias.swift */,
 				307D822D241669C7006D2490 /* LocationManager.swift */,
-<<<<<<< HEAD
 				AE0AA9552478191900D42A7F /* GridCollectionViewFlowLayout.swift */,
-=======
 				AE6EC5272497B9B200A400E4 /* ThumbnailCache.swift */,
->>>>>>> thumbnails are generated on background thread + cached and restored from cache
 			);
 			path = Helper;
 			sourceTree = "<group>";

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		AE4AEE3522B1030D000AA495 /* PreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4AEE3422B1030D000AA495 /* PreviewController.swift */; };
 		AE52EA19229EB53C00C586C9 /* ContactDetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE52EA18229EB53C00C586C9 /* ContactDetailHeader.swift */; };
 		AE52EA20229EB9F000C586C9 /* EditGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE52EA1F229EB9F000C586C9 /* EditGroupViewController.swift */; };
+		AE6EC5242497663200A400E4 /* UIImageView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6EC5232497663200A400E4 /* UIImageView+Extensions.swift */; };
+		AE6EC5282497B9B200A400E4 /* ThumbnailCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6EC5272497B9B200A400E4 /* ThumbnailCache.swift */; };
 		AE728F15229D5C390047565B /* PhotoPickerAlertAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE728F14229D5C390047565B /* PhotoPickerAlertAction.swift */; };
 		AE76E5EE242BF2EA003CF461 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE76E5ED242BF2EA003CF461 /* WelcomeViewController.swift */; };
 		AE77838D23E32ED20093EABD /* ContactDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77838C23E32ED20093EABD /* ContactDetailViewModel.swift */; };
@@ -429,6 +431,8 @@
 		AE4AEE3422B1030D000AA495 /* PreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewController.swift; sourceTree = "<group>"; };
 		AE52EA18229EB53C00C586C9 /* ContactDetailHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDetailHeader.swift; sourceTree = "<group>"; };
 		AE52EA1F229EB9F000C586C9 /* EditGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditGroupViewController.swift; sourceTree = "<group>"; };
+		AE6EC5232497663200A400E4 /* UIImageView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extensions.swift"; sourceTree = "<group>"; };
+		AE6EC5272497B9B200A400E4 /* ThumbnailCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailCache.swift; sourceTree = "<group>"; };
 		AE728F14229D5C390047565B /* PhotoPickerAlertAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerAlertAction.swift; sourceTree = "<group>"; };
 		AE76E5ED242BF2EA003CF461 /* WelcomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
 		AE77838C23E32ED20093EABD /* ContactDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDetailViewModel.swift; sourceTree = "<group>"; };
@@ -598,7 +602,11 @@
 				3059620D234614E700C80F33 /* DcContact+Extension.swift */,
 				3059620F2346154D00C80F33 /* String+Extension.swift */,
 				302B84CD2397F6CD001C261F /* URL+Extension.swift */,
+<<<<<<< HEAD
 				AE0AA957247834A400D42A7F /* Date+Extension.swift */,
+=======
+				AE6EC5232497663200A400E4 /* UIImageView+Extensions.swift */,
+>>>>>>> thumbnails are generated on background thread + cached and restored from cache
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -939,7 +947,11 @@
 				AE1988A423EB2FBA00B4CD5F /* Errors.swift */,
 				AEFBE23023FF09B20045327A /* TypeAlias.swift */,
 				307D822D241669C7006D2490 /* LocationManager.swift */,
+<<<<<<< HEAD
 				AE0AA9552478191900D42A7F /* GridCollectionViewFlowLayout.swift */,
+=======
+				AE6EC5272497B9B200A400E4 /* ThumbnailCache.swift */,
+>>>>>>> thumbnails are generated on background thread + cached and restored from cache
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -1359,6 +1371,7 @@
 				3040F460234F419400FA34D5 /* BasicAudioController.swift in Sources */,
 				30A2EC36247D72720024ADD8 /* AnimatedImageMessageCell.swift in Sources */,
 				305962082346125100C80F33 /* MediaMessageSizeCalculator.swift in Sources */,
+				AE6EC5282497B9B200A400E4 /* ThumbnailCache.swift in Sources */,
 				AE52EA20229EB9F000C586C9 /* EditGroupViewController.swift in Sources */,
 				AE18F294228C602A0007B1BE /* SecuritySettingsController.swift in Sources */,
 				305961FD2346125100C80F33 /* TypingBubble.swift in Sources */,
@@ -1438,6 +1451,7 @@
 				305961DD2346125100C80F33 /* SenderType.swift in Sources */,
 				305961E32346125100C80F33 /* MessagesDataSource.swift in Sources */,
 				AEFBE22F23FEF23D0045327A /* ProviderInfoCell.swift in Sources */,
+				AE6EC5242497663200A400E4 /* UIImageView+Extensions.swift in Sources */,
 				305961E22346125100C80F33 /* MessagesDisplayDelegate.swift in Sources */,
 				305962092346125100C80F33 /* AudioMessageSizeCalculator.swift in Sources */,
 				305961DB2346125100C80F33 /* AudioItem.swift in Sources */,

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -561,6 +561,7 @@ class ChatViewController: MessagesViewController {
         case .photo, .video:
             let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+            cell.asyncDelegate = self
             return cell
         case .photoText, .videoText:
             let cell = messagesCollectionView.dequeueReusableCell(TextMediaMessageCell.self, for: indexPath)
@@ -1502,5 +1503,11 @@ extension MessageCollectionViewCell {
                     forItemAt: indexPath, withSender: sender)
             }
         }
+    }
+}
+
+extension ChatViewController: AsyncContentLoadDelegate {
+    func contentDidLoad() {
+        messagesCollectionView.reloadData()
     }
 }

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -561,7 +561,6 @@ class ChatViewController: MessagesViewController {
         case .photo, .video:
             let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
-            cell.asyncDelegate = self
             return cell
         case .photoText, .videoText:
             let cell = messagesCollectionView.dequeueReusableCell(TextMediaMessageCell.self, for: indexPath)
@@ -1503,11 +1502,5 @@ extension MessageCollectionViewCell {
                     forItemAt: indexPath, withSender: sender)
             }
         }
-    }
-}
-
-extension ChatViewController: AsyncContentLoadDelegate {
-    func contentDidLoad() {
-        messagesCollectionView.reloadData()
     }
 }

--- a/deltachat-ios/DC/DcMsg+Extension.swift
+++ b/deltachat-ios/DC/DcMsg+Extension.swift
@@ -48,13 +48,18 @@ extension DcMsg: MessageType {
     }
 
     internal func createVideoMessage(text: String) -> MessageKind {
-        let thumbnail = DcUtils.generateThumbnailFromVideo(url: fileURL)
         if text.isEmpty {
+            var thumbnail: UIImage?
+            if let fileURL = fileURL {
+                thumbnail = ThumbnailCache.shared.restoreImage(key: fileURL.absoluteString)
+            }
             return MessageKind.video(Media(url: fileURL, image: thumbnail))
         }
-        let attributedString = NSAttributedString(string: text, attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
-                                                                             NSAttributedString.Key.foregroundColor: DcColors.defaultTextColor])
-        return MessageKind.videoText(Media(url: fileURL, image: thumbnail, text: [attributedString]))
+        let attributedString = NSAttributedString(string: text, attributes: [
+            NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
+            NSAttributedString.Key.foregroundColor: DcColors.defaultTextColor]
+        )
+        return MessageKind.videoText(Media(url: fileURL, text: [attributedString]))
     }
 
     internal func createImageMessage(text: String) -> MessageKind {

--- a/deltachat-ios/DC/DcMsg+Extension.swift
+++ b/deltachat-ios/DC/DcMsg+Extension.swift
@@ -48,18 +48,19 @@ extension DcMsg: MessageType {
     }
 
     internal func createVideoMessage(text: String) -> MessageKind {
+        var thumbnail: UIImage?
+        if let fileURL = fileURL {
+            thumbnail = ThumbnailCache.shared.restoreImage(key: fileURL.absoluteString)
+        }
         if text.isEmpty {
-            var thumbnail: UIImage?
-            if let fileURL = fileURL {
-                thumbnail = ThumbnailCache.shared.restoreImage(key: fileURL.absoluteString)
-            }
+
             return MessageKind.video(Media(url: fileURL, image: thumbnail))
         }
         let attributedString = NSAttributedString(string: text, attributes: [
             NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
             NSAttributedString.Key.foregroundColor: DcColors.defaultTextColor]
         )
-        return MessageKind.videoText(Media(url: fileURL, text: [attributedString]))
+        return MessageKind.videoText(Media(url: fileURL, image: thumbnail, text: [attributedString]))
     }
 
     internal func createImageMessage(text: String) -> MessageKind {

--- a/deltachat-ios/Extensions/UIImageView+Extensions.swift
+++ b/deltachat-ios/Extensions/UIImageView+Extensions.swift
@@ -1,0 +1,17 @@
+import UIKit
+import DcCore
+
+extension UIImageView {
+
+    func loadVideoThumbnail(from url: URL, placeholderImage: UIImage?, completionHandler: ((UIImage?)->Void)?) {
+
+        self.image = placeholderImage
+        DispatchQueue.global(qos: .background).async {
+            let thumbnailImage = DcUtils.generateThumbnailFromVideo(url: url)
+            DispatchQueue.main.async { [weak self] in
+                self?.image = thumbnailImage
+                completionHandler?(thumbnailImage)
+            }
+        }
+    }
+}

--- a/deltachat-ios/Extensions/UIImageView+Extensions.swift
+++ b/deltachat-ios/Extensions/UIImageView+Extensions.swift
@@ -3,7 +3,7 @@ import DcCore
 
 extension UIImageView {
 
-    func loadVideoThumbnail(from url: URL, placeholderImage: UIImage?, completionHandler: ((UIImage?)->Void)?) {
+    func loadVideoThumbnail(from url: URL, placeholderImage: UIImage?, completionHandler: ((UIImage?) -> Void)?) {
 
         self.image = placeholderImage
         DispatchQueue.global(qos: .background).async {

--- a/deltachat-ios/Extensions/UIImageView+Extensions.swift
+++ b/deltachat-ios/Extensions/UIImageView+Extensions.swift
@@ -10,6 +10,7 @@ extension UIImageView {
             let thumbnailImage = DcUtils.generateThumbnailFromVideo(url: url)
             DispatchQueue.main.async { [weak self] in
                 self?.image = thumbnailImage
+                self?.setNeedsDisplay()
                 completionHandler?(thumbnailImage)
             }
         }

--- a/deltachat-ios/Helper/ThumbnailCache.swift
+++ b/deltachat-ios/Helper/ThumbnailCache.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+class ThumbnailCache {
+
+    static let shared = ThumbnailCache()
+    private init() { }
+
+    private lazy var cache: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.name = "thumbnail_cache"
+        return cache
+    }()
+
+    func storeImage(image: UIImage, key: String){
+        cache.setObject(image, forKey: NSString(string: key))
+    }
+
+    func restoreImage(key: String) -> UIImage? {
+        return cache.object(forKey: NSString(string: key))
+    }
+}

--- a/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
+++ b/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
@@ -31,8 +31,6 @@ open class MediaMessageSizeCalculator: MessageSizeCalculator {
         return UIScreen.main.bounds.size.height * 0.7
     }
 
-    private let defaultHeight: CGFloat = 350
-
     open override func messageContainerSize(for message: MessageType) -> CGSize {
         let maxWidth = messageContainerMaxWidth(for: message)
         let sizeForMediaItem = { (maxWidth: CGFloat, item: MediaItem) -> CGSize in
@@ -58,7 +56,7 @@ open class MediaMessageSizeCalculator: MessageSizeCalculator {
         case .video(let item):
             if item.image == nil {
                 // no cached thumbnail -> is generated asynchronously
-                return CGSize(width: maxWidth, height: defaultHeight)
+                return CGSize(width: maxWidth, height: maxWidth)
             } else {
                 return sizeForMediaItem(maxWidth, item)
             }

--- a/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
+++ b/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
@@ -31,6 +31,8 @@ open class MediaMessageSizeCalculator: MessageSizeCalculator {
         return UIScreen.main.bounds.size.height * 0.7
     }
 
+    private let defaultHeight: CGFloat = 250
+
     open override func messageContainerSize(for message: MessageType) -> CGSize {
         let maxWidth = messageContainerMaxWidth(for: message)
         let sizeForMediaItem = { (maxWidth: CGFloat, item: MediaItem) -> CGSize in
@@ -54,7 +56,12 @@ open class MediaMessageSizeCalculator: MessageSizeCalculator {
         case .photo(let item):
             return sizeForMediaItem(maxWidth, item)
         case .video(let item):
-            return sizeForMediaItem(maxWidth, item)
+            if item.image == nil {
+                // no cached thumbnail -> is generated asynchronously
+                return CGSize(width: maxWidth, height: defaultHeight)
+            } else {
+                return sizeForMediaItem(maxWidth, item)
+            }
         default:
             fatalError("messageContainerSize received unhandled MessageDataType: \(message.kind)")
         }

--- a/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
+++ b/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
@@ -53,8 +53,14 @@ open class MediaMessageSizeCalculator: MessageSizeCalculator {
         switch message.kind {
         case .photo(let item):
             return sizeForMediaItem(maxWidth, item)
-        case .video:
-            return CGSize(width: maxWidth, height: maxWidth)
+        case .video(let item):
+            // return CGSize(width: maxWidth, height: defaultHeight)
+            if item.image == nil {
+                // no cached thumbnail -> is generated asynchronously
+                return CGSize(width: maxWidth, height: defaultHeight)
+            } else {
+                return sizeForMediaItem(maxWidth, item)
+            }
         default:
             fatalError("messageContainerSize received unhandled MessageDataType: \(message.kind)")
         }

--- a/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
+++ b/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
@@ -31,8 +31,6 @@ open class MediaMessageSizeCalculator: MessageSizeCalculator {
         return UIScreen.main.bounds.size.height * 0.7
     }
 
-    private let defaultHeight: CGFloat = 250
-
     open override func messageContainerSize(for message: MessageType) -> CGSize {
         let maxWidth = messageContainerMaxWidth(for: message)
         let sizeForMediaItem = { (maxWidth: CGFloat, item: MediaItem) -> CGSize in
@@ -55,13 +53,8 @@ open class MediaMessageSizeCalculator: MessageSizeCalculator {
         switch message.kind {
         case .photo(let item):
             return sizeForMediaItem(maxWidth, item)
-        case .video(let item):
-            if item.image == nil {
-                // no cached thumbnail -> is generated asynchronously
-                return CGSize(width: maxWidth, height: defaultHeight)
-            } else {
-                return sizeForMediaItem(maxWidth, item)
-            }
+        case .video:
+            return CGSize(width: maxWidth, height: maxWidth)
         default:
             fatalError("messageContainerSize received unhandled MessageDataType: \(message.kind)")
         }

--- a/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
+++ b/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
@@ -31,6 +31,8 @@ open class MediaMessageSizeCalculator: MessageSizeCalculator {
         return UIScreen.main.bounds.size.height * 0.7
     }
 
+    private let defaultHeight: CGFloat = 350
+
     open override func messageContainerSize(for message: MessageType) -> CGSize {
         let maxWidth = messageContainerMaxWidth(for: message)
         let sizeForMediaItem = { (maxWidth: CGFloat, item: MediaItem) -> CGSize in
@@ -54,7 +56,6 @@ open class MediaMessageSizeCalculator: MessageSizeCalculator {
         case .photo(let item):
             return sizeForMediaItem(maxWidth, item)
         case .video(let item):
-            // return CGSize(width: maxWidth, height: defaultHeight)
             if item.image == nil {
                 // no cached thumbnail -> is generated asynchronously
                 return CGSize(width: maxWidth, height: defaultHeight)

--- a/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
+++ b/deltachat-ios/MessageKit/Layout/MediaMessageSizeCalculator.swift
@@ -53,13 +53,8 @@ open class MediaMessageSizeCalculator: MessageSizeCalculator {
         switch message.kind {
         case .photo(let item):
             return sizeForMediaItem(maxWidth, item)
-        case .video(let item):
-            if item.image == nil {
-                // no cached thumbnail -> set default size
-                return CGSize(width: maxWidth, height: maxWidth)
-            } else {
-                return sizeForMediaItem(maxWidth, item)
-            }
+        case .video:
+            return CGSize(width: maxWidth, height: maxWidth)
         default:
             fatalError("messageContainerSize received unhandled MessageDataType: \(message.kind)")
         }

--- a/deltachat-ios/MessageKit/Layout/TextMediaMessageSizeCalculator.swift
+++ b/deltachat-ios/MessageKit/Layout/TextMediaMessageSizeCalculator.swift
@@ -81,13 +81,22 @@ open class TextMediaMessageSizeCalculator: MessageSizeCalculator {
 
             var messageContainerSize = CGSize(width: imageWidth, height: imageHeight)
             switch message.kind {
-            case .photoText(let mediaItem), .videoText(let mediaItem), .animatedImageText(let mediaItem):
+            case .photoText(let mediaItem), .animatedImageText(let mediaItem):
                 if let text = mediaItem.text?[MediaItemConstants.messageText] {
                     let textHeight = text.height(withConstrainedWidth: maxTextWidth)
                     messageContainerSize.height += textHeight
                     messageContainerSize.height +=  self.messageLabelInsets(for: message).vertical
                 }
                 return messageContainerSize
+            case .videoText(let mediaItem):
+                var videoContainerSize = CGSize(width: self.minTextWidth, height: self.minTextWidth)
+                if let text = mediaItem.text?[MediaItemConstants.messageText] {
+                    let textHeight = text.height(withConstrainedWidth: maxTextWidth)
+                    // static size for thumbnails
+                    videoContainerSize.height += textHeight
+                    videoContainerSize.height += self.messageLabelInsets(for: message).vertical
+                }
+                return videoContainerSize
             default:
                 return messageContainerSize
             }

--- a/deltachat-ios/MessageKit/Views/Cells/MediaMessageCell.swift
+++ b/deltachat-ios/MessageKit/Views/Cells/MediaMessageCell.swift
@@ -37,11 +37,8 @@ open class MediaMessageCell: MessageContentCell {
     open var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
         return imageView
-    }()
-
-    private lazy var imageViewHeightConstraint: NSLayoutConstraint = {
-        return imageView.heightAnchor.constraint(equalToConstant: 350)
     }()
 
     // MARK: - Methods
@@ -74,12 +71,10 @@ open class MediaMessageCell: MessageContentCell {
 
         switch message.kind {
         case .photo(let mediaItem):
-            imageViewHeightConstraint.isActive = false
             imageView.image = mediaItem.image ?? mediaItem.placeholderImage
             playButtonView.isHidden = true
         case .video(let mediaItem):
             if let url = mediaItem.url {
-                imageViewHeightConstraint.isActive = true
                 if let image = mediaItem.image {
                     imageView.image = image
                 } else {

--- a/deltachat-ios/MessageKit/Views/Cells/MediaMessageCell.swift
+++ b/deltachat-ios/MessageKit/Views/Cells/MediaMessageCell.swift
@@ -22,16 +22,10 @@
  SOFTWARE.
  */
 
-protocol AsyncContentLoadDelegate: class {
-    func contentDidLoad()
-}
-
 import UIKit
 
 /// A subclass of `MessageContentCell` used to display video and audio messages.
 open class MediaMessageCell: MessageContentCell {
-
-    weak var asyncDelegate: AsyncContentLoadDelegate?
 
     /// The play button view to display on video messages.
     open lazy var playButtonView: PlayButtonView = {
@@ -66,7 +60,6 @@ open class MediaMessageCell: MessageContentCell {
     open override func prepareForReuse() {
         super.prepareForReuse()
         self.imageView.image = nil
-        self.asyncDelegate = nil
     }
 
     open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
@@ -89,7 +82,6 @@ open class MediaMessageCell: MessageContentCell {
                     imageView.loadVideoThumbnail(from: url, placeholderImage: mediaItem.placeholderImage, completionHandler: { [weak self] thumbnail in
                         if let image = thumbnail {
                             self?.cache(thumbnail: image, key: url.absoluteString)
-                            self?.asyncDelegate?.contentDidLoad()
                         }
                     })
                 }

--- a/deltachat-ios/MessageKit/Views/Cells/MediaMessageCell.swift
+++ b/deltachat-ios/MessageKit/Views/Cells/MediaMessageCell.swift
@@ -22,10 +22,16 @@
  SOFTWARE.
  */
 
+protocol AsyncContentLoadDelegate: class {
+    func contentDidLoad()
+}
+
 import UIKit
 
 /// A subclass of `MessageContentCell` used to display video and audio messages.
 open class MediaMessageCell: MessageContentCell {
+
+    weak var asyncDelegate: AsyncContentLoadDelegate?
 
     /// The play button view to display on video messages.
     open lazy var playButtonView: PlayButtonView = {
@@ -60,6 +66,7 @@ open class MediaMessageCell: MessageContentCell {
     open override func prepareForReuse() {
         super.prepareForReuse()
         self.imageView.image = nil
+        self.asyncDelegate = nil
     }
 
     open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
@@ -82,6 +89,7 @@ open class MediaMessageCell: MessageContentCell {
                     imageView.loadVideoThumbnail(from: url, placeholderImage: mediaItem.placeholderImage, completionHandler: { [weak self] thumbnail in
                         if let image = thumbnail {
                             self?.cache(thumbnail: image, key: url.absoluteString)
+                            self?.asyncDelegate?.contentDidLoad()
                         }
                     })
                 }

--- a/deltachat-ios/MessageKit/Views/Cells/TextMediaMessageCell.swift
+++ b/deltachat-ios/MessageKit/Views/Cells/TextMediaMessageCell.swift
@@ -25,6 +25,7 @@ open class TextMediaMessageCell: MessageContentCell {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
         imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.clipsToBounds = true
         return imageView
     }()
 


### PR DESCRIPTION

closes #748 

In ChatViewController the thumbnails of video cells are now created in background thread and are no longer blocking the UI. Created thumbnails are cached and restored if possible.

When the table is loaded for the first time, there is now chance to calculate the video cells height. In that case we use the max width as default value, so video cells appear squared. 
Once the content has beed setup, the table will reload and the cell sizes are re-calculated.

Technically I wrote an extension of UIImage, so once the thumbnail images has been created it will be loaded into the imageView.

In ShareViewController thumbnails are created in main thread. I will create a separate ticket for it.