### PR TITLE
Enlarge profile image

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -759,12 +759,12 @@ public class DcChat {
 	}()
 
 	public var profileImageURL: URL? {
-		guard let cString = dc_chat_get_profile_image(chatPointer) else { return nil }
-		let filename = String(cString: cString)
-		dc_str_unref(cString)
-		let path: URL = URL(fileURLWithPath: filename, isDirectory: false)
-		return path
-	}
+        guard let cString = dc_chat_get_profile_image(chatPointer) else { return nil }
+        let filename = String(cString: cString)
+        dc_str_unref(cString)
+        let path: URL = URL(fileURLWithPath: filename, isDirectory: false)
+        return path
+    }
 
     public var isSendingLocations: Bool {
         return dc_chat_is_sending_locations(chatPointer) == 1

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -760,10 +760,10 @@ public class DcChat {
 
 	public var profileImageURL: URL? {
 		guard let cString = dc_chat_get_profile_image(chatPointer) else { return nil }
-        let filename = String(cString: cString)
-        dc_str_unref(cString)
-        let path: URL = URL(fileURLWithPath: filename, isDirectory: false)
-        return path
+		let filename = String(cString: cString)
+		dc_str_unref(cString)
+		let path: URL = URL(fileURLWithPath: filename, isDirectory: false)
+		return path
 	}
 
     public var isSendingLocations: Bool {

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -756,9 +756,9 @@ public class DcChat {
             }
         }
         return nil
-	}()
+    }()
 
