### PR TITLE
don't show sender name in a quoted chat message 

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -274,11 +274,18 @@ public class BaseMessageCell: UITableViewCell {
             quoteView.quote.text = quoteText
 
             if let quoteMsg = msg.quoteMessage {
-                let contact = quoteMsg.fromContact
-                quoteView.senderTitle.text = contact.displayName
-                quoteView.senderTitle.textColor = contact.color
-                quoteView.citeBar.backgroundColor = contact.color
                 quoteView.imagePreview.image = quoteMsg.image
+                if quoteMsg.isForwarded {
+                    quoteView.senderTitle.text = String.localized("forwarded_message")
+                    quoteView.senderTitle.textColor = DcColors.grayDateColor
+                    quoteView.citeBar.backgroundColor = DcColors.grayDateColor
+                } else {
+                    let contact = quoteMsg.fromContact
+                    quoteView.senderTitle.text = contact.displayName
+                    quoteView.senderTitle.textColor = contact.color
+                    quoteView.citeBar.backgroundColor = contact.color
+                }
+
             }
         } else {
             quoteView.isHidden = true

--- a/deltachat-ios/Chat/Views/QuotePreview.swift
+++ b/deltachat-ios/Chat/Views/QuotePreview.swift
@@ -31,11 +31,17 @@ public class QuotePreview: DraftPreview {
             compactView = draft.attachment != nil
             calculateQuoteHeight(compactView: compactView)
             if let quoteMessage = draft.quoteMessage {
-                let contact = quoteMessage.fromContact
-                quoteView.senderTitle.text = contact.displayName
-                quoteView.senderTitle.textColor = contact.color
-                quoteView.citeBar.backgroundColor = contact.color
                 quoteView.imagePreview.image = quoteMessage.image
+                if quoteMessage.isForwarded {
+                    quoteView.senderTitle.text = String.localized("forwarded_message")
+                    quoteView.senderTitle.textColor = DcColors.grayDateColor
+                    quoteView.citeBar.backgroundColor = DcColors.grayDateColor
+                } else {
+                    let contact = quoteMessage.fromContact
+                    quoteView.senderTitle.text = contact.displayName
+                    quoteView.senderTitle.textColor = contact.color
+                    quoteView.citeBar.backgroundColor = contact.color
+                }
             }
 
             isHidden = false


### PR DESCRIPTION
... if quoted message was forwarded
* both for a sent message and a drafted message

closes #1012 