### PR TITLE
fix summary for drafted quotes

### DIFF
--- a/deltachat-ios/Chat/DraftModel.swift
+++ b/deltachat-ios/Chat/DraftModel.swift
@@ -19,8 +19,16 @@ public class DraftModel {
     }
 
     public func setQuote(quotedMsg: DcMsg?) {
-        quoteMessage = quotedMsg
-        self.quoteText = quotedMsg?.text
+        if let quotedMsg = quotedMsg {
+            // create a temporary draft to get the correct quoteText
+            let draftMessage = DcMsg(viewType: DC_MSG_TEXT)
+            draftMessage.quoteMessage = quotedMsg
+            self.quoteText = draftMessage.quoteText
+            self.quoteMessage = quotedMsg
+        } else {
+            self.quoteText = nil
+            self.quoteMessage = nil
+        }
     }
 
     public func save(context: DcContext) {

--- a/deltachat-ios/View/QuotePreview.swift
+++ b/deltachat-ios/View/QuotePreview.swift
@@ -90,18 +90,18 @@ public class QuotePreview: UIView, InputItem {
     }
 
     public func configure(draft: DraftModel) {
-        if draft.quoteMessage == nil && draft.quoteText == nil {
+        if let quoteText = draft.quoteText {
+            quoteView.quote.text = quoteText
+            if let quoteMessage = draft.quoteMessage {
+                let contact = quoteMessage.fromContact
+                quoteView.senderTitle.text = contact.displayName
+                quoteView.senderTitle.textColor = contact.color
+                quoteView.citeBar.backgroundColor = contact.color
+                quoteView.imagePreview.image = quoteMessage.image
+            }
+            isHidden = false
+        } else {
             isHidden = true
-            return
         }
-        quoteView.quote.text = draft.quoteText ?? draft.quoteMessage?.summary(chars: 80)
-        if let quoteMessage = draft.quoteMessage {
-            let contact = quoteMessage.fromContact
-            quoteView.senderTitle.text = contact.displayName
-            quoteView.senderTitle.textColor = contact.color
-            quoteView.citeBar.backgroundColor = contact.color
-            quoteView.imagePreview.image = quoteMessage.image
-        }
-        isHidden = false
     }
 }


### PR DESCRIPTION
(this should be merged into swipe-to-reply branch)

core guarantees that there is always a quote text if there is a quote,
in QuotePreview::configure(), rely on that,
using a summary fallback is not needed.

moreover, in DraftModel::setQuote(), we use the core to set the quote summary.
this closes #996

(nb: quote summaries were alrady fine before when a
chat with a draft-quote was left and entered again,
this was because of the implicit draft creation that is now
done explicit in DraftModel::setQuote())