### PR TITLE
show context of Webxdc window

### DIFF
--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -137,7 +137,10 @@ class WebxdcViewController: WebViewViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.title = dcContext.getMessage(id: messageId).getWebxdcInfoDict()["name"] as? String
+        let msg = dcContext.getMessage(id: messageId)
+        let chatName = dcContext.getChat(chatId: msg.chatId).name
+        let webxdcName = msg.getWebxdcInfoDict()["name"] as? String ?? ""
+        self.title = chatName + " – " + webxdcName
     }
     
     override func willMove(toParent parent: UIViewController?) {

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -140,7 +140,7 @@ class WebxdcViewController: WebViewViewController {
         let msg = dcContext.getMessage(id: messageId)
         let chatName = dcContext.getChat(chatId: msg.chatId).name
         let webxdcName = msg.getWebxdcInfoDict()["name"] as? String ?? ""
-        self.title = chatName + " – " + webxdcName
+        self.title = webxdcName + " – " + chatName
     }
     
     override func willMove(toParent parent: UIViewController?) {


### PR DESCRIPTION
show the chat name in front of the webxdc name to
- prevent phishing (the window will not show just the name of your bank)
- give the user an idea about where the webxdc sends messages to
  (important eg. when using the same webxdc from different chats)

counterpart of https://github.com/deltachat/deltachat-desktop/pull/2751
see also https://github.com/deltachat/deltachat-core-rust/pull/3309