### PR TITLE
fix clearing drafts. 

### DIFF
--- a/deltachat-ios/Chat/DraftModel.swift
+++ b/deltachat-ios/Chat/DraftModel.swift
@@ -49,7 +49,7 @@ public class DraftModel {
     }
 
     public func save(context: DcContext) {
-        if text == nil && quoteMessage == nil {
+        if (text?.isEmpty ?? true) && quoteMessage == nil {
             context.setDraft(chatId: chatId, message: nil)
             return
         }


### PR DESCRIPTION
setting empty drafts was never really allowed (the error was there all the time), but checks were easygoing before.

closes #1443