### PR TITLE
start io unconditionally

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -51,10 +51,8 @@ public class DcAccounts {
         dc_accounts_maybe_network_lost(accountsPointer)
     }
 
-    public func maybeStartIo() {
-        if getSelected().isConfigured() {
-            dc_accounts_start_io(accountsPointer)
-        }
+    public func startIo() {
+        dc_accounts_start_io(accountsPointer)
     }
 
     public func stopIo() {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -81,7 +81,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         locationManager = LocationManager(dcAccounts: dcAccounts)
         UIApplication.shared.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalMinimum)
         notificationManager = NotificationManager(dcAccounts: dcAccounts)
-        dcAccounts.maybeStartIo()
+        dcAccounts.startIo()
         setStockTranslations()
 
         reachability.whenReachable = { reachability in
@@ -154,7 +154,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func applicationWillEnterForeground(_: UIApplication) {
         logger.info("➡️ applicationWillEnterForeground")
-        dcAccounts.maybeStartIo()
+        dcAccounts.startIo()
 
         DispatchQueue.global(qos: .background).async { [weak self] in
             guard let self = self else { return }
@@ -335,7 +335,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // we need to ensure IO is running as the function may be called from suspended state
     // (with app in memory, but gracefully shut down before; sort of freezed).
     // if the function was not called from suspended state,
-    // the call to maybeStartIo() did nothing, therefore, interrupt and force fetch.
+    // the call to startIo() did nothing, therefore, interrupt and force fetch.
     //
     // we have max. 30 seconds time for our job and to call the completion handler.
     // as the system tracks the elapsed time, power usage, and data costs, we return faster,
@@ -406,7 +406,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
 
         // we're in background, run IO for a little time
-        dcAccounts.maybeStartIo()
+        dcAccounts.startIo()
         dcAccounts.maybeNetwork()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in

--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -270,7 +270,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             action: { cell in
                 self.dcAccounts.stopIo()
                 self.dcContext.setConfigBool("inbox_watch", cell.isOn)
-                self.dcAccounts.maybeStartIo()
+                self.dcAccounts.startIo()
         })
     }()
 
@@ -281,7 +281,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             action: { cell in
                 self.dcAccounts.stopIo()
                 self.dcContext.setConfigBool("sentbox_watch", cell.isOn)
-                self.dcAccounts.maybeStartIo()
+                self.dcAccounts.startIo()
         })
     }()
 
@@ -292,7 +292,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             action: { cell in
                 self.dcAccounts.stopIo()
                 self.dcContext.setConfigBool("mvbox_watch", cell.isOn)
-                self.dcAccounts.maybeStartIo()
+                self.dcAccounts.startIo()
         })
     }()
 
@@ -649,7 +649,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             notification in
             if let ui = notification.userInfo {
                 if ui["error"] as! Bool {
-                    self.dcAccounts.maybeStartIo()
+                    self.dcAccounts.startIo()
                     var errorMessage = ui["errorMessage"] as? String
                     if let appDelegate = UIApplication.shared.delegate as? AppDelegate, appDelegate.reachability.connection == .none {
                         errorMessage = String.localized("login_error_no_internet_connection")
@@ -658,7 +658,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
                     }
                     self.updateProgressAlert(error: errorMessage)
                 } else if ui["done"] as! Bool {
-                    self.dcAccounts.maybeStartIo()
+                    self.dcAccounts.startIo()
                     self.updateProgressAlertSuccess(completion: self.handleLoginSuccess)
                 } else {
                     self.updateProgressAlertValue(value: ui["progress"] as? Int)
@@ -677,10 +677,10 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             notification in
             if let ui = notification.userInfo {
                 if ui["error"] as! Bool {
-                    self.dcAccounts.maybeStartIo()
+                    self.dcAccounts.startIo()
                     self.updateProgressAlert(error: ui["errorMessage"] as? String)
                 } else if ui["done"] as! Bool {
-                    self.dcAccounts.maybeStartIo()
+                    self.dcAccounts.startIo()
                     self.updateProgressAlertSuccess(completion: self.handleLoginSuccess)
                 } else {
                     self.updateProgressAlertValue(value: ui["progress"] as? Int)
@@ -727,6 +727,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             if let file = dcContext.imexHasBackup(filePath: documents[0]) {
                 logger.info("restoring backup: \(file)")
                 showProgressAlert(title: String.localized("import_backup_title"), dcContext: dcContext)
+                dcAccounts.stopIo()
                 dcContext.imex(what: DC_IMEX_IMPORT_BACKUP, directory: file)
             }
             else {

--- a/deltachat-ios/Handler/ProgressAlertHandler.swift
+++ b/deltachat-ios/Handler/ProgressAlertHandler.swift
@@ -75,10 +75,10 @@ extension ProgressAlertHandler {
             guard let self = self else { return }
             if let ui = notification.userInfo {
                 if ui["error"] as? Bool ?? false {
-                    dcAccounts.maybeStartIo()
+                    dcAccounts.startIo()
                     self.updateProgressAlert(error: ui["errorMessage"] as? String)
                 } else if ui["done"] as? Bool ?? false {
-                    dcAccounts.maybeStartIo()
+                    dcAccounts.startIo()
                     self.updateProgressAlertSuccess(completion: onSuccess)
                 } else {
                     self.updateProgressAlertValue(value: ui["progress"] as? Int)


### PR DESCRIPTION
checking some account for is_configured()
may result in io not being started,
eg. after an cancelled account creation,
closes #1341

the added stopIo() before imex() was just missing,
io must not be running during import/export -
it was working most times by accident as
by the is_configured() io was not started.