### PR TITLE
implement an error screen for closed account

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -595,6 +595,9 @@ public class DcContext {
     }
 
     public var displaynameAndAddr: String {
+        if !isOpen() {
+            return "(closed context)"
+        }
         var ret = addr ?? ""
         if let displayname = displayname {
             ret = "\(displayname) (\(ret))"

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -560,7 +560,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         notificationManager.reloadDcContext()
         RelayHelper.shared.cancel()
         _ = RelayHelper.setup(dcAccounts.getSelected())
-        if dcAccounts.getSelected().isConfigured() {
+        
+        let context = dcAccounts.getSelected()
+        if !context.isOpen() {
+            appCoordinator.presentClosedAccountController()
+        } else if context.isConfigured() {
             appCoordinator.resetTabBarRootViewControllers()
         } else {
             appCoordinator.presentWelcomeController()

--- a/deltachat-ios/Controller/ClosedAccountErrorViewController.swift
+++ b/deltachat-ios/Controller/ClosedAccountErrorViewController.swift
@@ -1,0 +1,107 @@
+//
+//  ClosedAccountErrorViewController.swift
+//  deltachat-ios
+//
+//  Created by bb on 05.07.22.
+//  Copyright © 2022 Jonas Reinsch. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import DcCore
+
+class ClosedAccountErrorView: UIView {
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Error: Account is closed"
+        label.textColor = DcColors.grayTextColor
+        label.textAlignment = .center
+        label.numberOfLines = 1
+        label.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        return label
+    }()
+    
+    private lazy var errorDescription1: UILabel = {
+        let label = UILabel()
+        label.text = "This should not happen, please report it to the developers"
+        label.textColor = DcColors.grayTextColor
+        label.textAlignment = .center
+        label.numberOfLines = 1
+        label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        return label
+    }()
+    
+    private lazy var errorDescription2: UILabel = {
+        let label = UILabel()
+        label.text = "Anyways: just kill and restart the app this should fix the error."
+        label.textColor = DcColors.grayTextColor
+        label.textAlignment = .center
+        label.numberOfLines = 1
+        label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        return label
+    }()
+    
+    
+    public init () {
+        super.init(frame: .infinite)
+        
+        addSubview(titleLabel)
+        addSubview(errorDescription1)
+        addSubview(errorDescription2)
+        
+        backgroundColor = DcColors.defaultBackgroundColor
+    }
+    
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+class ClosedAccountErrorViewController: UIViewController {
+    private let dcAccounts: DcAccounts
+    private let dcContext: DcContext
+    
+    private lazy var hasOtherAccounts: Bool = {
+        return dcAccounts.getAll().count >= 2
+    }()
+    
+    private lazy var closedAccountErrorView: ClosedAccountErrorView = {
+        let view2 = ClosedAccountErrorView()
+        view2.translatesAutoresizingMaskIntoConstraints = false
+        return view2
+    }()
+   
+    init(dcAccounts: DcAccounts) {
+        self.dcAccounts = dcAccounts
+        self.dcContext = dcAccounts.getSelected()
+        super.init(nibName: nil, bundle: nil)
+        title = "Closed Account Error"
+    }
+    
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Error: Account is closed"
+        label.textColor = DcColors.grayTextColor
+        label.textAlignment = .center
+        label.numberOfLines = 1
+        label.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        return label
+    }()
+    
+    private func setupSubviews() {
+        view.addSubview(closedAccountErrorView)
+        view.addSubview(titleLabel)
+    }
+    
+    
+    // MARK: - lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupSubviews()
+    }
+
+}

--- a/deltachat-ios/Controller/ClosedAccountErrorViewController.swift
+++ b/deltachat-ios/Controller/ClosedAccountErrorViewController.swift
@@ -10,7 +10,26 @@ import Foundation
 import UIKit
 import DcCore
 
-class ClosedAccountErrorView: UIView {
+
+class ClosedAccountErrorViewController: UIViewController {
+    private let dcAccounts: DcAccounts
+    private let dcContext: DcContext
+    
+    private lazy var hasOtherAccounts: Bool = {
+        return dcAccounts.getAll().count >= 2
+    }()
+   
+    init(dcAccounts: DcAccounts) {
+        self.dcAccounts = dcAccounts
+        self.dcContext = dcAccounts.getSelected()
+        super.init(nibName: nil, bundle: nil)
+        title = "Closed Account Error"
+    }
+    
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.text = "Error: Account is closed"
@@ -42,59 +61,20 @@ class ClosedAccountErrorView: UIView {
     }()
     
     
-    public init () {
-        super.init(frame: .infinite)
-        
-        addSubview(titleLabel)
-        addSubview(errorDescription1)
-        addSubview(errorDescription2)
-        
-        backgroundColor = DcColors.defaultBackgroundColor
-    }
-    
-    required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
-class ClosedAccountErrorViewController: UIViewController {
-    private let dcAccounts: DcAccounts
-    private let dcContext: DcContext
-    
-    private lazy var hasOtherAccounts: Bool = {
-        return dcAccounts.getAll().count >= 2
-    }()
-    
-    private lazy var closedAccountErrorView: ClosedAccountErrorView = {
-        let view2 = ClosedAccountErrorView()
-        view2.translatesAutoresizingMaskIntoConstraints = false
-        return view2
-    }()
-   
-    init(dcAccounts: DcAccounts) {
-        self.dcAccounts = dcAccounts
-        self.dcContext = dcAccounts.getSelected()
-        super.init(nibName: nil, bundle: nil)
-        title = "Closed Account Error"
-    }
-    
-    required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private lazy var titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "Error: Account is closed"
-        label.textColor = DcColors.grayTextColor
-        label.textAlignment = .center
-        label.numberOfLines = 1
-        label.font = UIFont.systemFont(ofSize: 24, weight: .bold)
-        return label
-    }()
-    
     private func setupSubviews() {
-        view.addSubview(closedAccountErrorView)
         view.addSubview(titleLabel)
+        view.addSubview(errorDescription1)
+        view.addSubview(errorDescription2)
+        
+        let qrDefaultWidth = view.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.75)
+        qrDefaultWidth.priority = UILayoutPriority(500)
+        qrDefaultWidth.isActive = true
+        let qrMinWidth = view.widthAnchor.constraint(lessThanOrEqualToConstant: 260)
+        qrMinWidth.priority = UILayoutPriority(999)
+        qrMinWidth.isActive = true
+        view.heightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.heightAnchor, multiplier: 1.05).isActive = true
+        view.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor).isActive = true
+        view.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
     }
     
     

--- a/deltachat-ios/Controller/ClosedAccountErrorViewController.swift
+++ b/deltachat-ios/Controller/ClosedAccountErrorViewController.swift
@@ -97,7 +97,7 @@ class ClosedAccountErrorViewController: UIViewController {
         }
         
         if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            appDelegate.appCoordinator.initializeRootController()
+            appDelegate.reloadDcContext()
         }
     }
     

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -236,6 +236,11 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         // remove only unconfigured and make sure, there is another account
         // (normally, both checks are not needed, however, some resilience wrt future program-flow-changes seems to be reasonable here)
         let selectedAccount = dcAccounts.getSelected()
