### PR TITLE
on scrollToRow(), check the real number of rows

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -757,7 +757,10 @@ class ChatViewController: UITableViewController {
         if !messageIds.isEmpty {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
-                self.tableView.scrollToRow(at: IndexPath(row: self.messageIds.count - 1, section: 0), at: .bottom, animated: animated)
+                let numberOfRows = self.tableView.numberOfRows(inSection: 0)
+                if numberOfRows > 0 {
+                    self.tableView.scrollToRow(at: IndexPath(row: numberOfRows - 1, section: 0), at: .bottom, animated: animated)
+                }
             }
         }
     }


### PR DESCRIPTION
messageIds.count may be out of sync;
it is probably okay to check that to avoid update,
but when the update is actually done,
we cannot scroll to a row that is not there
(otherwise, we get a crash)

fixes #1196, i first thought, that is related to the daymarkers,but the issue was proably also there before. maybe it has become more visible.

~~@cyBerta in case you are reading this - your mailbox is full, ppl tried to contact you~~ EDIT: that issue seems to be solved :)