### PR TITLE
add permanent hint about enabled server-deletion

### DIFF
--- a/deltachat-ios/Controller/SettingsAutodelOverviewController.swift
+++ b/deltachat-ios/Controller/SettingsAutodelOverviewController.swift
@@ -7,7 +7,6 @@ class SettingsAutodelOverviewController: UITableViewController {
 
     private struct SectionConfigs {
         let headerTitle: String?
-        let footerTitle: String?
         let cells: [UITableViewCell]
     }
 
@@ -35,12 +34,10 @@ class SettingsAutodelOverviewController: UITableViewController {
     private lazy var sections: [SectionConfigs] = {
         let autodelSection = SectionConfigs(
             headerTitle: String.localized("autodel_device_title"),
-            footerTitle: nil,
             cells: [autodelDeviceCell]
         )
         let autodelSection2 = SectionConfigs(
             headerTitle: String.localized("autodel_server_title"),
-            footerTitle: nil,
             cells: [autodelServerCell]
         )
         return [autodelSection, autodelSection2]
@@ -63,6 +60,7 @@ class SettingsAutodelOverviewController: UITableViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        tableView.reloadData() // needed to update footer
         autodelDeviceCell.textLabel?.text = SettingsAutodelSetController.getSummary(dcContext, fromServer: false)
         autodelServerCell.textLabel?.text = SettingsAutodelSetController.getSummary(dcContext, fromServer: true)
     }
@@ -86,7 +84,14 @@ class SettingsAutodelOverviewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return sections[section].footerTitle
+        guard let cellTag = CellTags(rawValue: section) else {
+            safe_fatalError()
+            return nil
+        }
+        if cellTag == .autodelServer && dcContext.getConfigInt("delete_server_after") != 0 {
+            return String.localized("autodel_server_enabled_hint")
+        }
+        return nil
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/deltachat-ios/Controller/SettingsAutodelSetController.swift
+++ b/deltachat-ios/Controller/SettingsAutodelSetController.swift
@@ -128,6 +128,7 @@ class SettingsAutodelSetController: UITableViewController {
                 oldSelectedCell?.accessoryType = .none
                 newSelectedCell?.accessoryType = .checkmark
                 self.currVal = newVal
+                self.tableView.reloadData() // needed to update footer
             }))
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
             present(alert, animated: true, completion: nil)
@@ -135,6 +136,7 @@ class SettingsAutodelSetController: UITableViewController {
             oldSelectedCell?.accessoryType = .none
             newSelectedCell?.accessoryType = .checkmark
             currVal = newVal
+            self.tableView.reloadData() // needed to update footer
         }
     }
 
@@ -144,6 +146,13 @@ class SettingsAutodelSetController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return String.localized(fromServer ? "autodel_server_title" : "autodel_device_title")
+    }
+
+    override func tableView(_: UITableView, titleForFooterInSection section: Int) -> String? {
+        if fromServer && currVal != 0 {
+            return String.localized("autodel_server_enabled_hint")
+        }
+        return nil
     }
 
     // MARK: - actions


### PR DESCRIPTION
when server-deletion is enabled, always show a hint about the impact below the option. this way, the user is more aware of the impact if enabling was done some time ago or the option was even enabled by the provider-db.

![Screen Shot 2020-11-19 at 23 19 52](https://user-images.githubusercontent.com/9800740/99731310-06baf280-2abe-11eb-871b-d36db1822a58.png)

![Screen Shot 2020-11-19 at 23 20 08](https://user-images.githubusercontent.com/9800740/99731316-07ec1f80-2abe-11eb-8151-fe04ddfe6ce9.png)

closes #998 
counterpart of https://github.com/deltachat/deltachat-android/pull/1737