### PR TITLE
Improve notification layout

### DIFF
--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -17,35 +17,37 @@ public class NotificationManager {
                let messageId = ui["message_id"] as? Int {
                 let chat = DcContext.shared.getChat(chatId: chatId)
                 if !UserDefaults.standard.bool(forKey: "notifications_disabled") && !chat.isMuted {
-                    let content = UNMutableNotificationContent()
-                    let msg = DcMsg(id: messageId)
-                    content.title = chat.isGroup ? chat.name : msg.getSenderName(msg.fromContact)
-                    content.body =  msg.summary(chars: 80) ?? ""
-                    content.subtitle = chat.isGroup ?  msg.getSenderName(msg.fromContact) : ""
-                    content.userInfo = ui
-                    content.sound = .default
+                    DispatchQueue.global(qos: .background).async {
+                        let content = UNMutableNotificationContent()
+                        let msg = DcMsg(id: messageId)
+                        content.title = chat.isGroup ? chat.name : msg.getSenderName(msg.fromContact)
+                        content.body =  msg.summary(chars: 80) ?? ""
+                        content.subtitle = chat.isGroup ?  msg.getSenderName(msg.fromContact) : ""
+                        content.userInfo = ui
+                        content.sound = .default
 
-                    if msg.type == DC_MSG_IMAGE || msg.type == DC_MSG_GIF,
-                       let url = msg.fileURL {
-                        do {
-                            // make a copy of the file first since UNNotificationAttachment will move attached files into the attachment data store
-                            // so that they can be accessed by all of the appropriate processes
-                            let tempUrl = url.deletingLastPathComponent()
-                                .appendingPathComponent("notification_tmp")
-                                .appendingPathExtension(url.pathExtension)
-                            try FileManager.default.copyItem(at: url, to: tempUrl)
-                            if let attachment = try? UNNotificationAttachment(identifier: Constants.notificationIdentifier, url: tempUrl, options: nil) {
-                                content.attachments = [attachment]
+                        if msg.type == DC_MSG_IMAGE || msg.type == DC_MSG_GIF,
+                           let url = msg.fileURL {
+                            do {
+                                // make a copy of the file first since UNNotificationAttachment will move attached files into the attachment data store
+                                // so that they can be accessed by all of the appropriate processes
+                                let tempUrl = url.deletingLastPathComponent()
+                                    .appendingPathComponent("notification_tmp")
+                                    .appendingPathExtension(url.pathExtension)
+                                try FileManager.default.copyItem(at: url, to: tempUrl)
+                                if let attachment = try? UNNotificationAttachment(identifier: Constants.notificationIdentifier, url: tempUrl, options: nil) {
+                                    content.attachments = [attachment]
+                                }
+                            } catch let error {
+                                logger.error("Failed to copy file \(url) for notification preview generation: \(error)")
                             }
-                        } catch let error {
-                            logger.error("Failed to copy file \(url) for notification preview generation: \(error)")
                         }
-                    }
-                    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
+                        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
 
-                    let request = UNNotificationRequest(identifier: Constants.notificationIdentifier, content: content, trigger: trigger)
-                    UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
-                    DcContext.shared.logger?.info("notifications: added \(content.title) \(content.body) \(content.userInfo)")
+                        let request = UNNotificationRequest(identifier: Constants.notificationIdentifier, content: content, trigger: trigger)
+                        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+                        DcContext.shared.logger?.info("notifications: added \(content.title) \(content.body) \(content.userInfo)")
+                    }
                 }
 
                 let array = DcContext.shared.getFreshMessages()

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -19,11 +19,28 @@ public class NotificationManager {
                 if !UserDefaults.standard.bool(forKey: "notifications_disabled") && !chat.isMuted {
                     let content = UNMutableNotificationContent()
                     let msg = DcMsg(id: messageId)
-                    content.title = msg.getSenderName(msg.fromContact)
-                    content.body = msg.summary(chars: 40) ?? ""
+                    content.title = chat.isGroup ? chat.name : msg.getSenderName(msg.fromContact)
+                    content.body =  msg.summary(chars: 80) ?? ""
+                    content.subtitle = chat.isGroup ?  msg.getSenderName(msg.fromContact) : ""
                     content.userInfo = ui
                     content.sound = .default
 
+                    if msg.type == DC_MSG_IMAGE || msg.type == DC_MSG_GIF,
+                       let url = msg.fileURL {
+                        do {
+                            // make a copy of the file first since UNNotificationAttachment will move attached files into the attachment data store
+                            // so that they can be accessed by all of the appropriate processes
+                            let tempUrl = url.deletingLastPathComponent()
+                                .appendingPathComponent("notification_tmp")
+                                .appendingPathExtension(url.pathExtension)
+                            try FileManager.default.copyItem(at: url, to: tempUrl)
+                            if let attachment = try? UNNotificationAttachment(identifier: Constants.notificationIdentifier, url: tempUrl, options: nil) {
+                                content.attachments = [attachment]
+                            }
+                        } catch let error {
+                            logger.error("Failed to copy file \(url) for notification preview generation: \(error)")
+                        }
+                    }
                     let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
 
                     let request = UNNotificationRequest(identifier: Constants.notificationIdentifier, content: content, trigger: trigger)


### PR DESCRIPTION
on top of #1095 (which needs to be reviewed and merged first)

closes #1107 

notification for a group:

![Notification1](https://user-images.githubusercontent.com/2614900/112499654-f9718580-8d87-11eb-848f-28b5d03df53c.png)

notification for a group - image message without text:
![Notification2](https://user-images.githubusercontent.com/2614900/112499663-fd050c80-8d87-11eb-82b3-9524947e1ba6.png)

notification for 1-1 chat from image message with text:
![Notification3](https://user-images.githubusercontent.com/2614900/112499664-fd9da300-8d87-11eb-85b2-6481aefc5c21.png)


