### PR TITLE
[wip] stop ChatViewController timings

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -278,14 +278,18 @@ class ChatViewController: UITableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    let allStart = CFAbsoluteTimeGetCurrent()
     override func loadView() {
+        logger.info("🔨 *** ChatViewController: loadView starting ***")
         self.tableView = ChatTableView(messageInputBar: messageInputBar)
         self.tableView.delegate = self
         self.tableView.dataSource = self
         self.view = self.tableView
+        logger.info("🔨 ChatViewController: loadView ending")
     }
 
     override func viewDidLoad() {
+        logger.info("🔨 ChatViewController: viewDidLoad starting")
         super.viewDidLoad()
         tableView.backgroundView = backgroundContainer
         tableView.register(TextMessageCell.self, forCellReuseIdentifier: "text")
@@ -322,6 +326,7 @@ class ChatViewController: UITableViewController {
             messageInputBar.isHidden = true
         }
         loadMessages()
+        logger.info("🔨 ChatViewController: viewDidLoad ending")
     }
 
     private func configureUIForWriting() {
@@ -376,6 +381,7 @@ class ChatViewController: UITableViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        logger.info("🔨 ChatViewController: viewWillAppear starting")
         super.viewWillAppear(animated)
         // this will be removed in viewWillDisappear
         navigationController?.navigationBar.addGestureRecognizer(navBarTap)
@@ -440,6 +446,7 @@ class ChatViewController: UITableViewController {
         }
 
         prepareContextMenu()
+        logger.info("🔨 ChatViewController: viewWillAppear ending,  \(CFAbsoluteTimeGetCurrent()-allStart) s since startx")
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
on my iphone7, 3gig db:

- without the recent background_image pr,
  80ms are needed to set up views,
  _plus_ time needed for getChatMsgs(),
  so, overall, 0.2 to 1.0 s

- _with_ the recent background_image pr,
  100ms are needed to set up views.

so, all in all, backround_image pr add 20 ms,
on a quite old phone, mind you.

i think, we should streamline the measurement,
maybe removing all but the last line,
so that we can get a feeling about timings
on different devices with different wallpapers.

i will adapt that tomorrow then.

targets #1414