### PR TITLE
Draft: improve scrolling behavior

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		21D6C941260623F500D0755A /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D6C9392606190600D0755A /* NotificationManager.swift */; };
+		3001B560294265C200816B0C /* AtomicBoolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3001B55F294265C200816B0C /* AtomicBoolean.swift */; };
 		3008CB7224F93EB900E6A617 /* AudioMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008CB7124F93EB900E6A617 /* AudioMessageCell.swift */; };
 		3008CB7424F9436C00E6A617 /* AudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008CB7324F9436C00E6A617 /* AudioPlayerView.swift */; };
 		3008CB7624F95B6D00E6A617 /* AudioController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008CB7524F95B6D00E6A617 /* AudioController.swift */; };
@@ -253,6 +254,7 @@
 		21D6C9392606190600D0755A /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		21EE28844E7A690D73BF5285 /* Pods-deltachat-iosTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-deltachat-iosTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-deltachat-iosTests/Pods-deltachat-iosTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2F7009234DB9408201A6CDCB /* Pods_deltachat_iosTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_deltachat_iosTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3001B55F294265C200816B0C /* AtomicBoolean.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicBoolean.swift; sourceTree = "<group>"; };
 		3008CB7124F93EB900E6A617 /* AudioMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMessageCell.swift; sourceTree = "<group>"; };
 		3008CB7324F9436C00E6A617 /* AudioPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerView.swift; sourceTree = "<group>"; };
 		3008CB7524F95B6D00E6A617 /* AudioController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioController.swift; sourceTree = "<group>"; };
@@ -1000,6 +1002,7 @@
 				30E83EFC289BF32C0035614C /* ShortcutManager.swift */,
 				30CE137728D9C40700158DF4 /* ChatDropInteraction.swift */,
 				30E6E359293FEEA70093871E /* SimpleLogger.swift */,
+				3001B55F294265C200816B0C /* AtomicBoolean.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -1533,6 +1536,7 @@
 				21D6C941260623F500D0755A /* NotificationManager.swift in Sources */,
 				3080A023277DE09900E74565 /* SeparatorLine.swift in Sources */,
 				302B84C72396770B001C261F /* RelayHelper.swift in Sources */,
