### PR TITLE
move "recently seen dot" lower right

### DIFF
--- a/DcCore/DcCore/Views/InitialsBadge.swift
+++ b/DcCore/DcCore/Views/InitialsBadge.swift
@@ -2,7 +2,6 @@ import UIKit
 
 public class InitialsBadge: UIView {
 
-    private let verificationViewPadding: CGFloat = 2
     private let size: CGFloat
 
     var leadingImageAnchorConstraint: NSLayoutConstraint?
@@ -53,22 +52,11 @@ public class InitialsBadge: UIView {
         return imageViewContainer
     }()
 
-    public var cornerRadius: CGFloat {
-        get {
-            return layer.cornerRadius
-        }
-        set {
-            layer.cornerRadius = newValue
-            imageView.layer.cornerRadius = newValue
-        }
-    }
-
     public convenience init(name: String, color: UIColor, size: CGFloat, accessibilityLabel: String? = nil) {
         self.init(size: size, accessibilityLabel: accessibilityLabel)
         setName(name)
         setColor(color)
     }
-
 
     public convenience init (image: UIImage, size: CGFloat, accessibilityLabel: String? = nil) {
         self.init(size: size, accessibilityLabel: accessibilityLabel)
@@ -104,12 +92,12 @@ public class InitialsBadge: UIView {
 
         addSubview(verifiedView)
         addSubview(recentlySeenView)
-        let imgViewConstraints = [verifiedView.constraintAlignBottomTo(self, paddingBottom: -verificationViewPadding),
-                                  verifiedView.constraintAlignTrailingTo(self, paddingTrailing: -verificationViewPadding),
-                                  verifiedView.constraintAlignTopTo(self, paddingTop: radius + verificationViewPadding),
-                                  verifiedView.constraintAlignLeadingTo(self, paddingLeading: radius + verificationViewPadding),
+        let imgViewConstraints = [verifiedView.constraintAlignTopTo(self, paddingTop: radius * 0.15),
+                                  verifiedView.constraintAlignTrailingTo(self, paddingTrailing: radius * -0.1),
+                                  verifiedView.constraintHeightTo(radius * 0.8),
+                                  verifiedView.constraintWidthTo(radius * 0.8),
                                   recentlySeenView.constraintAlignBottomTo(self),
-                                  recentlySeenView.constraintAlignLeadingTo(self),
+                                  recentlySeenView.constraintAlignTrailingTo(self),
                                   recentlySeenView.constraintHeightTo(radius * 0.6),
                                   recentlySeenView.constraintWidthTo(radius * 0.6)
         ]


### PR DESCRIPTION
this moves the "recently seen dot" to the corner where it is shown also for many other apps: to the lower right corner.

as the lower right corner was already occupied by the "verified checkmark", that one is moved to the upper right corner, with a little bit of padding to the top. i played around with different positions, that one looked best.

also the combination of both indicators look fine now.

it is anyway a bit unclear what happens to the "verified" indicator for contacts, it may go away completely and being replaced by a line as "Verified by NAME", so it is good enough for now :)

@cyBerta i am not so much in these constraints - please push to this pr if i did sth wrong :)

<img width=320 src=https://user-images.githubusercontent.com/9800740/193934165-619be6d3-e50e-48c0-ba4b-0b1c8446c585.png>
<img width=320 src=https://user-images.githubusercontent.com/9800740/193934171-334d5c79-1d6e-4a0d-864e-b29062b52449.png> 
