### PR TITLE
tweak ordering, allow avatar-deletion

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -371,7 +371,7 @@ public class DcContext {
        return nil
     }
 
-    public func saveChatAvatarImage(chatId: Int, path: String) {
+    public func setChatProfileImage(chatId: Int, path: String?) {
         dc_set_chat_profile_image(contextPointer, UInt32(chatId), path)
     }
 

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -92,10 +92,10 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
 
     private func onAvatarTapped() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
-            let photoAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
-            let videoAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
-            alert.addAction(photoAction)
-            alert.addAction(videoAction)
+            let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
+            let galleryAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
+            alert.addAction(cameraAction)
+            alert.addAction(galleryAction)
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         self.present(alert, animated: true, completion: nil)
     }

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -6,8 +6,8 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
     private let chat: DcChat
     private var groupImage: UIImage?
 
-    private let rowAvatar = 0
-    private let rowGroupName = 1
+    private let rowGroupName = 0
+    private let rowAvatar = 1
 
     var avatarSelectionCell: AvatarSelectionCell
 

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -38,7 +38,7 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
     init(dcContext: DcContext, chat: DcChat) {
         self.dcContext = dcContext
         self.chat = chat
-        self.avatarSelectionCell = AvatarSelectionCell(chat: chat)
+        self.avatarSelectionCell = AvatarSelectionCell(image: chat.profileImage)
         super.init(style: .grouped)
         self.avatarSelectionCell.hintLabel.text = String.localized("group_avatar")
         self.avatarSelectionCell.onAvatarTapped = onAvatarTapped
@@ -86,7 +86,6 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
     }
 
     private func groupNameEdited(_ textField: UITextField) {
-        avatarSelectionCell.onInitialsChanged(text: textField.text)
         doneButton.isEnabled = true
     }
 
@@ -112,7 +111,7 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
         groupImage = image
         doneButton.isEnabled = true
 
-        avatarSelectionCell = AvatarSelectionCell(context: nil, with: groupImage)
+        avatarSelectionCell = AvatarSelectionCell(image: groupImage)
         avatarSelectionCell.hintLabel.text = String.localized("group_avatar")
         avatarSelectionCell.onAvatarTapped = onAvatarTapped
 

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -91,7 +91,7 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
     }
 
     private func onAvatarTapped() {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
+        let alert = UIAlertController(title: String.localized("group_avatar"), message: nil, preferredStyle: .safeActionSheet)
             let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
             let galleryAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
             alert.addAction(cameraAction)

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -95,13 +95,10 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
 
     private func onAvatarTapped() {
         let alert = UIAlertController(title: String.localized("group_avatar"), message: nil, preferredStyle: .safeActionSheet)
-            let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
-            let galleryAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
-            let deleteAction = UIAlertAction(title: String.localized("delete"), style: .destructive, handler: deleteGroupAvatarPressed(_:))
-            alert.addAction(cameraAction)
-            alert.addAction(galleryAction)
+            alert.addAction(PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:)))
+            alert.addAction(PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:)))
             if avatarSelectionCell.isAvatarSet() {
-                alert.addAction(deleteAction)
+                alert.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: deleteGroupAvatarPressed(_:)))
             }
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         self.present(alert, animated: true, completion: nil)

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -139,14 +139,10 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
 
     private func onAvatarTapped() {
         let alert = UIAlertController(title: String.localized("pref_profile_photo"), message: nil, preferredStyle: .safeActionSheet)
-        let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
-        let galleryAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
-        let deleteAction = UIAlertAction(title: String.localized("delete"), style: .destructive, handler: deleteProfileIconPressed(_:))
-
-        alert.addAction(cameraAction)
-        alert.addAction(galleryAction)
+        alert.addAction(PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:)))
+        alert.addAction(PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:)))
         if dcContext.getSelfAvatarImage() != nil {
-            alert.addAction(deleteAction)
+            alert.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: deleteProfileIconPressed(_:)))
         }
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
 

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -169,7 +169,7 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
     }
 
     private func createPictureAndNameCell() -> AvatarSelectionCell {
-        let cell = AvatarSelectionCell(context: dcContext)
+        let cell = AvatarSelectionCell(image: dcContext.getSelfAvatarImage())
         return cell
     }
 

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -139,12 +139,12 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
 
     private func onAvatarTapped() {
         let alert = UIAlertController(title: String.localized("pref_profile_photo"), message: nil, preferredStyle: .safeActionSheet)
-        let photoAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
-        let videoAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
+        let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
+        let galleryAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
         let deleteAction = UIAlertAction(title: String.localized("delete"), style: .destructive, handler: deleteProfileIconPressed(_:))
 
-        alert.addAction(photoAction)
-        alert.addAction(videoAction)
+        alert.addAction(cameraAction)
+        alert.addAction(galleryAction)
         if dcContext.getSelfAvatarImage() != nil {
             alert.addAction(deleteAction)
         }

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -282,10 +282,10 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
 
     private func onAvatarTapped() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
-            let photoAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
-            let videoAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
-            alert.addAction(photoAction)
-            alert.addAction(videoAction)
+            let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
+            let galleryAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
+            alert.addAction(cameraAction)
+            alert.addAction(galleryAction)
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         self.present(alert, animated: true, completion: nil)
     }

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -16,8 +16,8 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     private var workaroundObserver: NSObjectProtocol?
 
     private let sectionGroupDetails = 0
