### PR TITLE
show only one line for message title line, ellipsize end if necessary

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -95,6 +95,8 @@ public class BaseMessageCell: UITableViewCell {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.font = UIFont.preferredFont(for: .caption1, weight: .bold)
         view.layer.cornerRadius = 4
+        view.numberOfLines = 1
+        view.label.lineBreakMode = .byTruncatingTail
         view.clipsToBounds = true
         view.paddingLeading = 4
         view.paddingTrailing = 4


### PR DESCRIPTION
especially in compact design (image/gif fills whole message bubble) two lines look bad