### PR TITLE
show number of selected chats in title

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -389,6 +389,8 @@ class ChatListController: UITableViewController {
             editingBar.showUnpinning = viewModel.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows)
             if tableView.indexPathsForSelectedRows == nil {
                 setLongTapEditing(false)
+            } else {
+                updateMultiSelectSelectionCount()
             }
         }
     }
@@ -400,6 +402,7 @@ class ChatListController: UITableViewController {
         }
         if tableView.isEditing {
             editingBar.showUnpinning = viewModel.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows)
+            updateMultiSelectSelectionCount()
             return
         }
 
@@ -538,6 +541,7 @@ class ChatListController: UITableViewController {
 
     func handleMultiSelectTitle() {
         if tableView.isEditing {
+            updateMultiSelectSelectionCount()
             navigationItem.setLeftBarButton(cancelButton, animated: true)
             navigationItem.setRightBarButton(nil, animated: true)
         } else {
@@ -547,6 +551,12 @@ class ChatListController: UITableViewController {
             }
         }
         titleView.isUserInteractionEnabled = !tableView.isEditing
+    }
+
+    func updateMultiSelectSelectionCount() {
+        let cnt = tableView.indexPathsForSelectedRows?.count ?? 1
+        titleView.text = String.localized(stringID: "n_selected", count: cnt)
+        titleView.sizeToFit()
     }
 
     func handleChatListUpdate() {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -390,7 +390,7 @@ class ChatListController: UITableViewController {
             if tableView.indexPathsForSelectedRows == nil {
                 setLongTapEditing(false)
             } else {
-                updateMultiSelectSelectionCount()
+                updateTitle()
             }
         }
     }
@@ -402,7 +402,7 @@ class ChatListController: UITableViewController {
         }
         if tableView.isEditing {
             editingBar.showUnpinning = viewModel.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows)
-            updateMultiSelectSelectionCount()
+            updateTitle()
             return
         }
 
@@ -541,7 +541,8 @@ class ChatListController: UITableViewController {
 
     func handleMultiSelectTitle() {
         if tableView.isEditing {
-            updateMultiSelectSelectionCount()
+            let cnt = tableView.indexPathsForSelectedRows?.count ?? 1
+            titleView.text = String.localized(stringID: "n_selected", count: cnt)
             navigationItem.setLeftBarButton(cancelButton, animated: true)
             navigationItem.setRightBarButton(nil, animated: true)
         } else {
@@ -551,12 +552,6 @@ class ChatListController: UITableViewController {
             }
         }
         titleView.isUserInteractionEnabled = !tableView.isEditing
-    }
-
-    func updateMultiSelectSelectionCount() {
-        let cnt = tableView.indexPathsForSelectedRows?.count ?? 1
-        titleView.text = String.localized(stringID: "n_selected", count: cnt)
-        titleView.sizeToFit()
     }
 
     func handleChatListUpdate() {


### PR DESCRIPTION
this bit is missing somehow, having the wording "selected" in the title also underlines that one is in "select" mode.

<img width=320 src=https://user-images.githubusercontent.com/9800740/175655975-cc0152a1-5291-47ba-aac9-1403226dd156.PNG>

i was also thinking about saying "N Chats Selected" in the title bar, however, this will get easily to wide in translations, so, i decided for the short variation. also, that way the string can be reused in similar views ;)

