### PR TITLE
Gallery - context menu - 2nd Attempt

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		AE4AEE3522B1030D000AA495 /* PreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4AEE3422B1030D000AA495 /* PreviewController.swift */; };
 		AE52EA19229EB53C00C586C9 /* ContactDetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE52EA18229EB53C00C586C9 /* ContactDetailHeader.swift */; };
 		AE52EA20229EB9F000C586C9 /* EditGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE52EA1F229EB9F000C586C9 /* EditGroupViewController.swift */; };
+		AE57C0802552BBD0003CFE70 /* GalleryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE57C07F2552BBD0003CFE70 /* GalleryItem.swift */; };
 		AE6EC5242497663200A400E4 /* UIImageView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6EC5232497663200A400E4 /* UIImageView+Extensions.swift */; };
 		AE6EC5282497B9B200A400E4 /* ThumbnailCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6EC5272497B9B200A400E4 /* ThumbnailCache.swift */; };
 		AE728F15229D5C390047565B /* PhotoPickerAlertAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE728F14229D5C390047565B /* PhotoPickerAlertAction.swift */; };
@@ -351,6 +352,7 @@
 		AE4AEE3422B1030D000AA495 /* PreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewController.swift; sourceTree = "<group>"; };
 		AE52EA18229EB53C00C586C9 /* ContactDetailHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDetailHeader.swift; sourceTree = "<group>"; };
 		AE52EA1F229EB9F000C586C9 /* EditGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditGroupViewController.swift; sourceTree = "<group>"; };
+		AE57C07F2552BBD0003CFE70 /* GalleryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryItem.swift; sourceTree = "<group>"; };
 		AE6EC5232497663200A400E4 /* UIImageView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extensions.swift"; sourceTree = "<group>"; };
 		AE6EC5272497B9B200A400E4 /* ThumbnailCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailCache.swift; sourceTree = "<group>"; };
 		AE728F14229D5C390047565B /* PhotoPickerAlertAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerAlertAction.swift; sourceTree = "<group>"; };
@@ -614,6 +616,7 @@
 		7A9FB1421FB061E2001FEA36 /* deltachat-ios */ = {
 			isa = PBXGroup;
 			children = (
+				AE57C07E2552BBC0003CFE70 /* Model */,
 				304219D7244072E600516852 /* DC */,
 				AE1988AA23EB3C7600B4CD5F /* Assets */,
 				AE19887623EB2BDA00B4CD5F /* Assets */,
@@ -691,6 +694,14 @@
 				AE8DD450249D1DFB009A4BC1 /* DocumentGalleryFileCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		AE57C07E2552BBC0003CFE70 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				AE57C07F2552BBD0003CFE70 /* GalleryItem.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		AE77838B23E32EAA0093EABD /* ViewModel */ = {
@@ -1206,6 +1217,7 @@
 				AE77838F23E4276D0093EABD /* ContactCellViewModel.swift in Sources */,
 				B20462E62440C99600367A57 /* SettingsAutodelSetController.swift in Sources */,
 				3015634423A003BA00E9DEF4 /* AudioRecorderController.swift in Sources */,
+				AE57C0802552BBD0003CFE70 /* GalleryItem.swift in Sources */,
 				AE25F09022807AD800CDEA66 /* AvatarSelectionCell.swift in Sources */,
 				30A4149724F6EFBE00EC91EB /* InfoMessageCell.swift in Sources */,
 				302B84C6239676F0001C261F /* AvatarHelper.swift in Sources */,

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		AE52EA19229EB53C00C586C9 /* ContactDetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE52EA18229EB53C00C586C9 /* ContactDetailHeader.swift */; };
 		AE52EA20229EB9F000C586C9 /* EditGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE52EA1F229EB9F000C586C9 /* EditGroupViewController.swift */; };
 		AE57C0802552BBD0003CFE70 /* GalleryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE57C07F2552BBD0003CFE70 /* GalleryItem.swift */; };
+		AE57C084255310BB003CFE70 /* ContextMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE57C083255310BB003CFE70 /* ContextMenuController.swift */; };
 		AE6EC5242497663200A400E4 /* UIImageView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6EC5232497663200A400E4 /* UIImageView+Extensions.swift */; };
 		AE6EC5282497B9B200A400E4 /* ThumbnailCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6EC5272497B9B200A400E4 /* ThumbnailCache.swift */; };
 		AE728F15229D5C390047565B /* PhotoPickerAlertAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE728F14229D5C390047565B /* PhotoPickerAlertAction.swift */; };
@@ -353,6 +354,7 @@
 		AE52EA18229EB53C00C586C9 /* ContactDetailHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDetailHeader.swift; sourceTree = "<group>"; };
 		AE52EA1F229EB9F000C586C9 /* EditGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditGroupViewController.swift; sourceTree = "<group>"; };
 		AE57C07F2552BBD0003CFE70 /* GalleryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryItem.swift; sourceTree = "<group>"; };
+		AE57C083255310BB003CFE70 /* ContextMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuController.swift; sourceTree = "<group>"; };
 		AE6EC5232497663200A400E4 /* UIImageView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extensions.swift"; sourceTree = "<group>"; };
 		AE6EC5272497B9B200A400E4 /* ThumbnailCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailCache.swift; sourceTree = "<group>"; };
 		AE728F14229D5C390047565B /* PhotoPickerAlertAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerAlertAction.swift; sourceTree = "<group>"; };
@@ -758,6 +760,7 @@
 				AED423D2249F578B00B6B2BB /* AddGroupMembersViewController.swift */,
 				AED423D6249F580700B6B2BB /* BlockedContactsViewController.swift */,
 				AE39D322249CFC1A007346A1 /* DocumentGalleryController.swift */,
+				AE57C083255310BB003CFE70 /* ContextMenuController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -1195,6 +1198,7 @@
 				AE9DAF0F22C278C6004C9591 /* ChatTitleView.swift in Sources */,
 				AE4AEE3522B1030D000AA495 /* PreviewController.swift in Sources */,
 				7070FB9B2101ECBB000DC258 /* NewGroupController.swift in Sources */,
+				AE57C084255310BB003CFE70 /* ContextMenuController.swift in Sources */,
 				304219D92440734A00516852 /* DcMsg+Extension.swift in Sources */,
 				303492CF2587C2DC00A523D0 /* ChatInputBar.swift in Sources */,
 				AE52EA19229EB53C00C586C9 /* ContactDetailHeader.swift in Sources */,

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -566,6 +566,14 @@ class ChatViewController: UITableViewController {
         }
     }
 
