### PR TITLE
fix crashes on creating blobs

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -1107,14 +1107,17 @@ public class DcMsg {
         defer {
             ptrSize.deallocate()
         }
+
         guard let ccharPtr = dc_msg_get_webxdc_blob(messagePointer, filename, ptrSize) else {
             return Data()
+        }
+        defer {
+            dc_str_unref(ccharPtr)
         }
 
         let count = ptrSize.pointee
         let buffer = UnsafeBufferPointer<Int8>(start: ccharPtr, count: count)
         let data = Data(buffer: buffer)
-        dc_str_unref(ccharPtr)
         return data
     }
 

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -1113,8 +1113,9 @@ public class DcMsg {
 
         let count = ptrSize.pointee
         let buffer = UnsafeBufferPointer<Int8>(start: ccharPtr, count: count)
+        let data = Data(buffer: buffer)
         dc_str_unref(ccharPtr)
-        return Data(buffer: buffer)
+        return data
     }
 
     public func getWebxdcInfoJson() -> String {


### PR DESCRIPTION
do not try to create a Data object by UnsafeBufferPointer that point to already unref'd data.

otherwise, we had crashes or getting already overwritten data.

that may have been also the reason for other webxdc not working as expected.

EDIT: more concrete: the weird Triska background color (white/black padding mixed) is fixed and the older Triska that did not work are working with this pr now :)

closes #1473 
closes #1474