### PR TITLE
call ApplicationIconBadgeNumber from mainthread

### DIFF
--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -41,8 +41,6 @@ public class NotificationManager {
                         return
                     }
 
-                    let array = DcContext.shared.getFreshMessages()
-                    UIApplication.shared.applicationIconBadgeNumber = array.count
                     NotificationManager.updateApplicationIconBadge(reset: false)
 
                     let chat = DcContext.shared.getChat(chatId: chatId)

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -10,11 +10,13 @@ public class NotificationManager {
 
 
     public static func updateApplicationIconBadge(reset: Bool) {
-        if reset {
-            UIApplication.shared.applicationIconBadgeNumber = 0
-        } else {
-            let array = DcContext.shared.getFreshMessages()
-            UIApplication.shared.applicationIconBadgeNumber = array.count
+        var unreadMessages = 0
+        if !reset {
+            unreadMessages = DcContext.shared.getFreshMessages().count
+        }
+
+        DispatchQueue.main.async {
+            UIApplication.shared.applicationIconBadgeNumber = unreadMessages
         }
     }
 


### PR DESCRIPTION
successor of #1119, see my comment there

closes #1121

this can be tested only after #1120 was merged, it contains an important fix for the msgsNoticedObserver.