### PR TITLE
NotificationManager

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -140,29 +140,11 @@ public func handleEvent(event: DcEvent) {
             "chat_id": Int(data1),
         ]
 
+        DcContext.shared.logger?.info("incoming message \(userInfo)")
         DispatchQueue.main.async {
             nc.post(name: dcNotificationIncoming,
                     object: nil,
                     userInfo: userInfo)
-
-            let chat = DcContext.shared.getChat(chatId: Int(data1))
-            if !UserDefaults.standard.bool(forKey: "notifications_disabled") && !chat.isMuted {
-                let content = UNMutableNotificationContent()
-                let msg = DcMsg(id: Int(data2))
-                content.title = msg.getSenderName(msg.fromContact)
-                content.body = msg.summary(chars: 40) ?? ""
-                content.userInfo = userInfo
-                content.sound = .default
-
-                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
-
-                let request = UNNotificationRequest(identifier: Constants.notificationIdentifier, content: content, trigger: trigger)
-                UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
-                DcContext.shared.logger?.info("notifications: added \(content)")
-            }
-
-            let array = DcContext.shared.getFreshMessages()
-            UIApplication.shared.applicationIconBadgeNumber = array.count
         }
 
     case DC_EVENT_SMTP_MESSAGE_SENT:

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		21D6C941260623F500D0755A /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D6C9392606190600D0755A /* NotificationManager.swift */; };
 		3008CB7224F93EB900E6A617 /* AudioMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008CB7124F93EB900E6A617 /* AudioMessageCell.swift */; };
 		3008CB7424F9436C00E6A617 /* AudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008CB7324F9436C00E6A617 /* AudioPlayerView.swift */; };
 		3008CB7624F95B6D00E6A617 /* AudioController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008CB7524F95B6D00E6A617 /* AudioController.swift */; };
@@ -198,6 +199,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		21D6C9392606190600D0755A /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		21EE28844E7A690D73BF5285 /* Pods-deltachat-iosTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-deltachat-iosTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-deltachat-iosTests/Pods-deltachat-iosTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2F7009234DB9408201A6CDCB /* Pods_deltachat_iosTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_deltachat_iosTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3008CB7124F93EB900E6A617 /* AudioMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMessageCell.swift; sourceTree = "<group>"; };
@@ -815,6 +817,7 @@
 				307D822D241669C7006D2490 /* LocationManager.swift */,
 				AE0AA9552478191900D42A7F /* GridCollectionViewFlowLayout.swift */,
 				AE6EC5272497B9B200A400E4 /* ThumbnailCache.swift */,
+				21D6C9392606190600D0755A /* NotificationManager.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -1298,6 +1301,7 @@
 				AEA0F6A124474146009F887B /* ProfileInfoViewController.swift in Sources */,
 				303492A5257546B400A523D0 /* DraftPreview.swift in Sources */,
 				305961D02346125100C80F33 /* NSAttributedString+Extensions.swift in Sources */,
+				21D6C941260623F500D0755A /* NotificationManager.swift in Sources */,
 				302B84C72396770B001C261F /* RelayHelper.swift in Sources */,
 				305961CF2346125100C80F33 /* UIColor+Extensions.swift in Sources */,
 				AEACE2E51FB32E1900DCDD78 /* Utils.swift in Sources */,

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -60,6 +60,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         appCoordinator = AppCoordinator(window: window, dcContext: dcContext)
         locationManager = LocationManager(context: dcContext)
         UIApplication.shared.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalMinimum)
+        notificationManager = NotificationManager()
         dcContext.maybeStartIo()
         setStockTranslations()
 
@@ -296,7 +297,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 self?.maybeRegisterForRemoteNotifications()
             }
         }
-        notificationManager = NotificationManager()
     }
 
     // register on apple server for receiving push notifications

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -14,6 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     var appCoordinator: AppCoordinator!
     var relayHelper: RelayHelper!
     var locationManager: LocationManager!
+    var notificationManager: NotificationManager!
     private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
     var reachability = Reachability()!
     var window: UIWindow?
@@ -295,6 +296,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 self?.maybeRegisterForRemoteNotifications()
             }
         }
+        notificationManager = NotificationManager()
     }
 
     // register on apple server for receiving push notifications

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -1,0 +1,44 @@
+import Foundation
+import UserNotifications
+import DcCore
+import UIKit
+
+public class NotificationManager {
+    
+    var incomingMsgObserver: Any?
+    
+    init() {
+        incomingMsgObserver = NotificationCenter.default.addObserver(
+            forName: dcNotificationIncoming,
+            object: nil, queue: OperationQueue.main
+        ) { notification in
+            if let ui = notification.userInfo,
+               let chatId = ui["chat_id"] as? Int,
+               let messageId = ui["message_id"] as? Int {
+                let chat = DcContext.shared.getChat(chatId: chatId)
+                if !UserDefaults.standard.bool(forKey: "notifications_disabled") && !chat.isMuted {
+                    let content = UNMutableNotificationContent()
+                    let msg = DcMsg(id: messageId)
+                    content.title = msg.getSenderName(msg.fromContact)
+                    content.body = msg.summary(chars: 40) ?? ""
+                    content.userInfo = ui
+                    content.sound = .default
+
+                    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
+
+                    let request = UNNotificationRequest(identifier: Constants.notificationIdentifier, content: content, trigger: trigger)
+                    UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+                    DcContext.shared.logger?.info("notifications: added \(content.title) \(content.body) \(content.userInfo)")
+                }
+
+                let array = DcContext.shared.getFreshMessages()
+                UIApplication.shared.applicationIconBadgeNumber = array.count
+            }
+        }
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+}


### PR DESCRIPTION
initial implementation

this PR only moves the code that generates notifications out of event.swift because the code in that file is only reponsible for emitting events that other components listen to. 

adding code to jump to the right message will be done in a subsequent PR