### PR TITLE
tweak profile views

### DIFF
--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -1238,7 +1238,7 @@ extension ChatViewController: MessagesLayoutDelegate {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
         let galleryAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
         let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
-        let documentAction = UIAlertAction(title: String.localized("documents"), style: .default, handler: documentActionPressed(_:))
+        let documentAction = UIAlertAction(title: String.localized("files"), style: .default, handler: documentActionPressed(_:))
         let voiceMessageAction = UIAlertAction(title: String.localized("voice_message"), style: .default, handler: voiceMessageButtonPressed(_:))
         let isLocationStreaming = dcContext.isSendingLocationsToChat(chatId: chatId)
         let locationStreamingAction = UIAlertAction(title: isLocationStreaming ? String.localized("stop_sharing_location") : String.localized("location"),

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -30,7 +30,6 @@ class ContactDetailViewController: UITableViewController {
     private lazy var ephemeralMessagesCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.textLabel?.text = String.localized("ephemeral_messages")
-        cell.detailTextLabel?.text = String.localized(viewModel.chatIsEphemeral ? "on" : "off")
         cell.selectionStyle = .none
         cell.accessoryType = .disclosureIndicator
         return cell
@@ -70,8 +69,7 @@ class ContactDetailViewController: UITableViewController {
 
     private lazy var galleryCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("gallery")
-        cell.detailTextLabel?.text = "\(viewModel.galleryItemMessageIds.count)"
+        cell.textLabel?.text = String.localized("images_and_videos")
         cell.accessoryType = .disclosureIndicator
         if viewModel.chatId == 0 {
             cell.isUserInteractionEnabled = false
@@ -82,8 +80,7 @@ class ContactDetailViewController: UITableViewController {
 
     private lazy var documentsCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("documents")
-        cell.detailTextLabel?.text = "\(viewModel.documentItemMessageIds.count)"
+        cell.textLabel?.text = String.localized("files")
         cell.accessoryType = .disclosureIndicator
         if viewModel.chatId == 0 {
             cell.isUserInteractionEnabled = false
@@ -221,8 +218,8 @@ class ContactDetailViewController: UITableViewController {
 
     private func updateCellValues() {
         ephemeralMessagesCell.detailTextLabel?.text = String.localized(viewModel.chatIsEphemeral ? "on" : "off")
-        galleryCell.detailTextLabel?.text = "\(viewModel.galleryItemMessageIds.count)"
-        documentsCell.detailTextLabel?.text = "\(viewModel.documentItemMessageIds.count)"
+        galleryCell.detailTextLabel?.text = String.numberOrNone(viewModel.galleryItemMessageIds.count)
+        documentsCell.detailTextLabel?.text = String.numberOrNone(viewModel.documentItemMessageIds.count)
     }
 
     // MARK: - actions

--- a/deltachat-ios/Controller/DocumentGalleryController.swift
+++ b/deltachat-ios/Controller/DocumentGalleryController.swift
@@ -25,7 +25,7 @@ class DocumentGalleryController: UIViewController {
     init(fileMessageIds: [Int]) {
         self.fileMessageIds = fileMessageIds
         super.init(nibName: nil, bundle: nil)
-        self.title = String.localized("documents")
+        self.title = String.localized("files")
     }
 
     required init?(coder: NSCoder) {

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -59,7 +59,7 @@ class GalleryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupSubviews()
-        title = String.localized("gallery")
+        title = String.localized("images_and_videos")
         if mediaMessageIds.isEmpty {
             emptyStateView.isHidden = false
         }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -117,7 +117,6 @@ class GroupChatDetailViewController: UIViewController {
     private lazy var ephemeralMessagesCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.textLabel?.text = String.localized("ephemeral_messages")
-        cell.detailTextLabel?.text = String.localized(chatIsEphemeral ? "on" : "off")
         cell.selectionStyle = .none
         cell.accessoryType = .disclosureIndicator
         return cell
@@ -158,16 +157,14 @@ class GroupChatDetailViewController: UIViewController {
 
     private lazy var galleryCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("gallery")
-        cell.detailTextLabel?.text = "\(galleryItemMessageIds.count)"
+        cell.textLabel?.text = String.localized("images_and_videos")
         cell.accessoryType = .disclosureIndicator
         return cell
     }()
 
     private lazy var documentsCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("documents")
-        cell.detailTextLabel?.text = "\(documentItemMessageIds.count)"
+        cell.textLabel?.text = String.localized("files")
         cell.accessoryType = .disclosureIndicator
         return cell
     }()
@@ -239,8 +236,8 @@ class GroupChatDetailViewController: UIViewController {
 
     private func updateCellValues() {
         ephemeralMessagesCell.detailTextLabel?.text = String.localized(chatIsEphemeral ? "on" : "off")
-        galleryCell.detailTextLabel?.text = "\(galleryItemMessageIds.count)"
-        documentsCell.detailTextLabel?.text = "\(documentItemMessageIds.count)"
+        galleryCell.detailTextLabel?.text = String.numberOrNone(galleryItemMessageIds.count)
+        documentsCell.detailTextLabel?.text = String.numberOrNone(documentItemMessageIds.count)
     }
 
     // MARK: - actions

--- a/deltachat-ios/Extensions/String+Extension.swift
+++ b/deltachat-ios/Extensions/String+Extension.swift
@@ -57,4 +57,12 @@ extension String {
             return NSString.localizedStringWithFormat("%02li:%02li", minutes, seconds) as String
         }
     }
+
+    static func numberOrNone(_ number: Int) -> String {
+        if number == 0 {
+            return String.localized("none")
+        } else {
+            return "\(number)"
+        }
+    }
 }


### PR DESCRIPTION
- use clearer "Images and videos" instead of "Gallery",
  also as a counter for the latter is a bit unclear ("three galleries?")

- use "Files" instead of "Documents",
  this fits better to music (which is also included there)
  and is also mentioned in the category description this way

- show "None" instead of "0" - this looks a bit friendlier
  and less technical - esp. as the context of a number is missing

finally, the values are only set withing update(),
which is called withing viewWillAppear() and is sufficient therefore.