### PR TITLE
ensure encrypted accounts are always opened when resuming from background

### DIFF
--- a/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
@@ -2,6 +2,7 @@ import Foundation
 public extension UserDefaults {
     static var hasExtensionAttemptedToSend = "hasExtensionAttemptedToSend"
     static var hasSavedKeyToKeychain = "hasSavedKeyToKeychain"
+    static var upgradedKeychainEntry = "upgradedKeychainEntry_"
     static var shared: UserDefaults? {
         return UserDefaults(suiteName: "group.chat.delta.ios")
     }

--- a/DcCore/DcCore/Helper/KeychainManager.swift
+++ b/DcCore/DcCore/Helper/KeychainManager.swift
@@ -46,6 +46,7 @@ public class KeychainManager {
           kSecAttrAccount as String: "\(id)",
           kSecClass: kSecClassGenericPassword,
           kSecAttrAccessGroup as String: KcM.sharedKeychainGroup as AnyObject,
+          kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock,
         ] as CFDictionary
 
         let status = SecItemAdd(keychainItemQuery, nil)

--- a/DcCore/DcCore/Helper/KeychainManager.swift
+++ b/DcCore/DcCore/Helper/KeychainManager.swift
@@ -66,10 +66,14 @@ public class KeychainManager {
                                     kSecReturnData as String: true]
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
-        guard status != errSecItemNotFound else {
+        switch status {
+        case errSecSuccess:
+            break
+        case errSecItemNotFound:
             throw KeychainError.noPassword
-        }
-        guard status == errSecSuccess else {
+        case errSecInteractionNotAllowed:
+            throw KeychainError.unhandledError(message: "Keychain not yet available.", status: status)
+        default:
             throw KeychainError.unhandledError(message: "Unknown error while querying secret for account \(id):",
                                                status: status)
         }

--- a/DcCore/DcCore/Helper/KeychainManager.swift
+++ b/DcCore/DcCore/Helper/KeychainManager.swift
@@ -15,8 +15,8 @@ public class KeychainManager {
     private static let sharedKeychainGroup = "\(KcM.teamId).group.chat.delta.ios"
 
     public static func getAccountSecret(accountID: Int) throws -> String {
-        if let buildVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? Int,
-           buildVersion <= 74 {
+        if let sharedUserDefaults = UserDefaults.shared,
+            !sharedUserDefaults.bool(forKey: "\(UserDefaults.upgradedKeychainEntry)\(accountID)") {
             upgradeAccountSecret(id: accountID)
         }
 
@@ -46,27 +46,49 @@ public class KeychainManager {
     }
 
     private static func upgradeAccountSecret(id: Int) {
-        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+        // 1. search the keychain entry
+        let searchQuery: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
                                     kSecAttrAccount as String: "\(id)",
                                     kSecMatchLimit as String: kSecMatchLimitOne,
                                     kSecAttrAccessGroup as String: KcM.sharedKeychainGroup as AnyObject,
                                     kSecReturnAttributes as String: true,
                                     kSecReturnData as String: true,
-                                    kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked]
+                                    kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked as String]
         var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        let status = SecItemCopyMatching(searchQuery as CFDictionary, &item)
         if status == errSecSuccess {
-            let attributes: [String: Any] = [kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock]
-            let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-            switch status {
+            // 2. create an upgrade query
+            let updateQuery: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+                                              kSecAttrAccount as String: "\(id)",
+                                              kSecAttrAccessGroup as String: KcM.sharedKeychainGroup as AnyObject,
+                                              kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked as String]
+
+            // 3. create a dictionary, containing the updated keychain properties and the secret for authorization
+            guard let existingItem = item as? [String: AnyObject],
+                  let passwordData = existingItem[kSecValueData as String] as? Data
+            else {
+                print("Failed to upgrade access policy for account id \(id).")
+                return
+            }
+            let updatedAttributes: [String: Any] = [ kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+                                                     kSecValueData as String: passwordData ]
+
+            // 4. update
+            let updateStatus = SecItemUpdate(updateQuery as CFDictionary, updatedAttributes as CFDictionary)
+
+            switch updateStatus {
             case errSecSuccess:
                 print("successfully upgraded access policy upgrade for account \(id).")
+                UserDefaults.shared?.set(true, forKey: "\(UserDefaults.upgradedKeychainEntry)\(id)")
             case errSecItemNotFound:
                 print("no access policy upgrade for account \(id) needed.")
+                UserDefaults.shared?.set(true, forKey: "\(UserDefaults.upgradedKeychainEntry)\(id)")
             case errSecInteractionNotAllowed:
-                print("Keychain not yet available. (\(status))")
+                print("Keychain not yet available (\(status)).")
+            case errSecAuthFailed:
+                print("Authentication failed")
             default:
-                print("Failed to upgrade access policy for account id \(id) (\(status))")
+                print("Failed to upgrade access policy for account id \(id) (\(status)).")
             }
         }
     }

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -212,7 +212,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     func applicationProtectedDataWillBecomeUnavailable(_ application: UIApplication) {
-        logger.info("➡️ applicationProtectedDataWillBecomeUnavailable")
+        logger.info("⬅️ applicationProtectedDataWillBecomeUnavailable")
     }
 
     static func emitMsgsChangedIfShareExtensionWasUsed() {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -192,6 +192,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
     }
 
+    func applicationProtectedDataDidBecomeAvailable(_ application: UIApplication) {
+        logger.info("➡️ applicationProtectedDataDidBecomeAvailable")
+    }
+
+    func applicationProtectedDataWillBecomeUnavailable(_ application: UIApplication) {
+        logger.info("➡️ applicationProtectedDataWillBecomeUnavailable")
+    }
+
     func openAccounts(_ dcAccounts: DcAccounts) {
         let accountIds = dcAccounts.getAll()
         for accountId in accountIds {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -72,22 +72,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             }
         }
 
-        let accountIds = dcAccounts.getAll()
-        for accountId in accountIds {
-            let dcContext = dcAccounts.get(id: accountId)
-            if !dcContext.isOpen() {
-                do {
-                    let secret = try KeychainManager.getAccountSecret(accountID: accountId)
-                    if !dcContext.open(passphrase: secret) {
-                        logger.error("Failed to open database for account \(accountId)")
-                    }
-                } catch KeychainError.unhandledError(let message, let status) {
-                    logger.error("Keychain error. \(message). Error status: \(status)")
-                } catch {
-                    logger.error("\(error)")
-                }
-            }
-        }
+        openAccounts(dcAccounts)
 
         if dcAccounts.getAll().isEmpty, dcAccounts.add() == 0 {
            fatalError("Could not initialize a new account.")
@@ -204,6 +189,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             }
 
             AppDelegate.emitMsgsChangedIfShareExtensionWasUsed()
+        }
+    }
+
+    func openAccounts(_ dcAccounts: DcAccounts) {
+        let accountIds = dcAccounts.getAll()
+        for accountId in accountIds {
+            let dcContext = dcAccounts.get(id: accountId)
+            if !dcContext.isOpen() {
+                do {
+                    let secret = try KeychainManager.getAccountSecret(accountID: accountId)
+                    if !dcContext.open(passphrase: secret) {
+                        logger.error("Failed to open database for account \(accountId)")
+                    }
+                } catch KeychainError.unhandledError(let message, let status) {
+                    logger.error("Keychain error. \(message). Error status: \(status)")
+                } catch {
+                    logger.error("\(error)")
+                }
+            }
         }
     }
 
@@ -409,6 +413,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.info("➡️ Notifications: didReceiveRemoteNotification \(userInfo)")
         increaseDebugCounter("notify-remote-receive")
         pushToDebugArray("📡")
+        openAccounts(dcAccounts)
         performFetch(completionHandler: completionHandler)
     }
 
