### PR TITLE
fix layout constraints after implementing download-on-demand (#1355)

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -15,6 +15,7 @@ public class BaseMessageCell: UITableViewCell {
     private var mainContentViewLeadingConstraint: NSLayoutConstraint?
     private var mainContentViewTrailingConstraint: NSLayoutConstraint?
     private var actionBtnZeroHeightConstraint: NSLayoutConstraint?
+    private var actionBtnTrailingConstraint: NSLayoutConstraint?
 
     public var mainContentViewHorizontalPadding: CGFloat {
         get {
@@ -61,6 +62,7 @@ public class BaseMessageCell: UITableViewCell {
         set {
             mainContentAboveActionBtnConstraint?.constant = newValue ? -2 : 8
             actionBtnZeroHeightConstraint?.isActive = newValue
+            actionBtnTrailingConstraint?.isActive = !newValue
             actionButton.isHidden = newValue
         }
     }
@@ -199,7 +201,6 @@ public class BaseMessageCell: UITableViewCell {
             messageBackgroundContainer.constraintAlignTopTo(contentView, paddingTop: 3),
             messageBackgroundContainer.constraintAlignBottomTo(contentView, paddingBottom: 3),
             actionButton.constraintAlignLeadingTo(messageBackgroundContainer, paddingLeading: 12),
-            actionButton.constraintAlignTrailingTo(messageBackgroundContainer, paddingTrailing: 12),
             bottomLabel.constraintAlignLeadingMaxTo(messageBackgroundContainer, paddingLeading: 8),
             bottomLabel.constraintAlignTrailingTo(messageBackgroundContainer, paddingTrailing: 8),
             bottomLabel.constraintToBottomOf(actionButton, paddingTop: 8, priority: .defaultHigh),
@@ -223,6 +224,7 @@ public class BaseMessageCell: UITableViewCell {
         mainContentUnderBottomLabelConstraint = mainContentView.constraintAlignBottomTo(messageBackgroundContainer, paddingBottom: 0, priority: .defaultHigh)
 
         actionBtnZeroHeightConstraint = actionButton.constraintHeightTo(0)
+        actionBtnTrailingConstraint = actionButton.constraintAlignTrailingTo(messageBackgroundContainer, paddingTrailing: 12)
 
         topCompactView = false
         bottomCompactView = false


### PR DESCRIPTION
With #1355, I changed the layout constraints for the action button in order to ensure that the button text uses the full available space of a message bubble. However this change leads to some UI bugs for small messages, if no action button is shown. 
The fix sets the corresponding constraint only when the action button is actually shown.

before:

![Screen Shot 2021-09-28 at 12 04 51 PM](https://user-images.githubusercontent.com/2614900/135067755-3d87a388-a6ff-4952-a1ba-b7f20c944971.png)
![Screen Shot 2021-09-28 at 12 05 26 PM](https://user-images.githubusercontent.com/2614900/135067792-de3713d4-a123-4b07-aa1b-491d48c974c0.png)


after:
![Screen Shot 2021-09-28 at 12 07 00 PM](https://user-images.githubusercontent.com/2614900/135067837-f5e71637-532a-42e3-98fd-55a56c62478e.png)
