### PR TITLE
fix scroll-down btn visibility when opening a chat with many unread messages

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1042,17 +1042,17 @@ class ChatViewController: UITableViewController {
 
         let rectOfCellInTableView = tableView.rectForRow(at: lastIndexPath)
         // convert points to same coordination system
-        let inputBarTopInWindow = messageInputBar.convert(CGPoint(x: 0, y: messageInputBar.bounds.minY), to: window)
+        let inputBarTopInWindow = window.bounds.maxY - (messageInputBar.intrinsicContentSize.height + messageInputBar.keyboardHeight)
         var cellTopInWindow = tableView.convert(CGPoint(x: 0, y: rectOfCellInTableView.minY), to: window)
         cellTopInWindow.y = floor(cellTopInWindow.y)
         var cellBottomInWindow = tableView.convert(CGPoint(x: 0, y: rectOfCellInTableView.maxY), to: window)
         cellBottomInWindow.y = floor(cellBottomInWindow.y)
         let tableViewTopInWindow = tableView.convert(CGPoint(x: 0, y: tableView.bounds.minY), to: window)
         // check if top and bottom of the message are within the visible area
-        let isTopVisible = cellTopInWindow.y < inputBarTopInWindow.y && cellTopInWindow.y >= tableViewTopInWindow.y
-        let isBottomVisible = cellBottomInWindow.y <= inputBarTopInWindow.y && cellBottomInWindow.y >= tableViewTopInWindow.y
+        let isTopVisible = cellTopInWindow.y < inputBarTopInWindow && cellTopInWindow.y >= tableViewTopInWindow.y
+        let isBottomVisible = cellBottomInWindow.y <= inputBarTopInWindow && cellBottomInWindow.y >= tableViewTopInWindow.y
         // check if the message is visible, but top and bottom of cell exceed visible area
-        let messageExceedsScreen = cellTopInWindow.y < tableViewTopInWindow.y && cellBottomInWindow.y > inputBarTopInWindow.y
+        let messageExceedsScreen = cellTopInWindow.y < tableViewTopInWindow.y && cellBottomInWindow.y > inputBarTopInWindow
         if checkTopCellPostion && checkBottomCellPosition {
             return allowPartialVisibility ?
             isTopVisible || isBottomVisible || messageExceedsScreen :

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -774,7 +774,9 @@ class ChatViewController: UITableViewController {
     }
 
     private func updateScrollDownButtonVisibility() {
-        messageInputBar.scrollDownButton.isHidden = isLastRowVisible(checkTopCellPostion: true, checkBottomCellPosition: true, allowPartialVisibility: true)
+        messageInputBar.scrollDownButton.isHidden = messageIds.isEmpty || isLastRowVisible(checkTopCellPostion: true,
+                                                                                           checkBottomCellPosition: true,
+                                                                                           allowPartialVisibility: true)
     }
 
     private func configureContactRequestBar() {


### PR DESCRIPTION
* fix initial calculation of messageInputBars top y-coordinate
* fixes visibility of the scroll-down button when opening a chat from the global search or when opening chats with many unread messages


I haven't created a bug ticket for it, but I consider this a bug fix :)