### PR TITLE
show 'back button' in preview again

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1546,10 +1546,8 @@ class ChatViewController: UITableViewController {
     }
 
     private func showMediaGallery(currentIndex: Int, msgIds: [Int]) {
-        let betterPreviewController = PreviewController(dcContext: dcContext, type: .multi(msgIds, currentIndex))
-        let nav = UINavigationController(rootViewController: betterPreviewController)
-        nav.modalPresentationStyle = .fullScreen
-        navigationController?.present(nav, animated: true)
+        let previewController = PreviewController(dcContext: dcContext, type: .multi(msgIds, currentIndex))
+        navigationController?.pushViewController(previewController, animated: true)
     }
 
     private func webxdcButtonPressed(_ action: UIAlertAction) {
@@ -2214,9 +2212,7 @@ extension ChatViewController: DraftPreviewDelegate {
                     previewController.setEditing(true, animated: true)
                     previewController.delegate = self
                 }
-                let nav = UINavigationController(rootViewController: previewController)
-                nav.modalPresentationStyle = .fullScreen
-                navigationController?.present(nav, animated: true)
+                navigationController?.pushViewController(previewController, animated: true)
             }
         }
     }

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -495,12 +495,12 @@ class ContactDetailViewController: UITableViewController {
             if let url = chat.profileImageURL {
                 let previewController = PreviewController(dcContext: viewModel.context, type: .single(url))
                 previewController.customTitle = chat.name
-                present(previewController, animated: true, completion: nil)
+                navigationController?.pushViewController(previewController, animated: true)
             }
         } else if let url = viewModel.contact.profileImageURL {
             let previewController = PreviewController(dcContext: viewModel.context, type: .single(url))
             previewController.customTitle = viewModel.contact.displayName
-            present(previewController, animated: true, completion: nil)
+            navigationController?.pushViewController(previewController, animated: true)
         }
     }
 

--- a/deltachat-ios/Controller/DocumentGalleryController.swift
+++ b/deltachat-ios/Controller/DocumentGalleryController.swift
@@ -194,7 +194,7 @@ extension DocumentGalleryController {
             return
         }
         let previewController = PreviewController(dcContext: dcContext, type: .multi(fileMessageIds, index))
-        present(previewController, animated: true, completion: nil)
+        navigationController?.pushViewController(previewController, animated: true)
     }
 
     func redirectToMessage(of indexPath: IndexPath) {

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -305,7 +305,7 @@ private extension GalleryViewController {
 
         let previewController = PreviewController(dcContext: dcContext, type: .multi(mediaMessageIds, index))
         previewController.delegate = self
-        present(previewController, animated: true, completion: nil)
+        navigationController?.pushViewController(previewController, animated: true)
     }
 
     func redirectToMessage(of indexPath: IndexPath) {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -452,7 +452,7 @@ class GroupChatDetailViewController: UIViewController {
         if let url = chat.profileImageURL {
             let previewController = PreviewController(dcContext: dcContext, type: .single(url))
             previewController.customTitle = self.title
-            present(previewController, animated: true, completion: nil)
+            navigationController?.pushViewController(previewController, animated: true)
         }
     }
 }

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -13,11 +13,6 @@ class PreviewController: QLPreviewController {
     var customTitle: String?
     var dcContext: DcContext
 
-    private lazy var doneButtonItem: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: String.localized("done"), style: .done, target: self, action: #selector(doneButtonPressed(_:)))
-        return button
-    }()
-
     init(dcContext: DcContext, type: PreviewType) {
         self.previewType = type
         self.dcContext = dcContext
@@ -33,20 +28,6 @@ class PreviewController: QLPreviewController {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        if navigationController?.isBeingPresented ?? false {
-            /* QLPreviewController comes with a done-button by default. But if is embedded in UINavigationContrller we need to set a done-button manually.
-            */
-            navigationItem.leftBarButtonItem = doneButtonItem
-        }
-    }
-
-    // MARK: - actions
-    @objc private func doneButtonPressed(_ sender: UIBarButtonItem) {
-        self.dismiss(animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
`QLPreviewController` seems not to show a 'back' button if `present()`ed inside a `UINavigationController` - in the past, there was a hack that adds the button manually in this case.

this hack stopped working with ios16 -
resulting having no way to leave preview.

this pr removes the hack, stops using `present()`
and switches to `pushViewController()` -
this seems to be the natural way here and shows the proper back buttons.

moreover, the pr removes the sometimes used wrapper ("betterPreviewController"), not sure what was the reasinging for that, probably needed for some fullscreen-mode however, pushing a `UINavigationController` to a `UINavigationController` is not allowed, so it just cannot be used in this form anymore -
and we're "fullscreen" as usual anyway.

closes #1696