### PR TITLE
set number of lines in fileviews titleview

### DIFF
--- a/deltachat-ios/MessageKit/Views/FileView.swift
+++ b/deltachat-ios/MessageKit/Views/FileView.swift
@@ -10,6 +10,7 @@ class FileView: UIView {
     private lazy var titleView: MessageLabel = {
         let label = MessageLabel()
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 3
         return label
     }()
 


### PR DESCRIPTION
related to #741 

@cyBerta Could you please have a quick look if this is sufficient. It actually does restrict the number of lines of our document-cells. 