### PR TITLE
do not hide some avatars or combine bubbles

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -471,31 +471,21 @@ class ChatViewController: UITableViewController {
     }
 
     func configureAvatarVisibility(for message: DcMsg, at indexPath: IndexPath) -> Bool {
-        return isGroupChat && !message.isFromCurrentSender && !isNextMessageSameSender(currentMessage: message, at: indexPath)
+        return isGroupChat && !message.isFromCurrentSender
     }
 
     func configureMessageStyle(for message: DcMsg, at indexPath: IndexPath) -> UIRectCorner {
 
         var corners: UIRectCorner = []
 
-        if message.isFromCurrentSender { //isFromCurrentSender(message: message) {
+        if message.isFromCurrentSender {
             corners.formUnion(.topLeft)
             corners.formUnion(.bottomLeft)
-            if !isPreviousMessageSameSender(currentMessage: message, at: indexPath) {
-                corners.formUnion(.topRight)
-            }
-            if !isNextMessageSameSender(currentMessage: message, at: indexPath) {
-                corners.formUnion(.bottomRight)
-            }
+            corners.formUnion(.topRight)
         } else {
             corners.formUnion(.topRight)
             corners.formUnion(.bottomRight)
-            if !isPreviousMessageSameSender(currentMessage: message, at: indexPath) {
-                corners.formUnion(.topLeft)
-            }
-            if !isNextMessageSameSender(currentMessage: message, at: indexPath) {
-                corners.formUnion(.bottomLeft)
-            }
+            corners.formUnion(.topLeft)
         }
 
         return corners
@@ -504,31 +494,6 @@ class ChatViewController: UITableViewController {
     private func getBackgroundColor(for currentMessage: DcMsg) -> UIColor {
         return currentMessage.isFromCurrentSender ? DcColors.messagePrimaryColor : DcColors.messageSecondaryColor
     }
-
-    private func isPreviousMessageSameSender(currentMessage: DcMsg, at indexPath: IndexPath) -> Bool {
-        let previousRow = indexPath.row - 1
-        if previousRow < 0 {
-            return false
-        }
-
-        let messageId = messageIds[previousRow]
-        let previousMessage = DcMsg(id: messageId)
-
-        return previousMessage.fromContact.id == currentMessage.fromContact.id
-    }
-
-    private func isNextMessageSameSender(currentMessage: DcMsg, at indexPath: IndexPath) -> Bool {
-        let nextRow = indexPath.row + 1
-        if nextRow >= messageIds.count {
-            return false
-        }
-
-        let messageId = messageIds[nextRow]
-        let nextMessage = DcMsg(id: messageId)
-
-        return nextMessage.fromContact.id == currentMessage.fromContact.id
-    }
-
 
     private func updateTitle(chat: DcChat) {
         let titleView =  ChatTitleView()


### PR DESCRIPTION
this syncs bubble layout with android/desktion
and has the following advantages:

- clear ui - a message has an avatar and a time/delivery-info
- bubbles point to a direction
- for larger messags, left out avatars make it unneccessarily hard to see
  who wrote a message. same for a series of messages.
- sending button does not imply somehow that
  messages are combined, that might senders think over before hitting "send".
  not sure, though :)

finally, easier code and this also fixes a bug
when the next message is a system message.

closes #1007