### PR TITLE
make copying videochat invitations useful

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -148,7 +148,7 @@ class ChatViewController: UITableViewController {
                 let msg = self.dcContext.getMessage(id: id)
 
                 let pasteboard = UIPasteboard.general
-                if msg.type == DC_MSG_TEXT {
+                if msg.type == DC_MSG_TEXT || msg.type == DC_MSG_VIDEOCHAT_INVITATION {
                     pasteboard.string = msg.text
                 } else {
                     pasteboard.string = msg.summary(chars: 10000000)


### PR DESCRIPTION
when doing 'Copy to clipboard' for a videochat-invitation,
use the text text that includes the URL to clipboard;
this is also what android/desktop are doing.

before, only the text "Videotext Invitation" was copied,
which is quote pointless :)