### PR TITLE
emit DC_MSGS_CHANGED event after sharing from Delta to Delta

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -203,18 +203,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 self.dcAccounts.maybeNetwork()
             }
 
-            if let userDefaults = UserDefaults.shared, userDefaults.bool(forKey: UserDefaults.hasExtensionAttemptedToSend) {
-                userDefaults.removeObject(forKey: UserDefaults.hasExtensionAttemptedToSend)
-                DispatchQueue.main.async {
-                    NotificationCenter.default.post(
-                        name: dcNotificationChanged,
-                        object: nil,
-                        userInfo: [
-                            "message_id": Int(0),
-                            "chat_id": Int(0),
-                        ]
-                    )
-                }
+            AppDelegate.emitMsgsChangedIfShareExtensionWasUsed()
+        }
+    }
+
+    static func emitMsgsChangedIfShareExtensionWasUsed() {
+        if let userDefaults = UserDefaults.shared, userDefaults.bool(forKey: UserDefaults.hasExtensionAttemptedToSend) {
+            userDefaults.removeObject(forKey: UserDefaults.hasExtensionAttemptedToSend)
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: dcNotificationChanged,
+                    object: nil,
+                    userInfo: [
+                        "message_id": Int(0),
+                        "chat_id": Int(0),
+                    ]
+                )
             }
         }
     }

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -125,6 +125,9 @@ class ContactDetailViewController: UITableViewController {
         updateHeader() // maybe contact name has been edited
         updateCellValues()
         tableView.reloadData()
+
+        // see comment in GroupChatDetailViewController.viewWillAppear()
+        AppDelegate.emitMsgsChangedIfShareExtensionWasUsed()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -218,6 +218,11 @@ class GroupChatDetailViewController: UIViewController {
         updateHeader()
         updateMediaCellValues()
         updateEphemeralTimerCellValue()
+
+        // when sharing to ourself in DocumentGalleryController,
+        // end of sharing is not easily catchable nor results in applicationWillEnterForeground();
+        // therefore, do the update here.
+        AppDelegate.emitMsgsChangedIfShareExtensionWasUsed()
     }
 
     


### PR DESCRIPTION
alternative to #1592, fixes https://github.com/deltachat/deltachat-ios/issues/1591 for both, message-list and chat-list and without performance and ux regressions.

we are doing this by checking the flag `UserDefaults.hasExtensionAttemptedToSend` as soon as possible after using the share-function.


