### PR TITLE
Async image loading

### DIFF
--- a/deltachat-ios/Model/GalleryItem.swift
+++ b/deltachat-ios/Model/GalleryItem.swift
@@ -44,27 +44,36 @@ class GalleryItem: ContextMenuItem {
         switch viewtype {
         case .image:
             if url.pathExtension == "webp" {
-                loadAsyncImageThumbnail(from: url)
+                loadAsyncSDImageThumbnail(from: url)
             } else {
-                thumbnailImage = msg.image
+                loadAsyncUIImageThumbnail(from: url)
             }
         case .video:
             loadVideoThumbnail(from: url)
         case .gif:
-            loadAsyncImageThumbnail(from: url)
+            loadAsyncSDImageThumbnail(from: url)
         default:
             safe_fatalError("unsupported viewtype - viewtype \(viewtype) not supported.")
         }
     }
 
-    private func loadAsyncImageThumbnail(from url: URL) {
+    private func loadAsyncUIImageThumbnail(from url: URL) {
         DispatchQueue.global(qos: .userInteractive).async {
             guard let imageData = try? Data(contentsOf: url) else {
                 return
             }
-            let thumbnailImage = SDAnimatedImage(data: imageData)
+            let image = UIImage(data: imageData)
             DispatchQueue.main.async { [weak self] in
-                self?.thumbnailImage = thumbnailImage
+                    self?.thumbnailImage = image
+            }
+        }
+    }
+
+    private func loadAsyncSDImageThumbnail(from url: URL) {
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+            let image = SDAnimatedImage(contentsOfFile: url.path)
+            DispatchQueue.main.async { [weak self] in
+                    self?.thumbnailImage = image
             }
         }
     }


### PR DESCRIPTION
on top of #1245 (needs to be merged first, before this one can be reviewed)

Calling `DcMsg.image` is blocking and should be generally avoided whenever possible. 
This PR ensures that image loading in the gallery is always async.
for $reasons, SDAnimatedImage doesn't load all jpegs correctly, so that I had to implement a separate method to load pngs and jpegs in a UIImage
