### PR TITLE
[wip] call notify-completion-handler more accurate

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -115,6 +115,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         logger.info("---- background-fetch ----")
         increaseDebugCounter("notify-local-wakeup")
+        let oldFresh = DcContext.shared.getFreshMessages().count
 
         dcContext.maybeStartIo()
         dcContext.maybeNetwork()
@@ -123,7 +124,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             if !self.appIsInForeground {
                 self.dcContext.stopIo()
             }
-            completionHandler(.newData)
+            completionHandler(DcContext.shared.getFreshMessages().count > oldFresh ? .newData : .noData)
         }
     }
 
@@ -382,6 +383,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         logger.verbose("Notifications: didReceiveRemoteNotification \(userInfo)")
         increaseDebugCounter("notify-remote-receive")
+        let oldFresh = DcContext.shared.getFreshMessages().count
 
         dcContext.maybeStartIo()
         dcContext.maybeNetwork()
@@ -390,7 +392,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             if !self.appIsInForeground {
                 self.dcContext.stopIo()
             }
-            completionHandler(.newData)
+            completionHandler(DcContext.shared.getFreshMessages().count > oldFresh ? .newData : .noData)
         }
     }
 


### PR DESCRIPTION
_PLEASE DO NOT MERGE IN, it is not clear if this pr actually improves things ..._

apple seems to throttle silent-notifications and local-wakeup esp. in "do not disturb" mode and/or
when the phone is not moved/used (eg. laying on a table while user sleeping).
this is kind of okay, however, if that can be tweaked, we should try that :) this is what this pr is about.

before, we were always calling the notify-completion-handlers
with `.newData` - not sure in detail how apple handles throttling,
however, it is reasonable to assume that apple notifies less often knowing,
that there were just new data and eg. battery is low
(there are also some so posts pointing in that direction).

one could also agrue in the other direction, however,
i would also ignore return values from apps _always_ saying the same.

not sure, what exactly apple does here,
there is few documentation about that (or i did not found them)
maybe it is better to be just honest :)

nb: we could refactor the two entry points to one
function, however, now, during testing and tweaking,
it is better to have that separated.

also, at some point,
it would be useful to know better from the core when a fetch is completed,
however, until then, the "10 seconds" is the best we have :)