### PR TITLE
remote push

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -303,6 +303,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
       let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
       let token = tokenParts.joined()
       print("Device Token: \(token)")
+      // TODO: pass token to provider
     }
 
     func application(
@@ -313,7 +314,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     
      func application(
         _ application: UIApplication,
-        didReceiveRemoteNotification userInfo: [AnyHashable : Any]) {
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any]) {
+        // TODO: got notification from apple, check for new messages
         print("notification", userInfo)
     }
     

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -303,10 +303,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     ) {
         let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
         let tokenString = tokenParts.joined()
-        print("Device Token: \(tokenString)")
-
-        // TODO: persist token in config
-        // and post token to notification server only on changes
+        logger.verbose("device token: \(tokenString)")
 
         if let url = URL(string: "https://notifications.delta.chat/register?token=\(tokenString)") {
             var request = URLRequest(url: url)
@@ -321,6 +318,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 logger.info("request to notification server succeeded with respose, data: \(String(describing: response)), \(String(describing: data))")
             }
             task.resume()
+        } else {
+            logger.error("cannot create URL for token: \(tokenString)")
         }
     }
 

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -307,7 +307,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.verbose("device token: \(tokenString)")
 
         #if DEBUG
-        let endpoint = "https://notifications.delta.chat/register" // FIXME: use sandbox address
+        let endpoint = "https://sandbox.notifications.delta.chat/register"
         #else
         let endpoint = "https://notifications.delta.chat/register"
         #endif

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -305,6 +305,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let tokenString = tokenParts.joined()
         print("Device Token: \(tokenString)")
 
