### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,10 @@ xcuserdata/
 *.xcodeproj/*
 !*.xcodeproj/project.pbxproj
 !*.xcodeproj/xcshareddata/
+!*.xcodeproj/project.xcworkspace/
 !*.xcworkspace/contents.xcworkspacedata
 /*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
 
 .DS_Store
 


### PR DESCRIPTION
make sure,
`deltachat-ios.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings` is ignored. not sure if that file becomes in use by recent Xcode, however it is marked as being untracked after migrating to new M1 mac.

(updating that .gitignore from https://www.gitignore.io/api/xcode , the source that was used before, fixed it)