@@ -425,6 +430,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.info("➡️ Notifications: performFetchWithCompletionHandler")
         increaseDebugCounter("notify-local-wakeup")
         pushToDebugArray("🏠")
+        openAccounts(dcAccounts)
         performFetch(completionHandler: completionHandler)
     }
 

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -233,10 +233,10 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
     @objc private func cancelButtonPressed() {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         // take a bit care on account removal:
-        // remove only unconfigured and make sure, there is another account
+        // remove only openend and unconfigured and make sure, there is another account
         // (normally, both checks are not needed, however, some resilience wrt future program-flow-changes seems to be reasonable here)
         let selectedAccount = dcAccounts.getSelected()
-        if !selectedAccount.isConfigured() {
+        if selectedAccount.isOpen() && !selectedAccount.isConfigured() {
             _ = dcAccounts.remove(id: selectedAccount.id)
             if self.dcAccounts.getAll().isEmpty {
                 _ = self.dcAccounts.add()


### PR DESCRIPTION
another attempt to fix https://github.com/deltachat/deltachat-ios/issues/1504

* We change the access policy here, the app is allowed to access the keychain after the device was unlocked for the first time. 
* This PR also ensures no accounts gets deleted if they are in a closed state and the user presses cancel in the Welcome screen. 
* it also improves error logging for better debugging in the future 