### PR TITLE
add top padding to 'Show full message' button

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -136,6 +136,7 @@ public class BaseMessageCell: UITableViewCell {
         button.addTarget(self, action: #selector(onFullMessageButtonTapped), for: .touchUpInside)
         button.titleLabel?.font = UIFont.preferredFont(for: .body, weight: .regular)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
         button.accessibilityLabel = String.localized("show_full_message")
         return button
     }()


### PR DESCRIPTION
goal is to have roughly the same padding between
message and button as between two paragraphs.
(so that the button look more as belonging to the message
than to the last paragraph)

@cyBerta if that is okay, please merge this pr to message_web_view
and message_web_view to master then :)