### PR TITLE
finish app initialization as soon as the access to keychain is allowed

### DIFF
--- a/DcCore/DcCore/Helper/KeychainManager.swift
+++ b/DcCore/DcCore/Helper/KeychainManager.swift
@@ -3,6 +3,7 @@ import Security
 
 public enum KeychainError: Error {
     case noPassword
+    case accessError(message: String, status: OSStatus)
     case unhandledError(message: String, status: OSStatus)
 }
 
@@ -86,7 +87,7 @@ public class KeychainManager {
         case errSecItemNotFound:
             throw KeychainError.noPassword
         case errSecInteractionNotAllowed:
-            throw KeychainError.unhandledError(message: "Keychain not yet available.", status: status)
+            throw KeychainError.accessError(message: "Keychain not yet available.", status: status)
         default:
             throw KeychainError.unhandledError(message: "Unknown error while querying secret for account \(id):",
                                                status: status)

--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -90,7 +90,7 @@ class ShareViewController: SLComposeServiceViewController {
                 if !dcContext.open(passphrase: secret) {
                     logger.error("Failed to open database.")
                 }
-            } catch KeychainError.unhandledError(let message, let status) {
+            } catch KeychainError.unhandledError(let message, let status), KeychainError.accessError(let message, let status) {
                 logger.error("KeychainError. \(message). Error status: \(status)")
             } catch {
                 logger.error("\(error)")

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -24,6 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     var notifyToken: String?
     var applicationInForeground: Bool = false
     private var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    private var pendingAppInitialization = true;
 
     // purpose of `bgIoTimestamp` is to block rapidly subsequent calls to remote- or local-wakeups:
     //
@@ -50,6 +51,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // when the app wakes up from "suspended" state
     // (app is in memory in the background but no code is executed, IO stopped)
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        pendingAppInitialization = true;
         logger.info("➡️ didFinishLaunchingWithOptions")
         // explicitly ignore SIGPIPE to avoid crashes, see https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/CommonPitfalls/CommonPitfalls.html
         // setupCrashReporting() may create an additional handler, but we do not want to rely on that
@@ -169,6 +171,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
 
         launchOptions = nil
+        pendingAppInitialization = false
     }
 
     // `open` is called when an url should be opened by Delta Chat.
@@ -220,7 +223,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func applicationProtectedDataDidBecomeAvailable(_ application: UIApplication) {
         logger.info("➡️ applicationProtectedDataDidBecomeAvailable")
-        if launchOptions != nil {
+        if pendingAppInitialization {
             finishAppInitialization()
         }
     }


### PR DESCRIPTION
closes #1648

* it's not calling the new method `finishAppInitialization` idempotently, but checks in `applicationProtectedDataDidBecomeAvailable` if calling the method is really necessary