### PR TITLE
Import backup improvements

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -555,15 +555,6 @@ public class DcContext {
         dc_imex(contextPointer, what, directory, passphrase)
     }
 
-    public func imexHasBackup(filePath: String) -> String? {
-        var file: String?
-        if let cString = dc_imex_has_backup(contextPointer, filePath) {
-            file = String(cString: cString)
-            dc_str_unref(cString)
-        }
-        return file
-    }
-
     public func isSendingLocationsToChat(chatId: Int) -> Bool {
         return dc_is_sending_locations_to_chat(contextPointer, UInt32(chatId)) == 1
     }

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -266,6 +266,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         let lastSelectedAccountId = UserDefaults.standard.integer(forKey: Constants.Keys.lastSelectedAccountKey)
         if lastSelectedAccountId != 0 {
             _ = dcAccounts.select(id: lastSelectedAccountId)
+            dcAccounts.startIo()
         }
 
         appDelegate.reloadDcContext()

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -277,14 +277,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         if dcContext.isConfigured() {
             return
         }
-        addProgressHudBackupListener()
-
-        if let documentsDirectory = ensureDcDocFolderExists(),
-           let filePath = dcContext.imexHasBackup(filePath: documentsDirectory.relativePath) {
-            importBackup(at: filePath)
-        } else {
-            mediaPicker?.showDocumentLibrary(selectFolder: true)
-        }
+        mediaPicker?.showDocumentLibrary(selectFolder: true)
     }
 
     private func importBackup(at filepath: String) {
@@ -292,20 +285,6 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         showProgressAlert(title: String.localized("import_backup_title"), dcContext: dcContext)
         dcAccounts.stopIo()
         dcContext.imex(what: DC_IMEX_IMPORT_BACKUP, directory: filepath)
-    }
-
-    private func ensureDcDocFolderExists() -> URL? {
-        let fileManager = FileManager.default
-        guard let documentsDirectory = try? fileManager.url(for: .documentDirectory,
-                                                            in: .userDomainMask,
-                                                            appropriateFor: nil,
-                                                            create: true) else { return nil }
-
-        let emptyHiddenFileURL = documentsDirectory.appendingPathComponent(".Move your backup here")
-        if !fileManager.fileExists(atPath: emptyHiddenFileURL.relativePath) {
-            fileManager.createFile(atPath: emptyHiddenFileURL.relativePath, contents: nil)
-        }
-        return documentsDirectory
     }
 
     private func addProgressHudBackupListener() {
@@ -601,21 +580,14 @@ extension WelcomeViewController: MediaPickerDelegate {
         }
 
         if let selectedBackupFilePath = url.relativePath {
-             importBackup(at: selectedBackupFilePath)
+            addProgressHudBackupListener()
+            importBackup(at: selectedBackupFilePath)
         } else {
             onSelectionCancelled()
-            securityScopedResource = nil
         }
     }
 
     func onSelectionCancelled() {
-        let alert = UIAlertController(
-            title: String.localized("import_backup_title"),
-            message: String.localizedStringWithFormat(
-                String.localized("import_backup_no_backup_found"),
-                "➔ Mac-Finder or iTunes ➔ iPhone ➔ " + String.localized("files") + " ➔ Delta Chat"), // iTunes was used up to Maverick 10.4
-            preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: String.localized("ok"), style: .cancel))
-        present(alert, animated: true)
+        securityScopedResource = nil
     }
 }

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -306,14 +306,12 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
                         self.navigationItem.title = String.localized(self.canCancel ? "add_account" : "welcome_desktop")
                     }
                     self.updateProgressAlert(error: ui["errorMessage"] as? String)
-                    self.securityScopedResource?.stopAccessingSecurityScopedResource()
-                    self.securityScopedResource = nil
+                    self.stopAccessingSecurityScopedResource()
                     self.removeBackupProgressObserver()
                 } else if let done = ui["done"] as? Bool, done {
                     self.dcAccounts.startIo()
                     self.updateProgressAlertSuccess(completion: self.handleBackupRestoreSuccess)
-                    self.securityScopedResource?.stopAccessingSecurityScopedResource()
-                    self.securityScopedResource = nil
+                    self.stopAccessingSecurityScopedResource()
                 } else {
                     self.updateProgressAlertValue(value: ui["progress"] as? Int)
                 }
@@ -395,6 +393,11 @@ extension WelcomeViewController: QrCodeReaderDelegate {
     private func dismissQRReader() {
         self.navigationController?.popViewController(animated: true)
         self.qrCodeReader = nil
+    }
+
+    private func stopAccessingSecurityScopedResource() {
+        self.securityScopedResource?.stopAccessingSecurityScopedResource()
+        self.securityScopedResource = nil
     }
 }
 
@@ -583,11 +586,7 @@ extension WelcomeViewController: MediaPickerDelegate {
             addProgressHudBackupListener()
             importBackup(at: selectedBackupFilePath)
         } else {
-            onSelectionCancelled()
+            stopAccessingSecurityScopedResource()
         }
