### PR TITLE
Revert "reset search if user tapped on a chat in the chat list"

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -140,7 +140,6 @@ class ChatListController: UITableViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         stopTimer()
-        searchController.isActive = false
 
         let nc = NotificationCenter.default
         if let msgChangedObserver = self.msgChangedObserver {


### PR DESCRIPTION
This reverts commit 93fb08edeb107e6d1c1d4c57f5dae4d142adc356 as one part of #1110.

once a search is done and the user hits "back", it make sense imho to show the search result again; this is what we are doing on android as well and what also whatsapp is doing, "cancel" shows the chatlist then, this is easy enough.

i though, the .isActive hides only the keyboard when coming back to search, which, indeed, would be an improvement.