### PR TITLE
groupDetail / chatDetail -> background colors

### DIFF
--- a/DcCore/DcCore/Helper/DcColors.swift
+++ b/DcCore/DcCore/Helper/DcColors.swift
@@ -1,8 +1,9 @@
 import UIKit
 
 public struct DcColors {
-    private static let white						= #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
-    private static let actionCellBackgroundDark		= #colorLiteral(red: 0.1031623408, green: 0.1083367988, blue: 0.1185036376, alpha: 1)
+    private static let white                                  = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+    private static let actionCellBackgroundDark               = #colorLiteral(red: 0.1031623408, green: 0.1083367988, blue: 0.1185036376, alpha: 1)
+
 
     public static let primary = UIColor.systemBlue
     public static let colorDisabled = UIColor.themeColor(light: UIColor(white: 0.9, alpha: 1), dark: UIColor(white: 0.2, alpha: 1))
@@ -12,7 +13,7 @@ public struct DcColors {
                                                           dark: UIColor.init(hexString: "333333"))
     public static let contactCellBackgroundColor = UIColor.themeColor(light: .white, dark: .black)
     public static let defaultBackgroundColor = UIColor.themeColor(light: .white, dark: .black)
-	public static let sharedChatCellBackgroundColor = UIColor.themeColor(light: white, dark: actionCellBackgroundDark)
+    public static let sharedChatCellBackgroundColor = UIColor.themeColor(light: white, dark: actionCellBackgroundDark)
     public static let chatBackgroundColor = UIColor.themeColor(light: UIColor(red: 255, green: 255, blue: 255, alpha: 0), dark: .black)
     public static let checkmarkGreen = UIColor.themeColor(light: UIColor.rgb(red: 112, green: 177, blue: 92))
     public static let defaultTextColor = UIColor.themeColor(light: .darkText, dark: .white)

--- a/DcCore/DcCore/Helper/DcColors.swift
+++ b/DcCore/DcCore/Helper/DcColors.swift
@@ -1,9 +1,8 @@
 import UIKit
 
 public struct DcColors {
-
-	private static let white 									= #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
-	private static let actionCellBackgroundDark		 			= #colorLiteral(red: 0.1031623408, green: 0.1083367988, blue: 0.1185036376, alpha: 1)
+    private static let white						= #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+    private static let actionCellBackgroundDark		= #colorLiteral(red: 0.1031623408, green: 0.1083367988, blue: 0.1185036376, alpha: 1)
 
     public static let primary = UIColor.systemBlue
     public static let colorDisabled = UIColor.themeColor(light: UIColor(white: 0.9, alpha: 1), dark: UIColor(white: 0.2, alpha: 1))

--- a/DcCore/DcCore/Helper/DcColors.swift
+++ b/DcCore/DcCore/Helper/DcColors.swift
@@ -1,6 +1,10 @@
 import UIKit
 
 public struct DcColors {
+
+	private static let white 									= #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+	private static let actionCellBackgroundDark		 			= #colorLiteral(red: 0.1031623408, green: 0.1083367988, blue: 0.1185036376, alpha: 1)
+
     public static let primary = UIColor.systemBlue
     public static let colorDisabled = UIColor.themeColor(light: UIColor(white: 0.9, alpha: 1), dark: UIColor(white: 0.2, alpha: 1))
     public static let messagePrimaryColor = UIColor.themeColor(light: UIColor.rgb(red: 220, green: 248, blue: 198),
@@ -9,6 +13,7 @@ public struct DcColors {
                                                           dark: UIColor.init(hexString: "333333"))
     public static let contactCellBackgroundColor = UIColor.themeColor(light: .white, dark: .black)
     public static let defaultBackgroundColor = UIColor.themeColor(light: .white, dark: .black)
+	public static let sharedChatCellBackgroundColor = UIColor.themeColor(light: white, dark: actionCellBackgroundDark)
     public static let chatBackgroundColor = UIColor.themeColor(light: UIColor(red: 255, green: 255, blue: 255, alpha: 0), dark: .black)
     public static let checkmarkGreen = UIColor.themeColor(light: UIColor.rgb(red: 112, green: 177, blue: 92))
     public static let defaultTextColor = UIColor.themeColor(light: .darkText, dark: .white)

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -169,6 +169,7 @@ class ContactDetailViewController: UITableViewController {
         case .sharedChats:
             if let cell = tableView.dequeueReusableCell(withIdentifier: ContactCell.reuseIdentifier, for: indexPath) as? ContactCell {
                 viewModel.update(sharedChatCell: cell, row: row)
+                cell.backgroundColor = DcColors.sharedChatCellBackgroundColor
                 return cell
             }
         }
@@ -366,7 +367,7 @@ class ContactDetailViewController: UITableViewController {
             messageType3: DC_MSG_VIDEO
         ).reversed()
         let galleryController = GalleryViewController(mediaMessageIds: messageIds)
-            navigationController?.pushViewController(galleryController, animated: true)
+        navigationController?.pushViewController(galleryController, animated: true)
     }
 
     private func deleteChat() {

--- a/deltachat-ios/View/ContactDetailHeader.swift
+++ b/deltachat-ios/View/ContactDetailHeader.swift
@@ -35,7 +35,7 @@ class ContactDetailHeader: UIView {
 
     init() {
         super.init(frame: .zero)
-        backgroundColor = DcColors.contactCellBackgroundColor
+        backgroundColor =  .clear
         setupSubviews()
     }
 

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -102,7 +102,6 @@ class ContactDetailViewModel {
         let chatId = sharedChats.getChatId(index: index)
         let summary = sharedChats.getSummary(index: index)
         let unreadMessages = context.getUnreadMessages(chatId: chatId)
-
         let cellData = ChatCellData(chatId: chatId, summary: summary, unreadMessages: unreadMessages)
         let cellViewModel = ChatCellViewModel(dcContext: context, chatData: cellData)
         cell.updateCell(cellViewModel: cellViewModel)


### PR DESCRIPTION
closes #838 

![IMG_E8137DABEF65-1](https://user-images.githubusercontent.com/5249565/87778802-0965bc80-c82c-11ea-811a-6f19ccb05707.jpeg)


![IMG_5483](https://user-images.githubusercontent.com/5249565/87777815-72e4cb80-c82a-11ea-9d68-b4887687dfcd.PNG)

Unfortunately there is no defined background color for our actionCells (not sure what makes them gray in darkmode). I had to use the xcode's color tool to grab the color. It looks alright though.

I discovered **color-literals** lately and I added the new color as such. I find them very handy in Xcode, so maybe we want to use them for our color definitions.