### PR TITLE
[do not merge] no semaphores in background and other experiments

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -9,7 +9,7 @@ public class DcAccounts {
     let applicationGroupIdentifier = "group.chat.delta.ios"
     var accountsPointer: OpaquePointer?
     public var logger: Logger?
-    public var fetchSemaphore: DispatchSemaphore?
+    public var doExitPerformFetch: Bool = true
 
     public init() {
     }

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -210,8 +210,8 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_CONNECTIVITY_CHANGED:
-            if let sem = dcAccounts.fetchSemaphore, dcAccounts.isAllWorkDone() {
-                sem.signal()
+            if !dcAccounts.doExitPerformFetch && dcAccounts.isAllWorkDone() {
+                dcAccounts.doExitPerformFetch = true
             }
             if dcContext.id != dcAccounts.getSelected().id {
                 return

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -473,6 +473,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             guard let self = self else { completionHandler(.failed); return }
 
             // we're in background, run IO for a little time
+            self.dcAccounts.doExitPerformFetch = false
             self.dcAccounts.startIo()
             self.dcAccounts.maybeNetwork()
             self.pushToDebugArray("2")
@@ -481,9 +482,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
             // create a new semaphore to make sure the received DC_CONNECTIVITY_CONNECTED really belongs to maybeNetwork() from above
             // (maybeNetwork() sets connectivity to DC_CONNECTIVITY_CONNECTING, when fetch is done, we're back at DC_CONNECTIVITY_CONNECTED)
-            self.dcAccounts.fetchSemaphore = DispatchSemaphore(value: 0)
-            _ = self.dcAccounts.fetchSemaphore?.wait(timeout: .now() + 20)
-            self.dcAccounts.fetchSemaphore = nil
+            for _ in 0..<20 {
+                usleep(500_000)
+                if self.dcAccounts.doExitPerformFetch {
+                    break
+                }
+            }
 
             // TOCHECK: it seems, we are not always reaching this point in code,
             // semaphore?.wait() does not always exit after the given timeout and the app gets suspended -

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -484,6 +484,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             // (maybeNetwork() sets connectivity to DC_CONNECTIVITY_CONNECTING, when fetch is done, we're back at DC_CONNECTIVITY_CONNECTED)
             for _ in 0..<20 {
                 usleep(500_000)
+                self.pushToDebugArray(".")
                 if self.dcAccounts.doExitPerformFetch {
                     break
                 }
@@ -619,7 +620,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         if values != nil, let values = values as? [String] {
             slidingValues = values.suffix(512)
         }
-        slidingValues.append(value+"/"+DateUtils.getExtendedAbsTimeSpanString(timeStamp: Double(Date().timeIntervalSince1970)))
+        var item = value
+        if value != "." {
+            item += "/" + DateUtils.getExtendedAbsTimeSpanString(timeStamp: Double(Date().timeIntervalSince1970))
+        }
+        slidingValues.append(item)
         UserDefaults.standard.set(slidingValues, forKey: name)
     }
 

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -14,7 +14,9 @@ let logger = SwiftyBeaver.self
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     private let dcAccounts = DcAccounts()
-    var appCoordinator: AppCoordinator!
+    lazy var appCoordinator: AppCoordinator = {
+        return AppCoordinator(window: window!, dcAccounts: dcAccounts)
+    }()
     var relayHelper: RelayHelper!
     var locationManager: LocationManager!
     var notificationManager: NotificationManager!
@@ -48,7 +50,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // `didFinishLaunchingWithOptions` is _not_ called
     // when the app wakes up from "suspended" state
     // (app is in memory in the background but no code is executed, IO stopped)
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // explicitly ignore SIGPIPE to avoid crashes, see https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/CommonPitfalls/CommonPitfalls.html
         // setupCrashReporting() may create an additional handler, but we do not want to rely on that
         signal(SIGPIPE, SIG_IGN)
@@ -107,7 +109,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         installEventHandler()
         relayHelper = RelayHelper.setup(dcAccounts.getSelected())
-        appCoordinator = AppCoordinator(window: window, dcAccounts: dcAccounts)
         locationManager = LocationManager(dcAccounts: dcAccounts)
         UIApplication.shared.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalMinimum)
         notificationManager = NotificationManager(dcAccounts: dcAccounts)
@@ -147,6 +148,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             increaseDebugCounter("notify-remote-launch")
             pushToDebugArray("📡'")
             performFetch(completionHandler: { (_) -> Void in })
+        } else {
+            appCoordinator.startUI()
         }
 
         if dcAccounts.getSelected().isConfigured() && !UserDefaults.standard.bool(forKey: "notifications_disabled") {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -79,6 +79,10 @@ class AppCoordinator {
         }
     }
 
+    func startUI() {
+        // HACK, just needed to construct the object
+    }
+
     func showTab(index: Int) {
         tabBarController.selectedIndex = index
     }


### PR DESCRIPTION
while `performFetchWithCompletionHandler` and `didReceiveRemoteNotification` is meanwhile quite okay, the third entry point, `launchOptions?[.remoteNotification]` is not.

some background:

- `launchOptions?[.remoteNotification]` is emitted on some devices sometimes instead of `didReceiveRemoteNotification`
- often, but not always, `launchOptions?[.remoteNotification]` is followed by `performFetchWithCompletionHandler` or `didReceiveRemoteNotification`
- we have some detailed logging meanwhile, eg., we [print `2/time` before](https://github.com/deltachat/deltachat-ios/blob/master/deltachat-ios/AppDelegate.swift#L478) we start waiting for io to finish and [`3/time` afterwards](https://github.com/deltachat/deltachat-ios/blob/master/deltachat-ios/AppDelegate.swift#L494)

what's weird:

- we _sometimes_ on _some devices_ do not get that `3/time` at all
- one assumption was, that the waiting for the semaphore may put the app again to suspend mode, i replaced the semaphor by a loop in this pr, in fact, things seems to be little better, but still not good: https://gist.github.com/r10s/901ab95e44ed376ebad817cb31aa97f9 - also, this is a weird explanation

i am wondering, what exactly `launchOptions?[.remoteNotification]` is meant to be used for. it seems to be emitted in case the app was killed before, as a replacement for `didReceiveRemoteNotification` - but the issues here and also the missing option to call a completion handler make me doubt that. maybe we should not try a `performFetch()` on `launchOptions?[.remoteNotification]` - but then we would not wake up for hours, see the log.

maybe there are just internal crashes?
EDIT: in fact i found one, https://github.com/deltachat/deltachat-core-rust/issues/3264 , however, this does not explain all of failing wakeups, at least i cannot see a crash for every wakeup.

EDIT: some more log from iphone7 _running this pr_ for several hours: https://gist.github.com/r10s/b5b9ccc5a103d65af47dd7a5c37c0191
EDIT: and some log from the same phone _not running_ this pr: https://gist.github.com/r10s/9539b5e3fdb08f9c255b3e73ddd34a8f (not totally sure if they overlap, but the last 12h should be definetely without the pr)