+				3001B560294265C200816B0C /* AtomicBoolean.swift in Sources */,
 				305961CF2346125100C80F33 /* UIColor+Extensions.swift in Sources */,
 				AEACE2E51FB32E1900DCDD78 /* Utils.swift in Sources */,
 				3052C60E253F088E007D13EA /* DetectorType.swift in Sources */,

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -397,9 +397,15 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }
 
     private func adaptContentInset(isInitial: Bool = false) {
-        // TODO: figure out how we can calculate the bottom content inset dynamically for the inital run, currently we assume the default text size, incase of accessibility text sizes we need to adapt the value
-        let currentBottomOffset = self.tableView.contentInset.vertical
-        self.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: isInitial ? 50 : self.messageInputBar.keyboardHeight, right: 0)
+        if isInitial {
+            let fontSize = self.messageInputBar.inputTextView.font.pointSize
+            let padding = 32.0
+            let minBottomInset = 52.0
+            self.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: max(minBottomInset, fontSize + padding), right: 0)
+            logger.debug(">>>> initial font size: \(fontSize) bottom: \(max(minBottomInset, fontSize + padding))")
+        } else {
+            self.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: self.messageInputBar.keyboardHeight, right: 0)
+        }
     }
 
     private func resetContentInset() {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2451,9 +2451,10 @@ extension ChatViewController: AudioControllerDelegate {
 extension ChatViewController: UITextViewDelegate {
     func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
         if keepKeyboard.get() {
+            // the event is triggered twice on some devices, we're debouncing this
             logger.debug(">>>>> textViewShouldEndEditing - keep keyboard")
             let now = Double(Date().timeIntervalSince1970)
-            logger.debug(">>>> debounce time: \(lastTextViewShouldEndEditingUpdate - now)")
+            logger.debug(">>>> debounce time: \(now - lastTextViewShouldEndEditingUpdate)")
             if now - lastTextViewShouldEndEditingUpdate < 0.5 {
                 return false
             }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -387,6 +387,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
         if dcChat.canSend {
             configureUIForWriting()
+            adaptContentInset(isInitial: true)
         } else if dcChat.isContactRequest {
             configureContactRequestBar()
         } else {
@@ -395,15 +396,20 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         loadMessages()
     }
 
-    private func adaptContentInset() {
-        self.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: self.messageInputBar.keyboardHeight, right: 0)
-        logger.debug(">>>> adaptContentInset \(self.messageInputBar.keyboardHeight)")
+    private func adaptContentInset(isInitial: Bool = false) {
+        // TODO: figure out how we can calculate the bottom content inset dynamically for the inital run, currently we assume the default text size, incase of accessibility text sizes we need to adapt the value
+        let currentBottomOffset = self.tableView.contentInset.vertical
+        self.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: isInitial ? 50 : self.messageInputBar.keyboardHeight, right: 0)
     }
 
     private func resetContentInset() {
-        self.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        let currentBottomOffset = self.tableView.contentInset.vertical
+        if currentBottomOffset > 0 {
+            UIView.animate(withDuration: 0.2, delay: 0, options: .beginFromCurrentState) { [weak self] in
+                self?.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+            }
+        }
         logger.debug(">>>> resetContentInset \(0)")
-
     }
 
     private func configureUIForWriting() {
@@ -819,6 +825,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             markSeenMessagesInVisibleArea()
             updateScrollDownButtonVisibility()
         }
+        resetContentInset()
     }
 
     public override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -575,16 +575,8 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             guard let self = self else { return }
             if let ui = notification.userInfo {
                 logger.debug(">>> msgChangedObserver: \(String(describing: ui["message_id"]))")
-                if self.dcChat.canSend, let id = ui["message_id"] as? Int, id > 0 {
-                    let msg = self.dcContext.getMessage(id: id)
-                    if msg.isInfo,
-                       let parent = msg.parent,
-                       parent.type == DC_MSG_WEBXDC {
-                        self.refreshMessages()
-                    } else {
-                        self.updateMessage(msg)
-                    }
-                } else {
+                if let id = ui["chat_id"] as? Int, id == 0  || // deleted messages or batch insert
+                    id == self.chatId {
                     self.refreshMessages()
                     DispatchQueue.main.async {
                         self.updateScrollDownButtonVisibility()

--- a/deltachat-ios/Helper/AtomicBoolean.swift
+++ b/deltachat-ios/Helper/AtomicBoolean.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public class AtomicBoolean {
+    private var val: UInt8 = 0
+    public init(initialValue: Bool) {
+        self.val = (initialValue == false ? 0 : 1)
+    }
+
+
+    public func set(value: Bool) {
+        if value {
+            OSAtomicTestAndSet(7, &val)
+        } else {
+            OSAtomicTestAndClear(7, &val)
+        }
+    }
+    
+  public func getAndSet(value: Bool) -> Bool {
+    if value {
+      return  OSAtomicTestAndSet(7, &val)
+    } else {
+      return  OSAtomicTestAndClear(7, &val)
+    }
+  }
+
+  public func get() -> Bool {
+    return val != 0
+  }
+}


### PR DESCRIPTION
Trying to figure out the root cause for the weird scroll behavior. This PR is only to discuss possible changes. 
The reason I started investigating this is #1691. The fix for that issue is fairly simple, see [af5cefe](https://github.com/deltachat/deltachat-ios/pull/1767/commits/af5cefee713af559e90af2b18d27df3bb214ed3c), if we take the DC Android as an template. However the weird scrolling down and back up when sending a message always happens now. I will explain a little bit more in the comments.

Generally I've noticed that the scrolling-down and up happens, because the messageInputBar looses it's focus when the user taps on the send button. As a result normally the keyboard would disappear. We mitigate that by [re-requesting the focus for the messageInputBar](https://github.com/deltachat/deltachat-ios/pull/1767/files#diff-bf4dd3d619f49250044e05ac5777f82c9b4029e49d8d175f6e2bbfefc1fe4685R2461) when the messageInputBar's UITextViewDelegate calls back textViewShouldEndEditing(). Normally that is sufficient to keep the keyboard in place, on some devices and OS versions you may see a very small flickering. 
However the frame size of the UITableView immediately changes and all cells at the bottom get moved for a short moment to the bottom of the screen, before the size frame size regains it's previous size - above the keyboard.

While experimenting and reading on [stack overflow for possible solutions](https://stackoverflow.com/questions/50459798/increase-the-height-of-the-tableview-when-the-keyboard-disappears) I learned that we can use `contentInset` to avoid the content is dragged down to the bottom of the screen. I vaguely remember we already worked with `contentInset`s in the past in this controller, but scratched that approach because of other issues we had with it like wrong initialization.

My current idea is - contrary to what we tried in the past regarding `contentInset`s - to set the content inset _only temporarily_ at the bottom before the keyboard events are thrown / the tableViewFrame changes and reset it as soon as the reload() was done and the new message bubble appeared (but is still hidden below the keyboard). 

What's not yet clear to me is if any call to scrollDown would be still necessary after resetting the contentInset, or maybe after animating the contentInset value.

What I can confirm so far is that setting the contentInset in `textViewShouldEndEditing` (= before the keyboard events are thrown / before the tableViewFrame size changes) indeed prevents the messages being moved down if I [comment out scrolling completely.](https://github.com/deltachat/deltachat-ios/pull/1767/files#diff-bf4dd3d619f49250044e05ac5777f82c9b4029e49d8d175f6e2bbfefc1fe4685L1149-L1160)