### PR TITLE
Fix crash on copy message with iOS 14.8

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2023,7 +2023,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func copyToClipboard(ids: [Int]) {
         let pasteboard = UIPasteboard.general
-        pasteboard.string = nil
+        pasteboard.string = ""
         var stringsToCopy = ""
 
         if ids.count > 1 {


### PR DESCRIPTION
It seems that setting the pasteboard content to `nil` crashes consistently on iOS 14.8. Setting it to an empty string should not conflict with other things?