### PR TITLE
show download failure

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -358,8 +358,10 @@ public class BaseMessageCell: UITableViewCell {
         isActionButtonHidden = !hasWebxdc && !hasHtml && downloadState == DC_DOWNLOAD_DONE
         
         switch downloadState {
-        case DC_DOWNLOAD_FAILURE, DC_DOWNLOAD_AVAILABLE:
+        case DC_DOWNLOAD_AVAILABLE:
             actionButton.setTitle(String.localized("download"), for: .normal)
+        case DC_DOWNLOAD_FAILURE:
+            actionButton.setTitle(String.localized("download_failed"), for: .normal)
         case DC_DOWNLOAD_IN_PROGRESS:
             actionButton.isEnabled = false
             actionButton.setTitle(String.localized("downloading"), for: .normal)


### PR DESCRIPTION
tapping on the message, still allows re-downloading
in case of temporary errors.

fixes the same issue as in https://github.com/deltachat/deltachat-android/pull/2275 , also here, maybe the error message could be nicer, however, not sure if that is worth the effort, at least this is sth. for another time :)