### PR TITLE
fix potentially dangling pointer and bad arraysize

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -259,9 +259,10 @@ public class DcContext {
         return DcArray(arrayPointer: dc_get_fresh_msgs(contextPointer))
     }
 
-    public func markSeenMessages(messageIds: [UInt32], count: Int = 1) {
-        let ptr = UnsafePointer(messageIds)
-        dc_markseen_msgs(contextPointer, ptr, Int32(count))
+    public func markSeenMessages(messageIds: [UInt32]) {
+        messageIds.withUnsafeBufferPointer { ptr in
+            dc_markseen_msgs(contextPointer, ptr.baseAddress, Int32(ptr.count))
+        }
     }
 
     public func getChatMessages(chatId: Int) -> OpaquePointer {


### PR DESCRIPTION
this pr fixes two issues:

- using 'UnsafePointer<UInt32>' as before results in a warning saying that this
  results in a dangling pointer;
  this is fixed by using a closure and withUnsafeBufferPointer

- the 'count' argument was never given and defaulted to 1 -
  this results in not all messages beeing marked as unseen -
  and also even in a pointer error when, for whatever reason,
  an empty array as given.
  this is fixed by just removing the superfluous 'count' argument