### PR TITLE
don't deinit keyboardManager in ChatViewController too early:

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -518,7 +518,6 @@ class ChatViewController: UITableViewController {
         audioController.stopAnyOngoingPlaying()
         messageInputBar.inputTextView.resignFirstResponder()
         wasInputBarFirstResponder = false
-        keyboardManager = nil
     }
 
     override func willMove(toParent parent: UIViewController?) {
@@ -532,6 +531,12 @@ class ChatViewController: UITableViewController {
             setupObservers()
         }
      }
+
+    override func didMove(toParent parent: UIViewController?) {
+        if parent == nil {
+            keyboardManager = nil
+        }
+    }
 
     private func setupObservers() {
         let nc = NotificationCenter.default


### PR DESCRIPTION
* the tableview UI keeps reacting on keyboard showing up after coming back from profile
* Still avoids a memory leak initially fixed in ced2035196beb170abc6ca3140edff82f5cb5620)

fixes #1633 