### PR TITLE
Send correct DC_EVENT_MSGS_CHANGED when returning from share extension

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -197,7 +197,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                     NotificationCenter.default.post(
                         name: dcNotificationChanged,
                         object: nil,
-                        userInfo: [:]
+                        userInfo: [
+                            "message_id": Int(0),
+                            "chat_id": Int(0),
+                        ]
                     )
                 }
             }


### PR DESCRIPTION
this fixes the underlying issue of #1513 - that an incomplete event is sent - and fixes the issue also for other views than the ChatViewController (profile etc.)

issue was that the id was left out instead of set to `0` as it happens when the event comes from the core.

fixes #1513

the refactoring of #1518 probably still makes sense, however #1518 fixes the #1513 only for the ChatViewController.