### PR TITLE
switch accounts if nececssary for direct share shortcuts

### DIFF
--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -134,7 +134,7 @@ class ShareViewController: SLComposeServiceViewController {
         }
 
         let contact = dcContext.getContact(id: Int(DC_CONTACT_ID_SELF))
-        let title = dcContext.displayname ?? String.localized("pref_your_name")
+        let title = dcContext.displayname ?? dcContext.addr ?? ""
         initialsBadge.setName(title)
         initialsBadge.setColor(contact.color)
         if let image = contact.profileImage {


### PR DESCRIPTION
part of #1703 

not yet implemented: UI changes. 
We could add the account avatar to the navigation bar, e.g. left of the cancel button or left of the send button (maybe that get's more attention, before the user hits the send button). 
We can also add another row to the bottom showing the account name there (unfortunately but without an icon using the basic iOS share framework) and could give an option to switch accounts there. That might become especially useful in case the user didn't select a direct share shortcut, but the general delta chat share icon. 
Opinions welcome :)