### PR TITLE
cleanup saved-messages and device-chat profiles

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -111,9 +111,11 @@ class ContactDetailViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureTableView()
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: String.localized("global_menu_edit_desktop"),
-            style: .plain, target: self, action: #selector(editButtonPressed))
+        if !self.viewModel.isSavedMessages && !self.viewModel.isDeviceTalk {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: String.localized("global_menu_edit_desktop"),
+                style: .plain, target: self, action: #selector(editButtonPressed))
+        }
         self.title = String.localized("tab_contact")
     }
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -6,16 +6,7 @@ class ContactDetailViewController: UITableViewController {
     private let viewModel: ContactDetailViewModel
 
     private lazy var headerCell: ContactDetailHeader = {
-        let header = ContactDetailHeader()
-        header.updateDetails(title: viewModel.contact.displayName, subtitle: viewModel.contact.email)
-        if let img = viewModel.contact.profileImage {
-            header.setImage(img)
-        } else {
-            header.setBackupImage(name: viewModel.contact.displayName, color: viewModel.contact.color)
-        }
-        header.setVerified(isVerified: viewModel.contact.isVerified)
-        header.onAvatarTap = showContactAvatarIfNeeded
-        return header
+        return ContactDetailHeader()
     }()
 
 
@@ -228,6 +219,7 @@ class ContactDetailViewController: UITableViewController {
             headerCell.setBackupImage(name: viewModel.contact.displayName, color: viewModel.contact.color)
         }
         headerCell.setVerified(isVerified: viewModel.contact.isVerified)
+        headerCell.onAvatarTap = showContactAvatarIfNeeded
     }
 
     private func updateCellValues() {

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -212,13 +212,25 @@ class ContactDetailViewController: UITableViewController {
 
     // MARK: - updates
     private func updateHeader() {
-        headerCell.updateDetails(title: viewModel.contact.displayName, subtitle: viewModel.contact.email)
-        if let img = viewModel.contact.profileImage {
-            headerCell.setImage(img)
+        if viewModel.isSavedMessages {
+            let chat = viewModel.context.getChat(chatId: viewModel.chatId)
+            headerCell.updateDetails(title: chat.name, subtitle: String.localized("chat_self_talk_subtitle"))
+            if let img = chat.profileImage {
+                headerCell.setImage(img)
+            } else {
+                headerCell.setBackupImage(name: chat.name, color: chat.color)
+            }
+            headerCell.setVerified(isVerified: false)
         } else {
-            headerCell.setBackupImage(name: viewModel.contact.displayName, color: viewModel.contact.color)
+            headerCell.updateDetails(title: viewModel.contact.displayName,
+                                     subtitle: viewModel.isDeviceTalk ? String.localized("device_talk_subtitle") : viewModel.contact.email)
+            if let img = viewModel.contact.profileImage {
+                headerCell.setImage(img)
+            } else {
+                headerCell.setBackupImage(name: viewModel.contact.displayName, color: viewModel.contact.color)
+            }
+            headerCell.setVerified(isVerified: viewModel.contact.isVerified)
         }
-        headerCell.setVerified(isVerified: viewModel.contact.isVerified)
         headerCell.onAvatarTap = showContactAvatarIfNeeded
     }
 
@@ -389,10 +401,16 @@ class ContactDetailViewController: UITableViewController {
     }
 
     private func showContactAvatarIfNeeded() {
-        let contact = viewModel.contact
-        if let url =  contact.profileImageURL {
+        if viewModel.isSavedMessages {
+            let chat = viewModel.context.getChat(chatId: viewModel.chatId)
+            if let url = chat.profileImageURL {
+                let previewController = PreviewController(type: .single(url))
+                previewController.customTitle = chat.name
+                present(previewController, animated: true, completion: nil)
+            }
+        } else if let url = viewModel.contact.profileImageURL {
             let previewController = PreviewController(type: .single(url))
-            previewController.customTitle = contact.displayName
+            previewController.customTitle = viewModel.contact.displayName
             present(previewController, animated: true, completion: nil)
         }
     }

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -115,8 +115,10 @@ class ContactDetailViewController: UITableViewController {
             navigationItem.rightBarButtonItem = UIBarButtonItem(
                 title: String.localized("global_menu_edit_desktop"),
                 style: .plain, target: self, action: #selector(editButtonPressed))
+            self.title = String.localized("tab_contact")
+        } else {
+            self.title = String.localized("profile")
         }
-        self.title = String.localized("tab_contact")
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -447,8 +447,12 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             } else if row == membersRowQrInvite {
                 showQrCodeInvite(chatId: chat.id)
             } else {
-                let member = getGroupMember(at: row)
-                showContactDetail(of: member.id)
+                let memberId = getGroupMemberIdFor(row)
+                if memberId == DC_CONTACT_ID_SELF {
+                    tableView.deselectRow(at: indexPath, animated: true)
+                } else {
+                    showContactDetail(of: memberId)
+                }
             }
         case .chatActions:
             switch chatActions[row] {

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -46,19 +46,20 @@ class ContactDetailViewModel {
         self.chatId = dcContext.getChatIdByContactId(contactId: contactId)
         self.isSavedMessages = false
         self.isDeviceTalk = false
+        if chatId != 0 {
+            let dcChat = dcContext.getChat(chatId: chatId)
+            isSavedMessages = dcChat.isSelfTalk
+            isDeviceTalk = dcChat.isDeviceTalk
+        }
         self.sharedChats = context.getChatlist(flags: 0, queryString: nil, queryId: contactId)
 
         sections.append(.chatOptions)
-        if sharedChats.length > 0 {
+        if sharedChats.length > 0 && !isSavedMessages && !isDeviceTalk {
             sections.append(.sharedChats)
         }
         sections.append(.chatActions)
 
         if chatId != 0 {
-            let dcChat = dcContext.getChat(chatId: chatId)
-            isSavedMessages = dcChat.isSelfTalk
-            isDeviceTalk = dcChat.isDeviceTalk
-
             chatOptions = [.gallery, .documents]
             if !isDeviceTalk {
                 chatOptions.append(.ephemeralMessages)

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -33,6 +33,8 @@ class ContactDetailViewModel {
     }
 
     let chatId: Int
+    var isSavedMessages: Bool
+    var isDeviceTalk: Bool
     private let sharedChats: DcChatlist
     private var sections: [ProfileSections] = []
     private var chatActions: [ChatAction] = []
@@ -42,6 +44,8 @@ class ContactDetailViewModel {
         self.context = dcContext
         self.contactId = contactId
         self.chatId = dcContext.getChatIdByContactId(contactId: contactId)
+        self.isSavedMessages = false
+        self.isDeviceTalk = false
         self.sharedChats = context.getChatlist(flags: 0, queryString: nil, queryId: contactId)
 
         sections.append(.chatOptions)
@@ -51,8 +55,25 @@ class ContactDetailViewModel {
         sections.append(.chatActions)
 
         if chatId != 0 {
-            chatOptions = [.gallery, .documents, .ephemeralMessages, .muteChat, .startChat]
-            chatActions = [.archiveChat, .showEncrInfo, .blockContact, .deleteChat]
+            let dcChat = dcContext.getChat(chatId: chatId)
+            isSavedMessages = dcChat.isSelfTalk
+            isDeviceTalk = dcChat.isDeviceTalk
+
+            chatOptions = [.gallery, .documents]
+            if !isDeviceTalk {
+                chatOptions.append(.ephemeralMessages)
+            }
+            chatOptions.append(.muteChat)
+            if !isDeviceTalk {
+                chatOptions.append(.startChat)
+            }
+
+            chatActions = [.archiveChat]
+            if !isDeviceTalk && !isSavedMessages {
+                chatActions.append(.showEncrInfo)
+                chatActions.append(.blockContact)
+            }
+            chatActions.append(.deleteChat)
         } else {
             chatOptions = [.gallery, .documents, .startChat]
             chatActions = [.showEncrInfo, .blockContact]

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -64,7 +64,9 @@ class ContactDetailViewModel {
             if !isDeviceTalk {
                 chatOptions.append(.ephemeralMessages)
             }
-            chatOptions.append(.muteChat)
+            if !isSavedMessages {
+                chatOptions.append(.muteChat)
+            }
             if !isDeviceTalk {
                 chatOptions.append(.startChat)
             }


### PR DESCRIPTION
remove useless things from saved-messages and device-chat profiles. normal group/contact profiles are unchanged.

closes #967, closes #966, closes #965, close #969

counterpart of https://github.com/deltachat/deltachat-android/pull/1692

before/after screenshots:

<img width=300 src=https://user-images.githubusercontent.com/9800740/97113339-ffd0d800-16e9-11eb-9791-d0837e5e401c.png> <img width=300 src=https://user-images.githubusercontent.com/9800740/97113341-01020500-16ea-11eb-89c6-cea3787d0b3f.png>

<img width=300 src=https://user-images.githubusercontent.com/9800740/97113340-01020500-16ea-11eb-86cb-f78b3b6a177c.png> <img width=300 src=https://user-images.githubusercontent.com/9800740/97113342-019a9b80-16ea-11eb-89a7-4cbee5ff719b.png>

EDIT: also remove "mute" from saved-messages - for self-sent-messages, no notifications are sent at all.