### PR TITLE
show notification-status and backgroundRefreshStatus

### DIFF
--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -475,6 +475,13 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
     public static func showDebugToolkit(dcContext: DcContext) {
         var info = ""
 
+        let notifyEnabled = !UserDefaults.standard.bool(forKey: "notifications_disabled")
+        info += "notify-enabled=\(notifyEnabled)\n"
+
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            info += "notify-token=\(appDelegate.notifyToken ?? "<unset>")\n"
+        }
+
         for name in ["notify-remote-launch", "notify-remote-receive", "notify-local-wakeup"] {
             let cnt = UserDefaults.standard.integer(forKey: name + "-count")
 
@@ -487,9 +494,13 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
             info += "\(name)=\(cnt)x\(startStr)\(timestampStr)\n"
         }
 
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            info += "notify-token=\(appDelegate.notifyToken ?? "<unset>")\n"
+        var val = "?"
+        switch UIApplication.shared.backgroundRefreshStatus {
+        case .restricted: val = "restricted"
+        case .available: val = "available"
+        case .denied: val = "denied"
         }
+        info += "backgroundRefreshStatus=\(val)\n"
 
         #if DEBUG
         info += "DEBUG=1\n"

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -475,6 +475,9 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
     public static func showDebugToolkit(dcContext: DcContext) {
         var info = ""
 
+        let systemVersion = UIDevice.current.systemVersion
+        info += "iosVersion=\(systemVersion)\n"
+
         let notifyEnabled = !UserDefaults.standard.bool(forKey: "notifications_disabled")
         info += "notify-enabled=\(notifyEnabled)\n"
 


### PR DESCRIPTION
if possible, we should also add some information about silent-mode, do-not-disturb etc. also ios version is missing.

EDIT: for silent-mode, do-not-disturb - seems as if these modes are not easily/reliably detectable, see eg. https://stackoverflow.com/questions/17560765/how-can-i-detect-dnd-mode-within-an-app

closes #1165