### PR TITLE
add quick switch account avatar button to chatlist header

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -3,6 +3,7 @@ import UserNotifications
 
 public let dcNotificationChanged = Notification.Name(rawValue: "MrEventMsgsChanged")
 public let dcNotificationIncoming = Notification.Name(rawValue: "MrEventIncomingMsg")
+public let dcNotificationIncomingAnyAccount = Notification.Name(rawValue: "EventIncomingMsgAnyAccount")
 public let dcNotificationImexProgress = Notification.Name(rawValue: "dcNotificationImexProgress")
 public let dcNotificationConfigureProgress = Notification.Name(rawValue: "MrEventConfigureProgress")
 public let dcNotificationSecureInviterProgress = Notification.Name(rawValue: "MrEventSecureInviterProgress")
@@ -152,10 +153,17 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_INCOMING_MSG:
+            let nc = NotificationCenter.default
+            DispatchQueue.main.async {
+                nc.post(name: dcNotificationIncomingAnyAccount,
+                        object: nil,
+                        userInfo: nil)
+            }
+            
             if dcContext.id != dcAccounts.getSelected().id {
                 return
             }
-            let nc = NotificationCenter.default
+            
             let userInfo = [
                 "message_id": Int(data2),
                 "chat_id": Int(data1),

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		21CCE7C528E73AA500BC369E /* AccountSwitcherHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CCE7C428E73AA500BC369E /* AccountSwitcherHandler.swift */; };
 		21D6C941260623F500D0755A /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D6C9392606190600D0755A /* NotificationManager.swift */; };
 		3008CB7224F93EB900E6A617 /* AudioMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008CB7124F93EB900E6A617 /* AudioMessageCell.swift */; };
 		3008CB7424F9436C00E6A617 /* AudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008CB7324F9436C00E6A617 /* AudioPlayerView.swift */; };
@@ -242,6 +243,7 @@
 
 /* Begin PBXFileReference section */
 		08432784282DC739B8EAC1E2 /* Pods-DcShare.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DcShare.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DcShare/Pods-DcShare.debug.xcconfig"; sourceTree = "<group>"; };
+		21CCE7C428E73AA500BC369E /* AccountSwitcherHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSwitcherHandler.swift; sourceTree = "<group>"; };
 		21D6C9392606190600D0755A /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		21EE28844E7A690D73BF5285 /* Pods-deltachat-iosTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-deltachat-iosTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-deltachat-iosTests/Pods-deltachat-iosTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2F7009234DB9408201A6CDCB /* Pods_deltachat_iosTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_deltachat_iosTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1029,6 +1031,7 @@
 				AEC67A1B241CE9E4007DDBE1 /* AppStateRestorer.swift */,
 				AE8519E92272FDCA00ED86F0 /* DeviceContactsHandler.swift */,
 				AEE700242438E0E500D6992E /* ProgressAlertHandler.swift */,
+				21CCE7C428E73AA500BC369E /* AccountSwitcherHandler.swift */,
 			);
 			path = Handler;
 			sourceTree = "<group>";
@@ -1503,6 +1506,7 @@
 				30E348DF24F3F819005C93D1 /* ChatTableView.swift in Sources */,
 				30EF7308252F6A3300E2C54A /* PaddingTextView.swift in Sources */,
 				30E348E124F53772005C93D1 /* ImageTextCell.swift in Sources */,
+				21CCE7C528E73AA500BC369E /* AccountSwitcherHandler.swift in Sources */,
 				3008CB7624F95B6D00E6A617 /* AudioController.swift in Sources */,
 				3080A035277DE30100E74565 /* String+Extensions.swift in Sources */,
 				302B84CE2397F6CD001C261F /* URL+Extension.swift in Sources */,

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1022,6 +1022,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             self.navigationItem.setLeftBarButton(nil, animated: true)
         }
 
