### PR TITLE
adapt to new dc_configure() error handling

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -49,14 +49,13 @@ public func handleEvent(event: DcEvent) {
                     "progress": Int(data1),
                     "error": Int(data1) == 0,
                     "done": done,
-                    "errorMessage": DcContext.shared.lastErrorString as Any,
+                    "errorMessage": event.data2String,
                 ]
             )
 
             if done {
                 UserDefaults.standard.set(true, forKey: Constants.Keys.deltachatUserProvidedCredentialsKey)
                 UserDefaults.standard.synchronize()
-                DcContext.shared.lastErrorString = nil
             }
         }
 

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -196,6 +196,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         dcContext.setStockTranslation(id: DC_STR_MSGACTIONBYUSER, localizationKey: "systemmsg_action_by_user")
         dcContext.setStockTranslation(id: DC_STR_MSGACTIONBYME, localizationKey: "systemmsg_action_by_me")
         dcContext.setStockTranslation(id: DC_STR_DEVICE_MESSAGES, localizationKey: "device_talk")
+        dcContext.setStockTranslation(id: DC_STR_CONFIGURATION_FAILED, localizationKey: "configuration_failed_with_error")
     }
 
     func installEventHandler() {


### PR DESCRIPTION
errors that should be shown to the user
come from DC_EVENT_CONFIGURE_PROGRESS(data1=0) as data2
since https://github.com/deltachat/deltachat-core-rust/pull/1905;
there is no need to show the captured error any longer
(which was unreliable and hard to handle from core site).

there is some capturing-code left as needed for other parts,
but it is not used for configuration anymore.

closes #922 