### PR TITLE
Fix drafts on notification tap

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -457,7 +457,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             let userInfo = response.notification.request.content.userInfo
              if let chatId = userInfo["chat_id"] as? Int,
                  let msgId = userInfo["message_id"] as? Int {
-                 appCoordinator.showChat(chatId: chatId, msgId: msgId, animated: false, clearViewControllerStack: true)
+                 if !appCoordinator.isShowingChat(chatId: chatId) {
+                     appCoordinator.showChat(chatId: chatId, msgId: msgId, animated: false, clearViewControllerStack: true)
+                 }
              }
         }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -478,6 +478,7 @@ class ChatViewController: UITableViewController {
         if parent == nil {
             // logger.debug("chat observer: remove")
             removeObservers()
+            draft.save(context: dcContext)
         } else {
             // logger.debug("chat observer: setup")
             setupObservers()
@@ -622,6 +623,7 @@ class ChatViewController: UITableViewController {
     @objc func applicationWillResignActive(_ notification: NSNotification) {
         if navigationController?.visibleViewController == self {
             handleUserVisibility(isVisible: false)
+            draft.save(context: dcContext)
         }
     }
     
@@ -632,7 +634,6 @@ class ChatViewController: UITableViewController {
             markSeenMessagesInVisibleArea()
         } else {
             stopTimer()
-            draft.save(context: dcContext)
         }
     }
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -94,6 +94,15 @@ class AppCoordinator {
         }
     }
 
+    func isShowingChat(chatId: Int) -> Bool {
+        if let rootController = self.tabBarController.selectedViewController as? UINavigationController,
+           let chatViewController = rootController.viewControllers.last as? ChatViewController,
+           chatViewController.chatId == chatId {
+            return true
+        }
+        return false
+    }
+
     func showChat(chatId: Int, msgId: Int? = nil, animated: Bool = true, clearViewControllerStack: Bool = false) {
         showTab(index: chatsTab)
 


### PR DESCRIPTION
In case the user has enabled persitent notifications (disabled by default), drafts of an already opened chat have been withdrawn if the user tapped on a delivered notification (delivered to the UI, a state, where we cannot cancel notifications programatically anymore) for the same chat, see #1408

This fix ensures that drafts are always saved before a chat gets removed from the UIViewController stack. It also ensures that no action is made when the user tapped on a notification for an already opened chat. 

If a user has temporary notifications enabled instead of persistent notifications, there will never be the situation, where a notification appears for an already opened chat. 

fixes #1408 