### PR TITLE
fix scrolling of the chat when the inputbar size increases

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1605,7 +1605,7 @@ extension ChatViewController: InputBarAccessoryViewDelegate {
                                                    bottom: size.height + messageInputBar.keyboardHeight,
                                                    right: 0)
         if isLastRowVisible() && !tableView.isDragging && !tableView.isDecelerating  && highlightedMsg == nil && !ignoreInputBarChange {
-            self.scrollToBottom(animated: true)
+            self.tableView.setContentOffset(CGPoint(x: 0, y: tableView.contentSize.height), animated: true)
         }
     }
 }


### PR DESCRIPTION
changing the way we scroll down in case the input bar size changes seems to resolve the sudden (and unwanted) scroll animation

the tested scenario: write a message, send it, write a second one with at least two lines of text. Without this PR, the scrolling animation  showed up, now it should not anymore. 

@r10s could you please check if you can still reproduce this particular scroll bug with this PR?

