### PR TITLE
immediately update chatlist on swipe actions

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -445,13 +445,15 @@ class ChatListController: UITableViewController {
         let archiveActionTitle: String = String.localized(archived ? "unarchive" : "archive")
 
         let archiveAction = UITableViewRowAction(style: .destructive, title: archiveActionTitle) { [weak self] _, _ in
-            self?.viewModel?.archiveChatToggle(chatId: chatId)
+            self?.viewModel?.archiveChatToggle(chatId: chatId, notifyListener: true)
+            self?.setEditing(false, animated: true)
         }
         archiveAction.backgroundColor = UIColor.lightGray
 
         let pinned = chat.visibility==DC_CHAT_VISIBILITY_PINNED
         let pinAction = UITableViewRowAction(style: .destructive, title: String.localized(pinned ? "unpin" : "pin")) { [weak self] _, _ in
-            self?.viewModel?.pinChatToggle(chatId: chat.id)
+            self?.viewModel?.pinChatToggle(chatId: chat.id, notifyListerner: true)
+            self?.setEditing(false, animated: true)
         }
         pinAction.backgroundColor = UIColor.systemGreen
 
@@ -465,6 +467,7 @@ class ChatListController: UITableViewController {
 
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
+        tableView.setEditing(editing, animated: animated)
         viewModel?.setEditing(editing)
     }
 
@@ -555,8 +558,8 @@ class ChatListController: UITableViewController {
     }
 
     func handleChatListUpdate() {
-        if tableView.isEditing {
-            viewModel?.setPendingChatListUpdate()
+        if let viewModel = viewModel, viewModel.isEditing {
+            viewModel.setPendingChatListUpdate()
             return
         }
         if Thread.isMainThread {

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -42,7 +42,7 @@ class ChatListViewModel: NSObject {
     private var searchResultSections: [ChatListSectionType] = []
 
     private var isChatListUpdatePending = false
-    private var isEditing = false
+    private(set) var isEditing = false
 
     init(dcContext: DcContext, isArchive: Bool) {
         self.isArchive = isArchive
@@ -228,25 +228,25 @@ class ChatListViewModel: NSObject {
         INInteraction.delete(with: ["\(dcContext.id).\(chatId)"])
     }
 
-    func archiveChatToggle(chatId: Int) {
+    func archiveChatToggle(chatId: Int, notifyListener: Bool = false) {
         let chat = dcContext.getChat(chatId: chatId)
         let isArchivedBefore = chat.isArchived
         dcContext.archiveChat(chatId: chatId, archive: !isArchivedBefore)
         if !isArchivedBefore {
             NotificationManager.removeNotificationsForChat(dcContext: dcContext, chatId: chatId)
         }
-        updateChatList(notifyListener: false)
+        updateChatList(notifyListener: notifyListener)
     }
 
-    func pinChatToggle(chatId: Int) {
+    func pinChatToggle(chatId: Int, notifyListerner: Bool = false) {
         let chat: DcChat = dcContext.getChat(chatId: chatId)
         let pinned = chat.visibility == DC_CHAT_VISIBILITY_PINNED
-        pinChat(chatId: chatId, pinned: pinned)
+        pinChat(chatId: chatId, pinned: pinned, notifyListener: notifyListerner)
     }
 
-    func pinChat(chatId: Int, pinned: Bool) {
+    func pinChat(chatId: Int, pinned: Bool, notifyListener: Bool = false) {
         self.dcContext.setChatVisibility(chatId: chatId, visibility: pinned ? DC_CHAT_VISIBILITY_NORMAL : DC_CHAT_VISIBILITY_PINNED)
-        updateChatList(notifyListener: false)
+        updateChatList(notifyListener: notifyListener)
     }
 
     func hasOnlyPinnedChatsSelected(in indexPaths: [IndexPath]?) -> Bool {


### PR DESCRIPTION
fixes #1621 

the update is immediately happening now, so no swipe-back animation is shown if you tap on pin or archive. Delete is left as it was. 