### PR TITLE
Native image picker

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -743,12 +743,12 @@ class ChatViewController: MessagesViewController {
         }
     }
 
-    private func showDocumentLibrary(delegate: MediaPickerDelegate) {
-        mediaPicker?.showDocumentLibrary(delegate: delegate)
+    private func showDocumentLibrary() {
+        mediaPicker?.showDocumentLibrary()
     }
 
-    private func showVoiceMessageRecorder(delegate: MediaPickerDelegate) {
-        mediaPicker?.showVoiceRecorder(delegate: delegate)
+    private func showVoiceMessageRecorder() {
+        mediaPicker?.showVoiceRecorder()
     }
 
     private func showCameraViewController() {
@@ -1265,11 +1265,11 @@ extension ChatViewController: MessagesLayoutDelegate {
     }
 
     private func documentActionPressed(_ action: UIAlertAction) {
-        showDocumentLibrary(delegate: self)
+        showDocumentLibrary()
     }
 
     private func voiceMessageButtonPressed(_ action: UIAlertAction) {
-        showVoiceMessageRecorder(delegate: self)
+        showVoiceMessageRecorder()
     }
 
     private func cameraButtonPressed(_ action: UIAlertAction) {

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -756,7 +756,7 @@ class ChatViewController: MessagesViewController {
     }
 
     private func showPhotoVideoLibrary(delegate: MediaPickerDelegate) {
-        mediaPicker?.showPhotoVideoLibrary(delegate: delegate)
+        mediaPicker?.showPhotoVideoLibrary()
     }
 
     private func showMediaGallery(currentIndex: Int, mediaUrls urls: [URL]) {

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -101,7 +101,7 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
     }
 
     private func galleryButtonPressed(_ action: UIAlertAction) {
-        mediaPicker?.showPhotoGallery(delegate: self)
+        mediaPicker?.showPhotoGallery()
     }
 
     private func cameraButtonPressed(_ action: UIAlertAction) {

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -125,7 +125,7 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
 
     // MARK: - actions
     private func galleryButtonPressed(_ action: UIAlertAction) {
-        mediaPicker?.showPhotoGallery(delegate: self)
+        mediaPicker?.showPhotoGallery()
     }
 
     private func cameraButtonPressed(_ action: UIAlertAction) {

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -1,4 +1,3 @@
-import KK_ALCameraViewController
 import Contacts
 import UIKit
 import DcCore

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -346,7 +346,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     }
 
     private func showPhotoPicker(delegate: MediaPickerDelegate) {
-        mediaPicker?.showPhotoGallery(delegate: delegate)
+        mediaPicker?.showPhotoGallery()
     }
 
     private func showCamera(delegate: MediaPickerDelegate) {

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -123,7 +123,7 @@ class ProfileInfoViewController: UITableViewController {
     }
 
     private func galleryButtonPressed(_ action: UIAlertAction) {
-        mediaPicker?.showPhotoGallery(delegate: self)
+        mediaPicker?.showPhotoGallery()
     }
 
     private func cameraButtonPressed(_ action: UIAlertAction) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -1,5 +1,4 @@
 import UIKit
-import KK_ALCameraViewController
 import Photos
 import MobileCoreServices
 import DcCore

--- a/deltachat-ios/Extensions/UIImage+Extension.swift
+++ b/deltachat-ios/Extensions/UIImage+Extension.swift
@@ -65,6 +65,11 @@ extension UIImage {
             return result
         }
     }
+
+    func convertToJPEG(compressionQuality quality: CGFloat) -> UIImage? {
+        guard let jpegData = jpegData(compressionQuality: quality) else { return nil }
+        return UIImage(data: jpegData)
+    }
 }
 
 public enum ImageType: String {

--- a/deltachat-ios/Extensions/UIImage+Extension.swift
+++ b/deltachat-ios/Extensions/UIImage+Extension.swift
@@ -52,6 +52,19 @@ extension UIImage {
         guard let cgImage = image?.cgImage else { return nil }
         self.init(cgImage: cgImage)
     }
+
+    func upOrientationImage() -> UIImage? {
+        switch imageOrientation {
+        case .up:
+            return self
+        default:
+            UIGraphicsBeginImageContextWithOptions(size, false, scale)
+            draw(in: CGRect(origin: .zero, size: size))
+            let result = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            return result
+        }
+    }
 }
 
 public enum ImageType: String {

--- a/deltachat-ios/Extensions/UIImage+Extension.swift
+++ b/deltachat-ios/Extensions/UIImage+Extension.swift
@@ -52,24 +52,6 @@ extension UIImage {
         guard let cgImage = image?.cgImage else { return nil }
         self.init(cgImage: cgImage)
     }
-
-    func upOrientationImage() -> UIImage? {
-        switch imageOrientation {
-        case .up:
-            return self
-        default:
-            UIGraphicsBeginImageContextWithOptions(size, false, scale)
-            draw(in: CGRect(origin: .zero, size: size))
-            let result = UIGraphicsGetImageFromCurrentImageContext()
-            UIGraphicsEndImageContext()
-            return result
-        }
-    }
-
-    func convertToJPEG(compressionQuality quality: CGFloat) -> UIImage? {
-        guard let jpegData = jpegData(compressionQuality: quality) else { return nil }
-        return UIImage(data: jpegData)
-    }
 }
 
 public enum ImageType: String {

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -155,15 +155,10 @@ extension MediaPicker: UIImagePickerControllerDelegate {
                     handleVideoUrl(url: videoUrl)
                 }
             case .image:
-                var image: UIImage?
-                if let editedImage = info[.editedImage] as? UIImage {
-                    image = editedImage
-                } else if let originalImage = info[.originalImage] as? UIImage {
-                    image = originalImage
-                }
-                // orientation fix needed for images picked from photoGallery
-                if let image = image?.upOrientationImage(), let jpeg = image.convertToJPEG(compressionQuality: 1) {
-                    self.delegate?.onImageSelected(image: jpeg)
+                if let image = info[.editedImage] as? UIImage {
+                    self.delegate?.onImageSelected(image: image)
+                } else if let image = info[.originalImage] as? UIImage {
+                    self.delegate?.onImageSelected(image: image)
                 }
             }
         }

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -87,21 +87,22 @@ class MediaPicker: NSObject, UINavigationControllerDelegate, AudioRecorderContro
             kUTTypeVideo as String,
             kUTTypeImage as String
         ]
-        showPhotoLibrary(mediaTypes: mediaTypes)
+        showPhotoLibrary(allowsCropping: false, mediaTypes: mediaTypes)
     }
 
     func showPhotoGallery() {
         let mediaType = [kUTTypeImage as String]
-        showPhotoLibrary(mediaTypes: mediaType)
+        showPhotoLibrary(allowsCropping: true, mediaTypes: mediaType) // used mainly for avatar-selection, allow cropping therefore
     }
 
-    private func showPhotoLibrary(mediaTypes: [String]) {
+    private func showPhotoLibrary(allowsCropping: Bool, mediaTypes: [String]) {
         if UIImagePickerController.isSourceTypeAvailable(.photoLibrary) {
-            let imagePicker = UIImagePickerController()
-            imagePicker.delegate = self
-            imagePicker.sourceType = .photoLibrary
-            imagePicker.mediaTypes = mediaTypes
-            navigationController?.present(imagePicker, animated: true, completion: nil)
+            let imagePickerController = UIImagePickerController()
+            imagePickerController.delegate = self
+            imagePickerController.sourceType = .photoLibrary
+            imagePickerController.mediaTypes = mediaTypes
+            imagePickerController.allowsEditing = allowsCropping
+            navigationController?.present(imagePickerController, animated: true, completion: nil)
         }
     }
 
@@ -117,9 +118,7 @@ class MediaPicker: NSObject, UINavigationControllerDelegate, AudioRecorderContro
             case .allAvailable:
                 mediaTypes = UIImagePickerController.availableMediaTypes(for: .camera) ?? []
             }
-            if allowCropping {
-                imagePickerController.allowsEditing = true
-            }
+            imagePickerController.allowsEditing = allowCropping
             imagePickerController.mediaTypes = mediaTypes
             imagePickerController.setEditing(true, animated: true)
             navigationController?.present(imagePickerController, animated: true, completion: nil)

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -1,7 +1,6 @@
 import UIKit
 import Photos
 import MobileCoreServices
-import KK_ALCameraViewController
 
 protocol MediaPickerDelegate: class {
     func onImageSelected(image: UIImage)
@@ -56,7 +55,7 @@ class MediaPicker: NSObject, UINavigationControllerDelegate, AudioRecorderContro
         navigationController?.present(audioRecorderNavController, animated: true, completion: nil)
     }
 
-    func showPhotoVideoLibrary(delegate: MediaPickerDelegate) {
+    func showPhotoVideoLibrary() {
         if PHPhotoLibrary.authorizationStatus() != .authorized {
             PHPhotoLibrary.requestAuthorization { status in
                 DispatchQueue.main.async {
@@ -65,12 +64,12 @@ class MediaPicker: NSObject, UINavigationControllerDelegate, AudioRecorderContro
                     case  .denied, .notDetermined, .restricted:
                         print("denied")
                     case .authorized:
-                        self?.presentPhotoVideoLibrary(delegate: delegate)
+                        self?.presentPhotoVideoLibrary()
                     }
                 }
             }
         } else {
-            presentPhotoVideoLibrary(delegate: delegate)
+            presentPhotoVideoLibrary()
         }
     }
 
@@ -84,7 +83,7 @@ class MediaPicker: NSObject, UINavigationControllerDelegate, AudioRecorderContro
         navigationController?.present(documentPicker, animated: true, completion: nil)
     }
 
-    private func presentPhotoVideoLibrary(delegate: MediaPickerDelegate) {
+    private func presentPhotoVideoLibrary() {
         let mediaTypes = [
             kUTTypeMovie as String,
             kUTTypeVideo as String,

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -45,8 +45,7 @@ class MediaPicker: NSObject, UINavigationControllerDelegate, AudioRecorderContro
         self.navigationController = navigationController
     }
 
-    func showVoiceRecorder(delegate: MediaPickerDelegate) {
-        self.delegate = delegate
+    func showVoiceRecorder() {
         let audioRecorderController = AudioRecorderController()
         audioRecorderController.delegate = self
         //audioRecorderController.maximumRecordDuration = 1200
@@ -73,13 +72,12 @@ class MediaPicker: NSObject, UINavigationControllerDelegate, AudioRecorderContro
         }
     }
 
-    func showDocumentLibrary(delegate: MediaPickerDelegate) {
+    func showDocumentLibrary() {
         let types = [kUTTypePDF, kUTTypeText, kUTTypeRTF, kUTTypeSpreadsheet, kUTTypeVCard, kUTTypeZipArchive, kUTTypeImage]
         let documentPicker = UIDocumentPickerViewController(documentTypes: types as [String], in: .import)
         documentPicker.delegate = self
         documentPicker.allowsMultipleSelection = false
         documentPicker.modalPresentationStyle = .formSheet
-        self.delegate = delegate
         navigationController?.present(documentPicker, animated: true, completion: nil)
     }
 

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -164,8 +164,8 @@ extension MediaPicker: UIImagePickerControllerDelegate {
                     image = originalImage
                 }
                 // orientation fix needed for images picked from photoGallery
-                if let image = image?.upOrientationImage() {
-                    self.delegate?.onImageSelected(image: image)
+                if let image = image?.upOrientationImage(), let jpeg = image.convertToJPEG(compressionQuality: 1) {
+                    self.delegate?.onImageSelected(image: jpeg)
                 }
             }
         }


### PR DESCRIPTION
closes #847 

- using now native `UIDocumentPickerViewController` for selecting images
- picking images somehow did not respect original orientations so I these have to be manually rotated if needed
- since presentPhotoVideoLibrary and showPhotoGallery had a lot of duplicated code I had to do some refactorings

## Important:
with this PR our `KK-ALCameraViewController`-library is obsolete can be removed from our **Podfile**. 
I would like to do this in a subsequent PR and update all other Pods too.   