+    func scrollToMessage(msgId: Int, animated: Bool = true) {
+        guard let index = messageIds.firstIndex(of: msgId) else {
+            return
+        }
+        let indexPath = IndexPath(row: index, section: 0)
+        tableView.scrollToRow(at: indexPath, at: .top, animated: animated)
+    }
+
     private func showEmptyStateView(_ show: Bool) {
         if show {
             let dcChat = dcContext.getChat(chatId: chatId)
@@ -1108,10 +1116,8 @@ extension ChatViewController: BaseMessageCellDelegate {
     @objc func quoteTapped(indexPath: IndexPath) {
         _ = handleUIMenu()
         let msg = DcMsg(id: messageIds[indexPath.row])
-        if let quoteMsg = msg.quoteMessage,
-           let index = messageIds.firstIndex(of: quoteMsg.id) {
-            let indexPath = IndexPath(row: index, section: 0)
-            tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+        if let quoteMsg = msg.quoteMessage {
+            scrollToMessage(msgId: quoteMsg.id)
         }
     }
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -390,7 +390,7 @@ class ContactDetailViewController: UITableViewController {
 
     private func showDocuments() {
         let messageIds: [Int] = viewModel.documentItemMessageIds.reversed()
-        let fileGalleryController = DocumentGalleryController(fileMessageIds: messageIds)
+        let fileGalleryController = DocumentGalleryController(context: viewModel.context, fileMessageIds: messageIds)
         navigationController?.pushViewController(fileGalleryController, animated: true)
     }
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -396,7 +396,7 @@ class ContactDetailViewController: UITableViewController {
 
     private func showGallery() {
         let messageIds: [Int] = viewModel.galleryItemMessageIds.reversed()
-        let galleryController = GalleryViewController(mediaMessageIds: messageIds)
+        let galleryController = GalleryViewController(context: viewModel.context, mediaMessageIds: messageIds)
         navigationController?.pushViewController(galleryController, animated: true)
     }
 

--- a/deltachat-ios/Controller/ContextMenuController.swift
+++ b/deltachat-ios/Controller/ContextMenuController.swift
@@ -3,9 +3,17 @@ import AVFoundation
 import SDWebImage
 import DcCore
 
+// TODO: probably not able to trigger touch events this way
+// MARK: - ContextMenuDelegate
+protocol ContextMenuDelegate: class {
+    func contextMenu(_: ContextMenuController, event: ContextMenuController.Event)
+}
+
+// MARK: - ContextMenuController
 class ContextMenuController: UIViewController {
 
     let item: GalleryItem
+    weak var delegate: ContextMenuDelegate?
 
     init(item: GalleryItem) {
         self.item = item
@@ -36,17 +44,37 @@ class ContextMenuController: UIViewController {
         guard let contentView = thumbnailView else {
             return
         }
+
+        let hitTestView = HitTestView()
+
+        view.addSubview(hitTestView)
         view.addSubview(contentView)
+        hitTestView.translatesAutoresizingMaskIntoConstraints = false
         contentView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
+            hitTestView.leftAnchor.constraint(equalTo: view.leftAnchor),
+            hitTestView.rightAnchor.constraint(equalTo: view.rightAnchor),
+            hitTestView.topAnchor.constraint(equalTo: view.topAnchor),
+            hitTestView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
             contentView.leftAnchor.constraint(equalTo: view.leftAnchor),
             contentView.rightAnchor.constraint(equalTo: view.rightAnchor),
             contentView.topAnchor.constraint(equalTo: view.topAnchor),
             contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+
+        let button = UIButton(frame: CGRect(x: view.frame.midX, y: view.frame.midY, width: 100, height: 100))
+        button.makeBorder()
+        button.setTitle("Tap me", for: .normal)
+        button.addTarget(self, action: #selector(handleThumbnailTap(_:)), for: .touchUpInside)
+        view.addSubview(button)
+//        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleThumbnailTap(_:)))
+//        contentView.addGestureRecognizer(tapGesture)
+//        contentView.makeBorder()
     }
 
+    // MARK: - thumbnailView creation
     private func makeGifView(gifImage: UIImage?) -> UIView? {
         let view = SDAnimatedImageView()
         view.contentMode = .scaleAspectFill
@@ -102,4 +130,22 @@ class ContextMenuController: UIViewController {
         let height = image.size.height * (width / image.size.width)
         self.preferredContentSize = CGSize(width: width, height: height)
     }
+
+    // MARK: - actions
+    @objc private func handleThumbnailTap(_ tapGesture: UITapGestureRecognizer) {
+        delegate?.contextMenu(self, event: .tap(item))
+    }
+
+
 }
+
+// MARK: - inner class definitions
+extension ContextMenuController {
+    enum Event {
+        case tap(GalleryItem)
+        case doupleTap(GalleryItem)
+        case longPress(GalleryItem)
+        // add event types if needed
+    }
+}
+

--- a/deltachat-ios/Controller/ContextMenuController.swift
+++ b/deltachat-ios/Controller/ContextMenuController.swift
@@ -1,5 +1,7 @@
 import AVKit
 import AVFoundation
+import SDWebImage
+import DcCore
 
 class ContextMenuController: UIViewController {
 
@@ -25,6 +27,8 @@ class ContextMenuController: UIViewController {
             thumbnailView = makeImageView(image: item.msg.image)
         case .video:
             thumbnailView = makeVideoView(videoUrl: item.msg.fileURL)
+        case .gif:
+            thumbnailView = makeGifView(gifImage: item.thumbnailImage)
         default:
             return
         }
@@ -43,6 +47,19 @@ class ContextMenuController: UIViewController {
         ])
     }
 
+    private func makeGifView(gifImage: UIImage?) -> UIView? {
+        let view = SDAnimatedImageView()
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.backgroundColor = DcColors.defaultBackgroundColor
+        if let image = gifImage {
+            setPreferredContentSize(for: image)
+        }
+        view.image = gifImage
+
+        return view
+    }
+
     private func makeImageView(image: UIImage?) -> UIView? {
         guard let image = image else {
             safe_fatalError("unexpected nil value")
@@ -53,10 +70,7 @@ class ContextMenuController: UIViewController {
         imageView.clipsToBounds = true
         imageView.contentMode = .scaleAspectFill
         imageView.image = image
-
-        let width = view.bounds.width
-        let height = image.size.height * (width / image.size.width)
-        preferredContentSize = CGSize(width: width, height: height)
+        setPreferredContentSize(for: image)
         return imageView
     }
 
@@ -83,4 +97,12 @@ class ContextMenuController: UIViewController {
 
         return playerController.view
     }
+
+    private func setPreferredContentSize(for image: UIImage) {
+        let width = view.bounds.width
+        let height = image.size.height * (width / image.size.width)
+        self.preferredContentSize = CGSize(width: width, height: height)
+    }
+
+
 }

--- a/deltachat-ios/Controller/ContextMenuController.swift
+++ b/deltachat-ios/Controller/ContextMenuController.swift
@@ -56,7 +56,6 @@ class ContextMenuController: UIViewController {
             setPreferredContentSize(for: image)
         }
         view.image = gifImage
-
         return view
     }
 
@@ -103,6 +102,4 @@ class ContextMenuController: UIViewController {
         let height = image.size.height * (width / image.size.width)
         self.preferredContentSize = CGSize(width: width, height: height)
     }
-
-
 }

--- a/deltachat-ios/Controller/ContextMenuController.swift
+++ b/deltachat-ios/Controller/ContextMenuController.swift
@@ -4,12 +4,21 @@ import SDWebImage
 import DcCore
 
 
+protocol ContextMenuItem {
+    var msg: DcMsg { get set }
+    var thumbnailImage: UIImage? { get set  }
+}
+
 // MARK: - ContextMenuController
 class ContextMenuController: UIViewController {
 
-    let item: GalleryItem
-    
-    init(item: GalleryItem) {
+    let item: ContextMenuItem
+
+    var msg: DcMsg {
+        return item.msg
+    }
+
+    init(item: ContextMenuItem) {
         self.item = item
         super.init(nibName: nil, bundle: nil)
     }
@@ -22,13 +31,13 @@ class ContextMenuController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let viewType = item.msg.viewtype
+        let viewType = msg.viewtype
         var thumbnailView: UIView?
         switch viewType {
         case .image:
-            thumbnailView = makeImageView(image: item.msg.image)
+            thumbnailView = makeImageView(image: msg.image)
         case .video:
-            thumbnailView = makeVideoView(videoUrl: item.msg.fileURL)
+            thumbnailView = makeVideoView(videoUrl: msg.fileURL)
         case .gif:
             thumbnailView = makeGifView(gifImage: item.thumbnailImage)
         default:

--- a/deltachat-ios/Controller/ContextMenuController.swift
+++ b/deltachat-ios/Controller/ContextMenuController.swift
@@ -3,18 +3,12 @@ import AVFoundation
 import SDWebImage
 import DcCore
 
-// TODO: probably not able to trigger touch events this way
-// MARK: - ContextMenuDelegate
-protocol ContextMenuDelegate: class {
-    func contextMenu(_: ContextMenuController, event: ContextMenuController.Event)
-}
 
 // MARK: - ContextMenuController
 class ContextMenuController: UIViewController {
 
     let item: GalleryItem
-    weak var delegate: ContextMenuDelegate?
-
+    
     init(item: GalleryItem) {
         self.item = item
         super.init(nibName: nil, bundle: nil)
@@ -45,33 +39,15 @@ class ContextMenuController: UIViewController {
             return
         }
 
-        let hitTestView = HitTestView()
-
-        view.addSubview(hitTestView)
         view.addSubview(contentView)
-        hitTestView.translatesAutoresizingMaskIntoConstraints = false
         contentView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            hitTestView.leftAnchor.constraint(equalTo: view.leftAnchor),
-            hitTestView.rightAnchor.constraint(equalTo: view.rightAnchor),
-            hitTestView.topAnchor.constraint(equalTo: view.topAnchor),
-            hitTestView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-
             contentView.leftAnchor.constraint(equalTo: view.leftAnchor),
             contentView.rightAnchor.constraint(equalTo: view.rightAnchor),
             contentView.topAnchor.constraint(equalTo: view.topAnchor),
             contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
-
-        let button = UIButton(frame: CGRect(x: view.frame.midX, y: view.frame.midY, width: 100, height: 100))
-        button.makeBorder()
-        button.setTitle("Tap me", for: .normal)
-        button.addTarget(self, action: #selector(handleThumbnailTap(_:)), for: .touchUpInside)
-        view.addSubview(button)
-//        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleThumbnailTap(_:)))
-//        contentView.addGestureRecognizer(tapGesture)
-//        contentView.makeBorder()
     }
 
     // MARK: - thumbnailView creation
@@ -130,22 +106,4 @@ class ContextMenuController: UIViewController {
         let height = image.size.height * (width / image.size.width)
         self.preferredContentSize = CGSize(width: width, height: height)
     }
-
-    // MARK: - actions
-    @objc private func handleThumbnailTap(_ tapGesture: UITapGestureRecognizer) {
-        delegate?.contextMenu(self, event: .tap(item))
-    }
-
-
 }
-
-// MARK: - inner class definitions
-extension ContextMenuController {
-    enum Event {
-        case tap(GalleryItem)
-        case doupleTap(GalleryItem)
-        case longPress(GalleryItem)
-        // add event types if needed
-    }
-}
-

--- a/deltachat-ios/Controller/ContextMenuController.swift
+++ b/deltachat-ios/Controller/ContextMenuController.swift
@@ -95,8 +95,9 @@ class ContextMenuController: UIViewController {
         playerController.didMove(toParent: self)
         playerController.view.backgroundColor = .darkGray
         playerController.view.clipsToBounds = true
-        player.play()
         playerController.player = player
+        playerController.showsPlaybackControls = false
+        player.play()
 
         // truncate edges on top/bottom or sides
         let resizedHeightFactor = view.frame.height / videoSize.height

--- a/deltachat-ios/Controller/DocumentGalleryController.swift
+++ b/deltachat-ios/Controller/DocumentGalleryController.swift
@@ -125,6 +125,28 @@ extension DocumentGalleryController: UITableViewDelegate, UITableViewDataSource 
         showPreview(msgId: msgId)
         tableView.deselectRow(at: indexPath, animated: false)
     }
+
+    // MARK: - context menu
+    // context menu for iOS 11, 12
+    func tableView(_ tableView: UITableView, canPerformAction action: Selector, forRowAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
+        return contextMenuConfiguration.canPerformAction(action: action)
+    }
+
+    func tableView(_ tableView: UITableView, performAction action: Selector, forRowAt indexPath: IndexPath, withSender sender: Any?) {
+        contextMenuConfiguration.performAction(action: action, indexPath: indexPath)
+    }
+
+    // context menu for iOS 13+
+    @available(iOS 13, *)
+    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        return UIContextMenuConfiguration(
+            identifier: nil,
+            previewProvider: nil,
+            actionProvider: { [weak self] _ in
+                self?.contextMenuConfiguration.actionProvider(indexPath: indexPath)
+            }
+        )
+    }
 }
 
 // MARK: - coordinator

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -137,6 +137,7 @@ class GalleryViewController: UIViewController {
         }
     }
 
+    // MARK: - actions
     private func askToDeleteItem(at indexPath: IndexPath) {
         let title = String.localized(stringID: "ask_delete_messages", count: 1)
         let alertController =  UIAlertController(title: title, message: nil, preferredStyle: .safeActionSheet)

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -204,9 +204,10 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
 
     // context menu for iOS 13+
     @available(iOS 13, *)
-    func collectionView(_ collectionView: UICollectionView,
-                        contextMenuConfigurationForItemAt indexPath: IndexPath,
-                        point: CGPoint) -> UIContextMenuConfiguration? {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        contextMenuConfigurationForItemAt indexPath: IndexPath,
+        point: CGPoint) -> UIContextMenuConfiguration? {
         guard let galleryCell = collectionView.cellForItem(at: indexPath) as? GalleryCell, let item = galleryCell.item else {
             return nil
         }
@@ -214,7 +215,7 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
         return UIContextMenuConfiguration(
             identifier: nil,
             previewProvider: {
-                return XLPreviewViewController(imageUrl: item.fileUrl)
+                return XLPreviewViewController(item: item)
             },
             actionProvider: { [weak self] _ in
                 return self?.makeContextMenu(indexPath: indexPath)
@@ -299,11 +300,9 @@ private class XLPreviewViewController: UIViewController {
         return imageView
     }()
 
-    init(imageUrl: URL?) {
+    init(item: GalleryItem) {
         super.init(nibName: nil, bundle: nil)
-        if let url = imageUrl {
-            imageView.image = UIImage(named: url.relativePath)
-        }
+        imageView.image = item.thumbnailImage
     }
 
     required init?(coder: NSCoder) {

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -115,9 +115,9 @@ class GalleryViewController: UIViewController {
     }
 
     private func askToDeleteItem(at indexPath: IndexPath) {
-        let title = String.localized("delete")
+        let title = String.localized(stringID: "ask_delete_messages", count: 1)
         let alertController =  UIAlertController(title: title, message: nil, preferredStyle: .safeActionSheet)
-        let okAction = UIAlertAction(title: String.localized("ok"), style: .destructive, handler: { [weak self] _ in
+        let okAction = UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { [weak self] _ in
             self?.deleteItem(at: indexPath)
         })
         let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil)

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -257,7 +257,7 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
 
     @available(iOS 13, *)
     func collectionView(_ collectionView: UICollectionView, willEndContextMenuInteraction configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
-        if let msgId = (animator?.previewViewController as? ContextMenuController)?.item.msg.id {
+        if let msgId = (animator?.previewViewController as? ContextMenuController)?.msg.id {
             self.showPreview(msgId: msgId)
         }
     }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -250,12 +250,16 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
             image: UIImage(systemName: "trash")) { _ in
             self.askToDeleteItem(at: indexPath)
         }
+
+        let redirectAction = UIAction(title: String.localized("show_in_chat"), image: UIImage(systemName: "doc.text.magnifyingglass")) { _ in
+            self.redirectToMessage(of: indexPath)
+        }
         deleteAction.attributes = [.destructive]
         return UIMenu(
             title: "",
             image: nil,
             identifier: nil,
-            children: [deleteAction]
+            children: [redirectAction, deleteAction]
         )
     }
 }
@@ -299,7 +303,7 @@ private extension GalleryViewController {
 }
 
 // MARK: - coordinator
-extension GalleryViewController {
+private extension GalleryViewController {
     func showPreview(msgId: Int) {
         guard let index = mediaMessageIds.index(of: msgId) else {
             return
@@ -307,5 +311,22 @@ extension GalleryViewController {
 
         let previewController = PreviewController(type: .multi(mediaMessageIds, index))
         present(previewController, animated: true, completion: nil)
+    }
+
+    func redirectToMessage(of indexPath: IndexPath) {
+        let msgId = mediaMessageIds[indexPath.row]
+
+        guard
+            let chatViewController = navigationController?.viewControllers.filter ({ $0 is ChatViewController}).first as? ChatViewController,
+            let chatListController = navigationController?.viewControllers.filter({ $0 is ChatListController}).first as? ChatListController
+        else {
+            safe_fatalError("failt to retrieve chatViewController, chatListController in navigation stack")
+            return
+        }
+        self.navigationController?.viewControllers.remove(at: 1)
+
+        self.navigationController?.pushViewController(chatViewController, animated: true)
+        self.navigationController?.setViewControllers([chatListController, chatViewController], animated: false)
+        chatViewController.scrollToMessage(msgId: msgId)
     }
 }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -67,7 +67,7 @@ class GalleryViewController: UIViewController {
         )
 
         let config = ContextMenuConfiguration()
-        config.menu = [showInChatItem, deleteItem]
+        config.setMenu([showInChatItem, deleteItem])
         return config
     }()
 
@@ -333,6 +333,14 @@ class ContextMenuConfiguration {
 
     var menu: [ContextMenuItem] = []
 
+    init(menu: [ContextMenuItem] = []) {
+        self.menu = menu
+    }
+
+    func setMenu(_ menu: [ContextMenuItem]) {
+        self.menu = menu
+    }
+
     // iOS 12- action menu
     var menuItems: [UIMenuItem] {
         return menu.map { UIMenuItem(title: $0.title, action: $0.action) }
@@ -366,7 +374,6 @@ class ContextMenuConfiguration {
             children: children
         )
     }
-
 
     func canPerformAction(action: Selector) -> Bool {
         return !menu.filter {

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -1,7 +1,5 @@
 import UIKit
 import DcCore
-import AVFoundation
-import AVKit
 
 class GalleryViewController: UIViewController {
 
@@ -217,7 +215,7 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
         return UIContextMenuConfiguration(
             identifier: nil,
             previewProvider: {
-               return ContextMenuViewController(item: item)
+               return ContextMenuController(item: item)
             },
             actionProvider: { [weak self] _ in
                 return self?.makeContextMenu(indexPath: indexPath)
@@ -289,89 +287,5 @@ extension GalleryViewController {
 
         let previewController = PreviewController(type: .multi(mediaMessageIds, index))
         present(previewController, animated: true, completion: nil)
-    }
-}
-
-class ContextMenuViewController: UIViewController {
-
-    let item: GalleryItem
-
-    init(item: GalleryItem) {
-        self.item = item
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - lifecycle
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        let viewType = item.msg.viewtype
-        var thumbnailView: UIView?
-        switch viewType {
-        case .image:
-            thumbnailView = makeImageView(image: item.msg.image)
-        case .video:
-            thumbnailView = makeVideoView(videoUrl: item.msg.fileURL)
-        default:
-            return
-        }
-
-        guard let contentView = thumbnailView else {
-            return
-        }
-        view.addSubview(contentView)
-        contentView.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            contentView.leftAnchor.constraint(equalTo: view.leftAnchor),
-            contentView.rightAnchor.constraint(equalTo: view.rightAnchor),
-            contentView.topAnchor.constraint(equalTo: view.topAnchor),
-            contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
-    }
-
-    private func makeImageView(image: UIImage?) -> UIView? {
-        guard let image = image else {
-            safe_fatalError("unexpected nil value")
-            return nil
-        }
-
-        let imageView = UIImageView()
-        imageView.clipsToBounds = true
-        imageView.contentMode = .scaleAspectFill
-        imageView.image = image
-
-        let width = view.bounds.width
-        let height = image.size.height * (width / image.size.width)
-        preferredContentSize = CGSize(width: width, height: height)
-        return imageView
-    }
-
-    private func makeVideoView(videoUrl: URL?) -> UIView? {
-        guard let videoUrl = videoUrl, let videoSize = item.thumbnailImage?.size else { return nil }
-        let player = AVPlayer(url: videoUrl)
-        let playerController = AVPlayerViewController()
-        addChild(playerController)
-        view.addSubview(playerController.view)
-        playerController.didMove(toParent: self)
-        playerController.view.backgroundColor = .darkGray
-        playerController.view.clipsToBounds = true
-        player.play()
-        playerController.player = player
-
-        // truncate edges on top/bottom or sides
-        let resizedHeightFactor = view.frame.height / videoSize.height
-        let resizedWidthFactor = view.frame.width / videoSize.width
-        let effectiveResizeFactor = min(resizedWidthFactor, resizedHeightFactor)
-        let maxHeight = videoSize.height * effectiveResizeFactor
-        let maxWidth = videoSize.width * effectiveResizeFactor
-        let size = CGSize(width: maxWidth, height: maxHeight)
-        preferredContentSize = size
-
-        return playerController.view
     }
 }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -19,8 +19,8 @@ class GalleryViewController: UIViewController {
         return layout
     }()
 
-    private lazy var grid: UICollectionView = {
-        let collection = UICollectionView(frame: .zero, collectionViewLayout: gridLayout)
+    private lazy var grid: HitTestCollectionView = {
+        let collection = HitTestCollectionView(frame: .zero, collectionViewLayout: gridLayout)
         collection.dataSource = self
         collection.delegate = self
         collection.register(GalleryCell.self, forCellWithReuseIdentifier: GalleryCell.reuseIdentifier)
@@ -227,7 +227,9 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
         return UIContextMenuConfiguration(
             identifier: nil,
             previewProvider: {
-               return ContextMenuController(item: item)
+                let contextMenuController = ContextMenuController(item: item)
+                contextMenuController.delegate = self
+                return contextMenuController
             },
             actionProvider: { [weak self] _ in
                 return self?.makeContextMenu(indexPath: indexPath)
@@ -300,4 +302,36 @@ extension GalleryViewController {
         let previewController = PreviewController(type: .multi(mediaMessageIds, index))
         present(previewController, animated: true, completion: nil)
     }
+}
+
+extension GalleryViewController: ContextMenuDelegate {
+
+    func contextMenu(_: ContextMenuController, event: ContextMenuController.Event) {
+
+        switch event {
+        case .tap(let item):
+            let msgId = item.msg.id
+            showPreview(msgId: msgId)
+        default:
+            return
+        }
+    }
+}
+
+class HitTestCollectionView: UICollectionView {
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        print("collection hit test succeeded")
+        return self
+    }
+
+}
+
+class HitTestView: UIView {
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        print("thumbnail hit test succeeded")
+        return self
+    }
+
 }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -114,6 +114,18 @@ class GalleryViewController: UIViewController {
         }
     }
 
+    private func askToDeleteItem(at indexPath: IndexPath) {
+        let title = String.localized("delete")
+        let alertController =  UIAlertController(title: title, message: nil, preferredStyle: .safeActionSheet)
+        let okAction = UIAlertAction(title: String.localized("ok"), style: .destructive, handler: { [weak self] _ in
+            self?.deleteItem(at: indexPath)
+        })
+        let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil)
+        alertController.addAction(okAction)
+        alertController.addAction(cancelAction)
+        present(alertController, animated: true, completion: nil)
+    }
+
     private func deleteItem(at indexPath: IndexPath) {
         let msgId = mediaMessageIds.remove(at: indexPath.row)
         self.dcContext.deleteMessage(msgId: msgId)
@@ -196,7 +208,7 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
 
         switch action {
         case #selector(GalleryCell.itemDelete(_:)):
-            deleteItem(at: indexPath)
+            self.askToDeleteItem(at: indexPath)
         default:
             break
         }
@@ -228,9 +240,10 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
         let deleteAction = UIAction(
             title: String.localized("delete"),
             image: UIImage(systemName: "trash")) { _ in
-            self.deleteItem(at: indexPath)
+            self.askToDeleteItem(at: indexPath)
         }
 
+        deleteAction.attributes = [.destructive]
         return UIMenu(
             title: "",
             image: nil,

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -19,8 +19,8 @@ class GalleryViewController: UIViewController {
         return layout
     }()
 
-    private lazy var grid: HitTestCollectionView = {
-        let collection = HitTestCollectionView(frame: .zero, collectionViewLayout: gridLayout)
+    private lazy var grid: UICollectionView = {
+        let collection = UICollectionView(frame: .zero, collectionViewLayout: gridLayout)
         collection.dataSource = self
         collection.delegate = self
         collection.register(GalleryCell.self, forCellWithReuseIdentifier: GalleryCell.reuseIdentifier)
@@ -228,13 +228,19 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
             identifier: nil,
             previewProvider: {
                 let contextMenuController = ContextMenuController(item: item)
-                contextMenuController.delegate = self
                 return contextMenuController
             },
             actionProvider: { [weak self] _ in
                 return self?.makeContextMenu(indexPath: indexPath)
             }
         )
+    }
+
+    @available(iOS 13, *)
+    func collectionView(_ collectionView: UICollectionView, willEndContextMenuInteraction configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
+        if let msgId = (animator?.previewViewController as? ContextMenuController)?.item.msg.id {
+            self.showPreview(msgId: msgId)
+        }
     }
 
     @available(iOS 13, *)
@@ -302,36 +308,4 @@ extension GalleryViewController {
         let previewController = PreviewController(type: .multi(mediaMessageIds, index))
         present(previewController, animated: true, completion: nil)
     }
-}
-
-extension GalleryViewController: ContextMenuDelegate {
-
-    func contextMenu(_: ContextMenuController, event: ContextMenuController.Event) {
-
-        switch event {
-        case .tap(let item):
-            let msgId = item.msg.id
-            showPreview(msgId: msgId)
-        default:
-            return
-        }
-    }
-}
-
-class HitTestCollectionView: UICollectionView {
-
-    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        print("collection hit test succeeded")
-        return self
-    }
-
-}
-
-class HitTestView: UIView {
-
-    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        print("thumbnail hit test succeeded")
-        return self
-    }
-
 }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -46,8 +46,8 @@ class GalleryViewController: UIViewController {
         return label
     }()
 
-    private lazy var contextMenuConfiguration: ContextMenuConfiguration = {
-        let deleteItem = ContextMenuConfiguration.ContextMenuItem(
+    private lazy var contextMenu: ContextMenuProvider = {
+        let deleteItem = ContextMenuProvider.ContextMenuItem(
             title: String.localized("delete"),
             imageNames: ("trash", nil),
             option: .delete,
@@ -56,7 +56,7 @@ class GalleryViewController: UIViewController {
                 self?.askToDeleteItem(at: indexPath)
             }
         )
-        let showInChatItem = ContextMenuConfiguration.ContextMenuItem(
+        let showInChatItem = ContextMenuProvider.ContextMenuItem(
             title: String.localized("show_in_chat"),
             imageNames: ("doc.text.magnifyingglass", nil),
             option: .showInChat,
@@ -66,7 +66,7 @@ class GalleryViewController: UIViewController {
             }
         )
 
-        let config = ContextMenuConfiguration()
+        let config = ContextMenuProvider()
         config.setMenu([showInChatItem, deleteItem])
         return config
     }()
@@ -124,7 +124,7 @@ class GalleryViewController: UIViewController {
     }
 
     private func setupContextMenuIfNeeded() {
-        UIMenuController.shared.menuItems = contextMenuConfiguration.menuItems
+        UIMenuController.shared.menuItems = contextMenu.menuItems
         UIMenuController.shared.update()
     }
 
@@ -218,19 +218,19 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
         timeLabel.hide(animated: true)
     }
 
+    // MARK: - context menu
+    // context menu for iOS 11, 12
     func collectionView(_ collectionView: UICollectionView, shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
         return true
     }
 
-    // MARK: - context menu
-    // context menu for iOS 11, 12
     func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
-        return contextMenuConfiguration.canPerformAction(action: action)
+        return contextMenu.canPerformAction(action: action)
     }
 
     func collectionView(_ collectionView: UICollectionView, performAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) {
 
-        contextMenuConfiguration.performAction(action: action, indexPath: indexPath)
+        contextMenu.performAction(action: action, indexPath: indexPath)
     }
 
     // context menu for iOS 13+
@@ -250,7 +250,7 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
                 return contextMenuController
             },
             actionProvider: { [weak self] _ in
-                self?.contextMenuConfiguration.actionProvider(indexPath: indexPath)
+                self?.contextMenu.actionProvider(indexPath: indexPath)
             }
         )
     }
@@ -330,7 +330,7 @@ private extension GalleryViewController {
     }
 }
 
-class ContextMenuConfiguration {
+class ContextMenuProvider {
 
     var menu: [ContextMenuItem] = []
 
@@ -394,7 +394,7 @@ class ContextMenuConfiguration {
     }
 }
 
-extension ContextMenuConfiguration {
+extension ContextMenuProvider {
     typealias ImageSystemName = String
     struct ContextMenuItem {
         var title: String

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -100,6 +100,7 @@ class GalleryViewController: UIViewController {
 
     private func setupContextMenuIfNeeded() {
         UIMenuController.shared.menuItems = [
+            UIMenuItem(title: String.localized("show_in_chat"), action: #selector(GalleryCell.showInChat(_:))),
             UIMenuItem(title: String.localized("delete"), action: #selector(GalleryCell.itemDelete(_:))),
         ]
         UIMenuController.shared.update()
@@ -201,7 +202,9 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
     // MARK: - context menu
     // context menu for iOS 11, 12
     func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
-        return action ==  #selector(GalleryCell.itemDelete(_:))
+        return
+            action ==  #selector(GalleryCell.itemDelete(_:)) ||
+            action == #selector(GalleryCell.showInChat(_:))
     }
 
     func collectionView(_ collectionView: UICollectionView, performAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) {
@@ -209,6 +212,8 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
         switch action {
         case #selector(GalleryCell.itemDelete(_:)):
             self.askToDeleteItem(at: indexPath)
+        case #selector(GalleryCell.showInChat(_:)):
+            self.redirectToMessage(of: indexPath)
         default:
             break
         }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -80,9 +80,9 @@ class GalleryViewController: UIViewController {
     private func setupSubviews() {
         view.addSubview(grid)
         grid.translatesAutoresizingMaskIntoConstraints = false
-        grid.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0).isActive = true
+        grid.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 0).isActive = true
         grid.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-        grid.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0).isActive = true
+        grid.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: 0).isActive = true
         grid.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
 
         view.addSubview(timeLabel)

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import DcCore
-import SDWebImage
 
 class GalleryViewController: UIViewController {
 
@@ -327,82 +326,6 @@ private class XLPreviewViewController: UIViewController {
         if let image = imageView.image {
             let height = image.size.height * (width / image.size.width)
             preferredContentSize = CGSize(width: width, height: height)
-        }
-    }
-}
-
-class GalleryItem {
-
-    var onImageLoaded: ((UIImage?) -> Void)?
-
-    var msg: DcMsg
-
-    var fileUrl: URL? {
-        return msg.fileURL
-    }
-
-    var thumbnailImage: UIImage? {
-        willSet {
-           onImageLoaded?(newValue)
-        }
-    }
-
-    var showPlayButton: Bool {
-        switch msg.viewtype {
-        case .video:
-            return true
-        default:
-            return false
-        }
-    }
-
-    init(msgId: Int) {
-        self.msg = DcMsg(id: msgId)
-
-        if let key = msg.fileURL?.absoluteString, let image = ThumbnailCache.shared.restoreImage(key: key) {
-            self.thumbnailImage = image
-        } else {
-            loadThumbnail()
-        }
-    }
-
-    private func loadThumbnail() {
-        guard let viewtype = msg.viewtype, let url = msg.fileURL else {
-            return
-        }
-        switch viewtype {
-        case .image:
-            thumbnailImage = msg.image
-        case .video:
-            loadVideoThumbnail(from: url)
-        case .gif:
-            loadGifThumbnail(from: url)
-        default:
-           safe_fatalError("unsupported viewtype - viewtype \(viewtype) not supported.")
-        }
-    }
-
-    private func loadGifThumbnail(from url: URL) {
-        DispatchQueue.global(qos: .userInteractive).async {
-            guard let imageData = try? Data(contentsOf: url) else {
-                return
-            }
-            let thumbnailImage = SDAnimatedImage(data: imageData)
-            DispatchQueue.main.async { [weak self] in
-                self?.thumbnailImage = thumbnailImage
-            }
-        }
-    }
-
-    private func loadVideoThumbnail(from url: URL) {
-        DispatchQueue.global(qos: .userInteractive).async {
-            let thumbnailImage = DcUtils.generateThumbnailFromVideo(url: url)
-            DispatchQueue.main.async { [weak self] in
-                self?.thumbnailImage = thumbnailImage
-                if let image = thumbnailImage {
-                    ThumbnailCache.shared.storeImage(image: image, key: url.absoluteString)
-                }
-            }
         }
     }
 }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -217,10 +217,7 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
         return UIContextMenuConfiguration(
             identifier: nil,
             previewProvider: {
-
-                return VideoPreviewController(item: item)
-
-               // return XLPreviewViewController(item: item)
+               return ContextMenuViewController(item: item)
             },
             actionProvider: { [weak self] _ in
                 return self?.makeContextMenu(indexPath: indexPath)
@@ -295,61 +292,7 @@ extension GalleryViewController {
     }
 }
 
-private class VideoPreviewController: UIViewController {
-
-    var playerController = AVPlayerViewController()
-    let item: GalleryItem
-
-
-    init(item: GalleryItem) {
-        self.item = item
-        super.init(nibName: nil, bundle: nil)
-     }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - lifecycle
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        addChild(playerController)
-        view.addSubview(playerController.view)
-        playerController.didMove(toParent: self)
-        playerController.view.frame = self.view.frame
-        playerController.view.backgroundColor = .darkGray
-        playerController.view.clipsToBounds = true 
-        let url = item.msg.fileURL!
-        let player = AVPlayer(url: url)
-        player.play()
-        playerController.player = player
-
-        if let videoSize = item.thumbnailImage?.size {
-            print(videoSize)
-            // truncate edges on top/bottom or sides
-            let videoAspectRatio = videoSize.width / videoSize.height
-            let resizedHeightFactor = view.frame.height / videoSize.height
-            let resizedWidthFactor = view.frame.width / videoSize.width
-
-            let minFactor = min(resizedWidthFactor, resizedHeightFactor)
-            let maxHeight = videoSize.height * minFactor
-            let maxWidth = videoSize.width * minFactor
-
-            let size = CGSize(width: maxWidth, height: maxHeight)
-            preferredContentSize = size
-        }
-
-
-
-       // preferredContentSize = // CGSize(width: view.frame.width, height: view.frame.height)
-    }
-
-
-
-
-}
-
-private class XLPreviewViewController: UIViewController {
+class ContextMenuViewController: UIViewController {
 
     let item: GalleryItem
 
@@ -409,33 +352,26 @@ private class XLPreviewViewController: UIViewController {
     }
 
     private func makeVideoView(videoUrl: URL?) -> UIView? {
-        guard let videoUrl = videoUrl, let thumbnail = item.thumbnailImage else { return nil }
+        guard let videoUrl = videoUrl, let videoSize = item.thumbnailImage?.size else { return nil }
         let player = AVPlayer(url: videoUrl)
-        let playerLayer = AVPlayerLayer(player: player)
-
-
-        let maxWidth = min(view.bounds.width, thumbnail.size.width)
-        let maxHeight = min(view.bounds.height, thumbnail.size.height)
-        let size: CGSize
-        if view.bounds.height > view.bounds.width {
-            // portrait
-            let height = thumbnail.size.height * (maxWidth / thumbnail.size.width)
-            size = CGSize(width: maxWidth, height: height)
-        } else {
-            // landscape
-            let width = thumbnail.size.width * (maxHeight / thumbnail.size.height)
-            size = CGSize(width: width, height: maxHeight)
-        }
-        playerLayer.frame = CGRect(origin: .zero, size: size)
-        playerLayer.videoGravity = .resizeAspect
-        print(view.bounds.size)
-        print(size)
-        print(thumbnail.size)
-
-        let playerView = UIView()
-        playerView.layer.addSublayer(playerLayer)
+        let playerController = AVPlayerViewController()
+        addChild(playerController)
+        view.addSubview(playerController.view)
+        playerController.didMove(toParent: self)
+        playerController.view.backgroundColor = .darkGray
+        playerController.view.clipsToBounds = true
         player.play()
+        playerController.player = player
+
+        // truncate edges on top/bottom or sides
+        let resizedHeightFactor = view.frame.height / videoSize.height
+        let resizedWidthFactor = view.frame.width / videoSize.width
+        let effectiveResizeFactor = min(resizedWidthFactor, resizedHeightFactor)
+        let maxHeight = videoSize.height * effectiveResizeFactor
+        let maxWidth = videoSize.width * effectiveResizeFactor
+        let size = CGSize(width: maxWidth, height: maxHeight)
         preferredContentSize = size
-        return playerView
+
+        return playerController.view
     }
 }

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -242,7 +242,6 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
             image: UIImage(systemName: "trash")) { _ in
             self.askToDeleteItem(at: indexPath)
         }
-
         deleteAction.attributes = [.destructive]
         return UIMenu(
             title: "",

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -304,7 +304,7 @@ class GroupChatDetailViewController: UIViewController {
 
     private func showDocuments() {
         let messageIds: [Int] = documentItemMessageIds.reversed()
-        let fileGalleryController = DocumentGalleryController(fileMessageIds: messageIds)
+        let fileGalleryController = DocumentGalleryController(context: dcContext, fileMessageIds: messageIds)
         navigationController?.pushViewController(fileGalleryController, animated: true)    }
 
     private func showGallery() {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -309,7 +309,7 @@ class GroupChatDetailViewController: UIViewController {
 
     private func showGallery() {
         let messageIds: [Int] = galleryItemMessageIds.reversed()
-        let galleryController = GalleryViewController(mediaMessageIds: messageIds)
+        let galleryController = GalleryViewController(context: dcContext, mediaMessageIds: messageIds)
         navigationController?.pushViewController(galleryController, animated: true)
     }
 

--- a/deltachat-ios/Model/GalleryItem.swift
+++ b/deltachat-ios/Model/GalleryItem.swift
@@ -1,0 +1,79 @@
+import UIKit
+import DcCore
+import SDWebImage
+
+class GalleryItem {
+
+    var onImageLoaded: ((UIImage?) -> Void)?
+
+    var msg: DcMsg
+
+    var fileUrl: URL? {
+        return msg.fileURL
+    }
+
+    var thumbnailImage: UIImage? {
+        willSet {
+            onImageLoaded?(newValue)
+        }
+    }
+
+    var showPlayButton: Bool {
+        switch msg.viewtype {
+        case .video:
+            return true
+        default:
+            return false
+        }
+    }
+
+    init(msgId: Int) {
+        self.msg = DcMsg(id: msgId)
+
+        if let key = msg.fileURL?.absoluteString, let image = ThumbnailCache.shared.restoreImage(key: key) {
+            self.thumbnailImage = image
+        } else {
+            loadThumbnail()
+        }
+    }
+
+    private func loadThumbnail() {
+        guard let viewtype = msg.viewtype, let url = msg.fileURL else {
+            return
+        }
+        switch viewtype {
+        case .image:
+            thumbnailImage = msg.image
+        case .video:
+            loadVideoThumbnail(from: url)
+        case .gif:
+            loadGifThumbnail(from: url)
+        default:
+            safe_fatalError("unsupported viewtype - viewtype \(viewtype) not supported.")
+        }
+    }
+
+    private func loadGifThumbnail(from url: URL) {
+        DispatchQueue.global(qos: .userInteractive).async {
+            guard let imageData = try? Data(contentsOf: url) else {
+                return
+            }
+            let thumbnailImage = SDAnimatedImage(data: imageData)
+            DispatchQueue.main.async { [weak self] in
+                self?.thumbnailImage = thumbnailImage
+            }
+        }
+    }
+
+    private func loadVideoThumbnail(from url: URL) {
+        DispatchQueue.global(qos: .userInteractive).async {
+            let thumbnailImage = DcUtils.generateThumbnailFromVideo(url: url)
+            DispatchQueue.main.async { [weak self] in
+                self?.thumbnailImage = thumbnailImage
+                if let image = thumbnailImage {
+                    ThumbnailCache.shared.storeImage(image: image, key: url.absoluteString)
+                }
+            }
+        }
+    }
+}

--- a/deltachat-ios/Model/GalleryItem.swift
+++ b/deltachat-ios/Model/GalleryItem.swift
@@ -2,7 +2,7 @@ import UIKit
 import DcCore
 import SDWebImage
 
-class GalleryItem {
+class GalleryItem: ContextMenuItem {
 
     var onImageLoaded: ((UIImage?) -> Void)?
 

--- a/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
+++ b/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
@@ -84,6 +84,25 @@ class DocumentGalleryFileCell: UITableViewCell {
             let controller = UIDocumentInteractionController(url: url)
             fileImageView.image = controller.icons.first ?? placeholder
         }
+    }
 
+    // needed for iOS 12 context men
+    @objc func itemDelete(_ sender: Any) {
+        self.performAction(#selector(DocumentGalleryFileCell.itemDelete(_:)), with: sender)
+    }
+
+    @objc func showInChat(_ sender: Any) {
+        self.performAction(#selector(DocumentGalleryFileCell.showInChat(_:)), with: sender)
+    }
+
+    func performAction(_ action: Selector, with sender: Any?) {
+        if let tableView = self.superview as? UITableView, let indexPath = tableView.indexPath(for: self) {
+            tableView.delegate?.tableView?(
+                tableView,
+                performAction: action,
+                forRowAt: indexPath,
+                withSender: sender
+            )
+        }
     }
 }

--- a/deltachat-ios/View/Cell/GalleryCell.swift
+++ b/deltachat-ios/View/Cell/GalleryCell.swift
@@ -66,4 +66,19 @@ class GalleryCell: UICollectionViewCell {
             imageView.alpha = newValue ? 0.75 : 1.0
         }
     }
+
+    @objc func itemDelete(_ sender: Any) {
+        self.performAction(#selector(GalleryCell.itemDelete(_:)), with: sender)
+    }
+
+    func performAction(_ action: Selector, with sender: Any?) {
+        if let collectionView = self.superview as? UICollectionView, let indexPath = collectionView.indexPath(for: self) {
+            collectionView.delegate?.collectionView?(
+                collectionView,
+                performAction: action,
+                forItemAt: indexPath,
+                withSender: sender
+            )
+        }
+    }
 }

--- a/deltachat-ios/View/Cell/GalleryCell.swift
+++ b/deltachat-ios/View/Cell/GalleryCell.swift
@@ -71,6 +71,10 @@ class GalleryCell: UICollectionViewCell {
         self.performAction(#selector(GalleryCell.itemDelete(_:)), with: sender)
     }
 
+    @objc func showInChat(_ sender: Any) {
+        self.performAction(#selector(GalleryCell.showInChat(_:)), with: sender)
+    }
+
     func performAction(_ action: Selector, with sender: Any?) {
         if let collectionView = self.superview as? UICollectionView, let indexPath = collectionView.indexPath(for: self) {
             collectionView.delegate?.collectionView?(


### PR DESCRIPTION
closes #944 
closes #891 

Since MessageKit-files were deleted I was not able to rebase properly, so I had to rebase "manually" using this branch.

## This PR:
- context menu now displays (and plays) videos like on Telegram.
- context menu works on different device rotations 
- context menu closes on device rotation -> this is intended native behaviour
- context menu for documents gallery in iOS 13
- `contextMenuProvider` to generate legacy and new styled context menus 
- context menu provides **show in chat** that redirects to the message in chat view
- same menu applied to `DocumentGalleryController` (modern context menu uses default preview)
 
Gallery did not look nice in landscape on devices with notch. I did a quick fix in this PR too.

## To test: 
- use videos+images in landscape and portrait 
- try device in portrait and landscape

replaces #952