+        if !selectedAccount.isOpen() {
+            // prevent wrong return value of dc_is_configured / isConfigured
+            return
+        }
+        
         if !selectedAccount.isConfigured() {
             _ = dcAccounts.remove(id: selectedAccount.id)
             if self.dcAccounts.getAll().isEmpty {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -143,7 +143,7 @@ class AppCoordinator {
 
     func initializeRootController() {
         let context = dcAccounts.getSelected()
-        if(true || !context.isOpen()) {
+        if !context.isOpen() {
             presentClosedAccountController()
         } else if context.isConfigured() {
             presentTabBarController()
@@ -159,8 +159,7 @@ class AppCoordinator {
     }
     
     func presentClosedAccountController() {
-        loginNavController.setViewControllers([ClosedAccountErrorViewController(dcAccounts: dcAccounts)], animated: true)
-        window.rootViewController = loginNavController
+        window.rootViewController = ClosedAccountErrorViewController(dcAccounts: dcAccounts)
         window.makeKeyAndVisible()
     }
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -142,7 +142,10 @@ class AppCoordinator {
     }
 
     func initializeRootController() {
-        if dcAccounts.getSelected().isConfigured() {
+        let context = dcAccounts.getSelected()
+        if(true || !context.isOpen()) {
+            presentClosedAccountController()
+        } else if context.isConfigured() {
             presentTabBarController()
         } else {
             presentWelcomeController()
@@ -153,6 +156,12 @@ class AppCoordinator {
         // (according to https://learnui.design/blog/ios-font-size-guidelines.html )
         // (it would be a bit nicer, if we would query the system font and pass it to chatlist, but well :)
         UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17, weight: .semibold)]
+    }
+    
+    func presentClosedAccountController() {
+        loginNavController.setViewControllers([ClosedAccountErrorViewController(dcAccounts: dcAccounts)], animated: true)
+        window.rootViewController = loginNavController
+        window.makeKeyAndVisible()
     }
 
     func presentWelcomeController() {


### PR DESCRIPTION
This pr includes:
- display closed accounts as `(closed account)` instead of falsely displaying them as `(unconfigured)`
- guard against deleting the account if it is closed in the welcome screen
- an error screen instead of the welcome screen when we encounter the problem
    - there is also an experimental "try fix without restart" button in the error screen, that worked in my testing

solves the "account may be forgotten" part of #1504, but the bug of a closed encrypted account is still there