### PR TITLE
add 'connectivity changed' observers in time

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -93,6 +93,15 @@ class ChatListController: UITableViewController {
 
         // create view
         navigationItem.titleView = titleView
+
+        // set connectivity changed observer before we acutally init the title,
+        // otherwise, we may miss events and the title is not correct.
+        let nc = NotificationCenter.default
+        connectivityChangedObserver = nc.addObserver(forName: dcNotificationConnectivityChanged,
+                                                     object: nil,
+                                                     queue: nil) { [weak self] _ in
+                                                        self?.updateTitle()
+                                                     }
         updateTitle()
 
         viewModel.refreshData()
@@ -125,11 +134,6 @@ class ChatListController: UITableViewController {
             queue: nil) { [weak self] _ in
                 self?.refreshInBg()
             }
-        connectivityChangedObserver = nc.addObserver(forName: dcNotificationConnectivityChanged,
-                                                     object: nil,
-                                                     queue: nil) { [weak self] _ in
-                                                        self?.updateTitle()
-                                                     }
 
         nc.addObserver(
             self,

--- a/deltachat-ios/Controller/ConnectivityViewController.swift
+++ b/deltachat-ios/Controller/ConnectivityViewController.swift
@@ -14,21 +14,25 @@ class ConnectivityViewController: WebViewViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // called only once after loading
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = String.localized("connectivity")
         self.webView.isOpaque = false
         self.webView.backgroundColor = .clear
         view.backgroundColor = DcColors.defaultBackgroundColor
-        loadHtml()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
+    // called everytime the view will appear
+    override func viewWillAppear(_ animated: Bool) {
+        // set connectivity changed observer before we acutally init html,
+        // otherwise, we may miss events and the html is not correct.
         connectivityChangedObserver = NotificationCenter.default.addObserver(forName: dcNotificationConnectivityChanged,
                                                      object: nil,
                                                      queue: nil) { [weak self] _ in
                                                         self?.loadHtml()
                                                      }
+        loadHtml()
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -259,6 +259,17 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        // set connectivity changed observer before we acutally init `connectivityCell.detailTextLabel` in `updateCells()`,
+        // otherwise, we may miss events and the label is not correct.
+        connectivityChangedObserver = NotificationCenter.default.addObserver(forName: dcNotificationConnectivityChanged,
+                                                                             object: nil,
+                                                                             queue: nil) { [weak self] _ in
+            guard let self = self else { return }
+            self.connectivityCell.detailTextLabel?.text = DcUtils.getConnectivityString(dcContext: self.dcContext,
+                                                                                        connectedString: String.localized("connectivity_connected"))
+        }
+
         updateCells()
     }
 
@@ -272,13 +283,6 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
                     appDelegate.reloadDcContext()
                 }
             }
-        }
-        connectivityChangedObserver = NotificationCenter.default.addObserver(forName: dcNotificationConnectivityChanged,
-                                                                             object: nil,
-                                                                             queue: nil) { [weak self] _ in
-            guard let self = self else { return }
-            self.connectivityCell.detailTextLabel?.text = DcUtils.getConnectivityString(dcContext: self.dcContext,
-                                                                                        connectedString: String.localized("connectivity_connected"))
         }
     }
 


### PR DESCRIPTION
'connectivity changed' observers must be added before
the UI is inititalized - otherwise,
we may miss an event and UI is stuck at a wrong state.

in general, that means to move adding observers to viewWillAppear -
which seems also be more balanced as they're removed on viewDidDisappear -
so both in situations the view is not visible.

@cyBerta please have a closer look at this pr after your holidays - i merge that in to move forward, however.

closes #1337 (magic number!) 