### PR TITLE
Empty search -> make  empty state banner always visible

### DIFF
--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -166,7 +166,6 @@ extension GroupMembersViewController: UISearchResultsUpdating {
                 String.localized("search_no_result_for_x"),
                 searchText
             )
-
             emptySearchStateLabel.text = text
             emptySearchStateLabel.frame = CGRect(x: 0, y: 0, width: 0, height: emptySearchStateLabel.intrinsicContentSize.height)
             emptySearchStateLabel.isHidden = false
@@ -174,6 +173,7 @@ extension GroupMembersViewController: UISearchResultsUpdating {
         } else {
             emptySearchStateLabel.text = nil
             emptySearchStateLabel.isHidden = true
+            tableView.tableHeaderView = nil
         }
     }
 }

--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -82,18 +82,9 @@ class GroupMembersViewController: UITableViewController {
         navigationItem.hidesSearchBarWhenScrolling = false
         configureTableView()
         definesPresentationContext = true
-        setupSubviews()
     }
 
     // MARK: - setup + configuration
-    private func setupSubviews() {
-        view.addSubview(emptySearchStateLabel)
-        emptySearchStateLabel.translatesAutoresizingMaskIntoConstraints = false
-        emptySearchStateLabel.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor).isActive = true
-        emptySearchStateLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40).isActive = true
-        emptySearchStateLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40).isActive = true
-        emptySearchStateLabel.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
-    }
 
     private func configureTableView() {
         tableView.register(ContactCell.self, forCellReuseIdentifier: ContactCell.reuseIdentifier)
@@ -175,8 +166,11 @@ extension GroupMembersViewController: UISearchResultsUpdating {
                 String.localized("search_no_result_for_x"),
                 searchText
             )
+
             emptySearchStateLabel.text = text
+            emptySearchStateLabel.frame = CGRect(x: 0, y: 0, width: 0, height: emptySearchStateLabel.intrinsicContentSize.height)
             emptySearchStateLabel.isHidden = false
+            tableView.tableHeaderView = emptySearchStateLabel
         } else {
             emptySearchStateLabel.text = nil
             emptySearchStateLabel.isHidden = true

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -84,22 +84,11 @@ class NewChatViewController: UITableViewController {
         }
         tableView.register(ActionCell.self, forCellReuseIdentifier: "actionCell")
         tableView.register(ContactCell.self, forCellReuseIdentifier: "contactCell")
-        setupSubviews()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         deviceContactAccessGranted = CNContactStore.authorizationStatus(for: .contacts) == .authorized
-    }
-
-    // MARK: - setup
-    private func setupSubviews() {
-        view.addSubview(emptySearchStateLabel)
-        emptySearchStateLabel.translatesAutoresizingMaskIntoConstraints = false
-        emptySearchStateLabel.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor).isActive = true
-        emptySearchStateLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40).isActive = true
-        emptySearchStateLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40).isActive = true
-        emptySearchStateLabel.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
     }
 
     // MARK: - actions
@@ -295,9 +284,12 @@ class NewChatViewController: UITableViewController {
             )
             emptySearchStateLabel.text = text
             emptySearchStateLabel.isHidden = false
+            emptySearchStateLabel.frame = CGRect(x: 0, y: 0, width: 0, height: emptySearchStateLabel.intrinsicContentSize.height)
+            tableView.tableHeaderView = emptySearchStateLabel
         } else {
             emptySearchStateLabel.text = nil
             emptySearchStateLabel.isHidden = true
+            tableView.tableHeaderView = nil
         }
     }
 

--- a/deltachat-ios/View/EmptyStateLabel.swift
+++ b/deltachat-ios/View/EmptyStateLabel.swift
@@ -26,6 +26,12 @@ class EmptyStateLabel: FlexLabel {
         }
     }
 
+    override var intrinsicContentSize: CGSize {
+        let width = layoutMargins.left + layoutMargins.right + label.intrinsicContentSize.width
+        let height = layoutMargins.top + layoutMargins.bottom + label.intrinsicContentSize.height
+        return CGSize(width: width, height: height)
+    }
+
     override init() {
         super.init()
         label.backgroundColor = DcColors.systemMessageBackgroundColor


### PR DESCRIPTION
closes #807 

Fixed by using the  `emptyStateLabel` as tableViewHeader.

![IMG_5962](https://user-images.githubusercontent.com/5249565/98935911-835d3800-24e4-11eb-9863-3621c550c2fc.PNG)
![IMG_5963](https://user-images.githubusercontent.com/5249565/98935923-87895580-24e4-11eb-8b8e-faadbba1e333.PNG)

 