### PR TITLE
some haptic feedback on entering multi-select mode

### DIFF
--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -219,6 +219,8 @@ class ContactCell: UITableViewCell {
         if sender.state == UIGestureRecognizer.State.began,
            let tableView = self.superview as? UITableView,
            let indexPath = tableView.indexPath(for: self) {
+            let generator = UIImpactFeedbackGenerator(style: .medium)
+            generator.impactOccurred()
             delegate?.onLongTap(at: indexPath)
         }
     }


### PR DESCRIPTION
there are different feedbacks possible, i think, this one fits semantically somehow, and feels not too soft and not to hard :)

(i tried the ones from https://www.hackingwithswift.com/example-code/uikit/how-to-generate-haptic-feedback-with-uifeedbackgenerator - maybe there are even more, eg. i did not really find the feedback that is used by the system when long-tapping messages) (so, when the menu is shown)

but at the end, i think, just _some_ haptic feedback is nice. it can be considered even as feature if it differs slightly between the screens.