### PR TITLE
fix dark mode info-messages

### DIFF
--- a/DcCore/DcCore/Helper/DcColors.swift
+++ b/DcCore/DcCore/Helper/DcColors.swift
@@ -35,7 +35,7 @@ public struct DcColors {
     public static let providerPreparationBackground = UIColor.init(hexString: "fdf7b2")
     public static let providerBrokenBackground = UIColor.themeColor(light: SystemColor.red.uiColor, dark: SystemColor.red.uiColor)
     public static let systemMessageBackgroundColor = UIColor.init(hexString: "65444444")
-    public static let systemMessageFontColor = UIColor.themeColor(light: .white, dark: UIColor.init(hexString: "A4A6A9"))
+    public static let systemMessageFontColor = UIColor.white
     public static let deaddropBackground = UIColor.themeColor(light: UIColor.init(hexString: "ebebec"), dark: UIColor.init(hexString: "1a1a1c"))
 }
 


### PR DESCRIPTION
as we are using the same info-messages background-color-transparency for light and dark mode, also use the same, contrasting foreground color.

before/after using a _really_ hard background (the daymarkers and info-messages use the same color set):

<img width=300 src=https://user-images.githubusercontent.com/9800740/163214476-98af82ed-7b80-41f8-a951-0ea3ec3fe5ab.PNG> <img width=300 src=https://user-images.githubusercontent.com/9800740/163214544-f53aac1c-f66d-454c-9ef0-46293877bad5.PNG>

closes #1462 