### PR TITLE
to go chat on mute/disappearing changes

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -251,6 +251,7 @@ class ContactDetailViewController: UITableViewController {
             if viewModel.chatIsMuted {
                 self.viewModel.context.setChatMuteDuration(chatId: self.viewModel.chatId, duration: 0)
                 muteChatCell.actionTitle = String.localized("menu_mute")
+                self.navigationController?.popViewController(animated: true)
             } else {
                 showMuteAlert()
             }
@@ -317,6 +318,7 @@ class ContactDetailViewController: UITableViewController {
         let action = UIAlertAction(title: String.localized(key), style: .default, handler: { _ in
             self.viewModel.context.setChatMuteDuration(chatId: self.viewModel.chatId, duration: duration)
             self.muteChatCell.actionTitle = String.localized("menu_unmute")
+            self.navigationController?.popViewController(animated: true)
         })
         alert.addAction(action)
     }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -431,6 +431,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 if chat.isMuted {
                     dcContext.setChatMuteDuration(chatId: chatId, duration: 0)
                     muteChatCell.actionTitle = String.localized("menu_mute")
+                    navigationController?.popViewController(animated: true)
                 } else {
                     showMuteAlert()
                 }
@@ -544,6 +545,7 @@ extension GroupChatDetailViewController {
         let action = UIAlertAction(title: String.localized(key), style: .default, handler: { _ in
             self.dcContext.setChatMuteDuration(chatId: self.chatId, duration: duration)
             self.muteChatCell.actionTitle = String.localized("menu_unmute")
+            self.navigationController?.popViewController(animated: true)
         })
         alert.addAction(action)
     }

--- a/deltachat-ios/Controller/SettingsEphemeralMessageController.swift
+++ b/deltachat-ios/Controller/SettingsEphemeralMessageController.swift
@@ -76,7 +76,10 @@ class SettingsEphemeralMessageController: UITableViewController {
 
     @objc private func okButtonPressed() {
         dcContext.setChatEphemeralTimer(chatId: chatId, duration: options[currentIndex])
-        navigationController?.popViewController(animated: true)
+
+        // pop two view controllers:
+        // go directly back to the chatview where also the confirmation message will be shown
+        navigationController?.popViewControllers(viewsToPop: 2, animated: true)
     }
 
 

--- a/deltachat-ios/Extensions/Extensions.swift
+++ b/deltachat-ios/Extensions/Extensions.swift
@@ -81,3 +81,13 @@ extension UIFont {
         return metrics.scaledFont(for: font)
     }
 }
+
+extension UINavigationController {
+    // pop up to viewsToPop viewControllers from the stack
+    func popViewControllers(viewsToPop: Int, animated: Bool) {
+        if viewControllers.count >= 2 && viewsToPop >= 1 {
+            let vc = viewControllers[max(0, viewControllers.count - viewsToPop - 1)]
+            popToViewController(vc, animated: animated)
+        }
+    }
+}


### PR DESCRIPTION
this pr pops directly to the chat-view
when changing mute/disappearing settings,
the profile-view is skipped.

the profile is partly used as a menu,
this change underlines that.

also, for the disappearing settings,
a message is generated and sent,
this way, this is directly visible to the user.
otherwise, this fact will be a bit hidden.

i think, these two options feel much more usable this way,
not sure, however, if that is totally usually on ios,
however, iirc, i've seen such behaviors here and there.

the code for poping two controllers was inspired by https://stackoverflow.com/questions/8236940/how-do-i-pop-two-views-at-once-from-a-navigation-controller