### PR TITLE
allow to quote messages when sending a voice message

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1712,8 +1712,15 @@ class ChatViewController: UITableViewController {
         DispatchQueue.global().async { [weak self] in
             guard let self = self else { return }
             let msg = self.dcContext.newMessage(viewType: DC_MSG_VOICE)
+            if let quoteMessage =  self.draft.quoteMessage {
+                msg.quoteMessage = quoteMessage
+            }
             msg.setFile(filepath: url.relativePath, mimeType: "audio/m4a")
             self.dcContext.sendMessage(chatId: self.chatId, message: msg)
+            DispatchQueue.main.async {
+                self.draft.setQuote(quotedMsg: nil)
+                self.draftArea.quotePreview.cancel()
+            }
         }
     }
 


### PR DESCRIPTION
closes #1635 

* entered text will be ignored and kept in the message input bar, only quotes are sent along with the voice message