### PR TITLE
Always set timer to nil after being invalidated

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -279,10 +279,13 @@ class ChatViewController: UITableViewController {
 
     private func startTimer() {
         stopTimer()
-        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in
             // reload table
-            DispatchQueue.main.async {
-                guard let self = self, let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self,
+                      let appDelegate = UIApplication.shared.delegate as? AppDelegate
+                else { return }
+                
                 if appDelegate.appIsInForeground() {
                     self.messageIds = self.getMessageIds()
                     self.reloadData()

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -278,26 +278,26 @@ class ChatViewController: UITableViewController {
     }
 
     private func startTimer() {
-        // check if the timer is not yet started
-        if !(timer?.isValid ?? false) {
-            timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
-                //reload table
-                DispatchQueue.main.async {
-                    guard let self = self, let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-                    if appDelegate.appIsInForeground() {
-                        self.messageIds = self.getMessageIds()
-                        self.reloadData()
-                    }
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            // reload table
+            DispatchQueue.main.async {
+                guard let self = self, let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+                if appDelegate.appIsInForeground() {
+                    self.messageIds = self.getMessageIds()
+                    self.reloadData()
                 }
             }
         }
     }
 
     private func stopTimer() {
-        // check if the timer is not already stopped
-        if timer?.isValid ?? false {
-            timer?.invalidate()
+        if let timer = timer {
+            if timer.isValid {
+                timer.invalidate()
+            }
         }
+        timer = nil
     }
 
     private func configureEmptyStateView() {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -295,9 +295,7 @@ class ChatViewController: UITableViewController {
 
     private func stopTimer() {
         if let timer = timer {
-            if timer.isValid {
-                timer.invalidate()
-            }
+            timer.invalidate()
         }
         timer = nil
     }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -279,7 +279,7 @@ class ChatViewController: UITableViewController {
 
     private func startTimer() {
         stopTimer()
-        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in
+        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             // reload table
             DispatchQueue.main.async { [weak self] in
                 guard let self = self,

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -286,6 +286,8 @@ class ChatViewController: UITableViewController {
                 if appDelegate.appIsInForeground() {
                     self.messageIds = self.getMessageIds()
                     self.reloadData()
+                } else {
+                    logger.warning("startTimer() must not be executed in background")
                 }
             }
         }

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -370,18 +370,23 @@ class ChatListController: UITableViewController {
     
     private func startTimer() {
         // check if the timer is not yet started
-        if !(timer?.isValid ?? false) {
-            timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
-                self?.refreshInBg()
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            guard let self = self, let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+            if appDelegate.appIsInForeground() {
+                self.refreshInBg()
+            } else {
+                logger.warning("startTimer() must not be executed in background")
             }
         }
     }
     
     private func stopTimer() {
         // check if the timer is not already stopped
-        if timer?.isValid ?? false {
-            timer?.invalidate()
+        if let timer = timer {
+            timer.invalidate()
         }
+        timer = nil
     }
 
     // MARK: - alerts

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -372,7 +372,11 @@ class ChatListController: UITableViewController {
         // check if the timer is not yet started
         stopTimer()
         timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
-            guard let self = self, let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+            
+            guard let self = self,
+                  let appDelegate = UIApplication.shared.delegate as? AppDelegate
+            else { return }
+            
             if appDelegate.appIsInForeground() {
                 self.refreshInBg()
             } else {


### PR DESCRIPTION
related to #1210 and #1202

it's a small refactoring, which still ensures that always only 1 timer is running. however this implementation invalidates always any running timer and starts a new one, whereas the old implementation skipped starting a timer, when there was already one running before. 

on stop the timer gets nil'ed now, that's probably the most important change

