### PR TITLE
Preview fix

### DIFF
--- a/deltachat-ios/Chat/ChatViewControllerNew.swift
+++ b/deltachat-ios/Chat/ChatViewControllerNew.swift
@@ -805,8 +805,8 @@ class ChatViewControllerNew: UITableViewController {
         mediaPicker?.showPhotoVideoLibrary()
     }
 
-    private func showMediaGallery(currentIndex: Int, mediaUrls urls: [URL]) {
-        let betterPreviewController = PreviewController(currentIndex: currentIndex, urls: urls)
+    private func showMediaGallery(currentIndex: Int, msgIds: [Int]) {
+        let betterPreviewController = PreviewController(type: .multi(msgIds, currentIndex))
         let nav = UINavigationController(rootViewController: betterPreviewController)
         nav.modalPresentationStyle = .fullScreen
         navigationController?.present(nav, animated: true)

--- a/deltachat-ios/Chat/ChatViewControllerNew.swift
+++ b/deltachat-ios/Chat/ChatViewControllerNew.swift
@@ -1012,14 +1012,10 @@ class ChatViewControllerNew: UITableViewController {
     }
 
     func showMediaGalleryFor(message: DcMsg) {
-        if let url = message.fileURL {
-            // find all other messages with same message type
-            let previousUrls: [URL] = message.previousMediaURLs()
-            let nextUrls: [URL] = message.nextMediaURLs()
-            // these are the files user will be able to swipe trough
-            let mediaUrls: [URL] = previousUrls + [url] + nextUrls
-            showMediaGallery(currentIndex: previousUrls.count, mediaUrls: mediaUrls)
-        }
+
+        let msgIds = dcContext.getChatMedia(chatId: chatId, messageType: Int32(message.type), messageType2: 0, messageType3: 0)
+        let index = msgIds.firstIndex(of: message.id) ?? 0
+        showMediaGallery(currentIndex: index, msgIds: msgIds)
     }
 
     private func didTapAsm(msg: DcMsg, orgText: String) {

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -1310,14 +1310,10 @@ extension ChatViewController: MessageCellDelegate {
             let message = messageList[indexPath.section]
             if message.isSetupMessage {
                 didTapAsm(msg: message, orgText: "")
-            } else if let url = message.fileURL {
-                // find all other messages with same message type
-                let previousUrls: [URL] = message.previousMediaURLs()
-                let nextUrls: [URL] = message.nextMediaURLs()
-
-                // these are the files user will be able to swipe trough
-                let mediaUrls: [URL] = previousUrls + [url] + nextUrls
-                showMediaGallery(currentIndex: previousUrls.count, mediaUrls: mediaUrls)
+            } else if message.fileURL != nil {
+                let msgIds = dcContext.getChatMedia(chatId: chatId, messageType: Int32(message.type), messageType2: 0, messageType3: 0)
+                let index = msgIds.firstIndex(of: message.id) ?? 0
+                showMediaGallery(currentIndex: index, msgIds: msgIds)
             }
         }
     }

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -1310,7 +1310,7 @@ extension ChatViewController: MessageCellDelegate {
             let message = messageList[indexPath.section]
             if message.isSetupMessage {
                 didTapAsm(msg: message, orgText: "")
-            } else if message.fileURL != nil {
+            } else {
                 let msgIds = dcContext.getChatMedia(chatId: chatId, messageType: Int32(message.type), messageType2: 0, messageType3: 0)
                 let index = msgIds.firstIndex(of: message.id) ?? 0
                 showMediaGallery(currentIndex: index, msgIds: msgIds)

--- a/deltachat-ios/Controller/ChatViewController.swift
+++ b/deltachat-ios/Controller/ChatViewController.swift
@@ -749,8 +749,8 @@ class ChatViewController: MessagesViewController {
         mediaPicker?.showPhotoVideoLibrary()
     }
 
-    private func showMediaGallery(currentIndex: Int, mediaUrls urls: [URL]) {
-        let betterPreviewController = PreviewController(currentIndex: currentIndex, urls: urls)
+    private func showMediaGallery(currentIndex: Int, msgIds: [Int]) {
+        let betterPreviewController = PreviewController(type: .multi(msgIds, currentIndex))
         let nav = UINavigationController(rootViewController: betterPreviewController)
         nav.modalPresentationStyle = .fullScreen
         navigationController?.present(nav, animated: true)

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -395,7 +395,7 @@ class ContactDetailViewController: UITableViewController {
     private func showContactAvatarIfNeeded() {
         let contact = viewModel.contact
         if let url =  contact.profileImageURL {
-            let previewController = PreviewController(currentIndex: 0, urls: [url])
+            let previewController = PreviewController(type: .single(url))
             previewController.customTitle = contact.displayName
             present(previewController, animated: true, completion: nil)
         }

--- a/deltachat-ios/Controller/DocumentGalleryController.swift
+++ b/deltachat-ios/Controller/DocumentGalleryController.swift
@@ -87,11 +87,7 @@ extension DocumentGalleryController {
         guard let index = fileMessageIds.index(of: msgId) else {
             return
         }
-
-        let mediaUrls = fileMessageIds.compactMap {
-            return DcMsg(id: $0).fileURL
-        }
-        let previewController = PreviewController(currentIndex: index, urls: mediaUrls)
+        let previewController = PreviewController(type: .multi(fileMessageIds, index))
         present(previewController, animated: true, completion: nil)
     }
 }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -210,11 +210,7 @@ extension GalleryViewController {
         guard let index = mediaMessageIds.index(of: msgId) else {
             return
         }
-
-        let mediaUrls = mediaMessageIds.compactMap {
-            return DcMsg(id: $0).fileURL
-        }
-        let previewController = PreviewController(currentIndex: index, urls: mediaUrls)
+        let previewController = PreviewController(type: .multi(mediaMessageIds, index))
         present(previewController, animated: true, completion: nil)
     }
 }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -326,7 +326,7 @@ class GroupChatDetailViewController: UIViewController {
 
     private func showGroupAvatarIfNeeded() {
         if let url = chat.profileImageURL {
-            let previewController = PreviewController(currentIndex: 0, urls: [url])
+            let previewController = PreviewController(type: .single(url))
             previewController.customTitle = self.title
             present(previewController, animated: true, completion: nil)
         }

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -4,8 +4,17 @@ import DcCore
 
 class PreviewController: QLPreviewController {
 
+    enum PreviewType {
+        case single(URL)
+        case multi([Int], Int) // msgIds, index
+    }
+
+    let previewType: PreviewType
+
+    /*
     var msgIds: [Int] = []
     var url: URL?
+    */
 
     var customTitle: String?
 
@@ -14,6 +23,12 @@ class PreviewController: QLPreviewController {
         return button
     }()
 
+    init(type: PreviewType) {
+        self.previewType = type
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    /*
     convenience init(url: URL) {
         self.init(currentIndex: 0, msgIds: [])
         self.url = url
@@ -25,6 +40,7 @@ class PreviewController: QLPreviewController {
         dataSource = self
         currentPreviewItemIndex = currentIndex
     }
+    */
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -48,18 +64,21 @@ class PreviewController: QLPreviewController {
 extension PreviewController: QLPreviewControllerDataSource {
 
     func numberOfPreviewItems(in _: QLPreviewController) -> Int {
-        if url != nil {
+        switch previewType {
+        case .single:
             return 1
+        case .multi(let msgIds, _):
+            return msgIds.count
         }
-        return msgIds.count
     }
 
     func previewController(_: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
-        if let url = self.url {
+        switch previewType {
+        case .single(let url):
             return PreviewItem(url: url, title: self.customTitle)
-        } else {
+        case .multi(let msgIds, let index):
             let msg = DcMsg(id: msgIds[index])
-            return PreviewItem(url: url ?? msg.fileURL, title: self.customTitle)
+            return PreviewItem(url: msg.fileURL, title: self.customTitle)
         }
     }
 }

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -3,18 +3,12 @@ import UIKit
 import DcCore
 
 class PreviewController: QLPreviewController {
-
     enum PreviewType {
         case single(URL)
         case multi([Int], Int) // msgIds, index
     }
 
     let previewType: PreviewType
-
-    /*
-    var msgIds: [Int] = []
-    var url: URL?
-    */
 
     var customTitle: String?
 
@@ -26,21 +20,14 @@ class PreviewController: QLPreviewController {
     init(type: PreviewType) {
         self.previewType = type
         super.init(nibName: nil, bundle: nil)
-    }
-
-    /*
-    convenience init(url: URL) {
-        self.init(currentIndex: 0, msgIds: [])
-        self.url = url
-    }
-
-    init(currentIndex: Int, msgIds: [Int]) {
-        self.msgIds = msgIds
-        super.init(nibName: nil, bundle: nil)
         dataSource = self
-        currentPreviewItemIndex = currentIndex
+        switch type {
+        case .multi(_,let currentIndex):
+            currentPreviewItemIndex = currentIndex
+        case .single:
+            currentPreviewItemIndex = 0
+        }
     }
-    */
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -76,7 +63,7 @@ extension PreviewController: QLPreviewControllerDataSource {
         switch previewType {
         case .single(let url):
             return PreviewItem(url: url, title: self.customTitle)
-        case .multi(let msgIds, let index):
+        case .multi(let msgIds, _):
             let msg = DcMsg(id: msgIds[index])
             return PreviewItem(url: msg.fileURL, title: self.customTitle)
         }

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -1,9 +1,11 @@
 import QuickLook
 import UIKit
+import DcCore
 
 class PreviewController: QLPreviewController {
 
-    var urls: [URL]
+    var msgIds: [Int] = []
+    var url: URL?
 
     var customTitle: String?
 
@@ -12,8 +14,13 @@ class PreviewController: QLPreviewController {
         return button
     }()
 
-    init(currentIndex: Int, urls: [URL]) {
-        self.urls = urls
+    convenience init(url: URL) {
+        self.init(currentIndex: 0, msgIds: [])
+        self.url = url
+    }
+
+    init(currentIndex: Int, msgIds: [Int]) {
+        self.msgIds = msgIds
         super.init(nibName: nil, bundle: nil)
         dataSource = self
         currentPreviewItemIndex = currentIndex
@@ -41,11 +48,19 @@ class PreviewController: QLPreviewController {
 extension PreviewController: QLPreviewControllerDataSource {
 
     func numberOfPreviewItems(in _: QLPreviewController) -> Int {
-        return urls.count
+        if url != nil {
+            return 1
+        }
+        return msgIds.count
     }
 
     func previewController(_: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
-        return PreviewItem(url: urls[index], title: self.customTitle)
+        if let url = self.url {
+            return PreviewItem(url: url, title: self.customTitle)
+        } else {
+            let msg = DcMsg(id: msgIds[index])
+            return PreviewItem(url: url ?? msg.fileURL, title: self.customTitle)
+        }
     }
 }
 
@@ -54,7 +69,7 @@ class PreviewItem: NSObject, QLPreviewItem {
     var previewItemURL: URL?
     var previewItemTitle: String?
 
-    init(url: URL, title: String?) {
+    init(url: URL?, title: String?) {
         self.previewItemURL = url
         self.previewItemTitle = title ?? ""
     }


### PR DESCRIPTION
closes #936 

PreviewController now takes msgIds - so messages can be generated on demand.

I had to change the way how PreviewController is initialised. It takes an enum with associated type - this way single previews like we are using on avatar taps take an url, while chat/message related previews take msg-ids.