### PR TITLE
forward if message after daymarker is another marker

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -530,7 +530,11 @@ class ChatViewController: UITableViewController {
         if id == DC_MSG_ID_DAYMARKER {
             let cell = tableView.dequeueReusableCell(withIdentifier: "info", for: indexPath) as? InfoMessageCell ?? InfoMessageCell()
             if messageIds.count > indexPath.row + 1 {
-                let nextMessageId = messageIds[indexPath.row + 1]
+                var nextMessageId = messageIds[indexPath.row + 1]
+                if nextMessageId == DC_MSG_ID_MARKER1 && messageIds.count > indexPath.row + 2 {
+                    nextMessageId = messageIds[indexPath.row + 2]
+                }
+
                 let nextMessage = dcContext.getMessage(id: nextMessageId)
                 cell.update(text: DateUtils.getDateString(date: nextMessage.sentDate))
             } else {


### PR DESCRIPTION
alternative to #1279, closes #1276
 
a loop seems not to be required as three are no longer chains of markers. in the long-term, however, the date from the daymarker itself can be used, which, however, would require some more refactoring