### PR TITLE
fix string for two-hours-mute

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -287,7 +287,7 @@ class ContactDetailViewController: UITableViewController {
         let alert = UIAlertController(title: String.localized("mute"), message: nil, preferredStyle: .safeActionSheet)
         let forever = -1
         addDurationSelectionAction(to: alert, key: "mute_for_one_hour", duration: Time.oneHour)
-        addDurationSelectionAction(to: alert, key: "mute_for_one_hour", duration: Time.twoHours)
+        addDurationSelectionAction(to: alert, key: "mute_for_two_hours", duration: Time.twoHours)
         addDurationSelectionAction(to: alert, key: "mute_for_one_day", duration: Time.oneDay)
         addDurationSelectionAction(to: alert, key: "mute_for_seven_days", duration: Time.oneWeek)
         addDurationSelectionAction(to: alert, key: "mute_forever", duration: forever)

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -487,7 +487,7 @@ extension GroupChatDetailViewController {
         let alert = UIAlertController(title: String.localized("mute"), message: nil, preferredStyle: .safeActionSheet)
         let forever = -1
         addDurationSelectionAction(to: alert, key: "mute_for_one_hour", duration: Time.oneHour)
-        addDurationSelectionAction(to: alert, key: "mute_for_one_hour", duration: Time.twoHours)
+        addDurationSelectionAction(to: alert, key: "mute_for_two_hours", duration: Time.twoHours)
         addDurationSelectionAction(to: alert, key: "mute_for_one_day", duration: Time.oneDay)
         addDurationSelectionAction(to: alert, key: "mute_for_seven_days", duration: Time.oneWeek)
         addDurationSelectionAction(to: alert, key: "mute_forever", duration: forever)


### PR DESCRIPTION
just a typo, results in having two times the option "mute for one hour"