### PR TITLE
add minimal left padding to avatars in chat messages

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -160,7 +160,7 @@ public class BaseMessageCell: UITableViewCell {
         contentView.addSubview(avatarView)
 
         contentView.addConstraints([
-            avatarView.constraintAlignLeadingTo(contentView),
+            avatarView.constraintAlignLeadingTo(contentView, paddingLeading: 2),
             avatarView.constraintAlignBottomTo(contentView),
             avatarView.constraintWidthTo(28, priority: .defaultHigh),
             avatarView.constraintHeightTo(28, priority: .defaultHigh),


### PR DESCRIPTION
* so that they're not touching the left screen boarder and are horizontally centered between screen boarder and message bubble

closes #949