-    }
-
-    func onSelectionCancelled() {
-        securityScopedResource = nil
     }
 }

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -579,10 +579,9 @@ class WelcomeContentView: UIView {
 
 extension WelcomeViewController: MediaPickerDelegate {
     func onDocumentSelected(url: NSURL) {
-        logger.debug("onDocumentsSelected: \(String(describing: url.relativePath))")
         // ensure we can access folders outside of the app's sandbox
-        let shouldStopAccessing = url.startAccessingSecurityScopedResource()
-        if shouldStopAccessing {
+        let isSecurityScopedResource = url.startAccessingSecurityScopedResource()
+        if isSecurityScopedResource {
             securityScopedResource = url
         }
 

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -324,6 +324,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
                         KeychainManager.deleteAccountSecret(id: accountId)
                         _ = self.dcAccounts.add()
                         self.dcContext = self.dcAccounts.getSelected()
+                        self.navigationItem.title = String.localized(self.canCancel ? "add_account" : "welcome_desktop")
                     }
                     self.updateProgressAlert(error: ui["errorMessage"] as? String)
                     self.securityScopedResource?.stopAccessingSecurityScopedResource()

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -119,8 +119,13 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
             nc.removeObserver(observer)
             self.progressObserver = nil
         }
+        removeBackupProgressObserver()
+    }
+
+    private func removeBackupProgressObserver() {
         if let backupProgressObserver = self.backupProgressObserver {
-            nc.removeObserver(backupProgressObserver)
+            NotificationCenter.default.removeObserver(backupProgressObserver)
+            self.backupProgressObserver = nil
         }
     }
 

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -585,8 +585,8 @@ extension WelcomeViewController: MediaPickerDelegate {
             securityScopedResource = url
         }
 
-        if let path = url.relativePath, let filePath = dcContext.imexHasBackup(filePath: path) {
-            importBackup(at: filePath)
+        if let selectedBackupFilePath = url.relativePath {
+             importBackup(at: selectedBackupFilePath)
         } else {
             onSelectionCancelled()
             securityScopedResource = nil

--- a/deltachat-ios/Controller/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/WelcomeViewController.swift
@@ -231,7 +231,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
                 logger.error("Failed to open account database for account \(dcContext.id)")
                 return
             }
-            self.navigationItem.title = "Add encrypted account"
+            self.navigationItem.title = String.localized("add_encrypted_account")
         } catch KeychainError.unhandledError(let message, let status) {
             logger.error("Keychain error. Failed to create encrypted account. \(message). Error status: \(status)")
         } catch {

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -86,9 +86,9 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
         let documentPicker: UIDocumentPickerViewController
         if selectFolder {
             if #available(iOS 15.0, *) {
-                documentPicker = UIDocumentPickerViewController(forOpeningContentTypes: [UTType.folder], asCopy: false)
+                documentPicker = UIDocumentPickerViewController(forOpeningContentTypes: [UTType.archive], asCopy: false)
             } else {
-                documentPicker = UIDocumentPickerViewController(documentTypes: [kUTTypeFolder] as [String], in: .open)
+                documentPicker = UIDocumentPickerViewController(documentTypes: [kUTTypeArchive] as [String], in: .open)
             }
         } else {
             if #available(iOS 15.0, *) {

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -9,7 +9,6 @@ protocol MediaPickerDelegate: class {
     func onVoiceMessageRecorded(url: NSURL)
     func onVoiceMessageRecorderClosed()
     func onDocumentSelected(url: NSURL)
-    func onSelectionCancelled()
 }
 
 extension MediaPickerDelegate {
@@ -30,9 +29,6 @@ extension MediaPickerDelegate {
     }
     func onDocumentSelected(url: NSURL) {
         logger.debug("document selected: \(url)")
-    }
-    func onSelectionCancelled() {
-        logger.debug("media selection cancelled")
     }
 }
 
@@ -224,9 +220,5 @@ extension MediaPicker: UIDocumentPickerDelegate {
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         let url = urls[0] as NSURL
         self.delegate?.onDocumentSelected(url: url)
-    }
-
-    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
-        self.delegate?.onSelectionCancelled()
     }
 }

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -987,3 +987,4 @@
 "shortcut_add_to_home_description" = "Select - Add to Home Screen - to add the app to your home screen.";
 "connectivity_low_data_mode" = "Disabled by system's \"Low Data Mode\".";
 "connectivity_low_power_mode" = "Disabled by system's \"Low Power Mode\".";
+"add_encrypted_account" = "Add encrypted account";

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -7,4 +7,5 @@
     <string name ="shortcut_add_to_home_description">Select - Add to Home Screen - to add the app to your home screen.</string>
     <string name="connectivity_low_data_mode">Disabled by system's \"Low Data Mode\".</string>
     <string name="connectivity_low_power_mode">Disabled by system's \"Low Power Mode\".</string>
+    <string name="add_encrypted_account">Add encrypted account</string>
 </resources>


### PR DESCRIPTION
closes #872 

* automatically restores the latest backup in the DC backup folder
* if no backup is available there, a document picker shows up, the user can select a backup from arbitrary locations, also the cloud
* if manual backup selection was cancelled, the alert appears with a hint where to put the backup as before
* it is ensured the DC folder exists and can be found in the finder app
* also: cancelling an ongoing backup attempt replaced the half-configured account with an empty new one, cancelling was half-baked before
* cancelling an ongoing backup attempt into an encrypted database falls back to an unencrypted empty account