### PR TITLE
multiple notifications

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -426,6 +426,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // MARK: - Handle notification banners
 
     // This method will be called if an incoming message was received while the app was in forground.
+    // We don't show foreground notifications in the notification center because they don't get grouped properly
     func userNotificationCenter(_: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         logger.info("forground notification")
         completionHandler([.badge])

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -439,7 +439,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     // this method will be called if the user tapped on a notification
     func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        if response.notification.request.identifier == Constants.notificationIdentifier {
+        if !response.notification.request.identifier.containsExact(subSequence: Constants.notificationIdentifier).isEmpty {
             logger.info("handling notifications")
             let userInfo = response.notification.request.content.userInfo
              if let chatId = userInfo["chat_id"] as? Int,

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -426,15 +426,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // MARK: - Handle notification banners
 
     // This method will be called if an incoming message was received while the app was in forground.
-    // On iOS 14+ we show a non-intrusive notification in the notification center, if the notification doesn't belong to a currently opened chat.
-    // On pre iOS 14 this feature isn't available so we're just triggering to show the badge at the launcher icon. This will only have an effect for unread messages > 0
     func userNotificationCenter(_: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         logger.info("forground notification")
-        if #available(iOS 14.0, *) {
-            completionHandler([.list, .badge])
-        } else {
-            completionHandler([.badge])
-        }
+        completionHandler([.badge])
     }
 
     // this method will be called if the user tapped on a notification

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -323,6 +323,8 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
             if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
                 appDelegate.registerForNotifications()
             }
+        } else {
+            NotificationManager.deleteAllNotifications()
         }
         UserDefaults.standard.synchronize()
         NotificationManager.updateApplicationIconBadge(reset: !sender.isOn)

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -324,7 +324,7 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
                 appDelegate.registerForNotifications()
             }
         } else {
-            NotificationManager.deleteAllNotifications()
+            NotificationManager.removeAllNotifications()
         }
         UserDefaults.standard.synchronize()
         NotificationManager.updateApplicationIconBadge(reset: !sender.isOn)

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -40,11 +40,6 @@ public class NotificationManager {
                    let chatId = ui["chat_id"] as? Int,
                    let messageId = ui["message_id"] as? Int,
                    !UserDefaults.standard.bool(forKey: "notifications_disabled") {
-                    
-                    if let lastChatId = AppStateRestorer.shared.restoreLastActiveChatId(),
-                       lastChatId == chatId {
-                        return
-                    }
 
                     NotificationManager.updateApplicationIconBadge(reset: false)
 

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -24,7 +24,7 @@ public class NotificationManager {
         }
     }
 
-    public static func deleteAllNotifications() {
+    public static func removeAllNotifications() {
         let nc = UNUserNotificationCenter.current()
         nc.removeAllDeliveredNotifications()
         nc.removeAllPendingNotificationRequests()

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -86,7 +86,7 @@ public class NotificationManager {
                                                         content: content,
                                                         trigger: trigger)
                     UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
-                    DcContext.shared.logger?.info("notifications: added \(content.title) \(content.body) \(content.userInfo)")
+                    logger.info("notifications: added \(content.title) \(content.body) \(content.userInfo)")
                 }
             }
         }

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -8,6 +8,10 @@ public class NotificationManager {
     var incomingMsgObserver: Any?
     var msgsNoticedObserver: Any?
 
+    init() {
+        initIncomingMsgsObserver()
+        initMsgsNoticedObserver()
+    }
 
     public static func updateApplicationIconBadge(reset: Bool) {
         var unreadMessages = 0
@@ -20,9 +24,10 @@ public class NotificationManager {
         }
     }
 
-    init() {
-        initIncomingMsgsObserver()
-        initMsgsNoticedObserver()
+    public static func deleteAllNotifications() {
+        let nc = UNUserNotificationCenter.current()
+        nc.removeAllDeliveredNotifications()
+        nc.removeAllPendingNotificationRequests()
     }
 
     private func initIncomingMsgsObserver() {
@@ -73,8 +78,13 @@ public class NotificationManager {
                         }
                     }
                     let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
-
-                    let request = UNNotificationRequest(identifier: Constants.notificationIdentifier, content: content, trigger: trigger)
+                    let accountEmail = DcContact(id: Int(DC_CONTACT_ID_SELF)).email
+                    if #available(iOS 12.0, *) {
+                        content.threadIdentifier = "\(accountEmail)\(chatId)"
+                    }
+                    let request = UNNotificationRequest(identifier: "\(Constants.notificationIdentifier).\(accountEmail).\(chatId).\(msg.messageId)",
+                                                        content: content,
+                                                        trigger: trigger)
                     UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
                     DcContext.shared.logger?.info("notifications: added \(content.title) \(content.body) \(content.userInfo)")
                 }
@@ -86,14 +96,48 @@ public class NotificationManager {
         msgsNoticedObserver =  NotificationCenter.default.addObserver(
             forName: dcMsgsNoticed,
             object: nil, queue: OperationQueue.main
-        ) { _ in
-            DispatchQueue.global(qos: .background).async {
+        ) { notification in
+            DispatchQueue.global(qos: .background).async { [weak self] in
                 if !UserDefaults.standard.bool(forKey: "notifications_disabled") {
                     NotificationManager.updateApplicationIconBadge(reset: false)
+                    if let ui = notification.userInfo,
+                       let chatId = ui["chat_id"] as? Int {
+                        self?.removePendingNotificationsFor(chatId: chatId)
+                        self?.removeDeliveredNotificationsFor(chatId: chatId)
+                    }
                 }
             }
         }
     }
+
+    private func removeDeliveredNotificationsFor(chatId: Int) {
+        var identifiers = [String]()
+        let nc = UNUserNotificationCenter.current()
+        nc.getDeliveredNotifications { notifications in
+            let accountEmail = DcContact(id: Int(DC_CONTACT_ID_SELF)).email
+            for notification in notifications {
+                if !notification.request.identifier.containsExact(subSequence: "\(Constants.notificationIdentifier).\(accountEmail).\(chatId)").isEmpty {
+                    identifiers.append(notification.request.identifier)
+                }
+            }
+            nc.removeDeliveredNotifications(withIdentifiers: identifiers)
+        }
+    }
+
+    private func removePendingNotificationsFor(chatId: Int) {
+        var identifiers = [String]()
+        let nc = UNUserNotificationCenter.current()
+        nc.getPendingNotificationRequests { notificationRequests in
+            let accountEmail = DcContact(id: Int(DC_CONTACT_ID_SELF)).email
+            for request in notificationRequests {
+                if !request.identifier.containsExact(subSequence: "\(Constants.notificationIdentifier).\(accountEmail).\(chatId)").isEmpty {
+                    identifiers.append(request.identifier)
+                }
+            }
+            nc.removePendingNotificationRequests(withIdentifiers: identifiers)
+        }
+    }
+
     
     deinit {
         NotificationCenter.default.removeObserver(self)


### PR DESCRIPTION
* show multiple background notifications, threaded per chat
* remove notifications if corresponding chat was opened
closes #1106 
* removes foreground notifications feature, see https://github.com/deltachat/deltachat-ios/pull/1124/commits/ed87be56092f446b465177af351202d70b304f7e: iOS handles foreground notifications visually differently than background notifications. It puts foreground notifications above grouped background notifications as a list of single notifications (thus the foreground notification option .list). This clutters the notification area (that you can reach by pulling down from the top of the screen) extremely fast. There's no API to force those foreground notifications being grouped even though they've got a threadIdentifier. After all, grouped background notifications seem to be more valuable than foreground notifications, so we remove the latter feature in favor of getting the former done right. 