### PR TITLE
hide signature in "Saved messages"

### DIFF
--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -57,9 +57,11 @@ class ContactDetailViewModel {
 
         sections.append(.chatOptions)
 
-        let dcContact = DcContact(id: contactId)
-        if !dcContact.status.isEmpty {
-            sections.append(.statusArea)
+        if !self.isSavedMessages {
+            let dcContact = DcContact(id: contactId)
+            if !dcContact.status.isEmpty {
+                sections.append(.statusArea)
+            }
         }
 
         if sharedChats.length > 0 && !isSavedMessages && !isDeviceTalk {


### PR DESCRIPTION
"Saved messages" would show the "Self" signature, while that may be okay if the chat would be named "Self chat" or so, for "Saved messages", this is a bit weird.

if we want a preview, we should add that somewhere else, it is not expected here.

also, this increases between-app-consistence: Android does not show the signature for "Saved messages" as well.