### PR TITLE
Narrow chat bubbles

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -4,7 +4,7 @@ import DcCore
 import SDWebImage
 
 class ImageTextCell: BaseMessageCell {
-
+    let minImageWidth: CGFloat = 175
     var imageHeightConstraint: NSLayoutConstraint?
     var imageWidthConstraint: NSLayoutConstraint?
 
@@ -112,9 +112,9 @@ class ImageTextCell: BaseMessageCell {
         self.imageWidthConstraint?.isActive = false
         
         // check if image has the allowed minimal width
-        if width < 175 {
-            height = (height / width) * 175
-            width = 175
+        if width < minImageWidth {
+            height = (height / width) * minImageWidth
+            width = minImageWidth
         }
         
         if  height > width {
@@ -138,7 +138,11 @@ class ImageTextCell: BaseMessageCell {
                 self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(lessThanOrEqualTo: self.contentImageView.heightAnchor,
                                                                                          multiplier: width/height)
             } else {
-                self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(lessThanOrEqualToConstant: width)
+                if width == minImageWidth {
+                    self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(equalToConstant: width)
+                } else {
+                    self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(lessThanOrEqualToConstant: width)
+                }
                 self.imageHeightConstraint = self.contentImageView.heightAnchor.constraint(
                     lessThanOrEqualTo: self.contentImageView.widthAnchor,
                     multiplier: height / width

--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -104,10 +104,19 @@ class ImageTextCell: BaseMessageCell {
         if height == 0 || width == 0 {
             return
         }
+        var width = width
+        var height = height
 
         let orientation = UIApplication.shared.statusBarOrientation
         self.imageHeightConstraint?.isActive = false
         self.imageWidthConstraint?.isActive = false
+        
+        // check if image has the allowed minimal width
+        if width < 175 {
+            height = (height / width) * 175
+            width = 175
+        }
+        
         if  height > width {
             // show square image for portrait images
             // restrict width to half of the screen in device landscape and to 5 / 6 in portrait

--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -139,8 +139,10 @@ class ImageTextCell: BaseMessageCell {
                                                                                          multiplier: width/height)
             } else {
                 if width == minImageWidth {
+                    // very small width images should be forced to not be scaled down further
                     self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(equalToConstant: width)
                 } else {
+                    // large width images might scale down until the max allowed text width
                     self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(lessThanOrEqualToConstant: width)
                 }
                 self.imageHeightConstraint = self.contentImageView.heightAnchor.constraint(


### PR DESCRIPTION
fixes #1147 

sets the minimal width of images with text to 175 dp, same for landscape images without text, see the image below 

<img width="321" alt="Screen Shot 2021-04-29 at 4 59 02 PM" src="https://user-images.githubusercontent.com/2614900/116572601-68ed0e80-a90c-11eb-8b64-3b8b9eca3bf0.png">


We might increase the minimal width even a little bit more. That can be done easily by changing a constant.