### PR TITLE
fix swipe-to-reply icon visibility issue on iOS 11 and 12

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -493,14 +493,15 @@ class ChatViewController: UITableViewController {
                                             self?.replyToMessage(at: indexPath)
                                             completionHandler(true)
                                         })
-        if #available(iOS 12.0, *) {
+        if #available(iOS 13.0, *) {
             action.image = UIImage(named: traitCollection.userInterfaceStyle == .light ? "ic_reply_black" : "ic_reply")
+            action.backgroundColor = DcColors.chatBackgroundColor
         } else {
             action.image = UIImage(named: "ic_reply_black")
+            action.backgroundColor = .systemBlue
         }
         action.image?.accessibilityTraits = .button
         action.image?.accessibilityLabel = String.localized("menu_reply")
-        action.backgroundColor = DcColors.chatBackgroundColor
         let configuration = UISwipeActionsConfiguration(actions: [action])
 
         return configuration


### PR DESCRIPTION
I noticed that on iOS 11 and 12 the reply icon has been invisible in light mode (white icon on white background).
I tried several approaches to force iOS to show the original image, showing a black arrow, without success. On these iOS versions the images are used as templates and the original color is replaced by white. 
Instead of fighting against the intended behaviour I'm suggesting to use a system blue background color for the swipe-to-reply feature on iOS 11 and 12..
 iOS 13+ allows different colored icons, so we can keep there the black icon on white background and vice versa.