### PR TITLE
Video recording

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -104,7 +104,7 @@ class ChatViewController: MessagesViewController, UINavigationControllerDelegate
 
     private lazy var mediaPicker: MediaPicker? = {
         let mediaPicker = MediaPicker(navigationController: navigationController)
-        mediaPicker.delegate = self 
+        mediaPicker.delegate = self
         return mediaPicker
     }()
 
@@ -1512,34 +1512,3 @@ extension MessageCollectionViewCell {
         }
     }
 }
-
-/*
-// MARK: - UIImagePickerControllerDelegate
-extension MediaPicker: UIImagePickerControllerDelegate {
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-
-        enum PickerMediaType: String {
-            case image = "public.image"
-            case video = "public.movie"
-         }
-
-        if let type = info[.mediaType] as? String, let mediaType = PickerMediaType(rawValue: type) {
-
-            switch mediaType {
-            case .video:
-                if let mediaUrl = info[.mediaURL] as? NSURL {
-                    sendVideo(url: mediaUrl)
-                }
-            case .image:
-                if let image = info[.editedImage] as? UIImage {
-                    sendImage(image)
-                } else if let image = info[.originalImage] as? UIImage {
-                    sendImage(image)
-                }
-            }
-        }
-        picker.dismiss(animated: true, completion: nil)
-    }
-
-}
-*/

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -39,7 +39,7 @@ extension ChatViewController: MediaPickerDelegate {
 
 }
 
