### PR TITLE
fix invisible hour glass for pending messages

### DIFF
--- a/deltachat-ios/Helper/MessageUtils.swift
+++ b/deltachat-ios/Helper/MessageUtils.swift
@@ -96,7 +96,7 @@ public class MessageUtils {
 
         switch Int32(state) {
         case DC_STATE_OUT_PENDING, DC_STATE_OUT_PREPARING, DC_DOWNLOAD_IN_PROGRESS:
-            imageAttachment.image = #imageLiteral(resourceName: "ic_hourglass_empty_white_36pt").scaleDownImage(toMax: 14)?.maskWithColor(color: DcColors.coreDark05)
+            imageAttachment.image = #imageLiteral(resourceName: "ic_hourglass_empty_white_36pt").scaleDownImage(toMax: 14)?.maskWithColor(color: color)
         case DC_STATE_OUT_DELIVERED:
             imageAttachment.image = #imageLiteral(resourceName: "ic_done_36pt").scaleDownImage(toMax: 16)?.sd_croppedImage(with: CGRect(x: 0, y: 4, width: 16, height: 14))?.maskWithColor(color: color)
             offset = -3.5


### PR DESCRIPTION
uses now the tint color (like sent and received icon) for hour glass, similar to android's color scheme for pending messages