### PR TITLE
use regular heartbeat server also in DEBUG mode

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -371,11 +371,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
         let tokenString = tokenParts.joined()
 
-        #if DEBUG
-        let endpoint = "https://sandbox.notifications.delta.chat/register"
-        #else
         let endpoint = "https://notifications.delta.chat/register"
-        #endif
 
         logger.info("Notifications: POST token: \(tokenString) to \(endpoint)")
 


### PR DESCRIPTION
using the sandbox on a few developer devices does not make sense as that way devs do not get aware of issues
if the regular heatbeat server is down - or up again.

also, getting rid of the sandbox saves us some maintainance effort.

closes #1772 

@missytake feel free to shut down the sandbox server :)