### PR TITLE
adjust quality-of-service for background task

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -411,12 +411,12 @@ class ChatListController: UITableViewController {
             self.showChat(chatId: chat.id)
         }))
         alert.addAction(UIAlertAction(title: String.localized("not_now"), style: .default, handler: { _ in
-            DispatchQueue.global(qos: .background).async {
+            DispatchQueue.global(qos: .userInitiated).async {
                 self.dcContext.decideOnContactRequest(msgId, DC_DECISION_NOT_NOW)
             }
         }))
         alert.addAction(UIAlertAction(title: blockButton, style: .destructive, handler: { _ in
-            DispatchQueue.global(qos: .background).async {
+            DispatchQueue.global(qos: .userInitiated).async {
                 self.dcContext.decideOnContactRequest(msgId, DC_DECISION_BLOCK)
             }
         }))

--- a/deltachat-ios/Controller/FullMessageViewController.swift
+++ b/deltachat-ios/Controller/FullMessageViewController.swift
@@ -132,7 +132,7 @@ class FullMessageViewController: WebViewViewController {
     }
 
     private func loadHtml() {
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
             let html = self.dcContext.getMsgHtml(msgId: self.messageId)
             DispatchQueue.main.async {

--- a/deltachat-ios/Controller/HelpViewController.swift
+++ b/deltachat-ios/Controller/HelpViewController.swift
@@ -21,7 +21,7 @@ class HelpViewController: WebViewViewController {
 
     private func loadHtmlContent(completionHandler: ((URL) -> Void)?) {
         // execute in background thread because file loading would blockui for a few milliseconds
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue.global(qos: .userInitiated).async {
             let langAndRegion = Locale.preferredLanguages.first ?? "en"
             let langOnly = String(langAndRegion.split(separator: "-").first ?? Substring("ErrLang"))
             var fileURL: URL?


### PR DESCRIPTION
~~`.userInteractive`~~ `.userInitiated` should be used for background tasks affecting the UI
and may block the user.
not sure, if that makes a huge difference, ist just came over that -
and i have the feeling, html-pages are loaded faster now :)

https://developer.apple.com/documentation/dispatch/dispatchqos