### PR TITLE
add basic switch-account controls

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -8,6 +8,7 @@ public class DcAccounts {
     /// The ID is created in the apple developer portal and can be changed there.
     let applicationGroupIdentifier = "group.chat.delta.ios"
     var accountsPointer: OpaquePointer?
+    public var logger: Logger?
 
     public init() {
     }
@@ -28,7 +29,7 @@ public class DcAccounts {
 
     public func get(id: Int) -> DcContext {
         let contextPointer = dc_accounts_get_account(accountsPointer, UInt32(id))
-        return DcContext(contextPointer: contextPointer)
+        return DcContext(contextPointer: contextPointer, logger: logger)
     }
 
     public func getAll() -> [Int] {
@@ -38,7 +39,7 @@ public class DcAccounts {
 
     public func getSelected() -> DcContext {
         let cPtr = dc_accounts_get_selected_account(accountsPointer)
-        return DcContext(contextPointer: cPtr)
+        return DcContext(contextPointer: cPtr, logger: logger)
     }
 
     // call maybeNetwork() from a worker thread.
@@ -95,11 +96,9 @@ public class DcContext {
     public var lastWarningString: String = "" // temporary thing to get a grip on some weird errors
     public var maxConfigureProgress: Int = 0 // temporary thing to get a grip on some weird errors
 
-    public init() {
-    }
-
-    public init(contextPointer: OpaquePointer?) {
+    public init(contextPointer: OpaquePointer?, logger: Logger?) {
         self.contextPointer = contextPointer
+        self.logger = logger
     }
     
     deinit {

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -64,10 +64,6 @@ public class DcAccounts {
         return dc_accounts_remove_account(accountsPointer, UInt32(id)) == 1
     }
 
-    public func importAccount(filePath: String) -> Int {
-        return Int(dc_accounts_import_account(accountsPointer, filePath))
-    }
-
     public func getEventEmitter() -> DcAccountsEventEmitter {
         let eventEmitterPointer = dc_accounts_get_event_emitter(accountsPointer)
         return DcAccountsEventEmitter(eventEmitterPointer: eventEmitterPointer)

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -538,6 +538,15 @@ public class DcContext {
         set { setConfig("displayname", newValue) }
     }
 
+    public var displaynameAndAddr: String {
+        var ret = addr ?? ""
+        if let displayname = displayname {
+            ret = "\(displayname) (\(ret))"
+        }
+        ret += configured ? "" : " (not configured)"
+        return ret.trimmingCharacters(in: .whitespaces)
+    }
+
     public var selfstatus: String? {
         get { return getConfig("selfstatus") }
         set { setConfig("selfstatus", newValue) }

--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -77,8 +77,8 @@ class ShareViewController: SLComposeServiceViewController {
     }
 
     override func presentationAnimationDidFinish() {
+        dcAccounts.logger = logger
         dcAccounts.openDatabase()
-        dcContext.logger = self.logger
         isAccountConfigured = dcContext.isConfigured()
         if isAccountConfigured {
             if #available(iOSApplicationExtension 13.0, *) {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -56,12 +56,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         console.format = "$DHH:mm:ss.SSS$d $C$L$c $M" // see https://docs.swiftybeaver.com/article/20-custom-format
         logger.addDestination(console)
 
+        dcAccounts.logger = DcLogger()
         dcAccounts.openDatabase()
         migrateToDcAccounts()
         if dcAccounts.getAll().isEmpty, dcAccounts.add() == 0 {
            fatalError("Could not initialize a new account.")
         }
-        dcAccounts.getSelected().logger = DcLogger()
         logger.info("➡️ didFinishLaunchingWithOptions")
 
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -469,6 +469,7 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
                     message: String.localized("forget_login_confirmation_desktop"), preferredStyle: .alert)
                 confirm2.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { [weak self] _ in
                     guard let self = self else { return }
+                    appDelegate.locationManager.disableLocationStreamingInAllChats()
                     _ = self.dcAccounts.remove(id: selectedAccountId)
                     if self.dcAccounts.getAll().isEmpty {
                         _ = self.dcAccounts.add()

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -448,14 +448,16 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
             var title = account.displaynameAndAddr
             title = (selectedAccountId==accountId ? "✔︎ " : "") + title
             menu.addAction(UIAlertAction(title: title, style: .default, handler: { [weak self] _ in
-                _ = self?.dcAccounts.select(id: accountId)
+                guard let self = self else { return }
+                _ = self.dcAccounts.select(id: accountId)
                 appDelegate.reloadDcContext()
             }))
         }
 
         // add account
         menu.addAction(UIAlertAction(title: String.localized("add_account"), style: .default, handler: { [weak self] _ in
-            _ = self?.dcAccounts.add()
+            guard let self = self else { return }
+            _ = self.dcAccounts.add()
             appDelegate.reloadDcContext()
         }))
 

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -38,6 +38,15 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         return view
     }()
 
+    private lazy var canCancel: Bool = {
+        // "cancel" removes selected unconfigured account, so there needs to be at least one other account
+        return dcAccounts.getAll().count >= 2
+    }()
+
+    private lazy var cancelButton: UIBarButtonItem = {
+        return UIBarButtonItem(title: String.localized("cancel"), style: .plain, target: self, action: #selector(cancelButtonPressed))
+    }()
+
     private var qrCodeReader: QrCodeReaderController?
     weak var progressAlert: UIAlertController?
 
@@ -45,7 +54,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         self.dcAccounts = dcAccounts
         self.dcContext = dcAccounts.getSelected()
         super.init(nibName: nil, bundle: nil)
-        self.navigationItem.title = String.localized("welcome_desktop")
+        self.navigationItem.title = String.localized(canCancel ? "add_account" : "welcome_desktop")
         onProgressSuccess = { [weak self] in
             guard let self = self else { return }
             let profileInfoController = ProfileInfoViewController(context: self.dcContext)
@@ -66,6 +75,9 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupSubviews()
+        if canCancel {
+            navigationItem.leftBarButtonItem = cancelButton
+        }
     }
 
     override func viewDidLayoutSubviews() {
@@ -142,6 +154,24 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default))
         present(alert, animated: true)
+    }
+
+    @objc private func cancelButtonPressed() {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+
+        // take a bit care on account removal:
+        // remove only unconfigured and make sure, there is another account
+        // (normally, both checks are not needed, however, some resilience wrt future program-flow-changes seems to be reasonable here)
+        let selectedAccount = dcAccounts.getSelected()
+        if !selectedAccount.isConfigured() {
+            _ = dcAccounts.remove(id: selectedAccount.id)
+            if self.dcAccounts.getAll().isEmpty {
+                _ = self.dcAccounts.add()
+            }
+        }
+
+        // do not just pop view controller as the stack is empty on restarts
+        appDelegate.reloadDcContext()
     }
 }
 

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -170,7 +170,6 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
             }
         }
 
-        // do not just pop view controller as the stack is empty on restarts
         appDelegate.reloadDcContext()
     }
 }


### PR DESCRIPTION
this pulls in the basic ui from #846 and closes #829 and closes #1288

successor of #1268, #1272

- [x] add ui
- [x] "add account"
- [x] "switch account"
- [x] "delete account" (if possible, that could delete the selected account; a list as on android is not-so-nice)
- [x] "welcome screen" needs a "cancel" button if there are other accounts available, on "cancel" the unconfigured account can be deleted
- [x] remove old "delete account" option
- [x] check that "import" works as expected ([`dc_accounts_import_account()`](https://c.delta.chat/classdc__accounts__t.html#ab554e69f329dd19b099a9bc425db925f) creates a new account) - EDIT: we keep on using [`dc_imex()`](https://c.delta.chat/classdc__context__t.html#ab04a07bb49363824f6fe3b03e6aaaca7), so things should be fine. wondering if `dc_accounts_import_account()` is needed at all, cmp https://github.com/deltachat/deltachat-core-rust/pull/2521
- [x] check location streaming, old delete account called disableLocationStreamingInAllChats on remove - what is needed now? however, as being experimental anyway, this is maybe sth. for another pr.

**there is a bug left:** subsequent account configuration does not end (account is okay after restart), however, that needs to be fixed in core, see https://github.com/deltachat/deltachat-core-rust/issues/2522

<img width=300 src=https://user-images.githubusercontent.com/9800740/123489597-a1f6e600-d612-11eb-88f2-6b8550463003.png>

