### PR TITLE
add default providers we have in desktop

### DIFF
--- a/deltachat-ios/Controller/SettingsController.swift
+++ b/deltachat-ios/Controller/SettingsController.swift
@@ -122,7 +122,6 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
         cell.tag = CellTags.videoChat.rawValue
         cell.textLabel?.text = String.localized("videochat_instance")
         cell.accessoryType = .disclosureIndicator
-        cell.detailTextLabel?.text = dcContext.getConfig("webrtc_instance")
         return cell
     }()
 
@@ -544,7 +543,7 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
         mediaQualityCell.detailTextLabel?.text = MediaQualityController.getValString(val: dcContext.getConfigInt("media_quality"))
         downloadOnDemandCell.detailTextLabel?.text = DownloadOnDemandViewController.getValString(
             val: dcContext.getConfigInt("download_limit"))
-        videoChatInstanceCell.detailTextLabel?.text = dcContext.getConfig("webrtc_instance")
+        videoChatInstanceCell.detailTextLabel?.text = SettingsVideoChatViewController.getValString(val: dcContext.getConfig("webrtc_instance") ?? "")
         autodelCell.detailTextLabel?.text = autodelSummary()
         connectivityCell.detailTextLabel?.text = DcUtils.getConnectivityString(dcContext: dcContext,
                                                                                connectedString: String.localized("connectivity_connected"))

