### PR TITLE
Bugfix: delete contact on active search in NewChatController

### DIFF
--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -258,7 +258,6 @@ class NewChatViewController: UITableViewController {
                 filteredContactIds = dcContext.getContacts(flags: DC_GCL_ADD_SELF, queryString: searchText)
             }
             tableView.deleteRows(at: [indexPath], with: .automatic)
-            // self.tableView.reloadData()
         }
     }
 


### PR DESCRIPTION
closes #758 

Solution: 
Deleting a contact while active search did not update filteredContacts.

Extra: 
- Using tableView.deleteRow instead of reloadData to get animation
- moved alert-functions into separate code block (attempt to give NewChatController some structure)