### PR TITLE
synchronize color and size more to android and other online indicators

### DIFF
--- a/DcCore/DcCore/Helper/DcColors.swift
+++ b/DcCore/DcCore/Helper/DcColors.swift
@@ -19,6 +19,7 @@ public struct DcColors {
     public static let profileCellBackgroundColor = UIColor.themeColor(light: white, dark: actionCellBackgroundDark)
     public static let chatBackgroundColor = UIColor.themeColor(light: .white, dark: .black)
     public static let checkmarkGreen = UIColor.themeColor(light: UIColor.rgb(red: 112, green: 177, blue: 92))
+    public static let recentlySeenDot = UIColor(hexString: "34c759")
     public static let unreadBadge = UIColor(hexString: "3792fc")
     public static let defaultTextColor = UIColor.themeColor(light: .darkText, dark: .white)
     public static let grayTextColor = UIColor.themeColor(light: .darkGray, dark: coreDark05)

--- a/DcCore/DcCore/Views/InitialsBadge.swift
+++ b/DcCore/DcCore/Views/InitialsBadge.swift
@@ -40,7 +40,7 @@ public class InitialsBadge: UIView {
     private var recentlySeenView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = DcColors.checkmarkGreen
+        view.backgroundColor = DcColors.recentlySeenDot
         view.clipsToBounds = true
         view.isHidden = true
         return view
@@ -110,10 +110,10 @@ public class InitialsBadge: UIView {
                                   verifiedView.constraintAlignLeadingTo(self, paddingLeading: radius + verificationViewPadding),
                                   recentlySeenView.constraintAlignBottomTo(self),
                                   recentlySeenView.constraintAlignLeadingTo(self),
-                                  recentlySeenView.constraintHeightTo(radius / 2),
-                                  recentlySeenView.constraintWidthTo(radius / 2)
+                                  recentlySeenView.constraintHeightTo(radius * 0.6),
+                                  recentlySeenView.constraintWidthTo(radius * 0.6)
         ]
-        recentlySeenView.layer.cornerRadius = radius / 4
+        recentlySeenView.layer.cornerRadius = radius * 0.3
         addConstraints(imgViewConstraints)
     }
 


### PR DESCRIPTION
some easy to target layout points:

- with the "connection view", we already have a green indicating sth. as "online", reuse that
  (the green used before is a bit too much of a muted color, this does not reflect "activity" well)
- the size is a bit bigger, more matching to android and also more visible in the title bar (where the avatar is smaller)

before / after:

<img width=320  src=https://user-images.githubusercontent.com/9800740/193680098-88a746eb-4ec5-4e84-a8ff-3ffa8c9dee0b.png> <img width =320 src=https://user-images.githubusercontent.com/9800740/193680099-517b12cf-40ba-467a-97b4-ea53a45e8acb.png>

corresponding android pr using the same color: https://github.com/deltachat/deltachat-android/pull/2393

maybe we can get online indicator also to the bottom-right corner, maybe above the checkmark that could move a little bit to the left (always), i was playing around with this and other ideas as getting the verified-checkmark to the title as on android/desktop etc. but that is sth. for a subsequent pr. easy things first :)