### PR TITLE
revert sharing webp files as stickers

### DIFF
--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -224,16 +224,6 @@ extension ShareViewController: ShareAttachmentDelegate {
             guard let self = self else { return }
             if let preview = self.preview {
                 preview.image = self.shareAttachment?.thumbnail ?? nil
-
-                if let image = preview.image, image.sd_imageFormat == .webP {
-                    self.previewImageWidthConstraint?.isActive = false
-                    self.previewImageHeightConstraint?.isActive = false
-                    preview.centerInSuperview()
-                    self.textView.text = nil
-                    self.textView.attributedText = nil
-                    self.placeholder = nil
-                    self.textView.isHidden = true
-                }
             }
         }
     }

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -115,12 +115,7 @@ class ShareAttachment {
             }
             if let result = result {
                 let path: String? = ImageFormat.saveImage(image: result)
-                var msg: DcMsg
-                if result.sd_imageFormat == .webP {
-                    msg = self.dcContext.newMessage(viewType: DC_MSG_STICKER)
-                } else {
-                    msg = self.dcContext.newMessage(viewType: DC_MSG_IMAGE)
-                }
+                let msg = self.dcContext.newMessage(viewType: DC_MSG_IMAGE)
                 msg.setFile(filepath: path)
                 self.messages.append(msg)
                 self.delegate?.onAttachmentChanged()


### PR DESCRIPTION
follow-up of https://github.com/deltachat/deltachat-ios/pull/1298

we decided to revert the hidden feature to share webp files as stickers, as it caused confusion