### PR TITLE
show webxdc document name where appropriate

### DIFF
--- a/deltachat-ios/Chat/Views/FileView.swift
+++ b/deltachat-ios/Chat/Views/FileView.swift
@@ -114,16 +114,17 @@ public class FileView: UIView {
                 fileImageView.image = UIImage(data: blob)?.sd_resizedImage(with: CGSize(width: 175, height: 175), scaleMode: .aspectFill)
             }
         }
+
+        let document = dict["document"] as? String ?? ""
+        let summary = dict["summary"] as? String ?? ""
+        let name = dict["name"] as? String ?? "ErrName" // name should not be empty
+
         fileTitle.numberOfLines = 1
         fileTitle.lineBreakMode = .byTruncatingTail
         fileTitle.font = UIFont.preferredBoldFont(for: .body)
         fileSubtitle.font = UIFont.preferredFont(forTextStyle: .body)
-        fileTitle.text = dict["name"] as? String
-        guard let summary = dict["summary"] as? String, !summary.isEmpty else {
-            fileSubtitle.text = "Webxdc"
-            return
-        }
-        fileSubtitle.text = summary
+        fileTitle.text = document.isEmpty ? name : "\(document) – \(name)"
+        fileSubtitle.text = summary.isEmpty ? "Webxdc" : summary
     }
 
     private func configureFile(message: DcMsg) {

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -138,9 +138,13 @@ class WebxdcViewController: WebViewViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         let msg = dcContext.getMessage(id: messageId)
+        let dict = msg.getWebxdcInfoDict()
+
+        let document = dict["document"] as? String ?? ""
+        let webxdcName = dict["name"] as? String ?? "ErrName" // name should not be empty
         let chatName = dcContext.getChat(chatId: msg.chatId).name
-        let webxdcName = msg.getWebxdcInfoDict()["name"] as? String ?? ""
-        self.title = webxdcName + " – " + chatName
+
+        self.title = document.isEmpty ? "\(webxdcName) – \(chatName)" : "\(document) – \(chatName)"
     }
     
     override func willMove(toParent parent: UIViewController?) {

--- a/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
+++ b/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
@@ -91,12 +91,12 @@ class DocumentGalleryFileCell: UITableViewCell {
             }
         }
 
-        title.text = dict["name"] as? String
-        guard let summary = dict["summary"] as? String, !summary.isEmpty else {
-            subtitle.text = "Webxdc"
-            return
-        }
-        subtitle.text = summary
+        let document = dict["document"] as? String ?? ""
+        let summary = dict["summary"] as? String ?? ""
+        let name = dict["name"] as? String ?? "ErrName" // name should not be empty
+
+        title.text = document.isEmpty ? name : "\(document) – \(name)"
+        subtitle.text = summary.isEmpty ? "Webxdc" : summary
     }
 
     private func generateThumbnailFor(url: URL, placeholder: UIImage?) {


### PR DESCRIPTION
- show document name _instead_ of webxdc name in titles,
  (there is also the chat name shown,
  and three names are definetely too much for typical phones)

- how document name _before_ webxdc name nearby icons

closes #1582
counterpart of https://github.com/deltachat/deltachat-android/pull/2300