### PR TITLE
speed up chatlist and globel search

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -53,7 +53,10 @@ public class DcContext {
     }
 
     public func getContacts(flags: Int32, queryString: String? = nil) -> [Int] {
+        let start = CFAbsoluteTimeGetCurrent()
         let cContacts = dc_get_contacts(contextPointer, UInt32(flags), queryString)
+        let diff = CFAbsoluteTimeGetCurrent() - start
+        logger?.info("⏰ getContacts: \(diff) s")
         return DcUtils.copyAndFreeArray(inputArray: cContacts)
     }
 
@@ -426,10 +429,13 @@ public class DcContext {
     }
 
     public func searchMessages(chatId: Int = 0, searchText: String) -> [Int] {
+        let start = CFAbsoluteTimeGetCurrent()
         guard let arrayPointer = dc_search_msgs(contextPointer, UInt32(chatId), searchText) else {
             return []
         }
         let messageIds = DcUtils.copyAndFreeArray(inputArray: arrayPointer)
+        let diff = CFAbsoluteTimeGetCurrent() - start
+        logger?.info("⏰ searchMessages: \(diff) s")
         return messageIds
     }
 

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -173,7 +173,9 @@ class ChatListController: UITableViewController {
     @objc func applicationDidBecomeActive(_ notification: NSNotification) {
         if navigationController?.visibleViewController == self {
             startTimer()
-            viewModel.refreshData()
+            DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+                self?.viewModel.refreshData()
+            }
         }
     }
 

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -79,8 +79,14 @@ class ChatListViewModel: NSObject, ChatListViewModelProtocol {
             gclFlags |= DC_GCL_FOR_FORWARDING
         }
         self.chatList = dcContext.getChatlist(flags: gclFlags, queryString: nil, queryId: 0)
-        if notifyListener {
-            onChatListUpdate?()
+        if notifyListener, let onChatListUpdate = onChatListUpdate {
+            if Thread.isMainThread {
+                onChatListUpdate()
+            } else {
+                DispatchQueue.main.async {
+                    onChatListUpdate()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
this pr speeds up the normal chatlist:

- by moving the expensive `getChatlist()` [1] to a background thread wherever possible. once the data are there, the update is dispatched to the main thread (see `ChatListController::refreshInBg()` to dispatch to bg and `ChatListViewModel` that dispatches calls to `onChatListUpdate()` again to main thread)

- moreover, when another refresh event arrives while we are already in updated, this is not directly dispatched as before (which would result in a "run after"). instead, the flag `needsAnotherBgRefresh` is set, and once the initial update is done, the bg thread waits a little time (to not starve ui) and an additional refresh is done.

- this way, some refreshes may be skipped, but the most recent one is always executed (sort of classical debouncing)

moreover, this pr speeds up the global search:

- using the same approaches as above

- plus, when a chat or contact result is there, but the search has changed in between, search for messages is aborted and the partial result is shown. this has the following benefits:
    - the slowest search (for messages [2]) is skipped often if favor to doing chat and contact search
    - the skipped search is usually not even visible to the user as chats/contacts are displayed above
    - the search for messages is done once there is enough time (user stops typing for some 100ms and the other searches are done

- plus, for a one-letter-search, search for messages is always skipped.

the pr is currently implemented using two boolean values, not sure of other "thread tools" are neeed, for testing that was pretty pretty sufficient - and, i did not see disadvantages yet. once they occur, we can improve anyway :)

due to some bad formatting in the source, better review with whitespace disabled.

closes #1149 

---
[1] `getChatlist()`  takes 200~300ms on my 3gig db on iphone7, this is not slow, but noticeable when the ui is blocked in that time
[2] `searchMessages()` may take 1000-2000ms, esp. for short terms. searching for >1 character, on my 3gig db i am usually below 1000ms