### PR TITLE
remove tap highlighting of members list in NewGroupController

### DIFF
--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -189,6 +189,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
                     contactCell.avatar.setImage(profileImage)
                 }
                 contactCell.setVerified(isVerified: contact.isVerified)
+                contactCell.selectionStyle = .none
             }
             return cell
         }


### PR DESCRIPTION
fixes #863 

I decided to remove the highlighting completely from that list even though there is the option to swipe to left. UX wise I'm not sure if it would be better to just should unhighlight after tapping. Otoh users might then try to tap and cannot trigger any action. 