### PR TITLE
prepare 1.34.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Delta Chat iOS Changelog
 
+## v1.34.7
+2022-12
+
+* show audio recorder on half screen
+* prevent From:-forgery attacks
+* disable Autocrypt & Authres-checking for mailing lists because they don't work well with mailing lists
+* small speedups
+* improve logging
+* fix crash on copy message with iOS 14.8
+* fix detection of "All mail", "Trash", "Junk" etc folders
+* fix reactions on partially downloaded messages by fetching messages sequentially
+* fix a bug where one malformed message blocked receiving any further messages
+* fix: set read/write timeouts for IMAP over SOCKS5
+* update translations
+* update to core103
+
+
 ## v1.34.6
 2022-11
 

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -1800,13 +1800,13 @@
 				CODE_SIGN_ENTITLEMENTS = DcShare/DcShare.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 79;
+				CURRENT_PROJECT_VERSION = 80;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = DcShare/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.34.6;
+				MARKETING_VERSION = 1.34.7;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.delta.DcShare;
@@ -1825,13 +1825,13 @@
 				CODE_SIGN_ENTITLEMENTS = DcShare/DcShare.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 79;
+				CURRENT_PROJECT_VERSION = 80;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = DcShare/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.34.6;
+				MARKETING_VERSION = 1.34.7;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.delta.DcShare;
 				PRODUCT_NAME = "Delta Chat";
@@ -1967,7 +1967,7 @@
 				CODE_SIGN_ENTITLEMENTS = "deltachat-ios/deltachat-ios.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 79;
+				CURRENT_PROJECT_VERSION = 80;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -1984,7 +1984,7 @@
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/release",
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/debug",
 				);
-				MARKETING_VERSION = 1.34.6;
+				MARKETING_VERSION = 1.34.7;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-isystem",
@@ -2037,7 +2037,7 @@
 				CODE_SIGN_ENTITLEMENTS = "deltachat-ios/deltachat-ios.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 79;
+				CURRENT_PROJECT_VERSION = 80;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -2054,7 +2054,7 @@
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/release",
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/debug",
 				);
-				MARKETING_VERSION = 1.34.6;
+				MARKETING_VERSION = 1.34.7;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-isystem",


### PR DESCRIPTION
this pulls in fixes from core103 and some recent changes wrt logging to exclude some potential issues form background-fetch.