### PR TITLE
allow unlabeled device messages

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -391,8 +391,8 @@ public class DcContext {
     }
 
     @discardableResult
-    public func addDeviceMessage(label: String, msg: DcMsg) -> Int {
-        return Int(dc_add_device_msg(contextPointer, label.cString(using: .utf8), msg.cptr))
+    public func addDeviceMessage(label: String?, msg: DcMsg) -> Int {
+        return Int(dc_add_device_msg(contextPointer, label, msg.cptr))
     }
 
     public func getProviderFromEmail(addr: String) -> DcProvider? {


### PR DESCRIPTION
messages with a label are added only once,
if no label is given, the messages are added unconditionally.

this pr makes the label an optional.