### PR TITLE
Group creation issues

### DIFF
--- a/deltachat-ios/Controller/AddGroupMembersViewController.swift
+++ b/deltachat-ios/Controller/AddGroupMembersViewController.swift
@@ -186,7 +186,7 @@ class AddGroupMembersViewController: GroupMembersViewController {
 
     private func showNewContactController() {
         let newContactController = NewContactController(dcContext: dcContext)
-        newContactController.openChatOnSave = false
+        newContactController.createChatOnSave = false
         navigationController?.pushViewController(newContactController, animated: true)
     }
 }

--- a/deltachat-ios/Controller/AddGroupMembersViewController.swift
+++ b/deltachat-ios/Controller/AddGroupMembersViewController.swift
@@ -22,8 +22,6 @@ class AddGroupMembersViewController: GroupMembersViewController {
         case memberList
     }
 
-    private var contactAddedObserver: NSObjectProtocol?
-
     private lazy var chatMemberIds: [Int] = {
         if let chat = chat {
             return chat.contactIds
@@ -86,44 +84,6 @@ class AddGroupMembersViewController: GroupMembersViewController {
         navigationItem.rightBarButtonItem = doneButton
         navigationItem.leftBarButtonItem = cancelButton
         contactIds = loadMemberCandidates()
-
-        let nc = NotificationCenter.default
-        contactAddedObserver = nc.addObserver(
-            forName: dcNotificationContactChanged,
-            object: nil,
-            queue: nil
-        ) { [weak self] notification in
-            guard let self = self else { return }
-            if let ui = notification.userInfo {
-                if let contactId = ui["contact_id"] as? Int {
-                    if contactId == 0 {
-                        return
-                    }
-                    self.contactIds = self.loadMemberCandidates()
-                    if self.contactIds.contains(contactId) {
-                        self.selectedContactIds.insert(contactId)
-                        self.tableView.reloadData()
-                    }
-
-                }
-            }
-        }
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-    }
-
-    override func viewWillDisappear(_: Bool) {
-        if !isMovingFromParent {
-            // a subview was added to the navigation stack, no action needed
-            return
-        }
-
-        let nc = NotificationCenter.default
-        if let observer = self.contactAddedObserver {
-            nc.removeObserver(observer)
-        }
     }
 
     @objc func cancelButtonPressed() {
@@ -187,6 +147,14 @@ class AddGroupMembersViewController: GroupMembersViewController {
     private func showNewContactController() {
         let newContactController = NewContactController(dcContext: dcContext)
         newContactController.createChatOnSave = false
+        newContactController.onContactSaved = { [weak self] (contactId: Int) -> Void in
+            guard let self = self else { return }
+            self.contactIds = self.loadMemberCandidates()
+            if self.contactIds.contains(contactId) {
+                self.selectedContactIds.insert(contactId)
+                self.tableView.reloadData()
+            }
+        }
         navigationController?.pushViewController(newContactController, animated: true)
     }
 }

--- a/deltachat-ios/Controller/AddGroupMembersViewController.swift
+++ b/deltachat-ios/Controller/AddGroupMembersViewController.swift
@@ -145,7 +145,7 @@ class AddGroupMembersViewController: GroupMembersViewController {
     }
 
     private func showNewContactController() {
-        let newContactController = NewContactController(dcContext: dcContext)
+        let newContactController = NewContactController(dcContext: dcContext, searchResult: searchText)
         newContactController.createChatOnSave = false
         newContactController.onContactSaved = { [weak self] (contactId: Int) -> Void in
             guard let self = self else { return }

--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -46,7 +46,7 @@ class GroupMembersViewController: UITableViewController {
         return searchController.searchBar.text?.isEmpty ?? true
     }
 
-    private var searchText: String? {
+    open var searchText: String? {
         return searchController.searchBar.text
     }
 

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -314,7 +314,7 @@ class NewChatViewController: UITableViewController {
     }
 
     private func showNewContactController() {
-        let newContactController = NewContactController(dcContext: dcContext)
+        let newContactController = NewContactController(dcContext: dcContext, searchResult: searchText)
         navigationController?.pushViewController(newContactController, animated: true)
     }
 

--- a/deltachat-ios/Controller/NewContactController.swift
+++ b/deltachat-ios/Controller/NewContactController.swift
@@ -5,6 +5,7 @@ class NewContactController: UITableViewController {
 
     let dcContext: DcContext
     var createChatOnSave = true
+    var prefilledSeachResult: String?
 
     let emailCell = TextFieldCell.makeEmailCell()
     let nameCell = TextFieldCell.makeNameCell()
@@ -30,9 +31,10 @@ class NewContactController: UITableViewController {
     let cells: [UITableViewCell]
 
     // for creating a new contact
-    init(dcContext: DcContext) {
+    init(dcContext: DcContext, searchResult: String? = nil) {
         self.dcContext = dcContext
         cells = [emailCell, nameCell]
+        prefilledSeachResult = searchResult
         super.init(style: .grouped)
         emailCell.textFieldDelegate = self
         nameCell.textFieldDelegate = self
@@ -53,6 +55,13 @@ class NewContactController: UITableViewController {
 
         emailCell.textField.addTarget(self, action: #selector(NewContactController.emailTextChanged), for: UIControl.Event.editingChanged)
         nameCell.textField.addTarget(self, action: #selector(NewContactController.nameTextChanged), for: UIControl.Event.editingChanged)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if let searchResult = prefilledSeachResult, searchResult.contains("@") {
+            emailCell.textField.insertText(searchResult)
+        }
     }
 
     override func viewDidAppear(_: Bool) {

--- a/deltachat-ios/Controller/NewContactController.swift
+++ b/deltachat-ios/Controller/NewContactController.swift
@@ -4,7 +4,7 @@ import DcCore
 class NewContactController: UITableViewController {
 
     let dcContext: DcContext
-    var openChatOnSave = true
+    var createChatOnSave = true
 
     let emailCell = TextFieldCell.makeEmailCell()
     let nameCell = TextFieldCell.makeNameCell()
@@ -73,8 +73,8 @@ class NewContactController: UITableViewController {
 
     @objc func saveContactButtonPressed() {
         let contactId = dcContext.createContact(name: model.name, email: model.email)
-        let chatId = dcContext.createChatByContactId(contactId: contactId)
-        if openChatOnSave {
+        if createChatOnSave {
+            let chatId = dcContext.createChatByContactId(contactId: contactId)
             showChat(chatId: chatId)
         } else {
             navigationController?.popViewController(animated: true)

--- a/deltachat-ios/Controller/NewContactController.swift
+++ b/deltachat-ios/Controller/NewContactController.swift
@@ -11,6 +11,8 @@ class NewContactController: UITableViewController {
     var doneButton: UIBarButtonItem?
     var cancelButton: UIBarButtonItem?
 
+    var onContactSaved: ((Int) -> Void)?
+
     func contactIsValid() -> Bool {
         return Utils.isValid(email: model.email)
     }
@@ -73,6 +75,9 @@ class NewContactController: UITableViewController {
 
     @objc func saveContactButtonPressed() {
         let contactId = dcContext.createContact(name: model.name, email: model.email)
+        if let onContactSaved = self.onContactSaved {
+            onContactSaved(contactId)
+        }
         if createChatOnSave {
             let chatId = dcContext.createChatByContactId(contactId: contactId)
             showChat(chatId: chatId)


### PR DESCRIPTION
targets #975

not implemented:

> when leaving the "New contact" dialog via "Done" button, currently, we go back to the "Add members" screen, the user has no clue if the added member is added or not. it is better to go back to the "Create group" screen where the user can directly see the added member (we should not forget to also add normally checked members)
this is one click more when adding another member, but i think, this is more straight-forward.

The newly created member has a check mark in the member list in the AddMembersViewController. So all it's needed is to scroll in the contact list or search for the contact to check if the new created member is added. At the same time it might be unexpected that a user doesn't get back where they came from. Plus adding further contacts are done with one tap less. 