### PR TITLE
set translations before starting I/O

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -111,8 +111,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         locationManager = LocationManager(dcAccounts: dcAccounts)
         UIApplication.shared.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalMinimum)
         notificationManager = NotificationManager(dcAccounts: dcAccounts)
-        dcAccounts.startIo()
         setStockTranslations()
+        dcAccounts.startIo()
 
         reachability.whenReachable = { reachability in
             // maybeNetwork() shall not be called in ui thread;


### PR DESCRIPTION
If there are pending MDNs, an MDN may be generated in English
because the translation is not set yet.

counterpart of https://github.com/deltachat/deltachat-android/issues/2288