### PR TITLE
support large text in document gallery view

### DIFF
--- a/deltachat-ios/Controller/DocumentGalleryController.swift
+++ b/deltachat-ios/Controller/DocumentGalleryController.swift
@@ -13,7 +13,7 @@ class DocumentGalleryController: UIViewController {
         table.register(DocumentGalleryFileCell.self, forCellReuseIdentifier: DocumentGalleryFileCell.reuseIdentifier)
         table.dataSource = self
         table.delegate = self
-        table.rowHeight = 60
+        table.rowHeight = DocumentGalleryFileCell.cellHeight
         return table
     }()
 
@@ -177,6 +177,13 @@ extension DocumentGalleryController: UITableViewDelegate, UITableViewDataSource 
                 self?.contextMenu.actionProvider(indexPath: indexPath)
             }
         )
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if previousTraitCollection?.preferredContentSizeCategory !=
+            traitCollection.preferredContentSizeCategory {
+            tableView.rowHeight = DocumentGalleryFileCell.cellHeight
+        }
     }
 }
 

--- a/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
+++ b/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
@@ -7,10 +7,10 @@ class DocumentGalleryFileCell: UITableViewCell {
 
     static var cellHeight: CGFloat {
         let textHeight = UIFont.preferredFont(forTextStyle: .headline).pointSize + UIFont.preferredFont(forTextStyle: .subheadline).pointSize + 24
-        if textHeight > 74.5 {
+        if textHeight > 60 {
             return textHeight
         }
-        return 74.5
+        return 60
     }
 
     private let fileImageView: UIImageView = {
@@ -23,6 +23,8 @@ class DocumentGalleryFileCell: UITableViewCell {
         let stackView = UIStackView(arrangedSubviews: [title, subtitle])
         stackView.axis = NSLayoutConstraint.Axis.vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.distribution = .fillProportionally
+        stackView.contentMode = .center
         return stackView
     }()
 

--- a/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
+++ b/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
@@ -69,8 +69,8 @@ class DocumentGalleryFileCell: UITableViewCell {
         fileImageView.widthAnchor.constraint(equalToConstant: 50).isActive = true
         stackView.constraintToTrailingOf(fileImageView, paddingLeading: 12).isActive = true
         stackView.constraintAlignTrailingTo(contentView, paddingTrailing: 12).isActive = true
-        stackView.constraintAlignTopTo(contentView, paddingTop: 12).isActive = true
-        stackView.constraintAlignBottomTo(contentView, paddingBottom: 12).isActive = true
+        stackView.constraintAlignTopTo(contentView, paddingTop: 6).isActive = true
+        stackView.constraintAlignBottomTo(contentView, paddingBottom: 6).isActive = true
 
     }
 

--- a/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
+++ b/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
@@ -5,6 +5,14 @@ class DocumentGalleryFileCell: UITableViewCell {
 
     static let reuseIdentifier = "document_gallery_file_cell"
 
+    static var cellHeight: CGFloat {
+        let textHeight = UIFont.preferredFont(forTextStyle: .headline).pointSize + UIFont.preferredFont(forTextStyle: .subheadline).pointSize + 24
+        if textHeight > 74.5 {
+            return textHeight
+        }
+        return 74.5
+    }
+
     private let fileImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
@@ -15,20 +23,19 @@ class DocumentGalleryFileCell: UITableViewCell {
         let stackView = UIStackView(arrangedSubviews: [title, subtitle])
         stackView.axis = NSLayoutConstraint.Axis.vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.clipsToBounds = true
         return stackView
     }()
 
     private lazy var title: UILabel = {
         let title = UILabel()
-        title.font = UIFont.systemFont(ofSize: 16, weight: .regular)
+        title.font = UIFont.preferredFont(forTextStyle: .headline)
         title.translatesAutoresizingMaskIntoConstraints = false
         return title
     }()
 
     private lazy var subtitle: UILabel = {
         let subtitle = UILabel()
-        subtitle.font = UIFont.italicSystemFont(ofSize: 12)
+        subtitle.font = UIFont.preferredItalicFont(for: .subheadline)
         subtitle.translatesAutoresizingMaskIntoConstraints = false
         return subtitle
     }()


### PR DESCRIPTION
closes #1585

the cell hight is the same as for the contact and chat cells (in the chat list). Since it has a very similar layout (image, title, subtitle), I think that makes sense. 