### PR TITLE
keep keyboard open after cancelling drafts and quotes

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1558,11 +1558,13 @@ extension ChatViewController: InputBarAccessoryViewDelegate {
 // MARK: - DraftPreviewDelegate
 extension ChatViewController: DraftPreviewDelegate {
     func onCancelQuote() {
+        keepKeyboard = true
         draft.setQuote(quotedMsg: nil)
         configureDraftArea(draft: draft)
     }
 
     func onCancelAttachment() {
+        keepKeyboard = true
         draft.setAttachment(viewType: nil, path: nil, mimetype: nil)
         configureDraftArea(draft: draft)
         evaluateInputBar(draft: draft)


### PR DESCRIPTION
no ticket assigned to this PR

basically it completes the approach to keep the chat keyboard open as long as the user doesn't manually dismisses it. 

doesn't target #1243