### PR TITLE
signal when connectivity is "connected" again

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -9,6 +9,7 @@ public class DcAccounts {
     let applicationGroupIdentifier = "group.chat.delta.ios"
     var accountsPointer: OpaquePointer?
     public var logger: Logger?
+    public var fetchSemaphore: DispatchSemaphore?
 
     public init() {
     }

--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -56,6 +56,10 @@ public class DcAccounts {
         dc_accounts_maybe_network_lost(accountsPointer)
     }
 
+    public func isAllWorkDone() -> Bool {
+        return dc_accounts_all_work_done(accountsPointer) != 0
+    }
+
     public func startIo() {
         dc_accounts_start_io(accountsPointer)
     }

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -214,6 +214,9 @@ public class DcEventHandler {
                 return
             }
             dcContext.logger?.info("network: DC_EVENT_CONNECTIVITY_CHANGED: \(dcContext.getConnectivity())")
+            if let sem = dcAccounts.fetchSemaphore, dcContext.getConnectivity() == DC_CONNECTIVITY_CONNECTED {
+                sem.signal()
+            }
             DispatchQueue.main.async {
                 let nc = NotificationCenter.default
                 nc.post(

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -210,13 +210,13 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_CONNECTIVITY_CHANGED:
+            if let sem = dcAccounts.fetchSemaphore, dcAccounts.isAllWorkDone() {
+                sem.signal()
+            }
             if dcContext.id != dcAccounts.getSelected().id {
                 return
             }
             dcContext.logger?.info("network: DC_EVENT_CONNECTIVITY_CHANGED: \(dcContext.getConnectivity())")
-            if let sem = dcAccounts.fetchSemaphore, dcContext.getConnectivity() == DC_CONNECTIVITY_CONNECTED {
-                sem.signal()
-            }
             DispatchQueue.main.async {
                 let nc = NotificationCenter.default
                 nc.post(

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -445,7 +445,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             return
         }
         bgIoTimestamp = nowTimestamp
-        addDebugFetchTimestamp()
 
         // make sure to balance each call to `beginBackgroundTask` with `endBackgroundTask`
         var backgroundTask: UIBackgroundTaskIdentifier = .invalid
@@ -468,6 +467,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             // we're in background, run IO for a little time
             self.dcAccounts.startIo()
             self.dcAccounts.maybeNetwork()
+
+            self.addDebugFetchTimestamp()
 
             // create a new semaphore to make sure the received DC_CONNECTIVITY_CONNECTED really belongs to maybeNetwork() from above
             // (maybeNetwork() sets connectivity to DC_CONNECTIVITY_CONNECTING, when fetch is done, we're back at DC_CONNECTIVITY_CONNECTED)

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -471,6 +471,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             // this does not happen often, but still.
             // cmp. https://github.com/deltachat/deltachat-ios/pull/1542#pullrequestreview-951620906
             logger.info("⬅️ finishing fetch")
+            self.pushToDebugArray(name: "notify-fetch-durations", value: Double(Date().timeIntervalSince1970)-nowTimestamp)
 
             // dispatch back to main as we cannot check the foreground state from non-main thread
             // (this again has the risk to be delayed by tens of minutes, however, fetch is done and we're mostly fine)
@@ -483,10 +484,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
                 // to avoid 0xdead10cc exceptions, scheduled jobs need to be done before we get suspended;
                 // we increase the probabilty that this happens by waiting a moment before calling completionHandler()
-                DispatchQueue.global().async { [weak self] in
+                DispatchQueue.global().async {
                     usleep(1_000_000)
                     logger.info("⬅️ fetch done")
-                    self?.pushToDebugArray(name: "notify-fetch-durations", value: Double(Date().timeIntervalSince1970)-nowTimestamp)
                     completionHandler(.newData)
                     if backgroundTask != .invalid {
                         UIApplication.shared.endBackgroundTask(backgroundTask)

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -462,7 +462,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             // create a new semaphore to make sure the received DC_CONNECTIVITY_CONNECTED really belongs to maybeNetwork() from above
             // (maybeNetwork() sets connectivity to DC_CONNECTIVITY_CONNECTING, when fetch is done, we're back at DC_CONNECTIVITY_CONNECTED)
             self.dcAccounts.fetchSemaphore = DispatchSemaphore(value: 0)
-            _ = self.dcAccounts.fetchSemaphore?.wait(timeout: .now() + 10)
+            _ = self.dcAccounts.fetchSemaphore?.wait(timeout: .now() + 20)
             self.dcAccounts.fetchSemaphore = nil
 
             // TOCHECK: it seems, we are not always reaching this point in code,


### PR DESCRIPTION
this finishes the background-fetch much faster,
instead of always 11 seconds, things finish in less than 2 seconds usually
and take longer only when here is really something to download.

EDIT: after testing the pr for a day, there are some open points:
- [x] i agree with @cyBerta - we should check all accounts for reaching connected state - otherwise, if your active account is "fast", slower background account won't even get connected
- [x] we should not only abort on DC_CONNECTIVITY_CONNECTED but also for DC_CONNECTIVITY_NOT_CONNECTED - we may have no network or the server may be down. i had bad network at some place, and run always for 20 seconds therfore

fetchSemaphore is signalled when we receive the DC_CONNECTIVITY_CHANGED event
with connectivity set to DC_CONNECTIVITY_CONNECTED - we have called maybeNetwork()
just before which sets connectivity to CONNECTING,
we know pretty sure that one round is done.

we check that on the selected context only,
that is maybe not perfect, but probably good enough
(other accounts are checked as well, but may be stopped too soon)

this implements ideas already drafted at https://github.com/deltachat/deltachat-ios/pull/1461 and finally closes https://github.com/deltachat/deltachat-ios/issues/1157