### PR TITLE
on show_emails=all, open contact-request-chat

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -287,7 +287,12 @@ class ChatListController: UITableViewController {
         switch cellData.type {
         case .deaddrop(let deaddropData):
             safe_assert(deaddropData.chatId == DC_CHAT_ID_DEADDROP)
-            showDeaddropRequestAlert(msgId: deaddropData.msgId)
+            if dcContext.showEmails == DC_SHOW_EMAILS_ALL {
+                let deaddropViewController = MailboxViewController(dcContext: dcContext, chatId: Int(DC_CHAT_ID_DEADDROP))
+                navigationController?.pushViewController(deaddropViewController, animated: true)
+            } else {
+                showDeaddropRequestAlert(msgId: deaddropData.msgId)
+            }
         case .chat(let chatData):
             let chatId = chatData.chatId
             if chatId == DC_CHAT_ID_ARCHIVED_LINK {


### PR DESCRIPTION
if all emails are handled by Delta Chat,
there will typicaly be much more "contact requests" as usual.

handling these contact requests in the stacked way, one by one,
is some pain.
for a first improvement, we just open the contact-request-chat directly,
the user can pick a contact request from there.

more improvements are in disussion, see
https://github.com/deltachat/deltachat-android/issues/1896
and recent irc discussions.