### PR TITLE
fix emojis in webxdc

### DIFF
--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -55,6 +55,11 @@ class WebxdcViewController: WebViewViewController {
     """
     
     lazy var webxdcbridge: String = {
+        let addr = dcContext.addr?
+            .addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
+        let displayname = (dcContext.displayname ?? dcContext.addr)?
+            .addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
+        
         let script = """
         window.webxdc = (() => {
           let setUpdateListenerPromise = null
@@ -79,9 +84,9 @@ class WebxdcViewController: WebViewViewController {
           }
 
           return {
-            selfAddr: atob("\((dcContext.addr ?? "unknown").toBase64())"),
+            selfAddr: decodeURI("\((addr ?? "unknown"))"),
         
-            selfName: atob("\((dcContext.displayname ?? dcContext.addr ?? "unknown").toBase64())"),
+            selfName: decodeURI("\((displayname ?? "unknown"))"),
         
             setUpdateListener: (cb, serial) => {
                 update_listener = cb

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -67,9 +67,9 @@ class WebxdcViewController: WebViewViewController {
         
           var update_listener = () => {};
 
-          window.__webxdcUpdate = (updateString) => {
+          window.__webxdcUpdate = async (lastSerial) => {
             try {
-                var updates = JSON.parse(updateString);
+                const updates = await fetch("webxdc-update.json?"+lastSerial).then((response) => response.json())
                 updates.forEach((update) => {
                   update_listener(update);
                 });
@@ -276,7 +276,7 @@ class WebxdcViewController: WebViewViewController {
                let maxSerial = first["max_serial"] as? Int {
                 self.lastSerial = maxSerial
             }
-            webView.evaluateJavaScript("window.__webxdcUpdate(atob(\"\(statusUpdates.toBase64())\"))", completionHandler: nil)
+            webView.evaluateJavaScript("window.__webxdcUpdate(\(String(lastSerial)))", completionHandler: nil)
         }
     }
 
@@ -371,6 +371,18 @@ extension WebxdcViewController: WKScriptMessageHandler {
 extension WebxdcViewController: WKURLSchemeHandler {
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
         if let url = urlSchemeTask.request.url, let scheme = url.scheme, scheme == INTERNALSCHEMA {
+            if url.path == "/webxdc-update.json" || url.path == "webxdc-update.json" {
+                let lastKnownSerial = Int(url.query ?? "0") ?? 0
+                let data = Data(
+                    dcContext.getWebxdcStatusUpdates(msgId: messageId, lastKnownSerial: lastKnownSerial).utf8)
+                let response = URLResponse(url: url, mimeType: "application/json", expectedContentLength: data.count, textEncodingName: "utf-8")
+                
+                urlSchemeTask.didReceive(response)
+                urlSchemeTask.didReceive(data)
+                urlSchemeTask.didFinish()
+                return
+            }
+
             let file = url.path
             let dcMsg = dcContext.getMessage(id: messageId)
             var data: Data

--- a/deltachat-ios/Extensions/String+Extension.swift
+++ b/deltachat-ios/Extensions/String+Extension.swift
@@ -81,8 +81,4 @@ extension String {
             return "\(number)"
         }
     }
-
-    func toBase64() -> String {
-        return Data(self.utf8).base64EncodedString()
-    }
 }


### PR DESCRIPTION
- fix emojis in display name
- get webxdc update json over web request this is a solution fto circumvent or possible xss attacks (because executing the data concatenated into a command is possibly dangerous - the base64 encoding woraround broke the emojis)
- remove base64 string extention that is now unused
