### PR TITLE
become default iOS email app

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -188,6 +188,10 @@ public class DcContext {
         dc_add_address_book(contextPointer, contactString)
     }
 
+    public func lookupContactIdByAddress(_ address: String) -> Int {
+        return Int(dc_lookup_contact_id_by_addr(contextPointer, addr))
+    }
+
     public func getChat(chatId: Int) -> DcChat {
         let chatPointer = dc_get_chat(contextPointer, UInt32(chatId))
         return DcChat(chatPointer: chatPointer)

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -150,7 +150,7 @@ public class DcContext {
         return ids
     }
 
-    public func createContact(name: String, email: String) -> Int {
+    public func createContact(name: String?, email: String) -> Int {
         return Int(dc_create_contact(contextPointer, name, email))
     }
 

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -127,7 +127,7 @@ public class DcContext {
     }
 
     public func sendVideoChatInvitation(chatId: Int) -> Int {
-        return Int(dc_send_videochat_invitation(contextPointer,  UInt32(chatId)))
+        return Int(dc_send_videochat_invitation(contextPointer, UInt32(chatId)))
     }
 
     // TODO: remove count and from parameters if we don't use it

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -130,13 +130,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         //    NotificationCenter.default.post(name: NSNotification.Name("oauthLoginApproved"), object: nil, userInfo: ["token": token])
         // }
 
-        // Hack to format url properly
-        let urlString = url.absoluteString
-                       .replacingOccurrences(of: "openpgp4fpr", with: "OPENPGP4FPR", options: .literal, range: nil)
-                       .replacingOccurrences(of: "%23", with: "#", options: .literal, range: nil)
+        switch url.scheme?.lowercased() {
+        case "openpgp4fpr":
+            // Hack to format url properly
+            let urlString = url.absoluteString
+                           .replacingOccurrences(of: "openpgp4fpr", with: "OPENPGP4FPR", options: .literal, range: nil)
+                           .replacingOccurrences(of: "%23", with: "#", options: .literal, range: nil)
 
-        self.appCoordinator.handleQRCode(urlString)
-        return true
+            self.appCoordinator.handleQRCode(urlString)
+            return true
+        case "mailto":
+            self.appCoordinator.handleMailtoURL(url)
+            return true
+        default:
+            return false
+        }
     }
 
 

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -126,9 +126,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.info("➡️ open url")
 
         // gets here when app returns from oAuth2-Setup process - the url contains the provided token
-        if let params = url.queryParameters, let token = params["code"] {
-            NotificationCenter.default.post(name: NSNotification.Name("oauthLoginApproved"), object: nil, userInfo: ["token": token])
-        }
+        // if let params = url.queryParameters, let token = params["code"] {
+        //    NotificationCenter.default.post(name: NSNotification.Name("oauthLoginApproved"), object: nil, userInfo: ["token": token])
+        // }
 
         // Hack to format url properly
         let urlString = url.absoluteString

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -140,8 +140,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             self.appCoordinator.handleQRCode(urlString)
             return true
         case "mailto":
-            self.appCoordinator.handleMailtoURL(url)
-            return true
+            return self.appCoordinator.handleMailtoURL(url)
         default:
             return false
         }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -354,6 +354,9 @@ class ChatViewController: UITableViewController {
 
         if RelayHelper.sharedInstance.isForwarding() {
             askToForwardMessage()
+        } else if RelayHelper.sharedInstance.isMailtoHandling() {
+            messageInputBar.inputTextView.text = RelayHelper.sharedInstance.mailtoDraft
+            RelayHelper.sharedInstance.finishMailto()
         }
 
         prepareContextMenu()

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -450,39 +450,30 @@ class ChatListController: UITableViewController {
         present(alert, animated: true, completion: nil)
     }
 
-    private func askToChatWith(address: String) {
+    private func askToChatWith(address: String, contactId: Int = 0) {
+        var contactId = contactId
         let alert = UIAlertController(title: String.localizedStringWithFormat(String.localized("ask_start_chat_with"), address),
                                       message: nil,
                                       preferredStyle: .safeActionSheet)
         alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { [weak self] _ in
             guard let self = self else { return }
-            let contactId = self.dcContext.createContact(name: nil, email: address)
+            if contactId == 0 {
+                contactId = self.dcContext.createContact(name: nil, email: address)
+            }
             self.showNewChat(contactId: contactId)
         }))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
-            RelayHelper.sharedInstance.finishMailto()
+            if RelayHelper.sharedInstance.isMailtoHandling() {
+                RelayHelper.sharedInstance.finishMailto()
+            }
         }))
         present(alert, animated: true, completion: nil)
     }
 