+
         if let image = dcChat.profileImage {
             initialsBadge.setImage(image)
         } else {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1022,7 +1022,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             self.navigationItem.setLeftBarButton(nil, animated: true)
         }
 
-
         if let image = dcChat.profileImage {
             initialsBadge.setImage(image)
         } else {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -536,7 +536,7 @@ class ChatListController: UITableViewController {
     }
     
     lazy var accountButtonAvatar: InitialsBadge = {
-        let badge = InitialsBadge(size: 42)
+        let badge = InitialsBadge(size: 40)
         badge.setColor(UIColor.lightGray)
         badge.isAccessibilityElement = false
         return badge

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -549,7 +549,6 @@ class ChatListController: UITableViewController, AccountSwitcherHandler {
         return view
     }()
 
-
     private lazy var accountButton: UIBarButtonItem = {
         let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 37, height: 37))
         containerView.addSubview(accountButtonAvatar)
@@ -563,7 +562,6 @@ class ChatListController: UITableViewController, AccountSwitcherHandler {
     
     private func updateAccountButton() {
         let unreadCount = getUnreadCounterOfOtherAccounts()
-        // accountButton.title = "Account" + (unreadCount == 0 ? "" : " [" + String(unreadCount) + "]")
         accountButtonUnreadMessageCounter.setCount(unreadCount)
         accountButtonUnreadMessageCounter.isHidden = unreadCount == 0
         
@@ -573,8 +571,6 @@ class ChatListController: UITableViewController, AccountSwitcherHandler {
         if let image = contact.profileImage {
             accountButtonAvatar.setImage(image)
         }
-        
-        
     }
     
     private func getUnreadCounterOfOtherAccounts() -> Int {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -654,12 +654,11 @@ class ChatListController: UITableViewController {
                     titleView.accessibilityHint = "\(String.localized("connectivity_connected")): \(String.localized("a11y_connectivity_hint"))"
                 }
             }
+            navigationItem.setLeftBarButton(accountButton, animated: false)
+            updateAccountButton()
         }
         titleView.isUserInteractionEnabled = !tableView.isEditing
         titleView.sizeToFit()
-        
-        navigationItem.setLeftBarButton(accountButton, animated: false)
-        updateAccountButton()
     }
 
     func handleMultiSelectionTitle() -> Bool {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -1,10 +1,10 @@
 import UIKit
 import DcCore
 
-class ChatListController: UITableViewController {
+class ChatListController: UITableViewController, AccountSwitcherHandler {
     var viewModel: ChatListViewModel?
     let dcContext: DcContext
-    private let dcAccounts: DcAccounts
+    internal let dcAccounts: DcAccounts
     var isArchive: Bool
 
     private let chatCellReuseIdentifier = "chat_cell"
@@ -551,8 +551,6 @@ class ChatListController: UITableViewController {
 
 
     private lazy var accountButton: UIBarButtonItem = {
-        // let button = UIBarButtonItem(title: "Account", style: .plain, target: self, action: #selector(showSwitchAccountMenu))
-        
         // todo make pretty
         
         let rect = CGRect(x: 0, y: 0, width: 70, height: 50)
@@ -564,7 +562,7 @@ class ChatListController: UITableViewController {
         // this line is only to visualize the rect bounds for visual debugging
         // myView.backgroundColor = .blue
         
-        let tapGestureRecognizer =  UITapGestureRecognizer(target: self, action: #selector(showSwitchAccountMenu))
+        let tapGestureRecognizer =  UITapGestureRecognizer(target: self, action: #selector(showSwitchAccount))
         myView.addGestureRecognizer(tapGestureRecognizer)
         
         
@@ -602,33 +600,8 @@ class ChatListController: UITableViewController {
         return unreadCount
     }
     
-    @objc private func showSwitchAccountMenu() {
-        let accountIds = dcAccounts.getAll()
-        let selectedAccountId = dcAccounts.getSelected().id
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-
-        let prefs = UserDefaults.standard
-        // switch account
-        let menu = UIAlertController(title: String.localized("switch_account"), message: nil, preferredStyle: .safeActionSheet)
-        for accountId in accountIds {
-            let account = dcAccounts.get(id: accountId)
-            
-            let newMessages = account.getFreshMessages().count
-            let messageBadge = newMessages == 0 ? "" : " [" + String(newMessages) + "]"
-            
-            var title = account.displaynameAndAddr
-            title = (selectedAccountId==accountId ? "✔︎ " : "") + title + messageBadge
-            menu.addAction(UIAlertAction(title: title, style: .default, handler: { [weak self] _ in
-                guard let self = self else { return }
-                prefs.setValue(selectedAccountId, forKey: Constants.Keys.lastSelectedAccountKey)
-                _ = self.dcAccounts.select(id: accountId)
-                appDelegate.reloadDcContext()
-            }))
-        }
-
-
-        menu.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
-        present(menu, animated: true, completion: nil)
+    @objc private func showSwitchAccount() {
+        showSwitchAccountMenu()
     }
 
     // MARK: updates

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -535,17 +535,57 @@ class ChatListController: UITableViewController {
         }
     }
     
+    lazy var accountButtonAvatar: InitialsBadge = {
+        let badge = InitialsBadge(size: 42)
+        badge.setColor(UIColor.lightGray)
+        badge.isAccessibilityElement = false
+        return badge
+    }()
+    
+    private let accountButtonUnreadMessageCounter: MessageCounter = {
+        let view = MessageCounter(count: 0, size: 20)
+        view.backgroundColor = DcColors.unreadBadge
+        view.isHidden = true
+        return view
+    }()
+
+
     private lazy var accountButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: "Account", style: .plain, target: self, action: #selector(showSwitchAccountMenu))
+        // let button = UIBarButtonItem(title: "Account", style: .plain, target: self, action: #selector(showSwitchAccountMenu))
         
-       // todo make pretty
+        // todo make pretty
         
+        let rect = CGRect(x: 0, y: 0, width: 70, height: 50)
+        let myView = UIView(frame: rect)
+        
+        myView.addSubview(accountButtonAvatar)
+        myView.addSubview(accountButtonUnreadMessageCounter)
+        
+        // this line is only to visualize the rect bounds for visual debugging
+        // myView.backgroundColor = .blue
+        
+        let tapGestureRecognizer =  UITapGestureRecognizer(target: self, action: #selector(showSwitchAccountMenu))
+        myView.addGestureRecognizer(tapGestureRecognizer)
+        
+        
+        let button = UIBarButtonItem(customView: myView)
         return button
     }()
     
     private func updateAccountButton() {
         let unreadCount = getUnreadCounterOfOtherAccounts()
-        accountButton.title = "Account" + (unreadCount == 0 ? "" : " [" + String(unreadCount) + "]")
+        // accountButton.title = "Account" + (unreadCount == 0 ? "" : " [" + String(unreadCount) + "]")
+        accountButtonUnreadMessageCounter.setCount(unreadCount)
+        accountButtonUnreadMessageCounter.isHidden = unreadCount == 0
+        
+        let contact = dcContext.getContact(id: Int(DC_CONTACT_ID_SELF))
+        accountButtonAvatar.setColor(contact.color)
+        accountButtonAvatar.setName(contact.displayName)
+        if let image = contact.profileImage {
+            accountButtonAvatar.setImage(image)
+        }
+        
+        
     }
     
     private func getUnreadCounterOfOtherAccounts() -> Int {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -536,9 +536,9 @@ class ChatListController: UITableViewController, AccountSwitcherHandler {
     }
     
     lazy var accountButtonAvatar: InitialsBadge = {
-        let badge = InitialsBadge(size: 40)
-        badge.setColor(UIColor.lightGray)
-        badge.isAccessibilityElement = false
+        let badge = InitialsBadge(size: 37, accessibilityLabel: String.localized("switch_account"))
+        badge.setLabelFont(UIFont.systemFont(ofSize: 14))
+        badge.accessibilityTraits = .button
         return badge
     }()
     
@@ -551,23 +551,14 @@ class ChatListController: UITableViewController, AccountSwitcherHandler {
 
 
     private lazy var accountButton: UIBarButtonItem = {
-        // todo make pretty
-        
-        let rect = CGRect(x: 0, y: 0, width: 70, height: 50)
-        let myView = UIView(frame: rect)
-        
-        myView.addSubview(accountButtonAvatar)
-        myView.addSubview(accountButtonUnreadMessageCounter)
-        
-        // this line is only to visualize the rect bounds for visual debugging
-        // myView.backgroundColor = .blue
+        let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 37, height: 37))
+        containerView.addSubview(accountButtonAvatar)
+        containerView.addSubview(accountButtonUnreadMessageCounter)
         
         let tapGestureRecognizer =  UITapGestureRecognizer(target: self, action: #selector(showSwitchAccount))
-        myView.addGestureRecognizer(tapGestureRecognizer)
+        containerView.addGestureRecognizer(tapGestureRecognizer)
         
-        
-        let button = UIBarButtonItem(customView: myView)
-        return button
+        return UIBarButtonItem(customView: containerView)
     }()
     
     private func updateAccountButton() {

--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -3,7 +3,7 @@ import DcCore
 import DBDebugToolkit
 import Intents
 
-internal final class SettingsViewController: UITableViewController, ProgressAlertHandler {
+internal final class SettingsViewController: UITableViewController, ProgressAlertHandler, AccountSwitcherHandler {
 
     private struct SectionConfigs {
         let headerTitle: String?
@@ -33,7 +33,7 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
     }
 
     private var dcContext: DcContext
-    private let dcAccounts: DcAccounts
+    internal let dcAccounts: DcAccounts
 
     private let externalPathDescr = "File Sharing/Delta Chat"
 
@@ -522,69 +522,6 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
         let error = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         error.addAction(UIAlertAction(title: String.localized("ok"), style: .cancel))
         present(error, animated: true)
-    }
-
-    private func showSwitchAccountMenu() {
-        let accountIds = dcAccounts.getAll()
-        let selectedAccountId = dcAccounts.getSelected().id
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-
-        let prefs = UserDefaults.standard
-        // switch account
-        let menu = UIAlertController(title: String.localized("switch_account"), message: nil, preferredStyle: .safeActionSheet)
-        for accountId in accountIds {
-            let account = dcAccounts.get(id: accountId)
-            var title = account.displaynameAndAddr
-            title = (selectedAccountId==accountId ? "✔︎ " : "") + title
-            menu.addAction(UIAlertAction(title: title, style: .default, handler: { [weak self] _ in
-                guard let self = self else { return }
-                prefs.setValue(selectedAccountId, forKey: Constants.Keys.lastSelectedAccountKey)
-                _ = self.dcAccounts.select(id: accountId)
-                appDelegate.reloadDcContext()
-            }))
-        }
-
-        // add account
-        menu.addAction(UIAlertAction(title: String.localized("add_account"), style: .default, handler: { [weak self] _ in
-            guard let self = self else { return }
-            prefs.setValue(selectedAccountId, forKey: Constants.Keys.lastSelectedAccountKey)
-            _ = self.dcAccounts.add()
-            appDelegate.reloadDcContext()
-        }))
-
-        // delete account
-        menu.addAction(UIAlertAction(title: String.localized("delete_account"), style: .destructive, handler: { [weak self] _ in
-            let confirm1 = UIAlertController(title: String.localized("delete_account_ask"), message: nil, preferredStyle: .safeActionSheet)
-            confirm1.addAction(UIAlertAction(title: String.localized("delete_account"), style: .destructive, handler: { [weak self] _ in
-                guard let self = self else { return }
-                let account = self.dcAccounts.get(id: selectedAccountId)
-                let confirm2 = UIAlertController(title: account.displaynameAndAddr,
-                    message: String.localized("forget_login_confirmation_desktop"), preferredStyle: .alert)
-                confirm2.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { [weak self] _ in
-                    guard let self = self else { return }
-                    appDelegate.locationManager.disableLocationStreamingInAllChats()
-                    _ = self.dcAccounts.remove(id: selectedAccountId)
-                    KeychainManager.deleteAccountSecret(id: selectedAccountId)
-                    INInteraction.delete(with: "\(selectedAccountId)", completion: nil)
-                    if self.dcAccounts.getAll().isEmpty {
-                        _ = self.dcAccounts.add()
-                    } else {
-                        let lastSelectedAccountId = prefs.integer(forKey: Constants.Keys.lastSelectedAccountKey)
-                        if lastSelectedAccountId != 0 {
-                            _ = self.dcAccounts.select(id: lastSelectedAccountId)
-                        }
-                    }
-                    appDelegate.reloadDcContext()
-                }))
-                confirm2.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
-                self.present(confirm2, animated: true, completion: nil)
-            }))
-            confirm1.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
-            self?.present(confirm1, animated: true, completion: nil)
-        }))
-
-        menu.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
-        present(menu, animated: true, completion: nil)
     }
 
     private func startImex(what: Int32, passphrase: String? = nil) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -41,7 +41,7 @@ class AppCoordinator {
     }
 
     private func createChatsNavigationController() -> UINavigationController {
-        let root = ChatListController(dcContext: dcAccounts.getSelected(), isArchive: false)
+        let root = ChatListController(dcContext: dcAccounts.getSelected(), dcAccounts: dcAccounts, isArchive: false)
         let nav = UINavigationController(rootViewController: root)
         let settingsImage = UIImage(named: "ic_chat")
         nav.tabBarItem = UITabBarItem(title: String.localized("pref_chats"), image: settingsImage, tag: chatsTab)

--- a/deltachat-ios/Handler/AccountSwitcherHandler.swift
+++ b/deltachat-ios/Handler/AccountSwitcherHandler.swift
@@ -1,11 +1,3 @@
-//
-//  AccountSwitcherHandler.swift
-//  deltachat-ios
-//
-//  Created by bb on 30.09.22.
-//  Copyright © 2022 Jonas Reinsch. All rights reserved.
-//
-
 import Foundation
 import UIKit
 import DcCore

--- a/deltachat-ios/Handler/AccountSwitcherHandler.swift
+++ b/deltachat-ios/Handler/AccountSwitcherHandler.swift
@@ -1,0 +1,86 @@
+//
+//  AccountSwitcherHandler.swift
+//  deltachat-ios
+//
+//  Created by bb on 30.09.22.
+//  Copyright © 2022 Jonas Reinsch. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import DcCore
+import DBDebugToolkit
+import Intents
+
+protocol AccountSwitcherHandler: UIViewController {
+    var dcAccounts: DcAccounts { get }
+    func showSwitchAccountMenu()
+}
+
+extension AccountSwitcherHandler {
+    func showSwitchAccountMenu() {
+        let accountIds = dcAccounts.getAll()
+        let selectedAccountId = dcAccounts.getSelected().id
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+
+        let prefs = UserDefaults.standard
+        // switch account
+        let menu = UIAlertController(title: String.localized("switch_account"), message: nil, preferredStyle: .safeActionSheet)
+        for accountId in accountIds {
+            let account = dcAccounts.get(id: accountId)
+            let newMessages = account.getFreshMessages().count
+            let messageBadge = newMessages == 0 ? "" : " [" + String(newMessages) + "]"
+            
+            var title = account.displaynameAndAddr
+            title = (selectedAccountId==accountId ? "✔︎ " : "") + title + messageBadge
+            menu.addAction(UIAlertAction(title: title, style: .default, handler: { [weak self] _ in
+                guard let self = self else { return }
+                prefs.setValue(selectedAccountId, forKey: Constants.Keys.lastSelectedAccountKey)
+                _ = self.dcAccounts.select(id: accountId)
+                appDelegate.reloadDcContext()
+            }))
+        }
+
+        // add account
+        menu.addAction(UIAlertAction(title: String.localized("add_account"), style: .default, handler: { [weak self] _ in
+            guard let self = self else { return }
+            prefs.setValue(selectedAccountId, forKey: Constants.Keys.lastSelectedAccountKey)
+            _ = self.dcAccounts.add()
+            appDelegate.reloadDcContext()
+        }))
+
+        // delete account
+        menu.addAction(UIAlertAction(title: String.localized("delete_account"), style: .destructive, handler: { [weak self] _ in
+            let confirm1 = UIAlertController(title: String.localized("delete_account_ask"), message: nil, preferredStyle: .safeActionSheet)
+            confirm1.addAction(UIAlertAction(title: String.localized("delete_account"), style: .destructive, handler: { [weak self] _ in
+                guard let self = self else { return }
+                let account = self.dcAccounts.get(id: selectedAccountId)
+                let confirm2 = UIAlertController(title: account.displaynameAndAddr,
+                    message: String.localized("forget_login_confirmation_desktop"), preferredStyle: .alert)
+                confirm2.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { [weak self] _ in
+                    guard let self = self else { return }
+                    appDelegate.locationManager.disableLocationStreamingInAllChats()
+                    _ = self.dcAccounts.remove(id: selectedAccountId)
+                    KeychainManager.deleteAccountSecret(id: selectedAccountId)
+                    INInteraction.delete(with: "\(selectedAccountId)", completion: nil)
+                    if self.dcAccounts.getAll().isEmpty {
+                        _ = self.dcAccounts.add()
+                    } else {
+                        let lastSelectedAccountId = prefs.integer(forKey: Constants.Keys.lastSelectedAccountKey)
+                        if lastSelectedAccountId != 0 {
+                            _ = self.dcAccounts.select(id: lastSelectedAccountId)
+                        }
+                    }
+                    appDelegate.reloadDcContext()
+                }))
+                confirm2.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
+                self.present(confirm2, animated: true, completion: nil)
+            }))
+            confirm1.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
+            self?.present(confirm1, animated: true, completion: nil)
+        }))
+
+        menu.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+        present(menu, animated: true, completion: nil)
+    }
+}


### PR DESCRIPTION
Highly experimental, layout still needs to be done to make it look good, also there is no custom menu on tapping it 
yet, it's just a modified version of the alert menu to only allow account switching(removed the possible destructive 
options for adding or 
removing account for now) and added unread count for each account.

What is this and why did you do it?
~~I'm planning to draw some sketches and do a real feature proposal for this over at out forum soon. (I also want it on 
android)~~
https://support.delta.chat/t/account-selector-on-avatar-on-chat-list/2242


### Progress

- [X] Logic
- [ ] make the Avatar Button with unread counter look nice
- [ ] custom nice looking context menu that also shows avatars, the android design would already be good, but I hope 
for something like what telegram is doing.

#### Bugs
- [x] custom icon replaces back button for archived chats, it should not do that, it should just be on the root/home view of the chatlist
- [x] reuse old function -> also show add and delete for now until we have a custom menu

## some sneak peaks

![Bildschirmfoto 2022-09-18 um 20 19 34](https://user-images.githubusercontent.com/18725968/190922427-aa64e57d-d593-4692-888f-6dd848c905c7.png)

![Bildschirmfoto 2022-09-18 um 20 07 55](https://user-images.githubusercontent.com/18725968/190922449-4e44cbb8-4478-490f-a4ce-620c0f45bbd6.png)