-    private let sectionGroupDetailsRowAvatar = 0
-    private let sectionGroupDetailsRowName = 1
+    private let sectionGroupDetailsRowName = 0
+    private let sectionGroupDetailsRowAvatar = 1
     private let countSectionGroupDetails = 2
     private let sectionInvite = 1
     private let sectionInviteRowAddMembers = 0

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -281,7 +281,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     }
 
     private func onAvatarTapped() {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
+        let alert = UIAlertController(title: String.localized("group_avatar"), message: nil, preferredStyle: .safeActionSheet)
             let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
             let galleryAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
             alert.addAction(cameraAction)

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -39,7 +39,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     }()
 
     lazy var avatarSelectionCell: AvatarSelectionCell = {
-        let cell = AvatarSelectionCell(context: nil)
+        let cell = AvatarSelectionCell(image: nil)
         cell.hintLabel.text = String.localized("group_avatar")
         cell.onAvatarTapped = onAvatarTapped
         return cell
@@ -301,7 +301,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     func onImageSelected(image: UIImage) {
         groupImage = image
 
-        avatarSelectionCell = AvatarSelectionCell(context: nil, with: groupImage)
+        avatarSelectionCell = AvatarSelectionCell(image: groupImage)
         avatarSelectionCell.hintLabel.text = String.localized("group_avatar")
         avatarSelectionCell.onAvatarTapped = onAvatarTapped
 

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -287,13 +287,10 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
 
     private func onAvatarTapped() {
         let alert = UIAlertController(title: String.localized("group_avatar"), message: nil, preferredStyle: .safeActionSheet)
-            let cameraAction = PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:))
-            let galleryAction = PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:))
-            let deleteAction = UIAlertAction(title: String.localized("delete"), style: .destructive, handler: deleteGroupAvatarPressed(_:))
-            alert.addAction(cameraAction)
-            alert.addAction(galleryAction)
+            alert.addAction(PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:)))
+            alert.addAction(PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:)))
             if avatarSelectionCell.isAvatarSet() {
-                alert.addAction(deleteAction)
+                alert.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: deleteGroupAvatarPressed(_:)))
             }
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         self.present(alert, animated: true, completion: nil)

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -22,7 +22,7 @@ class ProfileInfoViewController: UITableViewController {
     }()
 
     private lazy var avatarCell: AvatarSelectionCell = {
-        let cell = AvatarSelectionCell(context: self.dcContext)
+        let cell = AvatarSelectionCell(image: dcContext.getSelfAvatarImage())
         cell.onAvatarTapped = avatarTapped
         return cell
     }()
