### PR TITLE
non-blocking group-joins

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -5,7 +5,6 @@ public let dcNotificationChanged = Notification.Name(rawValue: "MrEventMsgsChang
 public let dcNotificationIncoming = Notification.Name(rawValue: "MrEventIncomingMsg")
 public let dcNotificationImexProgress = Notification.Name(rawValue: "dcNotificationImexProgress")
 public let dcNotificationConfigureProgress = Notification.Name(rawValue: "MrEventConfigureProgress")
-public let dcNotificationSecureJoinerProgress = Notification.Name(rawValue: "MrEventSecureJoinerProgress")
 public let dcNotificationSecureInviterProgress = Notification.Name(rawValue: "MrEventSecureInviterProgress")
 public let dcNotificationContactChanged = Notification.Name(rawValue: "MrEventContactsChanged")
 public let dcNotificationChatModified = Notification.Name(rawValue: "dcNotificationChatModified")
@@ -194,24 +193,6 @@ public class DcEventHandler {
                 )
             }
 
-        case DC_EVENT_SECUREJOIN_JOINER_PROGRESS:
-            if dcContext.id != dcAccounts.getSelected().id {
-                return
-            }
-            dcContext.logger?.info("securejoin joiner progress \(data1)")
-            let nc = NotificationCenter.default
-            DispatchQueue.main.async {
-                nc.post(
-                    name: dcNotificationSecureJoinerProgress,
-                    object: nil,
-                    userInfo: [
-                        "contact_id": Int(data1),
-                        "progress": Int(data2),
-                        "error": Int(data2) == 0,
-                        "done": Int(data2) == 1000,
-                    ]
-                )
-            }
         case DC_EVENT_CONTACTS_CHANGED:
             if dcContext.id != dcAccounts.getSelected().id {
                 return

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -592,6 +592,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         dcContext.setStockTranslation(id: DC_STR_MESSAGES, localizationKey: "messages")
         dcContext.setStockTranslation(id: DC_STR_BROADCAST_LIST, localizationKey: "broadcast_list")
         dcContext.setStockTranslation(id: DC_STR_PART_OF_TOTAL_USED, localizationKey: "part_of_total_used")
+        dcContext.setStockTranslation(id: DC_STR_SECURE_JOIN_STARTED, localizationKey: "secure_join_started")
+        dcContext.setStockTranslation(id: DC_STR_SECURE_JOIN_REPLIES, localizationKey: "secure_join_replies")
     }
 
     func appIsInForeground() -> Bool {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -16,6 +16,7 @@ class ChatViewController: UITableViewController {
 
     var msgChangedObserver: NSObjectProtocol?
     var incomingMsgObserver: NSObjectProtocol?
+    var chatModifiedObserver: NSObjectProtocol?
     var ephemeralTimerModifiedObserver: NSObjectProtocol?
     // isDismissing indicates whether the ViewController is/was about to dismissed.
     // The VC can be dismissed by pressing back '<' or by a swipe-to-dismiss gesture.
@@ -507,6 +508,16 @@ class ChatViewController: UITableViewController {
             }
         }
 
+        chatModifiedObserver = nc.addObserver(
+            forName: dcNotificationChatModified,
+            object: nil, queue: OperationQueue.main
+        ) { [weak self] notification in
+            guard let self = self else { return }
+            if let ui = notification.userInfo, self.chatId == ui["chat_id"] as? Int {
+
+            }
+        }
+
         ephemeralTimerModifiedObserver = nc.addObserver(
             forName: dcEphemeralTimerModified,
             object: nil, queue: OperationQueue.main
@@ -533,6 +544,9 @@ class ChatViewController: UITableViewController {
         }
         if let incomingMsgObserver = self.incomingMsgObserver {
             nc.removeObserver(incomingMsgObserver)
+        }
+        if let chatModifiedObserver = self.chatModifiedObserver {
+            nc.removeObserver(chatModifiedObserver)
         }
         if let ephemeralTimerModifiedObserver = self.ephemeralTimerModifiedObserver {
             nc.removeObserver(ephemeralTimerModifiedObserver)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -266,11 +266,7 @@ class ChatViewController: UITableViewController {
     }
 
     override func loadView() {
-        let dcChat = dcContext.getChat(chatId: chatId)
         self.tableView = ChatTableView(messageInputBar: messageInputBar)
-        if !dcChat.canSend {
-            messageInputBar.isHidden = true
-        }
         self.tableView.delegate = self
         self.tableView.dataSource = self
         self.view = self.tableView
@@ -303,6 +299,8 @@ class ChatViewController: UITableViewController {
             configureUIForWriting()
         } else if dcChat.isContactRequest {
             configureContactRequestBar()
+        } else {
+            messageInputBar.isHidden = true
         }
         loadMessages()
     }
@@ -520,13 +518,15 @@ class ChatViewController: UITableViewController {
                 let dcChat = self.dcContext.getChat(chatId: self.chatId)
                 if dcChat.canSend {
                     if self.messageInputBar.isHidden {
-                        self.messageInputBar.isHidden = false
                         self.configureUIForWriting()
+                        self.messageInputBar.isHidden = false
 
-                        // TODO: this update method works in the emulator only.
-                        // the view is there, however,
-                        // going to profile and back shows the view also on real devices
-                        self.setNeedsFocusUpdate()
+                        // TODO: if the viewController is opened initially with hidden input bar,
+                        // it is _not_ shown that way. however, it is kind of there, opening+closing the profile shows it.
+                        //
+                        // (if the the viewController is opened initially with input bar,
+                        // showing and hiding works any number of times)
+                        // (you can test that with a second device/emulator and add/remove the other member)
                     }
                 } else if !dcChat.isContactRequest {
                     if !self.messageInputBar.isHidden {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -517,7 +517,22 @@ class ChatViewController: UITableViewController {
         ) { [weak self] notification in
             guard let self = self else { return }
             if let ui = notification.userInfo, self.chatId == ui["chat_id"] as? Int {
+                let dcChat = self.dcContext.getChat(chatId: self.chatId)
+                if dcChat.canSend {
+                    if self.messageInputBar.isHidden {
+                        self.messageInputBar.isHidden = false
+                        self.configureUIForWriting()
 
+                        // TODO: this update method works in the emulator only.
+                        // the view is there, however,
+                        // going to profile and back shows the view also on real devices
+                        self.setNeedsFocusUpdate()
+                    }
+                } else if !dcChat.isContactRequest {
+                    if !self.messageInputBar.isHidden {
+                        self.messageInputBar.isHidden = true
+                    }
+                }
             }
         }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -267,8 +267,10 @@ class ChatViewController: UITableViewController {
 
     override func loadView() {
         let dcChat = dcContext.getChat(chatId: chatId)
-        let inputBar = !dcChat.canSend && !dcChat.isContactRequest ? nil : messageInputBar
-        self.tableView = ChatTableView(messageInputBar: inputBar)
+        self.tableView = ChatTableView(messageInputBar: messageInputBar)
+        if !dcChat.canSend {
+            messageInputBar.isHidden = true
+        }
         self.tableView.delegate = self
         self.tableView.dataSource = self
         self.view = self.tableView

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -520,13 +520,6 @@ class ChatViewController: UITableViewController {
                     if self.messageInputBar.isHidden {
                         self.configureUIForWriting()
                         self.messageInputBar.isHidden = false
-
-                        // TODO: if the viewController is opened initially with hidden input bar,
-                        // it is _not_ shown that way. however, it is kind of there, opening+closing the profile shows it.
-                        //
-                        // (if the the viewController is opened initially with input bar,
-                        // showing and hiding works any number of times)
-                        // (you can test that with a second device/emulator and add/remove the other member)
                     }
                 } else if !dcChat.isContactRequest {
                     if !self.messageInputBar.isHidden {

--- a/deltachat-ios/Chat/Views/ChatTableView.swift
+++ b/deltachat-ios/Chat/Views/ChatTableView.swift
@@ -6,7 +6,7 @@ class ChatTableView: UITableView {
     var messageInputBar: InputBarAccessoryView
     
     override var inputAccessoryView: UIView? {
-        return messageInputBar.isHidden ? nil : messageInputBar
+        return messageInputBar
     }
 
     override var canBecomeFirstResponder: Bool {

--- a/deltachat-ios/Chat/Views/ChatTableView.swift
+++ b/deltachat-ios/Chat/Views/ChatTableView.swift
@@ -3,18 +3,17 @@ import InputBarAccessoryView
 
 class ChatTableView: UITableView {
 
-    var messageInputBar: InputBarAccessoryView?
+    var messageInputBar: InputBarAccessoryView
+    
     override var inputAccessoryView: UIView? {
-        return messageInputBar
+        return messageInputBar.isHidden ? nil : messageInputBar
     }
-
 
     override var canBecomeFirstResponder: Bool {
         return true
     }
 
-
-    public init(messageInputBar: InputBarAccessoryView?) {
+    public init(messageInputBar: InputBarAccessoryView) {
         self.messageInputBar = messageInputBar
         super.init(frame: .zero, style: .plain)
     }
@@ -22,5 +21,4 @@ class ChatTableView: UITableView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
 }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -354,7 +354,12 @@ class GroupChatDetailViewController: UIViewController {
      }
 
     private func getGroupMemberIdFor(_ row: Int) -> Int {
-        return groupMemberIds[row - memberManagementRows]
+        let index = row - memberManagementRows
+        if index >= 0 && index < groupMemberIds.count {
+            return groupMemberIds[index]
+        } else {
+            return 0
+        }
     }
 
     private func isMemberManagementRow(row: Int) -> Bool {


### PR DESCRIPTION
some ui adaptions needed for https://github.com/deltachat/deltachat-core-rust/pull/2508 (there are also some screenshots from android)

corresponding android pr: https://github.com/deltachat/deltachat-android/pull/2095

the adaption wrt `can_send()` are not only related to the on-blocking group-joins; this is a general fix and also needed eg. when leaving a group.

- [x] add new strings
- [x] remove superfluous progress-dialogs
- [x] handle `can_send()` in profile view
- [x] remove caching of `can_send()` in chat view
- [x] handle `can_send()` in chat view

@cyBerta for review: the messageInputBar is added unconditionally - and shown/hidden as needed. this was already partly used before, when a mailinglist was accepted, the input bar was hidden.  
all in all, this seems to work well, however, the scrollbar is a bit wrong when the inputBar is hidden, probably some offsets are calculated not correctly. i am a bit lost there, maybe you have an idea :)  
we could also revert adding unconditionally, however, we would need to add the messageInputBar later then, and i did not found an easy way to do so.

to move forward, maybe we should merge this pr in and tweak things in a subsequent pr.

closes https://github.com/deltachat/deltachat-ios/issues/1378