### PR TITLE
mark overridden senders in quotes

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -329,7 +329,7 @@ public class BaseMessageCell: UITableViewCell {
                     quoteView.citeBar.backgroundColor = DcColors.grayDateColor
                 } else {
                     let contact = quoteMsg.fromContact
-                    quoteView.senderTitle.text = quoteMsg.getSenderName(contact)
+                    quoteView.senderTitle.text = quoteMsg.getSenderName(contact, markOverride: true)
                     quoteView.senderTitle.textColor = contact.color
                     quoteView.citeBar.backgroundColor = contact.color
                 }

--- a/deltachat-ios/Chat/Views/QuotePreview.swift
+++ b/deltachat-ios/Chat/Views/QuotePreview.swift
@@ -40,7 +40,7 @@ public class QuotePreview: DraftPreview {
                     quoteView.citeBar.backgroundColor = DcColors.grayDateColor
                 } else {
                     let contact = quoteMessage.fromContact
-                    quoteView.senderTitle.text = quoteMessage.getSenderName(contact)
+                    quoteView.senderTitle.text = quoteMessage.getSenderName(contact, markOverride: true)
                     quoteView.senderTitle.textColor = contact.color
                     quoteView.citeBar.backgroundColor = contact.color
                 }


### PR DESCRIPTION
if the original author of a quote is shown
and known to be overridden,
that should be marked with the character `~`
as for the normal names,
esp. as they are look very similar otherwise,
eg. also bold, also colored.
the missing `~` looks like a bug here.

cmp. https://github.com/deltachat/deltachat-android/pull/1826