### PR TITLE
fix chat navigation bar on ios12

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -258,6 +258,7 @@ class ChatViewController: UITableViewController {
         tableView.separatorStyle = .none
         tableView.keyboardDismissMode = .interactive
         tableView.contentInsetAdjustmentBehavior = .never
+        navigationController?.setNavigationBarHidden(false, animated: false)
 
         if !dcContext.isConfigured() {
             // TODO: display message about nothing being configured

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -140,6 +140,7 @@ class ChatListController: UITableViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         stopTimer()
+        searchController.isActive = false
 
         let nc = NotificationCenter.default
         if let msgChangedObserver = self.msgChangedObserver {


### PR DESCRIPTION
fixes #1102 
* also resets the search in the chat list disappears. It can be assumed the search has been finished then.