### PR TITLE
use updated videochat strings

### DIFF
--- a/deltachat-ios/Controller/SettingsVideoChatViewController.swift
+++ b/deltachat-ios/Controller/SettingsVideoChatViewController.swift
@@ -44,7 +44,7 @@ class SettingsVideoChatViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return String.localized("videochat_instance_explain")
+        return String.localized("videochat_instance_explain_2") + "\n\n" + String.localized("videochat_instance_example")
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
`videochat_instance_explain_2`+`videochat_instance_example`
is mostly the same as `videochat_instance_explain`
but offers nicer layout on desktop.

to make things easier for translators,
we aim to remove `videochat_instance_explain`.

counterpart of https://github.com/deltachat/deltachat-android/pull/2325