### PR TITLE
show name and address below qr-code

### DIFF
--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -12,10 +12,18 @@ class QrPageController: UIPageViewController, ProgressAlertHandler {
     private lazy var qrCodeHint: String = {
         var qrCodeHint = ""
         if dcContext.isConfigured() {
-            let contact = DcContact(id: Int(DC_CONTACT_ID_SELF))
+            // we cannot use dc_contact_get_displayname() as this would result in "Me" instead of the real name
+            let name = dcContext.getConfig("displayname") ?? ""
+            let addr = dcContext.getConfig("addr") ?? ""
+            var nameAndAddress = ""
+            if name.isEmpty {
+                nameAndAddress = addr
+            } else {
+                nameAndAddress = name + " (" + addr + ")"
+            }
             qrCodeHint = String.localizedStringWithFormat(
                 String.localized("qrshow_join_contact_hint"),
-                contact.email
+                nameAndAddress
             )
         }
         return qrCodeHint

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -9,7 +9,7 @@ class QrPageController: UIPageViewController, ProgressAlertHandler {
 
     private var selectedIndex: Int = 0
 
-    private lazy var qrCodeHint: String = {
+    private func getQrCodeHint() -> String {
         var qrCodeHint = ""
         if dcContext.isConfigured() {
             // we cannot use dc_contact_get_displayname() as this would result in "Me" instead of the real name
@@ -19,7 +19,7 @@ class QrPageController: UIPageViewController, ProgressAlertHandler {
             if name.isEmpty {
                 nameAndAddress = addr
             } else {
-                nameAndAddress = name + " (" + addr + ")"
+                nameAndAddress = "\(name) (\(addr))"
             }
             qrCodeHint = String.localizedStringWithFormat(
                 String.localized("qrshow_join_contact_hint"),
@@ -27,7 +27,7 @@ class QrPageController: UIPageViewController, ProgressAlertHandler {
             )
         }
         return qrCodeHint
-    }()
+    }
 
     private lazy var qrSegmentControl: UISegmentedControl = {
         let control = UISegmentedControl(
@@ -55,7 +55,7 @@ class QrPageController: UIPageViewController, ProgressAlertHandler {
         delegate = self
         navigationItem.titleView = qrSegmentControl
 
-        let qrController = QrViewController(dcContext: dcContext, qrCodeHint: qrCodeHint)
+        let qrController = QrViewController(dcContext: dcContext, qrCodeHint: getQrCodeHint())
         setViewControllers(
             [qrController],
             direction: .forward,
@@ -85,7 +85,7 @@ class QrPageController: UIPageViewController, ProgressAlertHandler {
     // MARK: - actions
     @objc private func qrSegmentControlChanged(_ sender: UISegmentedControl) {
         if sender.selectedSegmentIndex == 0 {
-            let qrController = QrViewController(dcContext: dcContext, qrCodeHint: qrCodeHint)
+            let qrController = QrViewController(dcContext: dcContext, qrCodeHint: getQrCodeHint())
             setViewControllers([qrController], direction: .reverse, animated: true, completion: nil)
         } else {
             let qrCodeReaderController = makeQRReader()
@@ -121,7 +121,7 @@ extension QrPageController: UIPageViewControllerDataSource, UIPageViewController
         if viewController is QrViewController {
             return nil
         }
-        return QrViewController(dcContext: dcContext, qrCodeHint: qrCodeHint)
+        return QrViewController(dcContext: dcContext, qrCodeHint: getQrCodeHint())
     }
 
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -80,8 +80,6 @@ class QrPageController: UIPageViewController, ProgressAlertHandler {
         self.progressObserver = nil
     }
 
-
-
     // MARK: - actions
     @objc private func qrSegmentControlChanged(_ sender: UISegmentedControl) {
         if sender.selectedSegmentIndex == 0 {


### PR DESCRIPTION
this pr shows the name _and_ the address below the qr-invite-code; previously, only the address was shown.