### PR TITLE
remove workaround for updating member list on qr-group-scan

### DIFF
--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -15,8 +15,6 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     let isVerifiedGroup: Bool
     let dcContext: DcContext
     private var contactAddedObserver: NSObjectProtocol?
-    ///TODO: remove the the line below as soon as deltachat-core 4b7b6d6cb3c26d817e3f3eeb6a20d8e8c66a4578 was released
-    private var workaroundObserver: NSObjectProtocol?
 
     private let sectionGroupDetails = 0
     private let sectionGroupDetailsRowName = 0
@@ -90,33 +88,11 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
                 }
             }
         }
-
-        ///TODO: remove the the lines below as soon as deltachat-core 4b7b6d6cb3c26d817e3f3eeb6a20d8e8c66a4578 was released
-        workaroundObserver = nc.addObserver(
-            forName: dcNotificationChanged,
-            object: nil,
-            queue: nil
-        ) { [weak self] notification in
-            guard let self = self else { return }
-            if let ui = notification.userInfo {
-                if let chatId = ui["chat_id"] as? Int {
-                    if self.groupChatId == 0 || chatId != self.groupChatId {
-                        return
-                    }
-                    self.updateGroupContactIdsOnQRCodeInvite()
-                }
-            }
-        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         if let observer = self.contactAddedObserver {
             NotificationCenter.default.removeObserver(observer)
-        }
-
-        ///TODO: remove the the lines below as soon as deltachat-core 4b7b6d6cb3c26d817e3f3eeb6a20d8e8c66a4578 was released
-        if let workaroundObserver = self.workaroundObserver {
-            NotificationCenter.default.removeObserver(workaroundObserver)
         }
     }
 


### PR DESCRIPTION
since https://github.com/deltachat/deltachat-core-rust/pull/1141
the correct event (DC_EVENT_CHAT_MODIFIED) is fired on adding members
and a workaround is no longer needed.

come cleanup before we pull in https://github.com/deltachat/deltachat-core-rust/pull/1942 that will need a few adaptions on events.

closes #716