### PR TITLE
set stock translations on account changes

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -473,6 +473,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     func reloadDcContext() {
+        setStockTranslations()
         locationManager.reloadDcContext()
         notificationManager.reloadDcContext()
         RelayHelper.sharedInstance.cancel()


### PR DESCRIPTION
updates are done on switch/add/delete -
the latter is needed as a previously unused accout may be selected.

before, on account changes, the untranslated strings from the core were used.