-class ChatViewController: MessagesViewController, UINavigationControllerDelegate {
+class ChatViewController: MessagesViewController {
     var dcContext: DcContext
     let outgoingAvatarOverlap: CGFloat = 17.5
     let loadCount = 30

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -103,7 +103,9 @@ class ChatViewController: MessagesViewController, UINavigationControllerDelegate
     var showCustomNavBar = true
 
     private lazy var mediaPicker: MediaPicker? = {
-        return MediaPicker(navigationController: navigationController)
+        let mediaPicker = MediaPicker(navigationController: navigationController)
+        mediaPicker.delegate = self 
+        return mediaPicker
     }()
 
     var emptyStateView: EmptyStateLabel = {
@@ -723,21 +725,7 @@ class ChatViewController: MessagesViewController, UINavigationControllerDelegate
     }
 
     private func showCameraViewController() {
-        if UIImagePickerController.isSourceTypeAvailable(.camera) {
-            let imagePickerController = UIImagePickerController()
-            imagePickerController.sourceType = .camera
-            imagePickerController.delegate = self
-            let mediaTypes: [String] = UIImagePickerController.availableMediaTypes(for: .camera) ?? []
-            imagePickerController.mediaTypes = mediaTypes
-            imagePickerController.setEditing(true, animated: true)
-            present(imagePickerController, animated: true, completion: nil)
-        } else {
-            let alert = UIAlertController(title: String.localized("chat_camera_unavailable"), message: nil, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: String.localized("ok"), style: .cancel, handler: { _ in
-                self.navigationController?.dismiss(animated: true, completion: nil)
-            }))
-            present(alert, animated: true, completion: nil)
-        }
+       mediaPicker?.showCamera(delegate: self)
     }
 
     private func showPhotoVideoLibrary(delegate: MediaPickerDelegate) {
@@ -1525,8 +1513,9 @@ extension MessageCollectionViewCell {
     }
 }
 
+/*
 // MARK: - UIImagePickerControllerDelegate
-extension ChatViewController: UIImagePickerControllerDelegate {
+extension MediaPicker: UIImagePickerControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
 
         enum PickerMediaType: String {
@@ -1553,3 +1542,4 @@ extension ChatViewController: UIImagePickerControllerDelegate {
     }
 
 }
+*/

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -725,7 +725,7 @@ class ChatViewController: MessagesViewController, UINavigationControllerDelegate
     }
 
     private func showCameraViewController() {
-       mediaPicker?.showCamera(delegate: self)
+       mediaPicker?.showCamera()
     }
 
     private func showPhotoVideoLibrary(delegate: MediaPickerDelegate) {

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -12,7 +12,9 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
     var avatarSelectionCell: AvatarSelectionCell
 
     private lazy var mediaPicker: MediaPicker? = {
-        return MediaPicker(navigationController: navigationController)
+        let mediaPicker = MediaPicker(navigationController: navigationController)
+        mediaPicker.delegate = self 
+        return mediaPicker
     }()
 
     lazy var groupNameCell: TextFieldCell = {
@@ -103,7 +105,7 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
     }
 
     private func cameraButtonPressed(_ action: UIAlertAction) {
-        mediaPicker?.showCamera(delegate: self)
+        mediaPicker?.showCamera(delegate: self, allowCropping: true, supportedMediaTypes: .photo)
     }
 
     func onImageSelected(image: UIImage) {

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -13,7 +13,7 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
 
     private lazy var mediaPicker: MediaPicker? = {
         let mediaPicker = MediaPicker(navigationController: navigationController)
-        mediaPicker.delegate = self 
+        mediaPicker.delegate = self
         return mediaPicker
     }()
 
@@ -105,7 +105,7 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
     }
 
     private func cameraButtonPressed(_ action: UIAlertAction) {
-        mediaPicker?.showCamera(delegate: self, allowCropping: true, supportedMediaTypes: .photo)
+        mediaPicker?.showCamera(allowCropping: true, supportedMediaTypes: .photo)
     }
 
     func onImageSelected(image: UIImage) {

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -127,7 +127,7 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
     }
 
     private func cameraButtonPressed(_ action: UIAlertAction) {
-        mediaPicker?.showCamera(delegate: self)
+        mediaPicker?.showCamera(delegate: self, allowCropping: true, supportedMediaTypes: .photo)
     }
 
     private func deleteProfileIconPressed(_ action: UIAlertAction) {

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -129,7 +129,7 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
     }
 
     private func cameraButtonPressed(_ action: UIAlertAction) {
-        mediaPicker?.showCamera(delegate: self, allowCropping: true, supportedMediaTypes: .photo)
+        mediaPicker?.showCamera(allowCropping: true, supportedMediaTypes: .photo)
     }
 
     private func deleteProfileIconPressed(_ action: UIAlertAction) {

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -21,7 +21,9 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
     private let tagAccountSettingsCell = 1
 
     private lazy var mediaPicker: MediaPicker? = {
-        return MediaPicker(navigationController: navigationController)
+        let mediaPicker = MediaPicker(navigationController: navigationController)
+        mediaPicker.delegate = self
+        return mediaPicker
     }()
 
     private lazy var statusCell: MultilineTextFieldCell = {

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -350,7 +350,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     }
 
     private func showCamera(delegate: MediaPickerDelegate) {
-        mediaPicker?.showCamera(delegate: self, allowCropping: true, supportedMediaTypes: .photo)
+        mediaPicker?.showCamera(allowCropping: true, supportedMediaTypes: .photo)
     }
 
     private func showQrCodeInvite(chatId: Int) {

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -26,7 +26,9 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     private let sectionGroupMembers = 2
 
     private lazy var mediaPicker: MediaPicker? = {
-        return MediaPicker(navigationController: navigationController)
+        let mediaPicker = MediaPicker(navigationController: navigationController)
+        mediaPicker.delegate = self
+        return mediaPicker
     }()
 
     lazy var groupNameCell: TextFieldCell = {

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -348,7 +348,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     }
 
     private func showCamera(delegate: MediaPickerDelegate) {
-        mediaPicker?.showCamera(delegate: delegate)
+        mediaPicker?.showCamera(delegate: self, allowCropping: true, supportedMediaTypes: .photo)
     }
 
     private func showQrCodeInvite(chatId: Int) {

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -7,7 +7,9 @@ class ProfileInfoViewController: UITableViewController {
     private var displayName: String?
 
     private lazy var mediaPicker: MediaPicker? = {
-        return MediaPicker(navigationController: navigationController)
+        let mediaPicker = MediaPicker(navigationController: navigationController)
+        mediaPicker.delegate = self
+        return mediaPicker
     }()
 
     private lazy var doneButtonItem: UIBarButtonItem = {

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -133,7 +133,7 @@ class ProfileInfoViewController: UITableViewController {
     }
 
     private func cameraButtonPressed(_ action: UIAlertAction) {
-        mediaPicker?.showCamera(delegate: self)
+        mediaPicker?.showCamera()
     }
 }
 

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -125,7 +125,7 @@ class MediaPicker: NSObject, UINavigationControllerDelegate, UIImagePickerContro
         navigationController?.present(controller, animated: true, completion: nil)
     }
 
-    func showCamera(delegate: MediaPickerDelegate, allowCropping: Bool, supportedMediaTypes: CameraMediaTypes) {
+    func showCamera(allowCropping: Bool, supportedMediaTypes: CameraMediaTypes) {
         if UIImagePickerController.isSourceTypeAvailable(.camera) {
             let imagePickerController = UIImagePickerController()
             imagePickerController.sourceType = .camera
@@ -156,8 +156,8 @@ class MediaPicker: NSObject, UINavigationControllerDelegate, UIImagePickerContro
         }
     }
 
-    func showCamera(delegate: MediaPickerDelegate) {
-        showCamera(delegate: delegate, allowCropping: false, supportedMediaTypes: .allAvailable)
+    func showCamera() {
+        showCamera(allowCropping: false, supportedMediaTypes: .allAvailable)
     }
 
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {


### PR DESCRIPTION
closes #828

So the idea was to use the native camera globally from now on. 

I replaced CameraViewController in our MediaPicker by the native camera. Since this one is used globally also for our ProfileImages etc. I had to do some configuration tweaking but after all it should be clear what's happening.

I also set the MediaPickerDelegate in our lazy closures. Makes a lot more sense this way instead of passing delegates around.




