### PR TITLE
don't allow swipe gesture to navigate back in WebxdcViewController

### DIFF
--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -168,7 +168,9 @@ class WebxdcViewController: WebViewViewController {
     
     override func willMove(toParent parent: UIViewController?) {
         super.willMove(toParent: parent)
-        if parent == nil {
+        let willBeRemoved = parent == nil
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = willBeRemoved
+        if willBeRemoved {
             // remove observer
             let nc = NotificationCenter.default
             if let webxdcUpdateObserver = webxdcUpdateObserver {


### PR DESCRIPTION
don't allow swipe to navigate back in WebxdcViewController, because the gesture interferes with interactions in webxdcs 


fixes my highscores in several games