+
     private func askToChatWith(contactId: Int) {
         let dcContact = dcContext.getContact(id: contactId)
-        let alert = UIAlertController(
-            title: String.localizedStringWithFormat(String.localized("ask_start_chat_with"), dcContact.nameNAddr),
-            message: nil,
-            preferredStyle: .safeActionSheet)
-        alert.addAction(UIAlertAction(
-            title: String.localized("start_chat"),
-            style: .default,
-            handler: { _ in
-                self.showNewChat(contactId: contactId)
-        }))
-        alert.addAction(UIAlertAction(
-            title: String.localized("cancel"),
-            style: .cancel,
-            handler: { _ in
-        }))
-        self.present(alert, animated: true, completion: nil)
+        askToChatWith(address: dcContact.nameNAddr, contactId: contactId)
     }
 
     private func deleteChat(chatId: Int, animated: Bool) {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -467,7 +467,7 @@ class ChatListController: UITableViewController {
     }
 
     // MARK: - coordinator
-    private func showNewChatController() {
+    func showNewChatController() {
         let newChatVC = NewChatViewController(dcContext: dcContext)
         navigationController?.pushViewController(newChatVC, animated: true)
     }

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -467,9 +467,9 @@ class ChatListController: UITableViewController {
     }
 
     // MARK: - coordinator
-    func showNewChatController() {
+    func showNewChatController(animated: Bool = true) {
         let newChatVC = NewChatViewController(dcContext: dcContext)
-        navigationController?.pushViewController(newChatVC, animated: true)
+        navigationController?.pushViewController(newChatVC, animated: animated)
     }
 
     func showChat(chatId: Int, highlightedMsg: Int? = nil, animated: Bool = true) {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -494,9 +494,9 @@ class ChatListController: UITableViewController {
     }
 
     // MARK: - coordinator
-    func showNewChatController(animated: Bool = true) {
+    private func showNewChatController() {
         let newChatVC = NewChatViewController(dcContext: dcContext)
-        navigationController?.pushViewController(newChatVC, animated: animated)
+        navigationController?.pushViewController(newChatVC, animated: true)
     }
 
     func showChat(chatId: Int, highlightedMsg: Int? = nil, animated: Bool = true) {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -393,6 +393,26 @@ class ChatListController: UITableViewController {
         timer = nil
     }
 
+    public func handleMailto() {
+        let mailtoAddress = RelayHelper.sharedInstance.mailtoAddress
+        // FIXME: the line below should work
+        // var contactId = dcContext.lookupContactIdByAddress(mailtoAddress)
+
+        // workaround:
+        let contacts: [Int] = dcContext.getContacts(flags: DC_GCL_ADD_SELF, queryString: mailtoAddress)
+        let index = contacts.firstIndex(where: { dcContext.getContact(id: $0).email == mailtoAddress }) ?? -1
+        var contactId = 0
+        if index >= 0 {
+            contactId = contacts[index]
+        }
+
+        if contactId != 0 && dcContext.getChatIdByContactId(contactId: contactId) != 0 {
+            showChat(chatId: dcContext.getChatIdByContactId(contactId: contactId), animated: false)
+        } else {
+            showNewChatController(animated: false)
+        }
+    }
+
     // MARK: - alerts
     private func showDeleteChatConfirmationAlert(chatId: Int) {
         let alert = UIAlertController(

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -94,11 +94,6 @@ class NewChatViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         deviceContactAccessGranted = CNContactStore.authorizationStatus(for: .contacts) == .authorized
-        if RelayHelper.sharedInstance.isMailtoHandling() {
-            if let mailtoAddress = RelayHelper.sharedInstance.mailtoAddress {
-                askToChatWith(address: mailtoAddress)
-            }
-        }
     }
 
     // MARK: - actions
@@ -385,22 +380,6 @@ extension NewChatViewController {
         }))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { [weak self] _ in
             self?.dismiss(animated: true, completion: nil)
-        }))
-        present(alert, animated: true, completion: nil)
-    }
-
-    private func askToChatWith(address: String) {
-        let alert = UIAlertController(title: String.localizedStringWithFormat(String.localized("ask_start_chat_with"), address),
-                                      message: nil,
-                                      preferredStyle: .safeActionSheet)
-        alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { [weak self] _ in
-            guard let self = self else { return }
-            let contactId = self.dcContext.createContact(name: nil, email: address)
-            self.showNewChat(contactId: contactId)
-        }))
-        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { [weak self] _ in
-            RelayHelper.sharedInstance.finishMailto()
-            self?.navigationController?.popToRootViewController(animated: true)
         }))
         present(alert, animated: true, completion: nil)
     }

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -98,7 +98,6 @@ class NewChatViewController: UITableViewController {
 
     // MARK: - actions
     @objc func cancelButtonPressed() {
-
         dismiss(animated: true, completion: nil)
     }
 
@@ -326,8 +325,8 @@ class NewChatViewController: UITableViewController {
 
     private func showChat(chatId: Int) {
         let chatViewController = ChatViewController(dcContext: dcContext, chatId: chatId)
-        self.navigationController?.pushViewController(chatViewController, animated: true)
-        self.navigationController?.viewControllers.remove(at: 1)
+        navigationController?.pushViewController(chatViewController, animated: true)
+        navigationController?.viewControllers.remove(at: 1)
     }
 
     private func showContactDetail(contactId: Int) {
@@ -375,12 +374,9 @@ extension NewChatViewController {
             preferredStyle: .safeActionSheet
         )
         alert.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { [weak self] _ in
-            self?.dismiss(animated: true, completion: nil)
             self?.deleteContact(contactId: contactId, indexPath: indexPath)
         }))
-        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { [weak self] _ in
-            self?.dismiss(animated: true, completion: nil)
-        }))
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         present(alert, animated: true, completion: nil)
     }
 
