### PR TITLE
Async gallery follow up

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -26,7 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         DBDebugToolkit.setup(with: []) // empty array will override default device shake trigger
         DBDebugToolkit.setupCrashReporting()
-
+        
         let console = ConsoleDestination()
         logger.addDestination(console)
         dcContext.logger = DcLogger()

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -253,7 +253,7 @@ class GalleryItem {
         }
     }
 
-    func loadThumbnail() {
+    private func loadThumbnail() {
         guard let viewtype = msg.viewtype, let url = msg.fileURL else {
             return
         }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -271,10 +271,15 @@ class GalleryItem {
     }
 
     private func loadGifThumbnail(from url: URL) {
-        guard let imageData = try? Data(contentsOf: url) else {
-            return
+        DispatchQueue.global(qos: .background).async {
+            guard let imageData = try? Data(contentsOf: url) else {
+                return
+            }
+            let thumbnailImage = SDAnimatedImage(data: imageData)
+            DispatchQueue.main.async { [weak self] in
+                self?.thumbnailImage = thumbnailImage
+            }
         }
-        self.thumbnailImage = SDAnimatedImage(data: imageData)
     }
 
     private func loadVideoThumbnail(from url: URL) {

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -225,10 +225,6 @@ class GalleryItem {
 
     var msg: DcMsg
 
-    var msgViewType: MessageViewType? {
-        return msg.viewtype
-    }
-
     var fileUrl: URL? {
         return msg.fileURL
     }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -74,10 +74,6 @@ class GalleryViewController: UIViewController {
         self.reloadCollectionViewLayout()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        ThumbnailCache.shared.clearCache()
-    }
-
     // MARK: - setup
     private func setupSubviews() {
         view.addSubview(grid)
@@ -226,7 +222,6 @@ extension GalleryViewController {
 class GalleryItem {
 
     var onImageLoaded: ((UIImage?) -> Void)?
-    var onGifLoaded: ((SDAnimatedImage?) -> Void)?
 
     var msg: DcMsg
 
@@ -241,13 +236,6 @@ class GalleryItem {
     var thumbnailImage: UIImage? {
         willSet {
            onImageLoaded?(newValue)
-        }
-    }
-
-    var gifImage: SDAnimatedImage? {
-        willSet {
-            print("onGifLoaded")
-            onGifLoaded?(newValue)
         }
     }
 
@@ -290,20 +278,7 @@ class GalleryItem {
         guard let imageData = try? Data(contentsOf: url) else {
             return
         }
-        self.gifImage = SDAnimatedImage(data: imageData)
-
-
-        /*
-        DispatchQueue.global(qos: .background).async {
-            let gifThumbnail = self.gifThumbnail(url: url)
-            DispatchQueue.main.async { [weak self] in
-                self?.thumbnailImage = gifThumbnail
-                if let image = gifThumbnail {
-                    ThumbnailCache.shared.storeImage(image: image, key: url.absoluteString)
-                }
-            }
-        }
-        */
+        self.thumbnailImage = SDAnimatedImage(data: imageData)
     }
 
     private func loadVideoThumbnail(from url: URL) {
@@ -316,38 +291,5 @@ class GalleryItem {
                 }
             }
         }
-    }
-
-    private func gifThumbnail(url: URL) -> UIImage? {
-        return getGifSequence(url: url)?.first ?? nil
-    }
-
-    private func getGifSequence(url: URL) -> [UIImage]? {
-
-        guard let imageData = try? Data(contentsOf: url) else {
-            return nil
-        }
-
-        let gifOptions = [
-            kCGImageSourceShouldAllowFloat as String: true as NSNumber,
-            kCGImageSourceCreateThumbnailWithTransform as String: true as NSNumber,
-            kCGImageSourceCreateThumbnailFromImageAlways as String: true as NSNumber
-            ] as CFDictionary
-
-        guard let imageSource = CGImageSourceCreateWithData(imageData as CFData, gifOptions) else {
-            debugPrint("Cannot create image source with data!")
-            return nil
-        }
-
-        let framesCount = CGImageSourceGetCount(imageSource)
-        var frameList = [UIImage]()
-
-        for index in 0 ..< framesCount {
-            if let cgImageRef = CGImageSourceCreateImageAtIndex(imageSource, index, nil) {
-                let uiImageRef = UIImage(cgImage: cgImageRef)
-                frameList.append(uiImageRef)
-            }
-        }
-        return frameList
     }
 }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -271,7 +271,7 @@ class GalleryItem {
     }
 
     private func loadGifThumbnail(from url: URL) {
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue.global(qos: .userInteractive).async {
             guard let imageData = try? Data(contentsOf: url) else {
                 return
             }
@@ -283,7 +283,7 @@ class GalleryItem {
     }
 
     private func loadVideoThumbnail(from url: URL) {
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue.global(qos: .userInteractive).async {
             let thumbnailImage = DcUtils.generateThumbnailFromVideo(url: url)
             DispatchQueue.main.async { [weak self] in
                 self?.thumbnailImage = thumbnailImage

--- a/deltachat-ios/Helper/ThumbnailCache.swift
+++ b/deltachat-ios/Helper/ThumbnailCache.swift
@@ -12,15 +12,10 @@ class ThumbnailCache {
     }()
 
     func storeImage(image: UIImage, key: String){
-     //   cache.setObject(image, forKey: NSString(string: key))
+        cache.setObject(image, forKey: NSString(string: key))
     }
 
     func restoreImage(key: String) -> UIImage? {
-        return nil
-        //  return cache.object(forKey: NSString(string: key))
-    }
-
-    func clearCache() {
-        cache.removeAllObjects()
+        return cache.object(forKey: NSString(string: key))
     }
 }

--- a/deltachat-ios/Helper/ThumbnailCache.swift
+++ b/deltachat-ios/Helper/ThumbnailCache.swift
@@ -12,11 +12,12 @@ class ThumbnailCache {
     }()
 
     func storeImage(image: UIImage, key: String){
-        cache.setObject(image, forKey: NSString(string: key))
+     //   cache.setObject(image, forKey: NSString(string: key))
     }
 
     func restoreImage(key: String) -> UIImage? {
-        return cache.object(forKey: NSString(string: key))
+        return nil
+        //  return cache.object(forKey: NSString(string: key))
     }
 
     func clearCache() {

--- a/deltachat-ios/Helper/ThumbnailCache.swift
+++ b/deltachat-ios/Helper/ThumbnailCache.swift
@@ -12,12 +12,11 @@ class ThumbnailCache {
     }()
 
     func storeImage(image: UIImage, key: String){
-        // cache.setObject(image, forKey: NSString(string: key))
+        cache.setObject(image, forKey: NSString(string: key))
     }
 
     func restoreImage(key: String) -> UIImage? {
-        return nil
-        //     return cache.object(forKey: NSString(string: key))
+        return cache.object(forKey: NSString(string: key))
     }
 
     func clearCache() {

--- a/deltachat-ios/Helper/ThumbnailCache.swift
+++ b/deltachat-ios/Helper/ThumbnailCache.swift
@@ -18,8 +18,4 @@ class ThumbnailCache {
     func restoreImage(key: String) -> UIImage? {
         return cache.object(forKey: NSString(string: key))
     }
-
-    func clearCache() {
-        cache.removeAllObjects()
-    }
 }

--- a/deltachat-ios/Helper/ThumbnailCache.swift
+++ b/deltachat-ios/Helper/ThumbnailCache.swift
@@ -12,10 +12,15 @@ class ThumbnailCache {
     }()
 
     func storeImage(image: UIImage, key: String){
-        cache.setObject(image, forKey: NSString(string: key))
+        // cache.setObject(image, forKey: NSString(string: key))
     }
 
     func restoreImage(key: String) -> UIImage? {
-        return cache.object(forKey: NSString(string: key))
+        return nil
+        //     return cache.object(forKey: NSString(string: key))
+    }
+
+    func clearCache() {
+        cache.removeAllObjects()
     }
 }

--- a/deltachat-ios/View/Cell/GalleryCell.swift
+++ b/deltachat-ios/View/Cell/GalleryCell.swift
@@ -55,8 +55,8 @@ class GalleryCell: UICollectionViewCell {
         item.onImageLoaded = { [weak self] image in
             self?.imageView.image = image
         }
-        imageView.image = item.thumbnailImage
         playButtonView.isHidden = !item.showPlayButton
+        imageView.image = item.thumbnailImage
     }
 
     override var isSelected: Bool {

--- a/deltachat-ios/View/Cell/GalleryCell.swift
+++ b/deltachat-ios/View/Cell/GalleryCell.swift
@@ -51,35 +51,12 @@ class GalleryCell: UICollectionViewCell {
     }
 
     func update(item: GalleryItem) {
-
-        guard let viewType = item.msgViewType else {
-            return
-        }
-
         self.item = item
         item.onImageLoaded = { [weak self] image in
             self?.imageView.image = image
         }
-        item.onGifLoaded = { [weak self] gifImage in
-            self?.imageView.image = gifImage
-        }
-
-        switch viewType {
-        case .gif:
-            imageView.image = item.gifImage
-        case .video:
-            imageView.image = item.thumbnailImage
-        case .image:
-            imageView.image = item.thumbnailImage
-        default:
-            safe_fatalError("unsupported viewtype - viewtype \(viewType) not supported.")
-        }
-
+        imageView.image = item.thumbnailImage
         playButtonView.isHidden = !item.showPlayButton
-    }
-
-    private func updateThumbnail() {
-
     }
 
     override var isSelected: Bool {

--- a/deltachat-ios/View/Cell/GalleryCell.swift
+++ b/deltachat-ios/View/Cell/GalleryCell.swift
@@ -7,8 +7,8 @@ class GalleryCell: UICollectionViewCell {
 
     weak var item: GalleryItem?
 
-    var imageView: UIImageView = {
-        let view = UIImageView()
+    var imageView: SDAnimatedImageView = {
+        let view = SDAnimatedImageView()
         view.contentMode = .scaleAspectFill
         view.clipsToBounds = true
         view.backgroundColor = DcColors.defaultBackgroundColor
@@ -20,7 +20,6 @@ class GalleryCell: UICollectionViewCell {
         playButtonView.isHidden = true
         return playButtonView
     }()
-
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -52,12 +51,35 @@ class GalleryCell: UICollectionViewCell {
     }
 
     func update(item: GalleryItem) {
+
+        guard let viewType = item.msgViewType else {
+            return
+        }
+
         self.item = item
         item.onImageLoaded = { [weak self] image in
             self?.imageView.image = image
         }
+        item.onGifLoaded = { [weak self] gifImage in
+            self?.imageView.image = gifImage
+        }
+
+        switch viewType {
+        case .gif:
+            imageView.image = item.gifImage
+        case .video:
+            imageView.image = item.thumbnailImage
+        case .image:
+            imageView.image = item.thumbnailImage
+        default:
+            safe_fatalError("unsupported viewtype - viewtype \(viewType) not supported.")
+        }
+
         playButtonView.isHidden = !item.showPlayButton
-        imageView.image = item.thumbnailImage
+    }
+
+    private func updateThumbnail() {
+
     }
 
     override var isSelected: Bool {

--- a/deltachat-ios/View/Cell/GalleryCell.swift
+++ b/deltachat-ios/View/Cell/GalleryCell.swift
@@ -33,6 +33,7 @@ class GalleryCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        item?.onImageLoaded = nil
         item = nil
     }
 
@@ -51,16 +52,13 @@ class GalleryCell: UICollectionViewCell {
     }
 
     func update(item: GalleryItem) {
+        self.item = item
         item.onImageLoaded = { [weak self] image in
-            print("dc_debug: image set")
             self?.imageView.image = image
         }
         playButtonView.isHidden = !item.showPlayButton
-        self.item = item
         imageView.image = item.thumbnailImage
-
     }
-
 
     override var isSelected: Bool {
         willSet {


### PR DESCRIPTION
follow up for #815 

I enabled CollectionView's `prefetching`-feature for our gallery, to enhance scrolling performance.

Since results needs to be stored/cached in the ViewController (not in the cell) I created a `GalleryItem that manages all the fetching + data. The GalleryItem is passed to the cell before display. 

The cell can use the `galleryItem.thumbnailImage` if already loaded or register for the incoming thumbnails.

For better testing: our ThumbnailCache has a clear-method, which you can use on GalleryViewController.viewWillAppear. 
