### PR TITLE
[postponed] use .provisional notifications

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -247,19 +247,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         notifyToken = nil
 
         // register for showing notifications
-        //
-        // note: the alert-dialog cannot be customized, however, since iOS 12,
-        // it can be avoided completely by using `.provisional`,
-        // https://developer.apple.com/documentation/usernotifications/asking_permission_to_use_notifications
+        var opt: UNAuthorizationOptions = [.alert, .sound, .badge]
+        if #available(iOS 12.0, *) {
+            // provisional
+            opt = [.alert, .sound, .badge]
+        }
         UNUserNotificationCenter.current()
-          .requestAuthorization(options: [.alert, .sound, .badge]) { [weak self] granted, _ in
+          .requestAuthorization(options: opt) { [weak self] granted, error in
             if granted {
                 // we are allowed to show notifications:
                 // register for receiving remote notifications
                 logger.info("Notifications: Permission granted: \(granted)")
                 self?.maybeRegisterForRemoteNotifications()
             } else {
-                logger.info("Notifications: Permission not granted.")
+                logger.info("Notifications: Permission not granted: \(String(describing: error))")
             }
         }
     }


### PR DESCRIPTION
use .provisional notifications that allows the user to opt in when there is actually a notification; also makes room for a customized dialog

postponed that, as it also has some minor drawbacks, cmp https://phiture.com/blog/provisional-push-what-is-it-and-how-will-it-impact-your-addressable-audience/) 