### PR TITLE
Adapt gallery image preview

### DIFF
--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -254,13 +254,6 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
             }
         )
     }
-
-    @available(iOS 13, *)
-    func collectionView(_ collectionView: UICollectionView, willEndContextMenuInteraction configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
-        if let msgId = (animator?.previewViewController as? ContextMenuController)?.msg.id {
-            self.showPreview(msgId: msgId)
-        }
-    }
 }
 
 // MARK: - grid layout + updates

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import DcCore
+import QuickLook
 
 class GalleryViewController: UIViewController {
 
@@ -302,6 +303,7 @@ private extension GalleryViewController {
         }
 
         let previewController = PreviewController(type: .multi(mediaMessageIds, index))
+        previewController.delegate = self
         present(previewController, animated: true, completion: nil)
     }
 
@@ -395,5 +397,13 @@ extension ContextMenuProvider {
         let option: Option
         var action: Selector
         var onPerform: ((IndexPath) -> Void)?
+    }
+}
+
+// MARK: - QLPreviewControllerDataSource
+extension GalleryViewController: QLPreviewControllerDelegate {
+    func previewController(_ controller: QLPreviewController, transitionViewFor item: QLPreviewItem) -> UIView? {
+        let indexPath = IndexPath(row: controller.currentPreviewItemIndex, section: 0)
+        return grid.cellForItem(at: indexPath)
     }
 }


### PR DESCRIPTION
closes #1025

* for now we don't open the preview on tap on the image in the context menu
* however the transition animation looks now like a zoom-in/zoom-out of the image, the zoom effect starts from the original position of the selected cell in the grid