### PR TITLE
update badge counter on account switch

### DIFF
--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -21,6 +21,7 @@ public class NotificationManager {
     public func reloadDcContext() {
         NotificationManager.removeAllNotifications()
         dcContext = dcAccounts.getSelected()
+        NotificationManager.updateApplicationIconBadge(dcContext: dcContext, reset: false)
     }
 
     public static func updateApplicationIconBadge(dcContext: DcContext, reset: Bool) {


### PR DESCRIPTION
fixes #1292

Instead of resetting the badge to 0 we're updating to the unread messages of the newly selected account for now. This way the badge counter aligns with the sum of all unread message counters in the chat list. 