### PR TITLE
update backup path, since Catalina 10.5, iTunes is replaced by Finder

### DIFF
--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -740,7 +740,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
                     title: String.localized("import_backup_title"),
                     message: String.localizedStringWithFormat(
                         String.localized("import_backup_no_backup_found"),
-                        "iTunes / <Your Device> / File Sharing / Delta Chat"), // TOOD: maybe better use an iOS-specific string here
+                        "➔ Mac-Finder or iTunes ➔ iPhone ➔ " + String.localized("files") + " ➔ Delta Chat"), // iTunes was used up to Maverick 10.4
                     preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: String.localized("ok"), style: .cancel))
                 present(alert, animated: true)


### PR DESCRIPTION
this is complicated anyway, i created a [how-to in the forum](https://support.delta.chat/t/import-backup-to-ios/1628), not sure if further improvements that in that dialog would really help and are worth the effort, esp. as a nicer multi-device-setup gets more reachable ;)