### PR TITLE
tweak profile

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -146,6 +146,8 @@ class ContactDetailViewController: UITableViewController {
                 return ephemeralMessagesCell
             case .muteChat:
                 return muteChatCell
+            case .startChat:
+                return startChatCell
             }
         case .chatActions:
             switch viewModel.chatActionFor(row: row) {
@@ -156,8 +158,6 @@ class ContactDetailViewController: UITableViewController {
             case .deleteChat:
                 return deleteChatCell
             }
-        case .startChat:
-            return startChatCell
         case .sharedChats:
             if let cell = tableView.dequeueReusableCell(withIdentifier: ContactCell.reuseIdentifier, for: indexPath) as? ContactCell {
                 viewModel.update(sharedChatCell: cell, row: row)
@@ -174,9 +174,6 @@ class ContactDetailViewController: UITableViewController {
             handleAttachmentAction(for: indexPath.row)
         case .chatActions:
             handleCellAction(for: indexPath.row)
-        case .startChat:
-            let contactId = viewModel.contactId
-            chatWith(contactId: contactId)
         case .sharedChats:
             let chatId = viewModel.getSharedChatIdAt(indexPath: indexPath)
             showChat(chatId: chatId)
@@ -186,7 +183,7 @@ class ContactDetailViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let type = viewModel.typeFor(section: indexPath.section)
         switch type {
-        case .chatActions, .startChat, .chatOptions:
+        case .chatActions, .chatOptions:
             return Constants.defaultCellHeight
         case .sharedChats:
             return ContactCell.cellHeight
@@ -241,6 +238,9 @@ class ContactDetailViewController: UITableViewController {
             } else {
                 showMuteAlert()
             }
+        case .startChat:
+            let contactId = viewModel.contactId
+            chatWith(contactId: contactId)
         }
     }
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -137,7 +137,7 @@ class ContactDetailViewController: UITableViewController {
         let cellType = viewModel.typeFor(section: indexPath.section)
         switch cellType {
         case .chatOptions:
-            switch viewModel.attachmentActionFor(row: row) {
+            switch viewModel.chatOptionFor(row: row) {
             case .documents:
                 return documentsCell
             case .gallery:
@@ -171,9 +171,9 @@ class ContactDetailViewController: UITableViewController {
         let type = viewModel.typeFor(section: indexPath.section)
         switch type {
         case .chatOptions:
-            handleAttachmentAction(for: indexPath.row)
+            handleChatOption(for: indexPath.row)
         case .chatActions:
-            handleCellAction(for: indexPath.row)
+            handleChatAction(for: indexPath.row)
         case .sharedChats:
             let chatId = viewModel.getSharedChatIdAt(indexPath: indexPath)
             showChat(chatId: chatId)
@@ -210,7 +210,7 @@ class ContactDetailViewController: UITableViewController {
     }
 
     // MARK: - actions
-    private func handleCellAction(for index: Int) {
+    private func handleChatAction(for index: Int) {
         let action = viewModel.chatActionFor(row: index)
         switch action {
         case .archiveChat:
@@ -222,8 +222,8 @@ class ContactDetailViewController: UITableViewController {
         }
     }
 
-    private func handleAttachmentAction(for index: Int) {
-        let action = viewModel.attachmentActionFor(row: index)
+    private func handleChatOption(for index: Int) {
+        let action = viewModel.chatOptionFor(row: index)
         switch action {
         case .documents:
             showDocuments()

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -136,7 +136,7 @@ class ContactDetailViewController: UITableViewController {
         let row = indexPath.row
         let cellType = viewModel.typeFor(section: indexPath.section)
         switch cellType {
-        case .attachments:
+        case .chatOptions:
             switch viewModel.attachmentActionFor(row: row) {
             case .documents:
                 return documentsCell
@@ -170,7 +170,7 @@ class ContactDetailViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let type = viewModel.typeFor(section: indexPath.section)
         switch type {
-        case .attachments:
+        case .chatOptions:
             handleAttachmentAction(for: indexPath.row)
         case .chatActions:
             handleCellAction(for: indexPath.row)
@@ -186,7 +186,7 @@ class ContactDetailViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let type = viewModel.typeFor(section: indexPath.section)
         switch type {
-        case .chatActions, .startChat, .attachments:
+        case .chatActions, .startChat, .chatOptions:
             return Constants.defaultCellHeight
         case .sharedChats:
             return ContactCell.cellHeight

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -142,13 +142,13 @@ class ContactDetailViewController: UITableViewController {
                 return documentsCell
             case .gallery:
                 return galleryCell
-            }
-        case .chatActions:
-            switch viewModel.chatActionFor(row: row) {
             case .ephemeralMessages:
                 return ephemeralMessagesCell
             case .muteChat:
                 return muteChatCell
+            }
+        case .chatActions:
+            switch viewModel.chatActionFor(row: row) {
             case .archiveChat:
                 return archiveChatCell
             case .blockContact:
@@ -216,15 +216,6 @@ class ContactDetailViewController: UITableViewController {
     private func handleCellAction(for index: Int) {
         let action = viewModel.chatActionFor(row: index)
         switch action {
-        case .ephemeralMessages:
-            showEphemeralMessagesController()
-        case .muteChat:
-            if viewModel.chatIsMuted {
-                self.viewModel.context.setChatMuteDuration(chatId: self.viewModel.chatId, duration: 0)
-                muteChatCell.actionTitle = String.localized("menu_mute")
-            } else {
-                showMuteAlert()
-            }
         case .archiveChat:
             toggleArchiveChat()
         case .blockContact:
@@ -241,6 +232,15 @@ class ContactDetailViewController: UITableViewController {
             showDocuments()
         case .gallery:
             showGallery()
+        case .ephemeralMessages:
+            showEphemeralMessagesController()
+        case .muteChat:
+            if viewModel.chatIsMuted {
+                self.viewModel.context.setChatMuteDuration(chatId: self.viewModel.chatId, duration: 0)
+                muteChatCell.actionTitle = String.localized("menu_mute")
+            } else {
+                showMuteAlert()
+            }
         }
     }
 

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -4,9 +4,14 @@ import DcCore
 class GroupChatDetailViewController: UIViewController {
 
     enum ProfileSections {
-        case attachments
+        case chatOptions
         case members
         case chatActions
+    }
+
+    enum ChatOption {
+        case gallery
+        case documents
     }
 
     enum ChatAction {
@@ -17,6 +22,10 @@ class GroupChatDetailViewController: UIViewController {
         case deleteChat
     }
 
+    private lazy var chatOptions: [ChatOption] = {
+        return [.gallery, .documents]
+    }()
+
     private lazy var chatActions: [ChatAction] = {
         var actions: [ChatAction] = [.muteChat, .archiveChat, .leaveGroup, .deleteChat]
         if UserDefaults.standard.bool(forKey: "ephemeral_messages") || dcContext.getChatEphemeralTimer(chatId: chatId) > 0 {
@@ -25,15 +34,13 @@ class GroupChatDetailViewController: UIViewController {
         return actions
     }()
 
-    private let attachmentsRowGallery = 0
-    private let attachmentsRowDocuments = 1
     private let membersRowAddMembers = 0
     private let membersRowQrInvite = 1
     private let memberManagementRows = 2
 
     private let dcContext: DcContext
 
-    private let sections: [ProfileSections] = [.attachments, .members, .chatActions]
+    private let sections: [ProfileSections] = [.chatOptions, .members, .chatActions]
 
     private var currentUser: DcContact? {
         let myId = groupMemberIds.filter { DcContact(id: $0).email == dcContext.addr }.first
@@ -287,8 +294,8 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
     func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
         let sectionType = sections[section]
         switch sectionType {
-        case .attachments:
-            return 2
+        case .chatOptions:
+            return chatOptions.count
         case .members:
             return groupMemberIds.count + memberManagementRows
         case .chatActions:
@@ -300,7 +307,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         let sectionType = sections[indexPath.section]
         let row = indexPath.row
         switch sectionType {
-        case .attachments, .chatActions:
+        case .chatOptions, .chatActions:
             return Constants.defaultCellHeight
         case .members:
             switch row {
@@ -316,10 +323,11 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         let row = indexPath.row
         let sectionType = sections[indexPath.section]
         switch sectionType {
-        case .attachments:
-            if row == attachmentsRowGallery {
+        case .chatOptions:
+            switch chatOptions[row] {
+            case .gallery:
                 return galleryCell
-            } else if row == attachmentsRowDocuments {
+            case .documents:
                 return documentsCell
             }
         case .members:
@@ -373,10 +381,11 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
         let row = indexPath.row
 
         switch sectionType {
-        case .attachments:
-            if row == attachmentsRowGallery {
+        case .chatOptions:
+            switch chatOptions[row] {
+            case .gallery:
                 showGallery()
-            } else if row == attachmentsRowDocuments {
+            case .documents:
                 showDocuments()
             }
         case .members:

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -69,7 +69,7 @@ class ContactDetailViewModel {
         return chatActions[row]
     }
 
-    func attachmentActionFor(row: Int) -> ContactDetailViewModel.ChatOption {
+    func chatOptionFor(row: Int) -> ContactDetailViewModel.ChatOption {
         return chatOptions[row]
     }
 

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -7,9 +7,14 @@ class ContactDetailViewModel {
 
     enum ProfileSections {
         case startChat
-        case attachments
+        case chatOptions
         case sharedChats
         case chatActions //  archive chat, block chat, delete chats
+    }
+
+    enum ChatOption {
+        case gallery
+        case documents
     }
 
     enum ChatAction {
@@ -18,11 +23,6 @@ class ContactDetailViewModel {
         case archiveChat
         case blockContact
         case deleteChat
-    }
-
-    enum AttachmentAction {
-        case gallery
-        case documents
     }
 
     var contactId: Int
@@ -35,7 +35,7 @@ class ContactDetailViewModel {
     private let sharedChats: DcChatlist
     private var sections: [ProfileSections] = []
     private var chatActions: [ChatAction] = []
-    private var attachmentActions: [AttachmentAction] = [.gallery, .documents]
+    private var chatOptions: [ChatOption] = [.gallery, .documents]
 
     init(dcContext: DcContext, contactId: Int) {
         self.context = dcContext
@@ -43,7 +43,7 @@ class ContactDetailViewModel {
         self.chatId = dcContext.getChatIdByContactId(contactId: contactId)
         self.sharedChats = context.getChatlist(flags: 0, queryString: nil, queryId: contactId)
 
-        sections.append(.attachments)
+        sections.append(.chatOptions)
         sections.append(.startChat)
         if sharedChats.length > 0 {
             sections.append(.sharedChats)
@@ -68,8 +68,8 @@ class ContactDetailViewModel {
         return chatActions[row]
     }
 
-    func attachmentActionFor(row: Int) -> ContactDetailViewModel.AttachmentAction {
-        return attachmentActions[row]
+    func attachmentActionFor(row: Int) -> ContactDetailViewModel.ChatOption {
+        return chatOptions[row]
     }
 
     var chatIsArchived: Bool {
@@ -86,7 +86,7 @@ class ContactDetailViewModel {
 
     func numberOfRowsInSection(_ section: Int) -> Int {
         switch sections[section] {
-        case .attachments: return 2
+        case .chatOptions: return chatOptions.count
         case .sharedChats: return sharedChats.length
         case .startChat: return 1
         case .chatActions: return chatActions.count

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -9,17 +9,17 @@ class ContactDetailViewModel {
         case startChat
         case chatOptions
         case sharedChats
-        case chatActions //  archive chat, block chat, delete chats
+        case chatActions
     }
 
     enum ChatOption {
         case gallery
         case documents
+        case ephemeralMessages
+        case muteChat
     }
 
     enum ChatAction {
-        case ephemeralMessages
-        case muteChat
         case archiveChat
         case blockContact
         case deleteChat
@@ -35,7 +35,7 @@ class ContactDetailViewModel {
     private let sharedChats: DcChatlist
     private var sections: [ProfileSections] = []
     private var chatActions: [ChatAction] = []
-    private var chatOptions: [ChatOption] = [.gallery, .documents]
+    private var chatOptions: [ChatOption] = []
 
     init(dcContext: DcContext, contactId: Int) {
         self.context = dcContext
@@ -51,11 +51,13 @@ class ContactDetailViewModel {
         sections.append(.chatActions)
 
         if chatId != 0 {
-            chatActions = [.muteChat, .archiveChat, .blockContact, .deleteChat]
+            chatOptions = [.gallery, .documents, .muteChat]
+            chatActions = [.archiveChat, .blockContact, .deleteChat]
             if UserDefaults.standard.bool(forKey: "ephemeral_messages") || dcContext.getChatEphemeralTimer(chatId: chatId) > 0 {
-                chatActions.insert(.ephemeralMessages, at: 0)
+                chatOptions.insert(.ephemeralMessages, at: 2)
             }
         } else {
+            chatOptions = [.gallery, .documents]
             chatActions = [.blockContact]
         }
     }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -6,7 +6,6 @@ class ContactDetailViewModel {
     let context: DcContext
 
     enum ProfileSections {
-        case startChat
         case chatOptions
         case sharedChats
         case chatActions
@@ -17,6 +16,7 @@ class ContactDetailViewModel {
         case documents
         case ephemeralMessages
         case muteChat
+        case startChat
     }
 
     enum ChatAction {
@@ -44,20 +44,19 @@ class ContactDetailViewModel {
         self.sharedChats = context.getChatlist(flags: 0, queryString: nil, queryId: contactId)
 
         sections.append(.chatOptions)
-        sections.append(.startChat)
         if sharedChats.length > 0 {
             sections.append(.sharedChats)
         }
         sections.append(.chatActions)
 
         if chatId != 0 {
-            chatOptions = [.gallery, .documents, .muteChat]
+            chatOptions = [.gallery, .documents, .muteChat, .startChat]
             chatActions = [.archiveChat, .blockContact, .deleteChat]
             if UserDefaults.standard.bool(forKey: "ephemeral_messages") || dcContext.getChatEphemeralTimer(chatId: chatId) > 0 {
                 chatOptions.insert(.ephemeralMessages, at: 2)
             }
         } else {
-            chatOptions = [.gallery, .documents]
+            chatOptions = [.gallery, .documents, .startChat]
             chatActions = [.blockContact]
         }
     }
@@ -90,7 +89,6 @@ class ContactDetailViewModel {
         switch sections[section] {
         case .chatOptions: return chatOptions.count
         case .sharedChats: return sharedChats.length
-        case .startChat: return 1
         case .chatActions: return chatActions.count
         }
     }


### PR DESCRIPTION
this pr tweaks the group- and contact-profiles:
- move mute ephemeral option up, so that it is reachable without scrolling (the ephermeral option will be renamed, this is currently under discussion, so i did not change that yet)
- archive/block/leave/delete stay abottom, this kind of stuff is typically expected at the end of a view on ios, also these actions are not used often
- add start-chat for contacts without chat

<img width="320" alt="Screen Shot 2020-07-09 at 02 05 11" src="https://user-images.githubusercontent.com/9800740/86982471-999b6600-c189-11ea-8bd6-332a80ab0971.png"> <img width="320" alt="Screen Shot 2020-07-09 at 02 06 09" src="https://user-images.githubusercontent.com/9800740/86982477-9ef8b080-c189-11ea-8f4e-b2527beff844.png">
tasks is subsequent prs:
- background color needs some streamlining, i will create an issue for that
- it would be nive to have a "value" for gallery/documents/ephemeral - that would be a number for gallery/documents and on/off for ephemeral (the whole option might get too long to show here, maybe sth. as 1h or so, but just on/off is aleady helpful)