### PR TITLE
improve VoiceOver navigation in chat

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1134,7 +1134,7 @@ class ChatViewController: UITableViewController {
                 guard let self = self else { return }
                 UIAccessibility.post(notification: .screenChanged, argument: self.tableView.cellForRow(at: indexPath))
                 self.markSeenMessagesInVisibleArea()
-                // TODO: with #1549 merged we can add here scrollDownlButton visibility
+                self.updateScrollDownButtonVisibility()
             })
         } else {
             self.tableView.scrollToRow(at: indexPath, at: .top, animated: animated)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1078,7 +1078,10 @@ class ChatViewController: UITableViewController {
                 guard let self = self else { return }
                 let numberOfRows = self.tableView.numberOfRows(inSection: 0)
                 if numberOfRows > 0 {
-                    self.scrollToRow(at: IndexPath(row: numberOfRows - 1, section: 0), position: .bottom, animated: animated, focusWithVoiceOver: focusOnVoiceOver)
+                    self.scrollToRow(at: IndexPath(row: numberOfRows - 1, section: 0),
+                                     position: .bottom,
+                                     animated: animated,
+                                     focusWithVoiceOver: focusOnVoiceOver)
                 }
             }
         }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -66,7 +66,7 @@ class ChatViewController: UITableViewController {
                              options: [.retryFailed]) { [weak self] (_, error, _, _) in
                 if let error = error {
                     logger.error("Error loading background image: \(error.localizedDescription)" )
-                    DispatchQueue.main.async {
+                    DispatchQueue.main.async { [weak self] in
                         self?.setDefaultBackgroundImage(view: view)
                     }
                 }
@@ -1547,7 +1547,8 @@ class ChatViewController: UITableViewController {
     }
 
     private func sendTextMessage(text: String, quoteMessage: DcMsg?) {
-        DispatchQueue.global().async {
+        DispatchQueue.global().async { [weak self] in
+            guard let self = self else { return }
             let message = self.dcContext.newMessage(viewType: DC_MSG_TEXT)
             message.text = text
             if let quoteMessage = quoteMessage {
@@ -1611,7 +1612,8 @@ class ChatViewController: UITableViewController {
     }
 
     private func sendImage(_ image: UIImage, message: String? = nil) {
-        DispatchQueue.global().async {
+        DispatchQueue.global().async { [weak self] in
+            guard let self = self else { return }
             if let path = ImageFormat.saveImage(image: image, directory: .cachesDirectory) {
                 self.sendAttachmentMessage(viewType: DC_MSG_IMAGE, filePath: path, message: message)
                 ImageFormat.deleteImage(atPath: path)
@@ -1620,7 +1622,8 @@ class ChatViewController: UITableViewController {
     }
 
     private func sendSticker(_ image: UIImage) {
-        DispatchQueue.global().async {
+        DispatchQueue.global().async { [weak self] in
+            guard let self = self else { return }
             if let path = ImageFormat.saveImage(image: image, directory: .cachesDirectory) {
                 self.sendAttachmentMessage(viewType: DC_MSG_STICKER, filePath: path, message: nil)
                 ImageFormat.deleteImage(atPath: path)
@@ -1639,7 +1642,8 @@ class ChatViewController: UITableViewController {
     }
 
     private func sendVoiceMessage(url: NSURL) {
-        DispatchQueue.global().async {
+        DispatchQueue.global().async { [weak self] in
+            guard let self = self else { return }
             let msg = self.dcContext.newMessage(viewType: DC_MSG_VOICE)
             msg.setFile(filepath: url.relativePath, mimeType: "audio/m4a")
             self.dcContext.sendMessage(chatId: self.chatId, message: msg)
@@ -2071,7 +2075,8 @@ extension ChatViewController: UISearchResultsUpdating {
         debounceTimer?.invalidate()
         debounceTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { _ in
             let searchText = searchController.searchBar.text ?? ""
-            DispatchQueue.global(qos: .userInteractive).async {
+            DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+                guard let self = self else { return }
                 let resultIds = self.dcContext.searchMessages(chatId: self.chatId, searchText: searchText)
                 DispatchQueue.main.async { [weak self] in
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -325,7 +325,11 @@ class ChatViewController: UITableViewController {
         keyboardManager?.bind(to: tableView)
         keyboardManager?.on(event: .didChangeFrame) { [weak self] _ in
             guard let self = self else { return }
-            if self.isLastRowVisible() && !self.tableView.isDragging && !self.tableView.isDecelerating && self.highlightedMsg == nil && !self.isInitial {
+            if self.isInitial {
+                self.isInitial = false
+                return
+            }
+            if self.isLastRowVisible() && !self.tableView.isDragging && !self.tableView.isDecelerating && self.highlightedMsg == nil {
                 self.scrollToBottom()
             }
         }.on(event: .willChangeFrame) { [weak self] _ in
@@ -425,7 +429,6 @@ class ChatViewController: UITableViewController {
                 if finished {
                     guard let self = self else { return }
                     self.highlightedMsg = nil
-                    self.isInitial = false
                     self.updateScrollDownButtonVisibility()
                 }
             })
@@ -438,7 +441,6 @@ class ChatViewController: UITableViewController {
             }, completion: { [weak self] finished in
                 guard let self = self else { return }
                 if finished {
-                    self.isInitial = false
                 }
             })
         }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1188,6 +1188,7 @@ class ChatViewController: UITableViewController {
 
     private func evaluateInputBar(draft: DraftModel) {
         messageInputBar.sendButton.isEnabled = draft.canSend()
+        messageInputBar.sendButton.accessibilityTraits = draft.canSend() ? .button : .notEnabled
     }
 
     private func configureInputBarItems() {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1075,7 +1075,7 @@ class ChatViewController: UITableViewController {
                 guard let self = self else { return }
                 let numberOfRows = self.tableView.numberOfRows(inSection: 0)
                 if numberOfRows > 0 {
-                    self.scrollToRow(at: IndexPath(row: numberOfRows - 1, section: 0), animated: animated, focusWithVoiceOver: focusOnVoiceOver)
+                    self.scrollToRow(at: IndexPath(row: numberOfRows - 1, section: 0), position: .bottom, animated: animated, focusWithVoiceOver: focusOnVoiceOver)
                 }
             }
         }
@@ -1127,9 +1127,9 @@ class ChatViewController: UITableViewController {
         }
     }
 
-    private func scrollToRow(at indexPath: IndexPath, animated: Bool, focusWithVoiceOver: Bool = true) {
+    private func scrollToRow(at indexPath: IndexPath, position: UITableView.ScrollPosition = .top, animated: Bool, focusWithVoiceOver: Bool = true) {
         if UIAccessibility.isVoiceOverRunning && focusWithVoiceOver {
-            self.tableView.scrollToRow(at: indexPath, at: .top, animated: false)
+            self.tableView.scrollToRow(at: indexPath, at: position, animated: false)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: { [weak self] in
                 guard let self = self else { return }
                 UIAccessibility.post(notification: .screenChanged, argument: self.tableView.cellForRow(at: indexPath))
@@ -1137,7 +1137,7 @@ class ChatViewController: UITableViewController {
                 self.updateScrollDownButtonVisibility()
             })
         } else {
-            self.tableView.scrollToRow(at: indexPath, at: .top, animated: animated)
+            self.tableView.scrollToRow(at: indexPath, at: position, animated: animated)
         }
     }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1923,6 +1923,7 @@ extension ChatViewController: MediaPickerDelegate {
 
     func onVoiceMessageRecorderClosed() {
         if UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .announcement, argument: nil)
             // we need to wait a little bit, otherwise the  UIAccessibility notification is ignored and
             // the first accessibility element on the screen gets selected
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -233,6 +233,11 @@ class ChatViewController: UITableViewController {
                     guard let self = self else { return }
                     let messageId = self.messageIds[indexPath.row]
                     self.setEditing(isEditing: true, selectedAtIndexPath: indexPath)
+                    if UIAccessibility.isVoiceOverRunning {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: { [weak self] in
+                            UIAccessibility.post(notification: .layoutChanged, argument: self?.tableView.cellForRow(at: indexPath))
+                        })
+                    }
                 }
             }
         )

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1184,6 +1184,7 @@ class ChatViewController: UITableViewController {
         messageInputBar.delegate = self
         messageInputBar.inputTextView.tintColor = DcColors.primary
         messageInputBar.inputTextView.placeholder = String.localized("chat_input_placeholder")
+        messageInputBar.inputTextView.accessibilityLabel = String.localized("write_message_desktop")
         messageInputBar.separatorLine.backgroundColor = DcColors.colorDisabled
         messageInputBar.inputTextView.tintColor = DcColors.primary
         messageInputBar.inputTextView.textColor = DcColors.defaultTextColor

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -441,6 +441,7 @@ class ChatViewController: UITableViewController {
             }, completion: { [weak self] finished in
                 guard let self = self else { return }
                 if finished {
+                    self.updateScrollDownButtonVisibility()
                 }
             })
         }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -843,7 +843,7 @@ class ChatViewController: UITableViewController {
         let message = dcContext.getMessage(id: self.messageIds[indexPath.row])
         self.draft.setQuote(quotedMsg: message)
         self.configureDraftArea(draft: self.draft)
-        self.messageInputBar.inputTextView.becomeFirstResponder()
+        focusInputTextView()
     }
 
     func markSeenMessagesInVisibleArea() {
@@ -1552,11 +1552,20 @@ class ChatViewController: UITableViewController {
         }
     }
 
+    private func focusInputTextView() {
+        self.messageInputBar.inputTextView.becomeFirstResponder()
+        if UIAccessibility.isVoiceOverRunning {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: { [weak self] in
+                UIAccessibility.post(notification: .layoutChanged, argument: self?.messageInputBar.inputTextView)
+            })
+        }
+    }
+
     private func stageDocument(url: NSURL) {
         keepKeyboard = true
         self.draft.setAttachment(viewType: url.pathExtension == "xdc" ? DC_MSG_WEBXDC : DC_MSG_FILE, path: url.relativePath)
         self.configureDraftArea(draft: self.draft)
-        self.messageInputBar.inputTextView.becomeFirstResponder()
+        self.focusInputTextView()
     }
 
     private func stageVideo(url: NSURL) {
@@ -1565,7 +1574,7 @@ class ChatViewController: UITableViewController {
             guard let self = self else { return }
             self.draft.setAttachment(viewType: DC_MSG_VIDEO, path: url.relativePath)
             self.configureDraftArea(draft: self.draft)
-            self.messageInputBar.inputTextView.becomeFirstResponder()
+            self.focusInputTextView()
         }
     }
 
@@ -1589,7 +1598,7 @@ class ChatViewController: UITableViewController {
                         self.draft.setAttachment(viewType: DC_MSG_IMAGE, path: pathInCachesDir)
                     }
                     self.configureDraftArea(draft: self.draft)
-                    self.messageInputBar.inputTextView.becomeFirstResponder()
+                    self.focusInputTextView()
                     ImageFormat.deleteImage(atPath: pathInCachesDir)
                 }
             }
@@ -1966,6 +1975,7 @@ extension ChatViewController: DraftPreviewDelegate {
         keepKeyboard = true
         draft.setQuote(quotedMsg: nil)
         configureDraftArea(draft: draft)
+        focusInputTextView()
     }
 
     func onCancelAttachment() {
@@ -1973,6 +1983,7 @@ extension ChatViewController: DraftPreviewDelegate {
         draft.clearAttachment()
         configureDraftArea(draft: draft)
         evaluateInputBar(draft: draft)
+        focusInputTextView()
     }
 
     func onAttachmentAdded() {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -259,7 +259,7 @@ class ChatViewController: UITableViewController {
     /// The `BasicAudioController` controll the AVAudioPlayer state (play, pause, stop) and update audio cell UI accordingly.
     private lazy var audioController = AudioController(dcContext: dcContext, chatId: chatId, delegate: self)
 
-    private lazy var keyboardManager: KeyboardManager = {
+    private lazy var keyboardManager: KeyboardManager? = {
         let manager = KeyboardManager()
         return manager
     }()
@@ -322,9 +322,8 @@ class ChatViewController: UITableViewController {
         definesPresentationContext = true
 
         // Binding to the tableView will enable interactive dismissal
-        keyboardManager.bind(to: tableView)
-
-        keyboardManager.on(event: .didChangeFrame) { [weak self] _ in
+        keyboardManager?.bind(to: tableView)
+        keyboardManager?.on(event: .didChangeFrame) { [weak self] _ in
             guard let self = self else { return }
             if self.isLastRowVisible() && !self.tableView.isDragging && !self.tableView.isDecelerating && self.highlightedMsg == nil && !self.isInitial {
                 self.scrollToBottom()
@@ -493,6 +492,7 @@ class ChatViewController: UITableViewController {
         audioController.stopAnyOngoingPlaying()
         messageInputBar.inputTextView.resignFirstResponder()
         wasInputBarFirstResponder = false
+        keyboardManager = nil
     }
 
     override func willMove(toParent parent: UIViewController?) {

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputTextView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputTextView.swift
@@ -84,7 +84,6 @@ open class InputTextView: UITextView {
     open var placeholder: String? = "Aa" {
         didSet {
             placeholderLabel.text = placeholder
-            accessibilityLabel = placeholder
         }
     }
     

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputTextView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputTextView.swift
@@ -76,6 +76,7 @@ open class InputTextView: UITextView {
         label.text = "Aa"
         label.backgroundColor = .clear
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.isAccessibilityElement = false
         return label
     }()
     
@@ -83,6 +84,7 @@ open class InputTextView: UITextView {
     open var placeholder: String? = "Aa" {
         didSet {
             placeholderLabel.text = placeholder
+            accessibilityLabel = placeholder
         }
     }
     

--- a/deltachat-ios/Chat/Views/ChatEditingBar.swift
+++ b/deltachat-ios/Chat/Views/ChatEditingBar.swift
@@ -48,6 +48,7 @@ public class ChatEditingBar: UIView, InputItem {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isUserInteractionEnabled = true
         view.imageView?.contentMode = .scaleAspectFit
+        view.accessibilityLabel = String.localized("delete")
         return view
     }()
 
@@ -58,6 +59,7 @@ public class ChatEditingBar: UIView, InputItem {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.imageView?.contentMode = .scaleAspectFit
         view.isUserInteractionEnabled = true
+        view.accessibilityLabel = String.localized("forward")
         return view
     }()
 

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -106,6 +106,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.accessibilityViewIsModal = true
         self.view.backgroundColor = UIColor.themeColor(light: .white, dark: .black)
         self.navigationController?.isToolbarHidden = false
         self.navigationController?.toolbar.isTranslucent = true


### PR DESCRIPTION
* jump to last message or last seen message or searched message when entering the screen with VoiceOver enabled
* closes https://github.com/deltachat/deltachat-ios/issues/1535, make it distinguishable if the send button is enabled or not 
* fixes missing accessibility labels in multi-select for forwarding and deleting messages
* fixes accessibility label for message input bar (placeholder was handled as own accessibility element and Voice Over read out the elements in the following order before: TextField - SendButton - Textfield placeholder 
* ensures after enabling multiselect the last selected message is focuessed
* ensures the message input bar is focussed (instead of the first element of the table view / the most outdated message) after an attachment or a quote was added
* same for cancelling attachments and quotes: message input bar is focussed instead of first element of the table view
* focus and read out new incoming messages 

EDIT:
* when debugging this PR I discovered some general bugs (bc469e79635095feaa2db6204dfdc16b20fb2ac8, f4d755ef804b45cfac992feaa7e319adbf6f2e80, ced2035196beb170abc6ca3140edff82f5cb5620, 01d0ccedb79a4c06e5e481df2edf02078b38ed70), that I fixed within this PR. 