### PR TITLE
log file size of backup import attempt

### DIFF
--- a/deltachat-ios/Controller/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetupController.swift
@@ -715,9 +715,16 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
         let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
         if !documents.isEmpty {
             logger.info("looking for backup in: \(documents[0])")
-
             if let file = dcContext.imexHasBackup(filePath: documents[0]) {
-                logger.info("restoring backup: \(file)")
+                var fileBytes: UInt64  = 0;
+                do {
+                    let attr = try FileManager.default.attributesOfItem(atPath: file)
+                    fileBytes = attr[FileAttributeKey.size] as! UInt64
+                } catch {
+                    logger.error("cannot get file size of \(file)")
+                }
+                logger.info("importing backup \(file), \(fileBytes) bytes")
+
                 showProgressAlert(title: String.localized("import_backup_title"), dcContext: dcContext)
                 dcAccounts.stopIo()
                 dcContext.imex(what: DC_IMEX_IMPORT_BACKUP, directory: file)


### PR DESCRIPTION
due to apple removed the progress bar (WTF!)
on copying files from Finder to iPhone,
it may easily happen, a backup is incomplete.

this will at least give a hint.

cmp. https://developer.apple.com/forums/thread/130051