### PR TITLE
make tracking core versions easier

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -13,12 +13,12 @@ on the command-line:
 3. update local help:
    $ ./scripts/create-local-help.py
 
-4. add a device message to ChatListController::viewWillAppear()
-   and update CHANGELOG.md
-   (the core-changelog at
-   https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md
-   and the "N commits to master since last release" on
-   https://github.com/deltachat/deltachat-ios/releases gives some good hints)
+4. a) update CHANGELOG.md
+      from https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md
+      and https://github.com/deltachat/deltachat-ios/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc
+   b) add used core version to CHANGELOG.md
+   c) add a device message to ConversationListActivity::onCreate()
+      or remove the old one
 
 in Xcode:
 

--- a/scripts/update-core.sh
+++ b/scripts/update-core.sh
@@ -12,11 +12,12 @@ git submodule update --init --recursive
 cd deltachat-ios/libraries/deltachat-core-rust
 git checkout master
 git pull
+commitmsg=`git log -1 --pretty=%s`
 cd ../../..
 
 # commit changes
 git add deltachat-ios/libraries/deltachat-core-rust
-git commit -m "update deltachat-core-rust submodule"
+git commit -m "update deltachat-core-rust submodule to '$commitmsg'"
 
 echo "changes are commited to local repo."
 echo "use 'git push' to use them or 'git reset HEAD~1; git submodule update --recursive' to abort on your own risk :)"


### PR DESCRIPTION
this is basically the same as in https://github.com/deltachat/deltachat-android/pull/2152