-	public var profileImageURL: URL? {
+    public var profileImageURL: URL? {
         guard let cString = dc_chat_get_profile_image(chatPointer) else { return nil }
         let filename = String(cString: cString)
         dc_str_unref(cString)
@@ -1107,12 +1107,12 @@ public class DcContact {
         return nil
     }()
 
-	public var profileImageURL: URL? {
-		guard let cString = dc_contact_get_profile_image(contactPointer) else { return nil }
-		let filename = String(cString: cString)
-		dc_str_unref(cString)
-		return URL(fileURLWithPath: filename, isDirectory: false)
-	}
+    public var profileImageURL: URL? {
+        guard let cString = dc_contact_get_profile_image(contactPointer) else { return nil }
+        let filename = String(cString: cString)
+        dc_str_unref(cString)
+        return URL(fileURLWithPath: filename, isDirectory: false)
+    }
 
     public var color: UIColor {
         return UIColor(netHex: Int(dc_contact_get_color(contactPointer)))

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -756,7 +756,15 @@ public class DcChat {
             }
         }
         return nil
-        }()
+	}()
+
+	public var profileImageURL: URL? {
+		guard let cString = dc_chat_get_profile_image(chatPointer) else { return nil }
+        let filename = String(cString: cString)
+        dc_str_unref(cString)
+        let path: URL = URL(fileURLWithPath: filename, isDirectory: false)
+        return path
+	}
 
     public var isSendingLocations: Bool {
         return dc_chat_is_sending_locations(chatPointer) == 1

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -1107,6 +1107,13 @@ public class DcContact {
         return nil
     }()
 
+	public var profileImageURL: URL? {
+		guard let cString = dc_contact_get_profile_image(contactPointer) else { return nil }
+		let filename = String(cString: cString)
+		dc_str_unref(cString)
+		return URL(fileURLWithPath: filename, isDirectory: false)
+	}
+
     public var color: UIColor {
         return UIColor(netHex: Int(dc_contact_get_color(contactPointer)))
     }

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -6,15 +6,16 @@ class ContactDetailViewController: UITableViewController {
     private let viewModel: ContactDetailViewModel
 
     private lazy var headerCell: ContactDetailHeader = {
-        let cell = ContactDetailHeader()
-        cell.updateDetails(title: viewModel.contact.displayName, subtitle: viewModel.contact.email)
+        let header = ContactDetailHeader()
+        header.updateDetails(title: viewModel.contact.displayName, subtitle: viewModel.contact.email)
         if let img = viewModel.contact.profileImage {
-            cell.setImage(img)
+            header.setImage(img)
         } else {
-            cell.setBackupImage(name: viewModel.contact.displayName, color: viewModel.contact.color)
+            header.setBackupImage(name: viewModel.contact.displayName, color: viewModel.contact.color)
         }
-        cell.setVerified(isVerified: viewModel.contact.isVerified)
-        return cell
+        header.setVerified(isVerified: viewModel.contact.isVerified)
+        header.onAvatarTap = showContactAvatarIfNeeded
+        return header
     }()
 
 
@@ -368,6 +369,15 @@ class ContactDetailViewController: UITableViewController {
         ).reversed()
         let galleryController = GalleryViewController(mediaMessageIds: messageIds)
         navigationController?.pushViewController(galleryController, animated: true)
+    }
+
+    private func showContactAvatarIfNeeded() {
+        let contact = viewModel.contact
+        if let url =  contact.profileImageURL {
+            let previewController = PreviewController(currentIndex: 0, urls: [url])
+            previewController.customTitle = contact.displayName
+            present(previewController, animated: true, completion: nil)
+        }
     }
 
     private func deleteChat() {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import DcCore
+import QuickLook
 
 class GroupChatDetailViewController: UIViewController {
 
@@ -86,6 +87,7 @@ class GroupChatDetailViewController: UIViewController {
         } else {
             header.setBackupImage(name: chat.name, color: chat.color)
         }
+        header.onAvatarTap = showGroupAvatarIfNeeded
         header.setVerified(isVerified: chat.isVerified)
         return header
     }()
@@ -292,6 +294,14 @@ class GroupChatDetailViewController: UIViewController {
         if let navigationController = navigationController {
             navigationController.popViewController(animated: false)
             navigationController.popViewController(animated: true)
+        }
+    }
+
+    private func showGroupAvatarIfNeeded() {
+        if let url = chat.profileImageURL {
+            let previewController = PreviewController(currentIndex: 0, urls: [url])
+            previewController.customTitle = self.title
+            present(previewController, animated: true, completion: nil)
         }
     }
 }

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -5,6 +5,8 @@ class PreviewController: QLPreviewController {
 
     var urls: [URL]
 
+    var customTitle: String?
+
     private lazy var doneButtonItem: UIBarButtonItem = {
         let button = UIBarButtonItem(title: String.localized("done"), style: .done, target: self, action: #selector(doneButtonPressed(_:)))
         return button
@@ -43,6 +45,17 @@ extension PreviewController: QLPreviewControllerDataSource {
     }
 
     func previewController(_: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
-        return urls[index] as QLPreviewItem
+        return PreviewItem(url: urls[index], title: self.customTitle)
+    }
+}
+
+// needed to prevent showing url-path in PreviewController's title (only relevant if url.count == 1)
+class PreviewItem: NSObject, QLPreviewItem {
+    var previewItemURL: URL?
+    var previewItemTitle: String?
+
+    init(url: URL, title: String?) {
+        self.previewItemURL = url
+        self.previewItemTitle = title ?? ""
     }
 }

--- a/deltachat-ios/Extensions/UIImage+Extension.swift
+++ b/deltachat-ios/Extensions/UIImage+Extension.swift
@@ -21,7 +21,15 @@ extension UIImage {
 
          let colorSpace = CGColorSpaceCreateDeviceRGB()
          let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
-         let context = CGContext(data: nil, width: Int(width), height: Int(height), bitsPerComponent: 8, bytesPerRow: 0, space: colorSpace, bitmapInfo: bitmapInfo.rawValue)!
+         let context = CGContext(
+            data: nil,
+            width: Int(width),
+            height: Int(height),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo.rawValue
+        )!
 
          context.clip(to: bounds, mask: maskImage)
          context.setFillColor(color.cgColor)

--- a/deltachat-ios/Extensions/UIImage+Extension.swift
+++ b/deltachat-ios/Extensions/UIImage+Extension.swift
@@ -35,7 +35,6 @@ extension UIImage {
          }
      }
 
-
     public convenience init?(color: UIColor, size: CGSize = CGSize(width: 1, height: 1)) {
         let rect = CGRect(origin: .zero, size: size)
         UIGraphicsBeginImageContextWithOptions(rect.size, false, 0.0)
@@ -47,7 +46,6 @@ extension UIImage {
         guard let cgImage = image?.cgImage else { return nil }
         self.init(cgImage: cgImage)
     }
-
 }
 
 public enum ImageType: String {

--- a/deltachat-ios/Extensions/UIImage+Extension.swift
+++ b/deltachat-ios/Extensions/UIImage+Extension.swift
@@ -12,16 +12,15 @@ extension UIImage {
         return self
     }
 
-     func maskWithColor(color: UIColor) -> UIImage? {
-         let maskImage = cgImage!
+    func maskWithColor(color: UIColor) -> UIImage? {
+        let maskImage = cgImage!
 
-         let width = size.width
-         let height = size.height
-         let bounds = CGRect(x: 0, y: 0, width: width, height: height)
-
-         let colorSpace = CGColorSpaceCreateDeviceRGB()
-         let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
-         let context = CGContext(
+        let width = size.width
+        let height = size.height
+        let bounds = CGRect(x: 0, y: 0, width: width, height: height)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+        let context = CGContext(
             data: nil,
             width: Int(width),
             height: Int(height),
@@ -30,18 +29,17 @@ extension UIImage {
             space: colorSpace,
             bitmapInfo: bitmapInfo.rawValue
         )!
+        context.clip(to: bounds, mask: maskImage)
+        context.setFillColor(color.cgColor)
+        context.fill(bounds)
 
-         context.clip(to: bounds, mask: maskImage)
-         context.setFillColor(color.cgColor)
-         context.fill(bounds)
-
-         if let cgImage = context.makeImage() {
-             let coloredImage = UIImage(cgImage: cgImage)
-             return coloredImage
-         } else {
-             return nil
-         }
-     }
+        if let cgImage = context.makeImage() {
+            let coloredImage = UIImage(cgImage: cgImage)
+            return coloredImage
+        } else {
+            return nil
+        }
+    }
 
     public convenience init?(color: UIColor, size: CGSize = CGSize(width: 1, height: 1)) {
         let rect = CGRect(origin: .zero, size: size)

--- a/deltachat-ios/View/ContactDetailHeader.swift
+++ b/deltachat-ios/View/ContactDetailHeader.swift
@@ -3,6 +3,8 @@ import DcCore
 
 class ContactDetailHeader: UIView {
 
+    var onAvatarTap: VoidFunction?
+
     public static let headerHeight: CGFloat = 74.5
 
     let badgeSize: CGFloat = 54
@@ -11,6 +13,8 @@ class ContactDetailHeader: UIView {
         let badge = InitialsBadge(size: badgeSize)
         badge.setColor(UIColor.lightGray)
         badge.isAccessibilityElement = false
+        let tap = UITapGestureRecognizer(target: self, action: #selector(avatarTapped(_:)))
+        badge.addGestureRecognizer(tap)
         return badge
     }()
 
@@ -90,4 +94,9 @@ class ContactDetailHeader: UIView {
     func setVerified(isVerified: Bool) {
         avatar.setVerified(isVerified)
     }
+
+    @objc private func avatarTapped(_ sender: InitialsBadge) {
+        onAvatarTap?()
+    }
+
 }


### PR DESCRIPTION
closes #831 

In GroupsDetail  or in ChatDetail-> tap on Avatar -> if there is a group/contact image the PreviewController displays that.

- I had to alter our core-functions to get profileImageUrls -> because they are needed in PreviewController
- by default PreviewController if there only one url (like here) displays the URL as title which is pretty ugly -> to display a title I had to **subclass QLPreviewItem**. 

Issues:
It seems that the contact avatar images have very low resolution, true? If so, we should save some backup image. 