+        // TODO: persist token in config
+        // and post token to notification server only on changes
+
         if let url = URL(string: "https://notifications.delta.chat/register?token=\(tokenString)") {
             var request = URLRequest(url: url)
             request.httpMethod = "POST"

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -306,7 +306,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let tokenString = tokenParts.joined()
         logger.verbose("device token: \(tokenString)")
 
-        if let url = URL(string: "https://notifications.delta.chat/register") {
+        #if DEBUG
+        let endpoint = "https://notifications.delta.chat/register" // FIXME: use sandbox address
+        #else
+        let endpoint = "https://notifications.delta.chat/register"
+        #endif
+
+        if let url = URL(string: endpoint) {
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
             let body = "{ \"token\": \"\(tokenString)\" }"

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -66,10 +66,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             print("Unable to start notifier")
         }
         
-        // Push Notifications
-        // Check if launched from notification
         let notificationOption = launchOptions?[.remoteNotification]
-        print(notificationOption)
+        logger.info("remoteNotification: \(String(describing: notificationOption))")
 
         if dcContext.isConfigured() {
             registerForShowingNotifications()

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -288,7 +288,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             switch settings.authorizationStatus {
             case .authorized, .provisional, .ephemeral:
                 DispatchQueue.main.async {
-                  // on success, we get a token at didRegisterForRemoteNotificationsWithDeviceToken
+                  // on success, we get a token at didRegisterForRemoteNotificationsWithDeviceToken;
+                  // on failure, didFailToRegisterForRemoteNotificationsWithError is called
                   UIApplication.shared.registerForRemoteNotifications()
                 }
             case .denied, .notDetermined:

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -301,10 +301,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
       _ application: UIApplication,
       didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-      let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
-      let token = tokenParts.joined()
-      print("Device Token: \(token)")
-      // TODO: pass token to provider
+        let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
+        let tokenString = tokenParts.joined()
+        print("Device Token: \(tokenString)")
+
+        if let url = URL(string: "https://notifications.delta.chat/register?token=\(tokenString)") {
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            //let param = "token=\(tokenString)"
+            //request.httpBody = param.data(using: String.Encoding.utf8)
+            let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+                if let error = error {
+                    logger.error("cannot POST to notification server: \(error)")
+                    return
+                }
+                logger.info("request to notification server succeeded with respose, data: \(String(describing: response)), \(String(describing: data))")
+            }
+            task.resume()
+        }
     }
 
     func application(

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -67,7 +67,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
         
         let notificationOption = launchOptions?[.remoteNotification]
-        logger.info("remoteNotification: \(String(describing: notificationOption))")
+        logger.info("Notifications: remoteNotification: \(String(describing: notificationOption))")
 
         if dcContext.isConfigured() && !UserDefaults.standard.bool(forKey: "notifications_disabled") {
             registerForNotifications()
@@ -271,7 +271,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // register for showing notifications
         UNUserNotificationCenter.current()
           .requestAuthorization(options: [.alert, .sound, .badge]) { [weak self] granted, _ in
-            logger.info("Permission granted: \(granted)")
+            logger.info("Notifications: Permission granted: \(granted)")
 
             if granted {
                 // we are allowd to show notifications:
@@ -283,7 +283,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     private func maybeRegisterForRemoteNotifications() {
         UNUserNotificationCenter.current().getNotificationSettings { settings in
-            logger.info("Notification settings: \(settings)")
+            logger.info("Notifications: Settings: \(settings)")
 
             switch settings.authorizationStatus {
             case .authorized, .provisional, .ephemeral:
@@ -304,13 +304,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     ) {
         let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
         let tokenString = tokenParts.joined()
-        logger.verbose("device token: \(tokenString)")
 
         #if DEBUG
         let endpoint = "https://sandbox.notifications.delta.chat/register"
         #else
         let endpoint = "https://notifications.delta.chat/register"
         #endif
+
+        logger.verbose("Notifications: POST token: \(tokenString) to \(endpoint)")
 
         if let url = URL(string: endpoint) {
             var request = URLRequest(url: url)
@@ -319,28 +320,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             request.httpBody = body.data(using: String.Encoding.utf8)
             let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
                 if let error = error {
-                    logger.error("cannot POST to notification server: \(error)")
+                    logger.error("Notifications: cannot POST to notification server: \(error)")
                     return
                 }
-                logger.info("request to notification server succeeded with respose, data: \(String(describing: response)), \(String(describing: data))")
+                logger.info("Notifications: request to notification server succeeded with respose, data: \(String(describing: response)), \(String(describing: data))")
             }
             task.resume()
         } else {
-            logger.error("cannot create URL for token: \(tokenString)")
+            logger.error("Notifications: cannot create URL for token: \(tokenString)")
         }
     }
 
     func application(
       _ application: UIApplication,
       didFailToRegisterForRemoteNotificationsWithError error: Error) {
-      print("Failed to register: \(error)")
+      print("Notifications: Failed to register: \(error)")
     }
     
      func application(
         _ application: UIApplication,
         didReceiveRemoteNotification userInfo: [AnyHashable: Any]) {
         // TODO: got notification from apple, check for new messages
-        print("notification", userInfo)
+        print("Notifications: didReceiveRemoteNotification", userInfo)
     }
     
     private func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -306,11 +306,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let tokenString = tokenParts.joined()
         logger.verbose("device token: \(tokenString)")
 
-        if let url = URL(string: "https://notifications.delta.chat/register?token=\(tokenString)") {
+        if let url = URL(string: "https://notifications.delta.chat/register") {
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
-            //let param = "token=\(tokenString)"
-            //request.httpBody = param.data(using: String.Encoding.utf8)
+            let body = "{ \"token\": \"\(tokenString)\" }"
+            request.httpBody = body.data(using: String.Encoding.utf8)
             let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
                 if let error = error {
                     logger.error("cannot POST to notification server: \(error)")

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -70,9 +70,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // Check if launched from notification
         let notificationOption = launchOptions?[.remoteNotification]
         print(notificationOption)
-        
-        registerForPushNotifications()
 
+        if dcContext.isConfigured() {
+            registerForShowingNotifications()
+        }
 
         return true
     }
@@ -266,19 +267,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     // MARK: - PushNotifications
 
-    func registerForPushNotifications() {
+    func registerForShowingNotifications() {
         print("register push")
         UNUserNotificationCenter.current().delegate = self
 
         UNUserNotificationCenter.current()
-            .requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
-                logger.info("permission granted: \(granted)")
-                guard granted else { return }
-                self.getNotificationSettings()
-            }
-        UNUserNotificationCenter.current()
           .requestAuthorization(options: [.alert, .sound, .badge]) {
-            [weak self] granted, error in
+            [weak self] granted, _ in
               
             print("Permission granted: \(granted)")
             guard granted else { return }

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -69,7 +69,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let notificationOption = launchOptions?[.remoteNotification]
         logger.info("remoteNotification: \(String(describing: notificationOption))")
 
-        if dcContext.isConfigured() {
+        if dcContext.isConfigured() && !UserDefaults.standard.bool(forKey: "notifications_disabled") {
             registerForNotifications()
         }
 

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -776,7 +776,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
     private func handleLoginSuccess() {
         // used when login hud successfully went through
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        appDelegate.registerForPushNotifications()
+        appDelegate.registerForShowingNotifications()
         initSelectionCells();
         if let onLoginSuccess = self.onLoginSuccess {
             onLoginSuccess()

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -776,7 +776,11 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
     private func handleLoginSuccess() {
         // used when login hud successfully went through
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        appDelegate.registerForNotifications()
+
+        if !UserDefaults.standard.bool(forKey: "notifications_disabled") {
+            appDelegate.registerForNotifications()
+        }
+
         initSelectionCells();
         if let onLoginSuccess = self.onLoginSuccess {
             onLoginSuccess()

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -776,7 +776,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
     private func handleLoginSuccess() {
         // used when login hud successfully went through
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        appDelegate.registerForShowingNotifications()
+        appDelegate.registerForNotifications()
         initSelectionCells();
         if let onLoginSuccess = self.onLoginSuccess {
             onLoginSuccess()

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -319,6 +319,11 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
 
     @objc private func handleNotificationToggle(_ sender: UISwitch) {
         UserDefaults.standard.set(!sender.isOn, forKey: "notifications_disabled")
+        if sender.isOn {
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                appDelegate.registerForNotifications()
+            }
+        }
         UserDefaults.standard.synchronize()
     }
 

--- a/deltachat-ios/Info.plist
+++ b/deltachat-ios/Info.plist
@@ -60,6 +60,7 @@
 	<array>
 		<string>fetch</string>
 		<string>location</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>


### PR DESCRIPTION
targets https://github.com/deltachat/deltachat-ios/issues/569

- [x] get token from apple and pass it to the [notification server](https://github.com/dignifiedquire/notifiers/)
- [x] wake up on notifications coming from apple, triggered by notification server (should work, but currently the notification server is not working)
- [x] respect "Notification" user setting (do not do token-dance when disabled; when state switches to enabled, do that token-dance at once)

maybe update the token on the notification server only on changes, however, for resilience (server issues), re-pass the token at least every some hours. ~~however, that can also go to a subsequent pr~~ we decided to do that in another pr, if at all.