### PR TITLE
Notification archived chats

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -420,6 +420,7 @@ class ContactDetailViewController: UITableViewController {
             return
         }
         viewModel.context.deleteChat(chatId: viewModel.chatId)
+        NotificationManager.removeNotificationsForChat(chatId: viewModel.chatId)
 
         // just pop to viewControllers - we've in chatlist or archive then
         // (no not use `navigationController?` here: popping self will make the reference becoming nil)

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -330,6 +330,7 @@ class GroupChatDetailViewController: UIViewController {
 
     private func deleteChat() {
         dcContext.deleteChat(chatId: chatId)
+        NotificationManager.removeNotificationsForChat(chatId: chatId)
 
         // just pop to viewControllers - we've in chatlist or archive then
         // (no not use `navigationController?` here: popping self will make the reference becoming nil)

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -255,6 +255,9 @@ class GroupChatDetailViewController: UIViewController {
 
     private func toggleArchiveChat() {
         let archivedBefore = chat.isArchived
+        if (!archivedBefore) {
+            NotificationManager.removeNotificationsForChat(chatId: chatId)
+        }
         dcContext.archiveChat(chatId: chat.id, archive: !archivedBefore)
         if archivedBefore {
             archiveChatCell.actionTitle = String.localized("menu_archive_chat")

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -182,7 +182,11 @@ class ChatListViewModel: NSObject {
 
     func archiveChatToggle(chatId: Int) {
         let chat = dcContext.getChat(chatId: chatId)
-        dcContext.archiveChat(chatId: chatId, archive: !chat.isArchived)
+        let isArchivedBefore = chat.isArchived
+        if (!isArchivedBefore) {
+            NotificationManager.removeNotificationsForChat(chatId: chatId)
+        }
+        dcContext.archiveChat(chatId: chatId, archive: !isArchivedBefore)
         updateChatList(notifyListener: false)
     }
 

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -164,7 +164,11 @@ class ContactDetailViewModel {
             safe_fatalError("there is no chatId - you are probably are calling this from ContactDetail - this should be only called from ChatDetail")
             return false
         }
-        context.archiveChat(chatId: chatId, archive: !chatIsArchived)
+        let isArchivedBefore = chatIsArchived
+        if !isArchivedBefore {
+            NotificationManager.removeNotificationsForChat(chatId: chatId)
+        }
+        context.archiveChat(chatId: chatId, archive: !isArchivedBefore)
         return chatIsArchived
     }
 }


### PR DESCRIPTION
* fixes #1215 
* and also more bugs around notifications and chats that get deleted in the ContactDetails and GroupChatDetails ViewController. 

I purposely didn't move  `NotificationManager.removeNotificationsForChat()` into DcContext.deleteChat / DcContext.archiveChat, because imo the DcCore module shouldn't handle notifications as it is sth. specific to the main app module.