### PR TITLE
set color of archived-link cell

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -208,6 +208,7 @@ class ChatListController: UITableViewController {
             let chatId = chatData.chatId
             if chatId == DC_CHAT_ID_ARCHIVED_LINK {
                 archiveCell.actionTitle = dcContext.getChat(chatId: chatId).name
+                archiveCell.backgroundColor = DcColors.chatBackgroundColor
                 return archiveCell
             } else if let chatCell = tableView.dequeueReusableCell(withIdentifier: chatCellReuseIdentifier, for: indexPath) as? ContactCell {
                 // default chatCell


### PR DESCRIPTION
while in lite mode, the background color of the archived link is same as for the other chatlist cells (just white), it differs for the dark mode (black vs. grey); this is fixed by this pr.

before/after:

<img width="320" alt="Screen Shot 2021-03-17 at 21 31 44" src="https://user-images.githubusercontent.com/9800740/111534554-6bcede00-8768-11eb-9cb0-fd46b92ed363.png"> <img width="320" alt="Screen Shot 2021-03-17 at 21 32 25" src="https://user-images.githubusercontent.com/9800740/111534564-6d98a180-8768-11eb-9b2d-72ef91111777.png">