@@ -394,7 +390,6 @@ extension NewChatViewController {
                                           message: nil,
                                           preferredStyle: .safeActionSheet)
             alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { _ in
-                self.dismiss(animated: true, completion: nil)
                 self.showNewChat(contactId: contactId)
             }))
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -103,7 +103,7 @@ class AppCoordinator {
             if let rootController = self.tabBarController.selectedViewController as? UINavigationController {
                 rootController.popToRootViewController(animated: false)
                 if let controller = rootController.viewControllers.first as? ChatListController {
-                    controller.showNewChatController(animated: true)
+                    controller.handleMailto()
                 }
             }
         } else {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -97,6 +97,20 @@ class AppCoordinator {
         }
     }
 
+    func handleMailtoURL(_ url: URL) {
+        if RelayHelper.sharedInstance.parseMailtoUrl(url) {
+            showTab(index: chatsTab)
+            if let rootController = self.tabBarController.selectedViewController as? UINavigationController {
+                rootController.popToRootViewController(animated: false)
+                if let controller = rootController.viewControllers.first as? ChatListController {
+                    controller.showNewChatController()
+                }
+            }
+        } else {
+            logger.warning("Could not parse mailto: URL")
+        }
+    }
+    
     func handleQRCode(_ code: String) {
         showTab(index: qrTab)
         if let navController = self.tabBarController.selectedViewController as? UINavigationController,

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -103,7 +103,7 @@ class AppCoordinator {
             if let rootController = self.tabBarController.selectedViewController as? UINavigationController {
                 rootController.popToRootViewController(animated: false)
                 if let controller = rootController.viewControllers.first as? ChatListController {
-                    controller.showNewChatController()
+                    controller.showNewChatController(animated: true)
                 }
             }
         } else {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -97,18 +97,21 @@ class AppCoordinator {
         }
     }
 
-    func handleMailtoURL(_ url: URL) {
+    func handleMailtoURL(_ url: URL) -> Bool {
         if RelayHelper.sharedInstance.parseMailtoUrl(url) {
             showTab(index: chatsTab)
             if let rootController = self.tabBarController.selectedViewController as? UINavigationController {
                 rootController.popToRootViewController(animated: false)
                 if let controller = rootController.viewControllers.first as? ChatListController {
                     controller.handleMailto()
+                    return true
                 }
             }
         } else {
             logger.warning("Could not parse mailto: URL")
         }
+        RelayHelper.sharedInstance.finishMailto()
+        return false
     }
     
     func handleQRCode(_ code: String) {

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -6,6 +6,9 @@ class RelayHelper {
     private static var dcContext: DcContext?
     var messageIds: [Int]?
 
+    var mailtoDraft: String = ""
+    var mailtoAddress: String?
+
     private init() {
         guard RelayHelper.dcContext != nil else {
             fatalError("Error - you must call RelayHelper.setup() before accessing RelayHelper.shared")
@@ -38,5 +41,58 @@ class RelayHelper {
 
     func cancel() {
         messageIds = nil
+    }
+
+    func isMailtoHandling() -> Bool {
+        return !mailtoDraft.isEmpty || mailtoAddress != nil
+    }
+
+    func finishMailto() {
+        mailtoDraft = ""
+        mailtoAddress = nil
+    }
+
+
+    func splitString(_ value: String) -> [String] {
+        return value.split(separator: ",").map(String.init)
+    }
+
+    /**
+            returns true if parsing was successful
+     */
+    func parseMailtoUrl(_ url: URL) -> Bool {
+        if Utils.isEmail(url: url),
+           let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
+           !urlComponents.path.isEmpty {
+            var subject: String = ""
+            var body: String = ""
+            let queryItems = urlComponents.queryItems ?? []
+            for queryItem in queryItems {
+                guard let value = queryItem.value else {
+                    continue
+                }
+                switch queryItem.name {
+                case "body":
+                    body = value
+                case "subject":
+                    subject = value
+                default:
+                    break
+                }
+            }
+
+            if !subject.isEmpty {
+                mailtoDraft = subject
+                if !body.isEmpty {
+                    mailtoDraft += "\n\n \(body)"
+                }
+            } else if (!body.isEmpty) {
+                mailtoDraft = body
+            }
+
+            mailtoAddress = splitString(urlComponents.path)[0] // we currently only allow 1 receipient
+            return true
+        }
+        return false
     }
 }

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -61,8 +61,7 @@ class RelayHelper {
             returns true if parsing was successful
      */
     func parseMailtoUrl(_ url: URL) -> Bool {
-        if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
-           !urlComponents.path.isEmpty {
+        if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
             var subject: String = ""
             var body: String = ""
             let queryItems = urlComponents.queryItems ?? []
@@ -83,14 +82,16 @@ class RelayHelper {
             if !subject.isEmpty {
                 mailtoDraft = subject
                 if !body.isEmpty {
-                    mailtoDraft += "\n\n \(body)"
+                    mailtoDraft += "\n\n\(body)"
                 }
             } else if !body.isEmpty {
                 mailtoDraft = body
             }
 
-            mailtoAddress = splitString(urlComponents.path)[0] // we currently only allow 1 receipient
-            return true
+            if !urlComponents.path.isEmpty {
+                mailtoAddress = splitString(urlComponents.path)[0] // we currently only allow 1 receipient
+            }
+            return mailtoAddress != nil || !mailtoDraft.isEmpty
         }
         return false
     }

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -86,7 +86,7 @@ class RelayHelper {
                 if !body.isEmpty {
                     mailtoDraft += "\n\n \(body)"
                 }
-            } else if (!body.isEmpty) {
+            } else if !body.isEmpty {
                 mailtoDraft = body
             }
 

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -61,8 +61,7 @@ class RelayHelper {
             returns true if parsing was successful
      */
     func parseMailtoUrl(_ url: URL) -> Bool {
-        if Utils.isEmail(url: url),
-           let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
+        if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
            !urlComponents.path.isEmpty {
             var subject: String = ""
             var body: String = ""

--- a/deltachat-ios/Info.plist
+++ b/deltachat-ios/Info.plist
@@ -31,6 +31,16 @@
 				<string>openpgp4fpr</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>chat.delta.mailto</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mailto</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>


### PR DESCRIPTION
* add mailto url scheme to info.plist 
* handle all cases described here: https://github.com/deltachat/interface/blob/master/user-testing/mailto-links.md

* cleanup: comment remove oauth2 handling bits, as we don't support oauth2 on iOS right now