### PR TITLE
mark 'delete account' as destructive

### DIFF
--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -500,7 +500,7 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
         }))
 
         // delete account
-        menu.addAction(UIAlertAction(title: String.localized("delete_account"), style: .default, handler: { [weak self] _ in
+        menu.addAction(UIAlertAction(title: String.localized("delete_account"), style: .destructive, handler: { [weak self] _ in
             let confirm1 = UIAlertController(title: String.localized("delete_account_ask"), message: nil, preferredStyle: .safeActionSheet)
             confirm1.addAction(UIAlertAction(title: String.localized("delete_account"), style: .destructive, handler: { [weak self] _ in
                 guard let self = self else { return }


### PR DESCRIPTION
even though, there is an alert for confirmation, i think, the gist of `.destructive` is to hint potentially dangerous operation already before.