### PR TITLE
Notification jump to message

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -7,7 +7,6 @@ public let dcNotificationImexProgress = Notification.Name(rawValue: "dcNotificat
 public let dcNotificationConfigureProgress = Notification.Name(rawValue: "MrEventConfigureProgress")
 public let dcNotificationSecureJoinerProgress = Notification.Name(rawValue: "MrEventSecureJoinerProgress")
 public let dcNotificationSecureInviterProgress = Notification.Name(rawValue: "MrEventSecureInviterProgress")
-public let dcNotificationViewChat = Notification.Name(rawValue: "MrEventViewChat")
 public let dcNotificationContactChanged = Notification.Name(rawValue: "MrEventContactsChanged")
 public let dcNotificationChatModified = Notification.Name(rawValue: "dcNotificationChatModified")
 public let dcEphemeralTimerModified =  Notification.Name(rawValue: "dcEphemeralTimerModified")

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -129,6 +129,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func applicationWillEnterForeground(_: UIApplication) {
         logger.info("---- foreground ----")
+        logger.debug("---- UNUserNotificationCenter.delegate:  \(UNUserNotificationCenter.current().delegate)---- ")
         appIsInForeground = true
         dcContext.maybeStartIo()
         if reachability.connection != .none {
@@ -415,7 +416,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         logger.info("forground notification")
-        completionHandler([.alert, .sound])
+        if #available(iOS 14.0, *) {
+            completionHandler([.list, .badge])
+        } else {
+            completionHandler([.badge])
+        }
     }
 
     func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -413,23 +413,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     // MARK: - Handle notification banners
 
-    private func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+    func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         logger.info("forground notification")
         completionHandler([.alert, .sound])
     }
 
-    private func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+    func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         if response.notification.request.identifier == Constants.notificationIdentifier {
             logger.info("handling notifications")
             let userInfo = response.notification.request.content.userInfo
-            let nc = NotificationCenter.default
-            DispatchQueue.main.async {
-                nc.post(
-                    name: dcNotificationViewChat,
-                    object: nil,
-                    userInfo: userInfo
-                )
-            }
+             if let chatId = userInfo["chat_id"] as? Int,
+                 let msgId = userInfo["message_id"] as? Int {
+                 appCoordinator.showChat(chatId: chatId, msgId: msgId)
+             }
         }
 
         completionHandler()

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -413,6 +413,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     // MARK: - Handle notification banners
 
+    // this method will be called if an incoming message was received while the app was in forground.
+    // on iOS 14+ we show a notification in the notification center, without triggering an alert that needs to be manually swiped away
+    // on pre iOS 14 this feature isn't available so we're just triggering to show the badge at the launcher icon
     func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         logger.info("forground notification")
         if #available(iOS 14.0, *) {
@@ -422,6 +425,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
     }
 
+    // this method will be called if the user tapped on a notification
     func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         if response.notification.request.identifier == Constants.notificationIdentifier {
             logger.info("handling notifications")

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -129,7 +129,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func applicationWillEnterForeground(_: UIApplication) {
         logger.info("---- foreground ----")
-        logger.debug("---- UNUserNotificationCenter.delegate:  \(UNUserNotificationCenter.current().delegate)---- ")
         appIsInForeground = true
         dcContext.maybeStartIo()
         if reachability.connection != .none {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -127,14 +127,6 @@ class ChatListController: UITableViewController {
             queue: nil) { [weak self] _ in
                 self?.viewModel.refreshData()
         }
-        viewChatObserver = nc.addObserver(
-            forName: dcNotificationViewChat,
-            object: nil,
-            queue: nil) { [weak self] notification in
-                if let chatId = notification.userInfo?["chat_id"] as? Int {
-                    self?.showChat(chatId: chatId)
-                }
-        }
         foregroundObserver = nc.addObserver(self,
                                             selector: #selector(applicationDidBecomeActive(_:)),
                                             name: UIApplication.didBecomeActiveNotification,
@@ -155,9 +147,6 @@ class ChatListController: UITableViewController {
         }
         if let incomingMsgObserver = self.incomingMsgObserver {
             nc.removeObserver(incomingMsgObserver)
-        }
-        if let viewChatObserver = self.viewChatObserver {
-            nc.removeObserver(viewChatObserver)
         }
         if let msgsNoticedObserver = self.msgsNoticedObserver {
             nc.removeObserver(msgsNoticedObserver)

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -85,10 +85,10 @@ class AppCoordinator {
         tabBarController.selectedIndex = index
     }
 
-    func showChat(chatId: Int, animated: Bool = true) {
+    func showChat(chatId: Int, msgId: Int? = nil, animated: Bool = true) {
         showTab(index: chatsTab)
         if let rootController = self.chatsNavController.viewControllers.first as? ChatListController {
-            rootController.showChat(chatId: chatId, animated: animated)
+            rootController.showChat(chatId: chatId, highlightedMsg: msgId, animated: animated)
         }
     }
 


### PR DESCRIPTION
* implements jumping from a notification to the message
* ensures foreground notifications (before not working at all, since the method signature was wrong), are shown in a non-intrusive way. Instead of showing an alert for each incoming message, (the last) unread message is only shown in the message center.

fixes #721 