### PR TITLE
fix flickering background when entering the connectiviy view

### DIFF
--- a/deltachat-ios/Controller/ConnectivityViewController.swift
+++ b/deltachat-ios/Controller/ConnectivityViewController.swift
@@ -17,6 +17,9 @@ class ConnectivityViewController: WebViewViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = String.localized("connectivity")
+        self.webView.isOpaque = false
+        self.webView.backgroundColor = .clear
+        view.backgroundColor = DcColors.defaultBackgroundColor
         loadHtml()
     }
 

--- a/deltachat-ios/Controller/HelpViewController.swift
+++ b/deltachat-ios/Controller/HelpViewController.swift
@@ -1,12 +1,15 @@
 import UIKit
 import WebKit
+import DcCore
 
 class HelpViewController: WebViewViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
         self.title = String.localized("menu_help")
+        self.webView.isOpaque = false
+        self.webView.backgroundColor = .clear
+        view.backgroundColor = DcColors.defaultBackgroundColor
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
fixes #1317 

fixes the same bug for the help pages

the fix not implemented in the root class (WebViewViewController) because FullMessageViewController doesn't adapt font colors in dark mode, thus we keep the webview background color there alsways white.