### PR TITLE
[wip] show unread-message-badge for chat requests

### DIFF
--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -233,7 +233,7 @@ class ContactCell: UITableViewCell {
     func setStatusIndicators(unreadCount: Int, status: Int, visibility: Int32, isLocationStreaming: Bool, isMuted: Bool, isContactRequest: Bool) {
         if isLargeText {
             unreadMessageCounter.setCount(unreadCount)
-            unreadMessageCounter.isHidden = unreadCount == 0 || isContactRequest
+            unreadMessageCounter.isHidden = unreadCount == 0
             unreadMessageCounter.backgroundColor = isMuted ? .gray : .red
             pinnedIndicator.isHidden = true
             deliveryStatusIndicator.isHidden = true
@@ -250,7 +250,7 @@ class ContactCell: UITableViewCell {
         } else if unreadCount > 0 {
             pinnedIndicator.isHidden = !(visibility == DC_CHAT_VISIBILITY_PINNED)
             unreadMessageCounter.setCount(unreadCount)
-            unreadMessageCounter.isHidden = isContactRequest
+            unreadMessageCounter.isHidden = false
             unreadMessageCounter.backgroundColor = isMuted ? .gray : .red
             deliveryStatusIndicator.isHidden = true
             archivedIndicator.isHidden = true


### PR DESCRIPTION
chat requests are notified since core61
and may also be added to the app-icon-unread-badge by the system therefore.

to not confuse users,
which chat is unread when tapping the app icon with the unread-badge,
we should show the unread-message-badge also for chat requests.

previously it was hidden with the reasoning
that chat requests are not notified,
https://github.com/deltachat/deltachat-ios/issues/1306
this has changed since then, by strong user requests :)
cmp https://github.com/deltachat/deltachat-core-rust/pull/2690