@@ -76,7 +76,7 @@ class ProfileInfoViewController: UITableViewController {
     // MARK: - updates
     private func updateAvatarCell() {
         if let avatarImage = dcContext.getSelfAvatarImage() {
-            avatarCell.updateAvatar(image: avatarImage)
+            avatarCell.setAvatar(image: avatarImage)
         }
         self.tableView.beginUpdates()
         let indexPath = IndexPath(row: 1, section: 0)

--- a/deltachat-ios/Helper/AvatarHelper.swift
+++ b/deltachat-ios/Helper/AvatarHelper.swift
@@ -20,11 +20,15 @@ class AvatarHelper {
         }
     }
 
-    static func saveChatAvatar(dcContext: DcContext, image: UIImage, for chatId: Int) {
+    static func saveChatAvatar(dcContext: DcContext, image: UIImage?, for chatId: Int) {
         do {
-            let groupFileName = try saveAvatarImageToFile(image: image)
-            dcContext.saveChatAvatarImage(chatId: chatId, path: groupFileName.path)
-            deleteAvatarFile(groupFileName)
+            if let image = image {
+                let groupFileName = try saveAvatarImageToFile(image: image)
+                dcContext.setChatProfileImage(chatId: chatId, path: groupFileName.path)
+                deleteAvatarFile(groupFileName)
+            } else {
+                dcContext.setChatProfileImage(chatId: chatId, path: nil)
+            }
         } catch let error {
             logger.error("Error saving Image: \(error.localizedDescription)")
         }

--- a/deltachat-ios/View/AvatarSelectionCell.swift
+++ b/deltachat-ios/View/AvatarSelectionCell.swift
@@ -3,6 +3,7 @@ import DcCore
 
 class AvatarSelectionCell: UITableViewCell {
     let badgeSize: CGFloat = 72
+    private var avatarSet = false
 
     var onAvatarTapped: (() -> Void)?
 
@@ -79,9 +80,15 @@ class AvatarSelectionCell: UITableViewCell {
     func setAvatar(image: UIImage?) {
         if let image = image {
             badge.setImage(image)
+            avatarSet = true
         } else {
             badge = InitialsBadge(image: defaultImage, size: badgeSize)
             badge.backgroundColor = DcColors.grayTextColor
+            avatarSet = false
         }
+    }
+
+    func isAvatarSet() -> Bool {
+        return avatarSet
     }
 }

--- a/deltachat-ios/View/AvatarSelectionCell.swift
+++ b/deltachat-ios/View/AvatarSelectionCell.swift
@@ -29,16 +29,9 @@ class AvatarSelectionCell: UITableViewCell {
         return label
     }()
 
-    init(chat: DcChat) {
+    init(image: UIImage?) {
         super.init(style: .default, reuseIdentifier: nil)
-        setAvatar(for: chat)
-        setupSubviews()
-    }
-
-    init(context: DcContext?, with defaultImage: UIImage? = nil) {
-        super.init(style: .default, reuseIdentifier: nil)
-        setAvatar(image: context?.getSelfAvatarImage(),
-                  with: defaultImage ?? self.defaultImage)
+        setAvatar(image: image)
         setupSubviews()
     }
 
@@ -69,12 +62,6 @@ class AvatarSelectionCell: UITableViewCell {
         selectionStyle = .none
     }
 
-    func onInitialsChanged(text: String?) {
-        if badge.showsInitials() {
-            badge.setName(text ?? "")
-        }
-    }
-
     @objc func onBadgeTouched(gesture: UILongPressGestureRecognizer) {
         switch gesture.state {
         case .began:
@@ -89,27 +76,12 @@ class AvatarSelectionCell: UITableViewCell {
         }
     }
 
-    // I think this is no good, we should rather update badge than overwriting it.
-    func setAvatar(for chat: DcChat) {
-        if let image = chat.profileImage {
-            badge = InitialsBadge(image: image, size: badgeSize)
-        } else {
-            badge = InitialsBadge(name: chat.name, color: chat.color, size: badgeSize)
-        }
-        badge.setVerified(chat.isVerified)
-    }
-
-    // I think this is no good, we should rather update badge than overwriting it.
-    func setAvatar(image: UIImage?, with defaultImage: UIImage?) {
+    func setAvatar(image: UIImage?) {
         if let image = image {
-            badge = InitialsBadge(image: image, size: badgeSize)
-        } else if let defaultImage = defaultImage {
+            badge.setImage(image)
+        } else {
             badge = InitialsBadge(image: defaultImage, size: badgeSize)
             badge.backgroundColor = DcColors.grayTextColor
         }
-    }
-
-    func updateAvatar(image: UIImage) {
-        badge.setImage(image)
     }
 }


### PR DESCRIPTION
- add avatar-delete-option to group-avatars
- streamline the avatar-default image (no initial-badge when in edit-mode, always show camera-icon (was already true for most cases))
- streamline the order of some items, commit comments for details

moreover, this or cleans up AvatarSelectionCell a bit. AvatarSelectionCell now just handled an image, the bit weird logic of passing context=nil etc. is gone.

closes #866 
