### PR TITLE
Open document gallery

### DIFF
--- a/deltachat-ios/Chat/ChatViewControllerNew.swift
+++ b/deltachat-ios/Chat/ChatViewControllerNew.swift
@@ -121,7 +121,6 @@ class ChatViewControllerNew: UITableViewController {
         tableView.register(NewAudioMessageCell.self, forCellReuseIdentifier: "audio")
         tableView.rowHeight = UITableView.automaticDimension
         tableView.separatorStyle = .none
-        tableView.allowsSelection = false
         super.viewDidLoad()
         if !dcContext.isConfigured() {
             // TODO: display message about nothing being configured
@@ -329,7 +328,22 @@ class ChatViewControllerNew: UITableViewController {
         cell.update(msg: message,
                     messageStyle: configureMessageStyle(for: message, at: indexPath),
                     isAvatarVisible: configureAvatarVisibility(for: message, at: indexPath))
+        cell.selectionStyle = .none
         return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let messageId = messageIds[indexPath.row]
+        let message = DcMsg(id: messageId)
+        if let url = message.fileURL {
+            // find all other messages with same message type
+            let previousUrls: [URL] = message.previousMediaURLs()
+            let nextUrls: [URL] = message.nextMediaURLs()
+
+            // these are the files user will be able to swipe trough
+            let mediaUrls: [URL] = previousUrls + [url] + nextUrls
+            showMediaGallery(currentIndex: previousUrls.count, mediaUrls: mediaUrls)
+        }
     }
 
     func configureAvatarVisibility(for message: DcMsg, at indexPath: IndexPath) -> Bool {

--- a/deltachat-ios/Chat/Views/Cells/NewFileTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/NewFileTextCell.swift
@@ -12,6 +12,7 @@ class NewFileTextCell: BaseMessageCell {
 
     private var imageWidthConstraint: NSLayoutConstraint?
     private var imageHeightConstraint: NSLayoutConstraint?
+    private var spacer: NSLayoutConstraint?
 
     private var horizontalLayout: Bool {
         set {
@@ -69,7 +70,6 @@ class NewFileTextCell: BaseMessageCell {
         return subtitle
     }()
 
-
     lazy var messageLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -81,10 +81,14 @@ class NewFileTextCell: BaseMessageCell {
 
     override func setupSubviews() {
         super.setupSubviews()
+        let spacerView = UIView()
+        spacer = spacerView.constraintHeightTo(8, priority: .defaultHigh)
+        spacer?.isActive = true
         mainContentView.addArrangedSubview(fileStackView)
+        mainContentView.addArrangedSubview(spacerView)
         mainContentView.addArrangedSubview(messageLabel)
         imageWidthConstraint = fileImageView.constraintWidthTo(50)
-        imageHeightConstraint = fileImageView.constraintHeightTo(50 * 1.3)
+        imageHeightConstraint = fileImageView.constraintHeightTo(50 * 1.3, priority: .defaultLow)
         horizontalLayout = true
     }
 
@@ -95,7 +99,12 @@ class NewFileTextCell: BaseMessageCell {
     }
 
     override func update(msg: DcMsg, messageStyle: UIRectCorner, isAvatarVisible: Bool) {
-        messageLabel.text = msg.text
+        if let text = msg.text, !text.isEmpty {
+            messageLabel.text = text
+            spacer?.isActive = true
+        } else {
+            spacer?.isActive = false
+        }
         if let url = msg.fileURL {
             generateThumbnailFor(url: url, placeholder: defaultImage)
         } else {


### PR DESCRIPTION
fixes
[x] a tap on file-view should open documents as before
[x] a tap on image-view should go to gallery as before
as well as for any other attached file types (audio, video)

improves file view layout