### PR TITLE
Fix chat cell layout

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -110,6 +110,7 @@ class ImageTextCell: BaseMessageCell {
 
         self.imageHeightConstraint?.isActive = false
         self.imageWidthConstraint?.isActive = false
+        self.contentImageView.contentMode = .scaleAspectFit
 
         // check if sticker has the allowed minimal width
         if width < minImageWidth {

--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -145,7 +145,8 @@ class ImageTextCell: BaseMessageCell {
         let orientation = UIApplication.shared.statusBarOrientation
         self.imageHeightConstraint?.isActive = false
         self.imageWidthConstraint?.isActive = false
-        
+        var scaleType = ContentMode.scaleAspectFill
+
         // check if image has the allowed minimal width
         if width < minImageWidth {
             height = (height / width) * minImageWidth
@@ -177,16 +178,19 @@ class ImageTextCell: BaseMessageCell {
                 if width < squareSize {
                     // very small width images should be forced to not be scaled down further
                     self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(greaterThanOrEqualToConstant: width)
+                    self.imageHeightConstraint = self.contentImageView.heightAnchor.constraint(equalToConstant: height)
+                    scaleType = ContentMode.scaleAspectFit
                 } else {
                     // large width images might scale down until the max allowed text width
                     self.imageWidthConstraint = self.contentImageView.widthAnchor.constraint(lessThanOrEqualToConstant: width)
+                    self.imageHeightConstraint = self.contentImageView.heightAnchor.constraint(
+                        lessThanOrEqualTo: self.contentImageView.widthAnchor,
+                        multiplier: height / width
+                    )
                 }
-                self.imageHeightConstraint = self.contentImageView.heightAnchor.constraint(
-                    lessThanOrEqualTo: self.contentImageView.widthAnchor,
-                    multiplier: height / width
-                )
             }
         }
+        self.contentImageView.contentMode = scaleType
         self.imageHeightConstraint?.isActive = true
         self.imageWidthConstraint?.isActive = true
     }


### PR DESCRIPTION
fixes #1261 without scaling small images up to the maximum square size

also avoids stickers from being cut-off