### PR TITLE
ChatList - add visual feedback when cell tapped

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -206,7 +206,7 @@ class ChatListController: UITableViewController {
         return viewModel.titleForHeaderIn(section: section)
     }
 
-    override func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cellData = viewModel.cellDataFor(section: indexPath.section, row: indexPath.row)
         switch cellData.type {
         case .deaddrop(let deaddropData):
@@ -227,6 +227,7 @@ class ChatListController: UITableViewController {
                 self.askToChatWith(contactId: contactId)
             }
         }
+        tableView.deselectRow(at: indexPath, animated: false)
     }
 
     override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -134,10 +134,8 @@ class ContactCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        selectionStyle = .none
-        backgroundColor = DcColors.contactCellBackgroundColor
-        contentView.backgroundColor = DcColors.contactCellBackgroundColor
         setupSubviews()
+        selectionStyle = .default
     }
 
     required init?(coder: NSCoder) {
@@ -275,10 +273,8 @@ class ContactCell: UITableViewCell {
                 titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)
             }
             if chat.visibility == DC_CHAT_VISIBILITY_PINNED {
-                backgroundColor = DcColors.deaddropBackground
                 contentView.backgroundColor = DcColors.deaddropBackground
             } else {
-                backgroundColor = DcColors.contactCellBackgroundColor
                 contentView.backgroundColor = DcColors.contactCellBackgroundColor
             }
             if let img = chat.profileImage {
@@ -310,6 +306,16 @@ class ContactCell: UITableViewCell {
                                 visibility: 0,
                                 isLocationStreaming: false,
                                 isMuted: false)
+        }
+    }
+
+    private var bgColor: UIColor?
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        if selected {
+            bgColor = contentView.backgroundColor
+            contentView.backgroundColor = nil
+        } else {
+            contentView.backgroundColor = bgColor
         }
     }
 }

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -252,7 +252,6 @@ class ContactCell: UITableViewCell {
         case .deaddrop(let deaddropData):
             safe_assert(deaddropData.chatId == DC_CHAT_ID_DEADDROP)
             backgroundColor = DcColors.deaddropBackground
-            // contentView.backgroundColor = DcColors.deaddropBackground
             let contact = DcContact(id: DcMsg(id: deaddropData.msgId).fromContactId)
             if let img = contact.profileImage {
                 resetBackupImage()

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -252,7 +252,7 @@ class ContactCell: UITableViewCell {
         case .deaddrop(let deaddropData):
             safe_assert(deaddropData.chatId == DC_CHAT_ID_DEADDROP)
             backgroundColor = DcColors.deaddropBackground
-            contentView.backgroundColor = DcColors.deaddropBackground
+            // contentView.backgroundColor = DcColors.deaddropBackground
             let contact = DcContact(id: DcMsg(id: deaddropData.msgId).fromContactId)
             if let img = contact.profileImage {
                 resetBackupImage()
@@ -273,9 +273,9 @@ class ContactCell: UITableViewCell {
                 titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)
             }
             if chat.visibility == DC_CHAT_VISIBILITY_PINNED {
-                contentView.backgroundColor = DcColors.deaddropBackground
+                backgroundColor = DcColors.deaddropBackground
             } else {
-                contentView.backgroundColor = DcColors.contactCellBackgroundColor
+                backgroundColor = DcColors.contactCellBackgroundColor
             }
             if let img = chat.profileImage {
                 resetBackupImage()
@@ -306,16 +306,6 @@ class ContactCell: UITableViewCell {
                                 visibility: 0,
                                 isLocationStreaming: false,
                                 isMuted: false)
-        }
-    }
-
-    private var bgColor: UIColor?
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        if selected {
-            bgColor = contentView.backgroundColor
-            contentView.backgroundColor = nil
-        } else {
-            contentView.backgroundColor = bgColor
         }
     }
 }


### PR DESCRIPTION
closes #522 

Currently some tables/cells provide visual feedback when tapped (->Settings).

Our tables containing ContactCells don't. Adding tapping feedback gives a very subtile feel of liveliness and is actually native behaviour.

I implemented it by setting ContactCells contents background color to nil (so the default `SelectedView` can shine through in selection state). I also realised that we're currently setting some backgroundColor to the cell, which I believe is not needed (contentview covers it completely), so I removed that. 