--- a/deltachat-ios/Controller/SettingsVideoChatViewController.swift
+++ b/deltachat-ios/Controller/SettingsVideoChatViewController.swift
@@ -2,18 +2,17 @@ import UIKit
 import DcCore
 
 class PredefinedVideoChatOptionCell: UITableViewCell {
-    
+
     public var url: String
-    
+
     init(label: String, url: String) {
         self.url = url
         super.init(style: UITableViewCell.CellStyle.subtitle, reuseIdentifier: label)
         self.textLabel?.text = label
         self.detailTextLabel?.text = url
         self.detailTextLabel?.textColor = .lightGray
-        
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -29,13 +28,13 @@ class SettingsVideoChatViewController: UITableViewController {
         PredefinedVideoChatOptionCell(label: "Systemli", url: "https://meet.systemli.org/$ROOM"),
         PredefinedVideoChatOptionCell(label: "Autistici", url: "https://vc.autistici.org/$ROOM"),
     ]
-    
+
     private lazy var offCell: UITableViewCell = {
         let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "off")
         cell.textLabel?.text = String.localized("off")
         return cell
     }()
-    
+
     private lazy var customInstanceCell: TextFieldCell = {
         let cell = TextFieldCell.makeConfigCell(labelID: String.localized("custom"),
                                                 placeholderID: String.localized("videochat_instance_placeholder"))
@@ -58,7 +57,7 @@ class SettingsVideoChatViewController: UITableViewController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Table view data source
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -90,7 +89,7 @@ class SettingsVideoChatViewController: UITableViewController {
         updateSelected(selectedCustom: selectedCustom)
         tableView.deselectRow(at: indexPath, animated: true)
     }
-    
+
     // called when editing the value of the custom field or clicking on it
     @objc private func setCustom(_ textField: UITextField) {
         let newInstance = customInstanceCell.getText()
@@ -109,7 +108,7 @@ class SettingsVideoChatViewController: UITableViewController {
             return customInstanceCell
         }
     }
-    
+
     var isCustom = false
     func updateSelected(selectedCustom: Bool) {
         self.isCustom = false
@@ -124,7 +123,7 @@ class SettingsVideoChatViewController: UITableViewController {
                 option.accessoryType = .none
             }
         }
-        
+
         if notDefault {
             if (currentUrl?.isEmpty) != nil || selectedCustom {
                 self.offCell.accessoryType = .none

--- a/deltachat-ios/Controller/SettingsVideoChatViewController.swift
+++ b/deltachat-ios/Controller/SettingsVideoChatViewController.swift
@@ -27,7 +27,7 @@ class SettingsVideoChatViewController: UITableViewController {
     private let defaultOptions = [
         PredefinedVideoChatOptionCell(label: "Jitsi", url: "https://meet.jit.si/$ROOM"),
         PredefinedVideoChatOptionCell(label: "Systemli", url: "https://meet.systemli.org/$ROOM"),
-        PredefinedVideoChatOptionCell(label: "autistici", url: "https://vc.autistici.org/$ROOM"),
+        PredefinedVideoChatOptionCell(label: "Autistici", url: "https://vc.autistici.org/$ROOM"),
     ]
     
     private lazy var offCell: UITableViewCell = {

--- a/deltachat-ios/Controller/SettingsVideoChatViewController.swift
+++ b/deltachat-ios/Controller/SettingsVideoChatViewController.swift
@@ -1,8 +1,17 @@
 import UIKit
 import DcCore
 
-class PredefinedVideoChatOptionCell: UITableViewCell {
+private class PredefinedOption {
+    public var label: String
+    public var url: String
 
+    init(label: String, url: String) {
+        self.label = label
+        self.url = url
+    }
+}
+
+private class PredefinedOptionCell: UITableViewCell {
     public var url: String
 
     init(label: String, url: String) {
@@ -18,21 +27,27 @@ class PredefinedVideoChatOptionCell: UITableViewCell {
     }
 }
 
-
 class SettingsVideoChatViewController: UITableViewController {
-
     private var dcContext: DcContext
 
-    private let defaultOptions = [
-        PredefinedVideoChatOptionCell(label: "Jitsi", url: "https://meet.jit.si/$ROOM"),
-        PredefinedVideoChatOptionCell(label: "Systemli", url: "https://meet.systemli.org/$ROOM"),
-        PredefinedVideoChatOptionCell(label: "Autistici", url: "https://vc.autistici.org/$ROOM"),
+    private static let predefinedOptions = [
+        PredefinedOption(label: "Jitsi", url: "https://meet.jit.si/$ROOM"),
+        PredefinedOption(label: "Systemli", url: "https://meet.systemli.org/$ROOM"),
+        PredefinedOption(label: "Autistici", url: "https://vc.autistici.org/$ROOM"),
     ]
 
     private lazy var offCell: UITableViewCell = {
         let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "off")
         cell.textLabel?.text = String.localized("off")
         return cell
+    }()
+
+    private lazy var predefinedCells: [PredefinedOptionCell] = {
+        var ret: [PredefinedOptionCell] = []
+        for option in SettingsVideoChatViewController.predefinedOptions {
+            ret.append(PredefinedOptionCell(label: option.label, url: option.url))
+        }
+        return ret
     }()
 
     private lazy var customInstanceCell: TextFieldCell = {
@@ -58,6 +73,15 @@ class SettingsVideoChatViewController: UITableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    static func getValString(val: String) -> String {
+        for option in predefinedOptions {
+            if option.url == val {
+                return option.label
+            }
+        }
+        return val
+    }
+
     // MARK: - Table view data source
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -65,7 +89,7 @@ class SettingsVideoChatViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.defaultOptions.count + 2
+        return self.predefinedCells.count + 2
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -77,8 +101,8 @@ class SettingsVideoChatViewController: UITableViewController {
         if indexPath.row == 0 {
             newInstance = ""
             self.view.endEditing(true)
-        } else if indexPath.row <= self.defaultOptions.count {
-            newInstance = self.defaultOptions[indexPath.row-1].url
+        } else if indexPath.row <= self.predefinedCells.count {
+            newInstance = self.predefinedCells[indexPath.row-1].url
             self.view.endEditing(true)
         } else {
             newInstance = customInstanceCell.getText()
@@ -102,8 +126,8 @@ class SettingsVideoChatViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.row == 0 {
             return offCell
-        } else if indexPath.row <= self.defaultOptions.count {
-            return self.defaultOptions[indexPath.row-1]
+        } else if indexPath.row <= self.predefinedCells.count {
+            return self.predefinedCells[indexPath.row-1]
         } else {
             return customInstanceCell
         }
@@ -115,7 +139,7 @@ class SettingsVideoChatViewController: UITableViewController {
         var notDefault = true
         let currentUrl = dcContext.getConfig("webrtc_instance")
         // set selection
-        for option in self.defaultOptions {
+        for option in self.predefinedCells {
             if option.url == currentUrl {
                 option.accessoryType = .checkmark
                 notDefault = false

--- a/deltachat-ios/Controller/SettingsVideoChatViewController.swift
+++ b/deltachat-ios/Controller/SettingsVideoChatViewController.swift
@@ -1,21 +1,50 @@
 import UIKit
 import DcCore
+
+class PredefinedVideoChatOptionCell: UITableViewCell {
+    
+    public var url: String
+    
+    init(label: String, url: String) {
+        self.url = url
+        super.init(style: UITableViewCell.CellStyle.subtitle, reuseIdentifier: label)
+        self.textLabel?.text = label
+        self.detailTextLabel?.text = url
+        self.detailTextLabel?.textColor = .lightGray
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+
 class SettingsVideoChatViewController: UITableViewController {
 
     private var dcContext: DcContext
 
-    private lazy var videoInstanceCell: TextFieldCell = {
-        let cell = TextFieldCell.makeConfigCell(labelID: String.localized("videochat_instance"),
+    private let defaultOptions = [
+        PredefinedVideoChatOptionCell(label: "Jitsi", url: "https://meet.jit.si/$ROOM"),
+        PredefinedVideoChatOptionCell(label: "Systemli", url: "https://meet.systemli.org/$ROOM"),
+        PredefinedVideoChatOptionCell(label: "autistici", url: "https://vc.autistici.org/$ROOM"),
+    ]
+    
+    private lazy var customInstanceCell: TextFieldCell = {
+        let cell = TextFieldCell.makeConfigCell(labelID: String.localized("custom"),
                                                 placeholderID: String.localized("videochat_instance_placeholder"))
         cell.textField.autocapitalizationType = .none
         cell.textField.autocorrectionType = .no
         cell.textField.textContentType = .URL
+        cell.textField.addTarget(self, action: #selector(setCustom), for: .editingDidBegin)
+        cell.textField.addTarget(self, action: #selector(setCustom), for: .valueChanged)
         return cell
     }()
 
     init(dcContext: DcContext) {
         self.dcContext = dcContext
         super.init(style: .grouped)
+        self.updateSelected()
         self.title = String.localized("videochat_instance")
         hidesBottomBarWhenPushed = true
     }
@@ -31,16 +60,64 @@ class SettingsVideoChatViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        return self.defaultOptions.count + 1
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // selection changed, save value of custom field to ui config
+        dcContext.setConfig("ui.custom_webrtc_instance", customInstanceCell.getText())
+        
+        var newInstance: String?
+        if indexPath.row < self.defaultOptions.count {
+            newInstance = self.defaultOptions[indexPath.row].url
+            self.view.endEditing(true)
+        } else {
+            newInstance = customInstanceCell.getText()
+        }
+        dcContext.setConfig("webrtc_instance", newInstance)
+        
+        updateSelected()
+        
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+    
+    // called when editing the value of the custom field or clicking on it
+    @objc private func setCustom(_ textField: UITextField) {
+        let newInstance = customInstanceCell.getText()
+        dcContext.setConfig("ui.custom_webrtc_instance", newInstance)
+        dcContext.setConfig("webrtc_instance", newInstance)
+        updateSelected()
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        videoInstanceCell.textField.text = dcContext.getConfig("webrtc_instance")
-        return videoInstanceCell
+        if indexPath.row < self.defaultOptions.count {
+            return self.defaultOptions[indexPath.row]
+        } else {
+            return customInstanceCell
+        }
+    }
+   
+    private var isCustom = true
+    
+    func updateSelected() {
+        let currentUrl = dcContext.getConfig("webrtc_instance")
+        // set selection
+        for option in self.defaultOptions {
+            if option.url == currentUrl {
+                option.accessoryType = .checkmark
+                self.isCustom = false
+            } else {
+                option.accessoryType = .none
+            }
+        }
+        
+        if self.isCustom {
+            customInstanceCell.accessoryType = .checkmark
+            customInstanceCell.textField.text = currentUrl
+        } else {
+            customInstanceCell.accessoryType = .none
+            customInstanceCell.textField.text = dcContext.getConfig("ui.custom_webrtc_instance")
+        }
     }
 
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
@@ -48,6 +125,9 @@ class SettingsVideoChatViewController: UITableViewController {
     }
 
     override func viewWillDisappear(_ animated: Bool) {
-        dcContext.setConfig("webrtc_instance", videoInstanceCell.getText())
+        dcContext.setConfig("ui.custom_webrtc_instance", customInstanceCell.getText())
+        if self.isCustom {
+            dcContext.setConfig("webrtc_instance", customInstanceCell.getText())
+        }
     }
 }


### PR DESCRIPTION
<img width=250 src="https://user-images.githubusercontent.com/18725968/197252481-8d8fdb6d-b8df-4f40-8ad9-aea62d14fe89.png">

they were asked for permission as far as I know.


Edit: checkmark works now as expected, we have now an "Off" option and also note that custom value get persisted in `ui.custom_webrtc_instance` so users don't loose what they typed in there when trying default instances out (we should add that behaviour on desktop too).
