### PR TITLE
disable zoom in wkwebview

### DIFF
--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -142,6 +142,7 @@ class WebxdcViewController: WebViewViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = dcContext.getMessage(id: messageId).getWebxdcInfoDict()["name"] as? String
+        webView.scrollView.bounces = false
     }
     
     override func willMove(toParent parent: UIViewController?) {

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -93,6 +93,12 @@ class WebxdcViewController: WebViewViewController {
         return script
     }()
     
+    private let disableZoom: String = "var meta = document.createElement('meta');" +
+        "meta.name = 'viewport';" +
+        "meta.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no';" +
+        "var head = document.getElementsByTagName('head')[0];" +
+        "head.appendChild(meta);"
+
     override var configuration: WKWebViewConfiguration {
         let config = WKWebViewConfiguration()
         let preferences = WKPreferences()
@@ -102,6 +108,9 @@ class WebxdcViewController: WebViewViewController {
         contentController.add(self, name: WebxdcHandler.getStatusUpdates.rawValue)
         contentController.add(self, name: WebxdcHandler.log.rawValue)
         
+        let disableZoomScript: WKUserScript = WKUserScript(source: disableZoom, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+        contentController.addUserScript(disableZoomScript)
+
         config.userContentController = contentController
         config.setURLSchemeHandler(self, forURLScheme: INTERNALSCHEMA)
         


### PR DESCRIPTION
it seems only to be reliable possible to disable zoom by adding javascript as it is done in this PR. 

However I'm not sure if this is the way to go or if we should instead add this example code to webxdc developer documentation, so that it's up to the webxdc to decide if zooming is allowed or not. 

relates to #1470