### PR TITLE
simplify chat deletion

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -458,9 +458,7 @@ class ChatListController: UITableViewController {
             return
         }
 
-        if let row = viewModel.deleteChat(chatId: chatId) {
-            tableView.deleteRows(at: [IndexPath(row: row, section: 0)], with: .fade)
-        }
+        viewModel.deleteChat(chatId: chatId)
     }
 
     // MARK: - coordinator

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -22,8 +22,7 @@ protocol ChatListViewModelProtocol: class, UISearchResultsUpdating {
     func titleForHeaderIn(section: Int) -> String? // only visible on search results
     var emptySearchText: String? { get }
 
-    /// returns ROW of table
-    func deleteChat(chatId: Int) -> Int?
+    func deleteChat(chatId: Int)
     func archiveChatToggle(chatId: Int)
     func pinChatToggle(chatId: Int)
     func refreshData()
@@ -201,18 +200,8 @@ class ChatListViewModel: NSObject, ChatListViewModelProtocol {
         return nil
     }
 
-    func deleteChat(chatId: Int) -> Int? {
-        // find index of chatId
-        let indexToDelete = Array(0..<chatList.length).filter { chatList.getChatId(index: $0) == chatId }.first
-        let chat = dcContext.getChat(chatId: chatId)
+    func deleteChat(chatId: Int) {
         dcContext.deleteChat(chatId: chatId)
-        updateChatList(notifyListener: false)
-        safe_assert(indexToDelete != nil)
-        // Do not return the index of the tableview cell for the selfTalk chat:
-        // Immediately after deleting the chat, a message to the device talk chat gets added.
-        // If the device talk chat was not existing it would be created and added to the table data source.
-        // That case invalidates the index.
-        return chat.isSelfTalk ? nil : indexToDelete
     }
 
     func archiveChatToggle(chatId: Int) {


### PR DESCRIPTION
that should be merged into https://github.com/deltachat/deltachat-ios/pull/1179

dc_delete_chat already emits DC_EVENT_MSGS_CHANGED
that we are observing and update the chatlist on changes -
so, there is nothing special to do beside calling dc_delete_chat :)

archive/pin also might do superfluous things, i have not checked that, that can go to another pr, however.

EDIT: that may skip a remove-animation, however, as we do not have that for "archive" as well (which is probably used as many times), that'd be fine. if desired, in another pr, we can re-add animation by _first_ doing ui-cell-removal and in its closure, finally calling deleteChat.