### PR TITLE
precheck with DC_INFO_WEBXDC_INFO_MESSAGE

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -1207,6 +1207,10 @@ public class DcMsg {
         return dc_msg_is_info(messagePointer) == 1
     }
 
+    public var infoType: Int32 {
+        return dc_msg_get_info_type(messagePointer)
+    }
+
     public var isSetupMessage: Bool {
         return dc_msg_is_setupmessage(messagePointer) == 1
     }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -746,7 +746,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         if message.isInfo {
             let cell = tableView.dequeueReusableCell(withIdentifier: "info", for: indexPath) as? InfoMessageCell ?? InfoMessageCell()
             cell.showSelectionBackground(tableView.isEditing)
-            if message.infoType == DC_INFO_WEBXDC_INFO_MESSAGE, let parent = message.parent, parent.type == DC_MSG_WEBXDC {
+            if message.infoType == DC_INFO_WEBXDC_INFO_MESSAGE, let parent = message.parent {
                 cell.update(text: message.text, image: parent.getWebxdcPreviewImage())
             } else {
                 cell.update(text: message.text)
@@ -973,7 +973,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             if let url = NSURL(string: message.getVideoChatUrl()) {
                 UIApplication.shared.open(url as URL)
             }
-        } else if message.isInfo, message.infoType == DC_INFO_WEBXDC_INFO_MESSAGE, let parent = message.parent, parent.type == DC_MSG_WEBXDC {
+        } else if message.isInfo, message.infoType == DC_INFO_WEBXDC_INFO_MESSAGE, let parent = message.parent {
             scrollToMessage(msgId: parent.id)
         }
         _ = handleUIMenu()

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -746,7 +746,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         if message.isInfo {
             let cell = tableView.dequeueReusableCell(withIdentifier: "info", for: indexPath) as? InfoMessageCell ?? InfoMessageCell()
             cell.showSelectionBackground(tableView.isEditing)
-            if let parent = message.parent, parent.type == DC_MSG_WEBXDC {
+            if message.infoType == DC_INFO_WEBXDC_INFO_MESSAGE, let parent = message.parent, parent.type == DC_MSG_WEBXDC {
                 cell.update(text: message.text, image: parent.getWebxdcPreviewImage())
             } else {
                 cell.update(text: message.text)
@@ -973,7 +973,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             if let url = NSURL(string: message.getVideoChatUrl()) {
                 UIApplication.shared.open(url as URL)
             }
-        } else if message.isInfo, let parent = message.parent, parent.type == DC_MSG_WEBXDC {
+        } else if message.isInfo, message.infoType == DC_INFO_WEBXDC_INFO_MESSAGE, let parent = message.parent, parent.type == DC_MSG_WEBXDC {
             scrollToMessage(msgId: parent.id)
         }
         _ = handleUIMenu()


### PR DESCRIPTION
this saves one database call if the info is not a webxdc info message, only a minor improvement, but still :)

in theory, the additional checks against `isInfo` and `type`, not totally sure in practice, so i left them for resilience :)