### PR TITLE
[WIP] Fixing memory leak in ChatListController

### DIFF
--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -235,12 +235,17 @@ class AppCoordinator {
     }
 
     func resetTabBarRootViewControllers() {
+        // call `willMove()` for the root view controllers of each tab, after popping to root.
+        // this is not always done by `setViewControllers()` the documentation is vague on this point:
+        // <https://developer.apple.com/documentation/uikit/uitabbarcontroller/1621177-setviewcontrollers>
+        // (calling `willMove()` is needed eg. to remove observers - otherwise we have a memory leak)
         self.tabBarController.viewControllers?.forEach { controller in
             if let navController = controller as? UINavigationController {
                 navController.popToRootViewController(animated: false)
                 navController.viewControllers[0].willMove(toParent: nil)
             }
         }
+
         self.tabBarController.setViewControllers([createQrNavigationController(),
                                                   createChatsNavigationController(),
                                                   createSettingsNavigationController()], animated: false)

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -235,6 +235,12 @@ class AppCoordinator {
     }
 
     func resetTabBarRootViewControllers() {
+        self.tabBarController.viewControllers?.forEach { controller in
+            if let navController = controller as? UINavigationController {
+                navController.popToRootViewController(animated: false)
+                navController.viewControllers[0].willMove(toParent: nil)
+            }
+        }
         self.tabBarController.setViewControllers([createQrNavigationController(),
                                                   createChatsNavigationController(),
                                                   createSettingsNavigationController()], animated: false)


### PR DESCRIPTION
Ensure that tabbar root controllers always call willMove before they get replaced during account switch. 

closes #1695