### PR TITLE
Encrypted Account improvements

### DIFF
--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -213,7 +213,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
                 logger.error("Failed to open account database for account \(dcContext.id)")
                 return
             }
-            showAccountSetupController()
+            self.navigationItem.title = "Add encrypted account"
         } catch KeychainError.unhandledError(let message, let status) {
             logger.error("Keychain error. Failed to create encrypted account. \(message). Error status: \(status)")
         } catch {


### PR DESCRIPTION
don't open the AccountSetupController after switching to an encrypted account

@r10s shall we localize the strings? the whole feature is not yet localized, but since we're improving this feature step by step, and since we don't know yet if and when this feature will become the default, we could also start translating the required strings.

closes #1644