### PR TITLE
set bgIoTimestamp also on init

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -20,11 +20,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     var window: UIWindow?
     var notifyToken: String?
 
-    // `bgIoTimestamp` is set to last enter-background or last remote- or local-wakeup.
-    // in the minute after these events, subsequent remote- or local-wakeups are skipped -
+    // purpose of `bgIoTimestamp` is to block rapidly subsequent calls to remote- or local-wakeups:
+    //
+    // `bgIoTimestamp` is set to last init, enter-background or last remote- or local-wakeup;
+    // in the minute after these events, subsequent remote- or local-wakeups are skipped
     // in favor to the chance of being awakened when it makes more sense
     // and to avoid issues with calling concurrent series of startIo/maybeNetwork/stopIo.
-    var bgIoTimestamp: Double = 0.0
+    private var bgIoTimestamp: Double = 0.0
 
 
     // MARK: - app main entry point
@@ -43,6 +45,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // explicitly ignore SIGPIPE to avoid crashes, see https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/CommonPitfalls/CommonPitfalls.html
         // setupCrashReporting() may create an additional handler, but we do not want to rely on that
         signal(SIGPIPE, SIG_IGN)
+
+        bgIoTimestamp = Double(Date().timeIntervalSince1970)
 
         DBDebugToolkit.setup(with: []) // empty array will override default device shake trigger
         DBDebugToolkit.setupCrashReporting()

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -488,10 +488,6 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
 
         if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
             info += "notify-token=\(appDelegate.notifyToken ?? "<unset>")\n"
-
-            let timestampDbl = appDelegate.bgIoTimestamp
-            let timestampStr = timestampDbl==0.0 ? "<unset>" : DateUtils.getExtendedRelativeTimeSpanString(timeStamp: timestampDbl)
-            info += "last-bg-io=\(timestampStr)\n"
         }
 
         #if DEBUG


### PR DESCRIPTION
the main purpose of the timestamp is to block rapidly subsequent calls
to remote- or local wakeup;
therefore set it also on init.

moreover, also on init, we're in background,
so it makes also sense from that perspective.