### PR TITLE
remove unused ChatListViewModelProtocol

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -2,7 +2,7 @@ import UIKit
 import DcCore
 
 class ChatListController: UITableViewController {
-    let viewModel: ChatListViewModelProtocol
+    let viewModel: ChatListViewModel
     let dcContext: DcContext
 
     private let chatCellReuseIdentifier = "chat_cell"
@@ -46,7 +46,7 @@ class ChatListController: UITableViewController {
         return label
     }()
 
-    init(dcContext: DcContext, viewModel: ChatListViewModelProtocol) {
+    init(dcContext: DcContext, viewModel: ChatListViewModel) {
         self.viewModel = viewModel
         self.dcContext = dcContext
         if viewModel.isArchive {

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -133,7 +133,6 @@ class ChatListViewModel: NSObject {
         return nil
     }
 
-    // needed to differentiate betweeen deaddrop / archive / default
     func chatIdFor(section: Int, row: Int) -> Int? {
         let cellData = cellDataFor(section: section, row: row)
         switch cellData.type {

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -1,35 +1,9 @@
 import UIKit
 import DcCore
 
-// MARK: - ChatListViewModelProtocol
-protocol ChatListViewModelProtocol: class, UISearchResultsUpdating {
-
-    var onChatListUpdate: VoidFunction? { get set }
-
-    var isArchive: Bool { get }
-
-    var numberOfSections: Int { get }
-    func numberOfRowsIn(section: Int) -> Int
-    func cellDataFor(section: Int, row: Int) -> AvatarCellViewModel
-
-    func msgIdFor(row: Int) -> Int?
-    func chatIdFor(section: Int, row: Int) -> Int? // needed to differentiate betweeen deaddrop / archive / default
-
-    // search related
-    var searchActive: Bool { get }
-    func beginSearch()
-    func endSearch()
-    func titleForHeaderIn(section: Int) -> String? // only visible on search results
-    var emptySearchText: String? { get }
-
-    func deleteChat(chatId: Int)
-    func archiveChatToggle(chatId: Int)
-    func pinChatToggle(chatId: Int)
-    func refreshData()
-}
 
 // MARK: - ChatListViewModel
-class ChatListViewModel: NSObject, ChatListViewModelProtocol {
+class ChatListViewModel: NSObject {
 
     var onChatListUpdate: VoidFunction?
 
@@ -42,10 +16,10 @@ class ChatListViewModel: NSObject, ChatListViewModelProtocol {
         case messages
     }
 
-    var isArchive: Bool
+    private(set) public var isArchive: Bool
     private let dcContext: DcContext
 
-    var searchActive: Bool = false
+    private(set) public var searchActive: Bool = false
 
     // if searchfield is empty we show default chat list
     private var showSearchResults: Bool {
@@ -137,6 +111,7 @@ class ChatListViewModel: NSObject, ChatListViewModelProtocol {
         return makeChatCellViewModel(index: row, searchText: "")
     }
 
+    // only visible on search results
     func titleForHeaderIn(section: Int) -> String? {
         if showSearchResults {
             switch searchResultSections[section] {
@@ -158,6 +133,7 @@ class ChatListViewModel: NSObject, ChatListViewModelProtocol {
         return nil
     }
 
+    // needed to differentiate betweeen deaddrop / archive / default
     func chatIdFor(section: Int, row: Int) -> Int? {
         let cellData = cellDataFor(section: section, row: row)
         switch cellData.type {


### PR DESCRIPTION
this pr removes the last unused `ViewModelProtocol`, we decided some time ago, to add complexity only when we have a use of that. as a rule of thumb, complex classes, used only once and splitting code over objects and files are questionable.

also removing `ChatListViewModel`, however, produces too much noise currently and may result in bugs, i would not go for that now. we can continue refactoring, when we are actually working on that part (we thought be would by the recent fixes, the they're related to other parts :)

overhead is already reduced by 1/3rd, so i suggest to merge that without further refactoring :)