### PR TITLE
Fix outdated settings

### DIFF
--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -116,24 +116,13 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
         changeGroupImage = nil
         deleteGroupImage = true
         doneButton.isEnabled = true
-        updateAvatarRow(image: nil)
+        avatarSelectionCell.setAvatar(image: nil)
     }
 
     func onImageSelected(image: UIImage) {
         changeGroupImage = image
         deleteGroupImage = false
         doneButton.isEnabled = true
-        updateAvatarRow(image: changeGroupImage)
-    }
-
-    func updateAvatarRow(image: UIImage?) {
-        avatarSelectionCell = AvatarSelectionCell(image: image)
-        avatarSelectionCell.hintLabel.text = String.localized("group_avatar")
-        avatarSelectionCell.onAvatarTapped = onAvatarTapped
-
-        self.tableView.beginUpdates()
-        let indexPath = IndexPath(row: rowAvatar, section: 0)
-        self.tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.none)
-        self.tableView.endUpdates()
+        avatarSelectionCell.setAvatar(image: changeGroupImage)
     }
 }

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -3,8 +3,6 @@ import DcCore
 
 class EditSettingsController: UITableViewController, MediaPickerDelegate {
     private let dcContext: DcContext
-    private var displayNameBackup: String?
-    private var statusCellBackup: String?
 
     private let section1 = 0
     private let section1Name = 0

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -156,10 +156,4 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
         self.avatarSelectionCell.setAvatar(image: dcContext.getSelfAvatarImage())
     }
 
-    private func updateCells() {
-        updateAvatarCell()
-        statusCell.setText(text: dcContext.selfstatus)
-        nameCell.setText(text: dcContext.displayname)
-    }
-
 }

--- a/deltachat-ios/Controller/EditSettingsController.swift
+++ b/deltachat-ios/Controller/EditSettingsController.swift
@@ -42,7 +42,7 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
     }()
 
     private lazy var avatarSelectionCell: AvatarSelectionCell = {
-        return createPictureAndNameCell()
+        return AvatarSelectionCell(image: dcContext.getSelfAvatarImage())
     }()
 
     private lazy var nameCell: TextFieldCell = {
@@ -134,7 +134,7 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
 
     private func deleteProfileIconPressed(_ action: UIAlertAction) {
         dcContext.selfavatar = nil
-        updateAvatarAndNameCell()
+        updateAvatarCell()
     }
 
     private func onAvatarTapped() {
@@ -151,22 +151,17 @@ class EditSettingsController: UITableViewController, MediaPickerDelegate {
 
     func onImageSelected(image: UIImage) {
         AvatarHelper.saveSelfAvatarImage(dcContext: dcContext, image: image)
-        updateAvatarAndNameCell()
+        updateAvatarCell()
     }
 
-    private func updateAvatarAndNameCell() {
-        self.avatarSelectionCell = createPictureAndNameCell()
-        self.avatarSelectionCell.onAvatarTapped = onAvatarTapped
-
-        self.tableView.beginUpdates()
-        let indexPath = IndexPath(row: section1Avatar, section: section1)
-        self.tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.none)
-        self.tableView.endUpdates()
+    private func updateAvatarCell() {
+        self.avatarSelectionCell.setAvatar(image: dcContext.getSelfAvatarImage())
     }
 
-    private func createPictureAndNameCell() -> AvatarSelectionCell {
-        let cell = AvatarSelectionCell(image: dcContext.getSelfAvatarImage())
-        return cell
+    private func updateCells() {
+        updateAvatarCell()
+        statusCell.setText(text: dcContext.selfstatus)
+        nameCell.setText(text: dcContext.displayname)
     }
 
 }

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -307,24 +307,13 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     private func deleteGroupAvatarPressed(_ action: UIAlertAction) {
         changeGroupImage = nil
         deleteGroupImage = true
-        updateAvatarRow(image: nil)
+        avatarSelectionCell.setAvatar(image: nil)
     }
 
     func onImageSelected(image: UIImage) {
         changeGroupImage = image
         deleteGroupImage = false
-        updateAvatarRow(image: changeGroupImage)
-    }
-
-    func updateAvatarRow(image: UIImage?) {
-        avatarSelectionCell = AvatarSelectionCell(image: image)
-        avatarSelectionCell.hintLabel.text = String.localized("group_avatar")
-        avatarSelectionCell.onAvatarTapped = onAvatarTapped
-
-        self.tableView.beginUpdates()
-        let indexPath = IndexPath(row: sectionGroupDetailsRowAvatar, section: sectionGroupDetails)
-        self.tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.none)
-        self.tableView.endUpdates()
+        avatarSelectionCell.setAvatar(image: changeGroupImage)
     }
 
     func updateGroupContactIdsOnQRCodeInvite() {

--- a/deltachat-ios/Controller/ProfileInfoViewController.swift
+++ b/deltachat-ios/Controller/ProfileInfoViewController.swift
@@ -78,10 +78,6 @@ class ProfileInfoViewController: UITableViewController {
         if let avatarImage = dcContext.getSelfAvatarImage() {
             avatarCell.setAvatar(image: avatarImage)
         }
-        self.tableView.beginUpdates()
-        let indexPath = IndexPath(row: 1, section: 0)
-        self.tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.none)
-        self.tableView.endUpdates()
     }
 
     // MARK: - actions

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -21,6 +21,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
                 [weak self] in
                 if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
                     appDelegate.appCoordinator.presentTabBarController()
+                    appDelegate.appCoordinator.popTabsToRootViewControllers()
                 }
             }
             self.navigationController?.pushViewController(accountSetupController, animated: true)

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -116,4 +116,10 @@ class AppCoordinator {
         showTab(index: chatsTab)
         window.makeKeyAndVisible()
     }
+
+    func popTabsToRootViewControllers() {
+        qrNavController.popToRootViewController(animated: false)
+        chatsNavController.popToRootViewController(animated: false)
+        settingsNavController.popToRootViewController(animated: false)
+    }
 }

--- a/deltachat-ios/View/AvatarSelectionCell.swift
+++ b/deltachat-ios/View/AvatarSelectionCell.swift
@@ -88,7 +88,7 @@ class AvatarSelectionCell: UITableViewCell {
             badge.setImage(image)
             avatarSet = true
         } else {
-            badge = InitialsBadge(image: defaultImage, size: badgeSize)
+            badge.setImage(defaultImage)
             badge.backgroundColor = DcColors.grayTextColor
             avatarSet = false
         }


### PR DESCRIPTION
fixes #897 

* this fix removes all sub view controller from qr tab, chats tab and settings tab view controller after a successful login. This ensures that the navigation is correctly reinitialized after an account switch. Also deprecated views are not shown anymore. 
* also improves the way AvatarSelectionCells get updated. Less code is needed to archieve the same with the change here: https://github.com/deltachat/deltachat-ios/compare/fix_outdated_settings?expand=1#diff-9abbfa531269f7fa425bb9249f47d7deL91