### PR TITLE
improve order of read out content by VoiceOver in chat list

### DIFF
--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -397,13 +397,11 @@ class ContactCell: UITableViewCell {
             isContactRequest: false)
         }
 
-        accessibilityLabel = """
-                              \(titleLabel.text ?? "")
-                              \(isContactRequest ?  String.localized("chat_request_label") : "")
-                              \(isArchived ? String.localized("chat_archived_label") : "")
-                              \(unreadMessages > 0 ? String.localized(stringID: "n_messages", count: unreadMessages) : "")
-                              \(timeLabel.text ?? "")
-                              \(subtitleLabel.text ?? "")
-                            """
+        accessibilityLabel = (titleLabel.text != nil ? ((titleLabel.text ?? "")+"\n") : "")
+            + (isContactRequest ? (String.localized("chat_request_label")+"\n") : "")
+            + (isArchived ? (String.localized("chat_archived_label")+"\n") : "")
+            + (unreadMessages > 0 ? (String.localized(stringID: "n_messages", count: unreadMessages)+"\n") : "")
+            + (timeLabel.text != nil ? ((timeLabel.text ?? "")+"\n") : "")
+            + (subtitleLabel.text != nil ? ((subtitleLabel.text ?? "")+"\n") : "")
     }
 }


### PR DESCRIPTION
picked from #1738

closes #1538

issues:

- [x] relatively loooooong pauses in voiceOver due to lots of empty lines always added to the `accessibilityLabel`. EDIT: fixed by recent commit