### PR TITLE
stop media playback if wbxdc is closed

### DIFF
--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -184,6 +184,13 @@ class WebxdcViewController: WebViewViewController {
         loadHtml()
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        if #available(iOS 15.0, *) {
+            webView.pauseAllMediaPlayback()
+        }
+    }
+
     
     private func loadRestrictedHtml() {
         // TODO: compile only once


### PR DESCRIPTION
there is an easy to use API for iOS15+ so that the issue of endless playback can be at least partially fixed without much effort.