### PR TITLE
open chat and scroll to correct message after tap on notification

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -139,30 +139,10 @@ public func handleEvent(event: DcEvent) {
             "message_id": Int(data2),
             "chat_id": Int(data1),
         ]
-
         DispatchQueue.main.async {
             nc.post(name: dcNotificationIncoming,
                     object: nil,
                     userInfo: userInfo)
-
-            let chat = DcContext.shared.getChat(chatId: Int(data1))
-            if !UserDefaults.standard.bool(forKey: "notifications_disabled") && !chat.isMuted {
-                let content = UNMutableNotificationContent()
-                let msg = DcMsg(id: Int(data2))
-                content.title = msg.getSenderName(msg.fromContact)
-                content.body = msg.summary(chars: 40) ?? ""
-                content.userInfo = userInfo
-                content.sound = .default
-
-                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
-
-                let request = UNNotificationRequest(identifier: Constants.notificationIdentifier, content: content, trigger: trigger)
-                UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
-                DcContext.shared.logger?.info("notifications: added \(content)")
-            }
-
-            let array = DcContext.shared.getFreshMessages()
-            UIApplication.shared.applicationIconBadgeNumber = array.count
         }
 
     case DC_EVENT_SMTP_MESSAGE_SENT:

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -279,13 +279,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     func userNotificationCenter(_: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        //remove foreground notifications after 4 seconds
-        if notification.request.identifier == Constants.notificationIdentifier {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-                UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [notification.request.identifier])
-            }
+        if #available(iOS 14.0, *) {
+            completionHandler([.list, .badge])
+        } else {
+            completionHandler([.badge])
         }
-        completionHandler([.alert, .sound])
     }
 
     func registerForPushNotifications() {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -278,8 +278,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         completionHandler()
     }
 
-    func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        logger.info("notifications: forground notification appeared")
+    func userNotificationCenter(_: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        //remove foreground notifications after 3 seconds
+        if notification.request.identifier == Constants.notificationIdentifier {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [notification.request.identifier])
+            }
+        }
         completionHandler([.alert, .sound])
     }
 

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -279,9 +279,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     func userNotificationCenter(_: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        //remove foreground notifications after 3 seconds
+        //remove foreground notifications after 4 seconds
         if notification.request.identifier == Constants.notificationIdentifier {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
                 UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [notification.request.identifier])
             }
         }

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -403,7 +403,6 @@ class ChatListController: UITableViewController {
     }
 
     func showChat(chatId: Int, highlightedMsg: Int? = nil, animated: Bool = true) {
-        //let chatVC = ChatViewController(dcContext: dcContext, chatId: chatId)
         let chatVC = ChatViewController(dcContext: dcContext, chatId: chatId, highlightedMsg: highlightedMsg)
         navigationController?.pushViewController(chatVC, animated: animated)
     }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -85,10 +85,10 @@ class AppCoordinator {
         tabBarController.selectedIndex = index
     }
 
-    func showChat(chatId: Int, animated: Bool = true) {
+    func showChat(chatId: Int, msgId: Int? = nil, animated: Bool = true) {
         showTab(index: chatsTab)
         if let rootController = self.chatsNavController.viewControllers.first as? ChatListController {
-            rootController.showChat(chatId: chatId, animated: animated)
+            rootController.showChat(chatId: chatId, msgId: msgId, animated: animated)
         }
     }
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -88,7 +88,7 @@ class AppCoordinator {
     func showChat(chatId: Int, msgId: Int? = nil, animated: Bool = true) {
         showTab(index: chatsTab)
         if let rootController = self.chatsNavController.viewControllers.first as? ChatListController {
-            rootController.showChat(chatId: chatId, msgId: msgId, animated: animated)
+            rootController.showChat(chatId: chatId, highlightedMsg: msgId, animated: animated)
         }
     }
 


### PR DESCRIPTION
closes #721 
* showing notifications when the app was in forground was buggy and is fixed by this PR
* foreground notifications are only generated if the user has not opened the corresponding chat of the incoming message
* foreground notifications disappear after 4 seconds
* background notifications keep on the system 'dashboard' 
* tapping on notifications, will open the correct chat and move the list so that the corresponding message is shown
* notifications show group names in group chats
* support for image previews