### PR TITLE
add some addtitional padding top/bottom of status

### DIFF
--- a/deltachat-ios/View/MultilineLabelCell.swift
+++ b/deltachat-ios/View/MultilineLabelCell.swift
@@ -37,10 +37,10 @@ class MultilineLabelCell: UITableViewCell {
         contentView.addSubview(label)
 
         let margins = contentView.layoutMarginsGuide
-        label.alignLeadingToAnchor(margins.leadingAnchor, paddingLeading: 0)
+        label.alignLeadingToAnchor(margins.leadingAnchor)
         label.alignTrailingToAnchor(margins.trailingAnchor)
-        label.alignTopToAnchor(margins.topAnchor)
-        label.alignBottomToAnchor(margins.bottomAnchor)
+        label.alignTopToAnchor(margins.topAnchor, paddingTop: 10)
+        label.alignBottomToAnchor(margins.bottomAnchor, paddingBottom: 10)
 
         let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTapGesture(_:)))
         gestureRecognizer.numberOfTapsRequired = 1


### PR DESCRIPTION
in comparison to most other cells in the contact-profile,
the status contains lots of text, resulting in some "blackness";
the additional whitespace makes that look more homogeneous
and less stocky.

before/after:

<img width=250 src=https://user-images.githubusercontent.com/9800740/119718732-36c9c080-be68-11eb-93c1-f7e1edc907c5.PNG> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; <img width=250 src=https://user-images.githubusercontent.com/9800740/119718790-46e1a000-be68-11eb-82b4-e98f5b552227.PNG>
