### PR TITLE
prepare 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Delta Chat iOS Changelog
 
+## 1.16.0
+2021-02
+
+* new staging area: images and other files
+  can be reviewed and sent together with a description now
+* show in chat: go to the the corresponding message
+  directly from images or documents in the gallery
+* new, redesigned context menus in chat, gallery and document view -
+  long-tap a message to feel the difference
+* multi-select in chat: long-tap a message and select more messages
+  for deletion or forwarding
+* improve several accessibility items and texts
+* improve keyboard layouts
+* fix: profile images can now always be cropped after selection
+* fix: hints in empty chats are no longer truncated
+* fix swipe-to-reply icon for iOS 11 and 12
+* more bug fixes
+* update translations and local help
+
+
 ## 1.14.4
 2020-12
 

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -1484,13 +1484,13 @@
 				CODE_SIGN_ENTITLEMENTS = DcShare/DcShare.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = DcShare/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.14.4;
+				MARKETING_VERSION = 1.16.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.delta.DcShare;
@@ -1509,13 +1509,13 @@
 				CODE_SIGN_ENTITLEMENTS = DcShare/DcShare.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = DcShare/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.14.4;
+				MARKETING_VERSION = 1.16.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.delta.DcShare;
 				PRODUCT_NAME = "Delta Chat";
@@ -1649,7 +1649,7 @@
 				CODE_SIGN_ENTITLEMENTS = "deltachat-ios/deltachat-ios.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -1666,7 +1666,7 @@
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/release",
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/debug",
 				);
-				MARKETING_VERSION = 1.14.4;
+				MARKETING_VERSION = 1.16.0;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-isystem",
@@ -1723,7 +1723,7 @@
 				CODE_SIGN_ENTITLEMENTS = "deltachat-ios/deltachat-ios.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -1740,7 +1740,7 @@
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/release",
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/debug",
 				);
-				MARKETING_VERSION = 1.14.4;
+				MARKETING_VERSION = 1.16.0;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-isystem",

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -77,18 +77,17 @@ class ChatListController: UITableViewController {
         // update messages - for new messages, do not reuse or modify strings but create new ones.
         // it is not needed to keep all past update messages, however, when deleted, also the strings should be deleted.
         let msg = DcMsg(viewType: DC_MSG_TEXT)
-        msg.text = "Some highlights of the 1.14 update:\n"
+        msg.text = "What's new in 1.16?\n"
             + "\n"
-            + "🧹 Swipe to reply: "
-            + "To answer a concrete message, just swipe it right (not here! you cannot answer here :) "
-            + "You\'ll see a quote above the compose line and can continue writing your message as usual.\n"
+            + "✍️ Add text to images and files before sending\n"
             + "\n"
-            + "🔥 Disappearing messages - the time has come :) "
-            + "Any chat can now be configured to delete sent and received messages after some time. "
-            + "Just select \"Disappearing messages\" from the chat\'s profile (again: not here)\n"
+            + "🎨 Draw on images before sending (tap the image selected for sending, then the icon in the upper right corner)\n"
             + "\n"
-            + "🎃 Finally, we\'ve again frightened many bugs! Lots were so scared, they won\'t come back."
-        dcContext.addDeviceMessage(label: "update_1_14c_ios", msg: msg)
+            + "✅ ☑️ Multi-select messages and forward or delete them with one tap "
+            + "(long tap on message, admire the new, much nicer context menu, then \"Select more\")\n"
+            + "\n"
+            + "As always, see https://delta.chat/blog for more news and updates."
+        dcContext.addDeviceMessage(label: "update_1_16g_ios", msg: msg)
 
         // create view
         updateTitle()


### PR DESCRIPTION
just noticed, ios is the first platform where "show in chat" will be released (although it exists a bit longer on android :)

draft of the device message:

![Screen Shot 2021-02-02 at 23 06 01](https://user-images.githubusercontent.com/9800740/106669046-55e7ce00-65ab-11eb-9a27-5a97ac177bce.png)
