### PR TITLE
stop performFetch using a semaphore

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -388,7 +388,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         DispatchQueue.global(qos: .background).async { [weak self] in
             logger.info("➡️ fetching")
-            _ = fetchSemaphore.wait(timeout: .now() + 1000)
+            _ = fetchSemaphore.wait(timeout: .now() + 10)
 
             DispatchQueue.main.async { [weak self] in
                 logger.info("⬅️ finishing fetch")


### PR DESCRIPTION
this is an alternative to https://github.com/deltachat/deltachat-ios/pull/1220, without using lots of AppDelegate-global variables and problems resulting from that.

that would also prepare nicely for #1157 as only a signal needs to be raised (otherwise we would also get the completion handler into the AppDelegate-global.