### PR TITLE
PreviewController - remove list item when accessed from Gallery

### DIFF
--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -169,7 +169,9 @@ private extension PreviewController {
         self.nativeToolbar = NativeToolbar(qlToolbar: qlToolbar, qlShareButton: shareButton)
 
         // this will bind native toolbar's alpha to our fake toolbar (used on swipe down events)
-        observerToken = qlToolbar.observe(\.alpha, changeHandler: { [weak self] toolbar, _ in self?.fakeToolbar.alpha = toolbar.alpha})
+        observerToken = qlToolbar.observe(\.alpha, changeHandler: { [weak self] toolbar, _ in
+            self?.fakeToolbar.alpha = toolbar.alpha * 2}  // use factor 2 to avoid real toolbar items shine through
+        )
 
         view.addSubview(fakeToolbar)
         fakeToolbar.translatesAutoresizingMaskIntoConstraints = false

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -5,6 +5,29 @@ class PreviewController: QLPreviewController {
 
     var urls: [URL]
 
+    // we use this toolbar to hide the default toolbar
+    lazy var customToolbar: UIToolbar = {
+        let toolbar = UIToolbar()
+        let shareItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(shareButtonTapped(_:)))
+        toolbar.items = [shareItem]
+        return toolbar
+    }()
+
+    var qlToolbar: UIToolbar?               // the  native toolbar
+    var qlShareButton: UIBarButtonItem?     // the native shareButton
+
+    var customToolbarLeadingConstraint: NSLayoutConstraint?
+    var customToolbarTrailingConstraint: NSLayoutConstraint?
+    var customToolbarTopConstraint: NSLayoutConstraint?
+    var customToolbarBottomConstraint: NSLayoutConstraint?
+
+    private var customToolbarHasLayout: Bool {
+        return customToolbarLeadingConstraint != nil
+            && customToolbarTopConstraint != nil
+            && customToolbarTrailingConstraint != nil
+            && customToolbarBottomConstraint != nil
+    }
+
     private lazy var doneButtonItem: UIBarButtonItem = {
         let button = UIBarButtonItem(title: String.localized("done"), style: .done, target: self, action: #selector(doneButtonPressed(_:)))
         return button
@@ -28,6 +51,59 @@ class PreviewController: QLPreviewController {
             */
             navigationItem.leftBarButtonItem = doneButtonItem
         }
+        view.addSubview(customToolbar)
+    }
+
+    @objc private func shareButtonTapped(_ sender: UIBarButtonItem) {
+        guard let defaultShareButton = self.qlShareButton else { return }
+        // execute action of nativeShareButton
+        _ = defaultShareButton.target?.perform(defaultShareButton.action, with: nil)
+    }
+
+    private func layoutCustumToolbarIfNeeded() {
+        guard let defaultToolbar = qlToolbar else {
+            return
+        }
+        if !customToolbarHasLayout {
+            customToolbar.translatesAutoresizingMaskIntoConstraints = false
+            customToolbarLeadingConstraint = customToolbar.leadingAnchor.constraint(equalTo: defaultToolbar.leadingAnchor, constant: 0)
+            customToolbarTopConstraint = customToolbar.topAnchor.constraint(equalTo: defaultToolbar.topAnchor, constant: 0)
+            customToolbarTrailingConstraint = customToolbar.trailingAnchor.constraint(equalTo: defaultToolbar.trailingAnchor, constant: 0)
+            customToolbarBottomConstraint = customToolbar.bottomAnchor.constraint(equalTo: defaultToolbar.bottomAnchor, constant: 0)
+            [
+                customToolbarLeadingConstraint, customToolbarTopConstraint, customToolbarTrailingConstraint, customToolbarBottomConstraint
+            ].forEach { $0?.isActive = true }
+        }
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // native toolbar is accessable after viewWillAppear
+        qlToolbar = traverseSearchToolbar(root: self.view)
+        layoutCustumToolbarIfNeeded()
+    }
+
+    private func traverseSearchToolbar(root: UIView) -> UIToolbar? {
+        if let toolbar = root as? UIToolbar, let items = toolbar.items {
+            if items.count == 3 {
+                // share item, flex item, list item
+                self.qlShareButton = items[0] // we need the share button to trigger share events
+                return toolbar
+            }
+        }
+        if root.subviews.isEmpty {
+            return nil
+        }
+
+        var subviews = root.subviews
+        var current = subviews.popLast()
+        while current != nil {
+            if let current = current, let toolbar = traverseSearchToolbar(root: current) {
+                return toolbar
+            }
+            current = subviews.popLast()
+        }
+        return nil
     }
 
     // MARK: - actions

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -168,7 +168,8 @@ private extension PreviewController {
 
         self.nativeToolbar = NativeToolbar(qlToolbar: qlToolbar, qlShareButton: shareButton)
 
-        self.observerToken = qlToolbar.observe(\.alpha, changeHandler: { [weak self] toolbar, _ in self?.fakeToolbar.alpha = toolbar.alpha})
+        // this will bind native toolbar's alpha to our fake toolbar (used on swipe down events)
+        _ = qlToolbar.observe(\.alpha, changeHandler: { [weak self] toolbar, _ in self?.fakeToolbar.alpha = toolbar.alpha})
 
         view.addSubview(fakeToolbar)
         fakeToolbar.translatesAutoresizingMaskIntoConstraints = false
@@ -185,7 +186,7 @@ private extension PreviewController {
 
     @objc private func shareButtonTapped(_ sender: UIBarButtonItem) {
          guard let defaultShareButton = self.nativeToolbar?.qlShareButton else { return }
-         // trigger action of nativeShareButton
+         // trigger action of native qlShareButton
          _ = defaultShareButton.target?.perform(defaultShareButton.action, with: nil)
      }
 

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -169,7 +169,7 @@ private extension PreviewController {
         self.nativeToolbar = NativeToolbar(qlToolbar: qlToolbar, qlShareButton: shareButton)
 
         // this will bind native toolbar's alpha to our fake toolbar (used on swipe down events)
-        _ = qlToolbar.observe(\.alpha, changeHandler: { [weak self] toolbar, _ in self?.fakeToolbar.alpha = toolbar.alpha})
+        observerToken = qlToolbar.observe(\.alpha, changeHandler: { [weak self] toolbar, _ in self?.fakeToolbar.alpha = toolbar.alpha})
 
         view.addSubview(fakeToolbar)
         fakeToolbar.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
closes #785 

### Observation: 
- On Iphones the the list button appears in a **bottom toolbar**
- On Ipads the list button appears in the **navigation bar** in the top
- All toolbar items are only accessible via subview traversing and can only be modified to a certain degree
- Toolbar at `viewDidLoad` always nil -> so customisation has to be done on `viewWillAppear`

Unfortunately the QL-toolbars are very resistant to customisation.  The solution was:
- traverse search the NavigationBar / BottomToolbar
- in the toolbar find the list item (can be identified by accessibility identifier)
- now: isHidden, remove etc. don't work, so the only solution was to disable it (or remove action), and hide it by setting `tintColor =.clear`

In case PreviewController is inside a navigationController this approach isn't meant to work, so the customisation won't be visible if the PreviewController is accessed from ChatView. 

[Update:]
for iOS 13.4 and lower the bottomToolbar is not customisable, so we cover it by a fake toolbar. 