### PR TITLE
adapt chat bubble size

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -4,7 +4,7 @@ import DcCore
 import SDWebImage
 
 class ImageTextCell: BaseMessageCell {
-    let minImageWidth: CGFloat = 175
+    let minImageWidth: CGFloat = 125
     var imageHeightConstraint: NSLayoutConstraint?
     var imageWidthConstraint: NSLayoutConstraint?
 
@@ -140,7 +140,7 @@ class ImageTextCell: BaseMessageCell {
             } else {
                 if width == minImageWidth {
                     // very small width images should be forced to not be scaled down further
-                    self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(equalToConstant: width)
+                    self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(greaterThanOrEqualToConstant: width)
                 } else {
                     // large width images might scale down until the max allowed text width
                     self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(lessThanOrEqualToConstant: width)

--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -117,14 +117,15 @@ class ImageTextCell: BaseMessageCell {
             width = minImageWidth
         }
         
+        // in some cases we show images in square sizes
+        // restrict width to half of the screen in device landscape and to 5 / 6 in portrait
+        // it results in a good balance between message text width and image size
+        let factor: CGFloat = orientation.isLandscape ? 1 / 2 : 5 / 6
+        var squareSize  = UIScreen.main.bounds.width * factor
+        
         if  height > width {
             // show square image for portrait images
-            // restrict width to half of the screen in device landscape and to 5 / 6 in portrait
-            // it results in a good balance between message text width and image size
-            let factor: CGFloat = orientation.isLandscape ? 1 / 2 : 5 / 6
-            var squareSize  = UIScreen.main.bounds.width * factor
-
-            //reduce the image square size if there's no message text so that it fits best in the viewable area
+            // reduce the image square size if there's no message text so that it fits best in the viewable area
             if squareSize > UIScreen.main.bounds.height * 5 / 8 && (messageLabel.text?.isEmpty ?? true) {
                 squareSize = UIScreen.main.bounds.height * 5 / 8
             }
@@ -138,7 +139,7 @@ class ImageTextCell: BaseMessageCell {
                 self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(lessThanOrEqualTo: self.contentImageView.heightAnchor,
                                                                                          multiplier: width/height)
             } else {
-                if width == minImageWidth {
+                if width < squareSize {
                     // very small width images should be forced to not be scaled down further
                     self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(greaterThanOrEqualToConstant: width)
                 } else {


### PR DESCRIPTION
* reduces minimal image width
* scales small images depending on message text width

<img width="612" alt="Screen Shot 2021-04-30 at 1 06 05 PM" src="https://user-images.githubusercontent.com/2614900/116687409-6abedc80-a9b5-11eb-8961-41789cc8f5ed.png">
<img width="330" alt="Screen Shot 2021-04-30 at 1 06 43 PM" src="https://user-images.githubusercontent.com/2614900/116687413-6d213680-a9b5-11eb-9e9f-baf1dafc538c.png">


follow up of https://github.com/deltachat/deltachat-ios/pull/1185


* personally, I like the design of https://github.com/deltachat/deltachat-ios/pull/1185 more