### PR TITLE
tweak archive, pinned and unread counter

### DIFF
--- a/DcCore/DcCore/Helper/DcColors.swift
+++ b/DcCore/DcCore/Helper/DcColors.swift
@@ -37,7 +37,7 @@ public struct DcColors {
     public static let providerBrokenBackground = UIColor.themeColor(light: SystemColor.red.uiColor, dark: SystemColor.red.uiColor)
     public static let systemMessageBackgroundColor = UIColor.init(hexString: "65444444")
     public static let systemMessageFontColor = UIColor.white
-    public static let deaddropBackground = UIColor.themeColor(light: UIColor.init(hexString: "ebebec"), dark: UIColor.init(hexString: "1a1a1c"))
+    public static let deaddropBackground = UIColor.themeColor(light: UIColor.init(hexString: "f2f2f6"), dark: UIColor.init(hexString: "1a1a1c"))
     public static let accountSwitchBackgroundColor = UIColor.themeColor(light: UIColor.init(hexString: "65CCCCCC"), dark: UIColor.init(hexString: "65444444"))
 }
 

--- a/DcCore/DcCore/Helper/DcColors.swift
+++ b/DcCore/DcCore/Helper/DcColors.swift
@@ -21,6 +21,7 @@ public struct DcColors {
     public static let checkmarkGreen = UIColor.themeColor(light: UIColor.rgb(red: 112, green: 177, blue: 92))
     public static let recentlySeenDot = UIColor(hexString: "34c759")
     public static let unreadBadge = UIColor(hexString: "3792fc")
+    public static let unreadBadgeMuted = UIColor.themeColor(light: UIColor.init(hexString: "b6b6bb"), dark: UIColor.init(hexString: "3b3b3b"))
     public static let defaultTextColor = UIColor.themeColor(light: .darkText, dark: .white)
     public static let grayTextColor = UIColor.themeColor(light: .darkGray, dark: coreDark05)
     public static let coreDark05 = UIColor.init(hexString: "EFEFEF") // naming according to DC Android

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -660,7 +660,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         dcContext.setStockTranslation(id: DC_STR_CONTACT_VERIFIED, localizationKey: "contact_verified")
         dcContext.setStockTranslation(id: DC_STR_CONTACT_NOT_VERIFIED, localizationKey: "contact_not_verified")
         dcContext.setStockTranslation(id: DC_STR_CONTACT_SETUP_CHANGED, localizationKey: "contact_setup_changed")
-        dcContext.setStockTranslation(id: DC_STR_ARCHIVEDCHATS, localizationKey: "chat_archived_chats_title")
+        dcContext.setStockTranslation(id: DC_STR_ARCHIVEDCHATS, localizationKey: "chat_archived_label")
         dcContext.setStockTranslation(id: DC_STR_AC_SETUP_MSG_SUBJECT, localizationKey: "autocrypt_asm_subject")
         dcContext.setStockTranslation(id: DC_STR_AC_SETUP_MSG_BODY, localizationKey: "autocrypt_asm_general_body")
         dcContext.setStockTranslation(id: DC_STR_CANNOT_LOGIN, localizationKey: "login_error_cannot_login")

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -461,14 +461,22 @@ class ChatListController: UITableViewController {
 
         guard let chatId = viewModel.chatIdFor(section: indexPath.section, row: indexPath.row) else {
             return []
-        }
-
-        if chatId==DC_CHAT_ID_ARCHIVED_LINK {
-            return []
             // returning nil may result in a default delete action,
             // see https://forums.developer.apple.com/thread/115030
         }
+
         let chat = dcContext.getChat(chatId: chatId)
+
+        if chatId==DC_CHAT_ID_ARCHIVED_LINK {
+            let archiveLinkBottom = dcContext.getConfigBool("archive_link_bottom")
+            let positionAction = UITableViewRowAction(style: .destructive, title: archiveLinkBottom ? "Move up" : "Move down") { [weak self] _, _ in
+                self?.viewModel?.archiveLinkPositionToggle(chatId: chat.id)
+                self?.setEditing(false, animated: true)
+            }
+            positionAction.backgroundColor = UIColor.lightGray
+            return [positionAction]
+        }
+
         let archived = chat.isArchived
         let archiveActionTitle: String = String.localized(archived ? "unarchive" : "archive")
 

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -461,22 +461,14 @@ class ChatListController: UITableViewController {
 
         guard let chatId = viewModel.chatIdFor(section: indexPath.section, row: indexPath.row) else {
             return []
+        }
+
+        if chatId==DC_CHAT_ID_ARCHIVED_LINK {
+            return []
             // returning nil may result in a default delete action,
             // see https://forums.developer.apple.com/thread/115030
         }
-
         let chat = dcContext.getChat(chatId: chatId)
-
-        if chatId==DC_CHAT_ID_ARCHIVED_LINK {
-            let archiveLinkBottom = dcContext.getConfigBool("archive_link_bottom")
-            let positionAction = UITableViewRowAction(style: .destructive, title: archiveLinkBottom ? "Move up" : "Move down") { [weak self] _, _ in
-                self?.viewModel?.archiveLinkPositionToggle(chatId: chat.id)
-                self?.setEditing(false, animated: true)
-            }
-            positionAction.backgroundColor = UIColor.lightGray
-            return [positionAction]
-        }
-
         let archived = chat.isArchived
         let archiveActionTitle: String = String.localized(archived ? "unarchive" : "archive")
 

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -40,6 +40,10 @@ class ChatListController: UITableViewController {
         return searchController
     }()
 
+    private lazy var archiveCell: ContactCell = {
+        return ContactCell()
+    }()
+
     private lazy var newButton: UIBarButtonItem = {
         let button = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.compose, target: self, action: #selector(didPressNewChat))
         button.tintColor = DcColors.primary
@@ -371,8 +375,12 @@ class ChatListController: UITableViewController {
         switch cellData.type {
         case .chat(let chatData):
             let chatId = chatData.chatId
-            if let chatCell = tableView.dequeueReusableCell(withIdentifier: chatCellReuseIdentifier, for: indexPath) as? ContactCell {
-                // default chatCell
+            if chatId == DC_CHAT_ID_ARCHIVED_LINK {
+                let chatCell = archiveCell
+                chatCell.updateCell(cellViewModel: cellData)
+                chatCell.delegate = self
+                return chatCell
+            } else if let chatCell = tableView.dequeueReusableCell(withIdentifier: chatCellReuseIdentifier, for: indexPath) as? ContactCell {
                 chatCell.updateCell(cellViewModel: cellData)
                 chatCell.delegate = self
                 return chatCell

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -261,7 +261,7 @@ class ChatListController: UITableViewController {
     
     private func setupSubviews() {
         emptyStateLabel.addCenteredTo(parentView: view)
-        navigationItem.backButtonTitle = isArchive ? String.localized("chat_archived_chats_title") : String.localized("pref_chats")
+        navigationItem.backButtonTitle = isArchive ? String.localized("chat_archived_label") : String.localized("pref_chats")
     }
 
     @objc
@@ -612,7 +612,7 @@ class ChatListController: UITableViewController {
                 navigationItem.setLeftBarButton(cancelButton, animated: true)
             }
         } else if isArchive {
-            titleView.text = String.localized("chat_archived_chats_title")
+            titleView.text = String.localized("chat_archived_label")
             if !handleMultiSelectionTitle() {
                 navigationItem.setLeftBarButton(nil, animated: true)
             }

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -325,7 +325,21 @@ class ChatListController: UITableViewController {
             stopTimer()
         }
     }
-    
+
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if indexPath.section == 0, indexPath.row == 0, let cellData = viewModel?.cellDataFor(section: 0, row: 0) {
+            switch cellData.type {
+            case .chat(let chatData):
+                if chatData.chatId == DC_CHAT_ID_ARCHIVED_LINK {
+                    return ContactCell.cellHeight * 0.7
+                }
+            default:
+                break
+            }
+        }
+        return ContactCell.cellHeight
+    }
+
     // MARK: - actions
     @objc func didPressNewChat() {
         showNewChatController()

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -40,11 +40,6 @@ class ChatListController: UITableViewController {
         return searchController
     }()
 
-    private lazy var archiveCell: ActionCell = {
-        let actionCell = ActionCell()
-        return actionCell
-    }()
-
     private lazy var newButton: UIBarButtonItem = {
         let button = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.compose, target: self, action: #selector(didPressNewChat))
         button.tintColor = DcColors.primary
@@ -376,11 +371,7 @@ class ChatListController: UITableViewController {
         switch cellData.type {
         case .chat(let chatData):
             let chatId = chatData.chatId
-            if chatId == DC_CHAT_ID_ARCHIVED_LINK {
-                archiveCell.actionTitle = dcContext.getChat(chatId: chatId).name
-                archiveCell.backgroundColor = DcColors.chatBackgroundColor
-                return archiveCell
-            } else if let chatCell = tableView.dequeueReusableCell(withIdentifier: chatCellReuseIdentifier, for: indexPath) as? ContactCell {
+            if let chatCell = tableView.dequeueReusableCell(withIdentifier: chatCellReuseIdentifier, for: indexPath) as? ContactCell {
                 // default chatCell
                 chatCell.updateCell(cellViewModel: cellData)
                 chatCell.delegate = self
@@ -407,9 +398,17 @@ class ChatListController: UITableViewController {
         if !tableView.isEditing {
             return indexPath
         }
+        guard let viewModel = viewModel else {
+            return nil
+        }
 
-        let cell = tableView.cellForRow(at: indexPath)
-        return cell == archiveCell ? nil : indexPath
+        let cellData = viewModel.cellDataFor(section: indexPath.section, row: indexPath.row)
+        switch cellData.type {
+        case .chat(let chatData):
+            return chatData.chatId == DC_CHAT_ID_ARCHIVED_LINK ? nil : indexPath
+        default:
+            return indexPath
+        }
     }
 
     override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
@@ -508,10 +507,8 @@ class ChatListController: UITableViewController {
                 editingBar.showUnpinning = viewModel.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows) ||
                                            viewModel.hasOnlyPinnedChatsSelected(in: initialIndexPath)
             }
-            archiveCell.selectionStyle = .none
         } else {
             removeEditingView()
-            archiveCell.selectionStyle = .default
         }
         updateTitle()
     }

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -103,6 +103,18 @@ class ChatListController: UITableViewController {
                 self.handleChatListUpdate()
             }
         }
+        if #available(iOS 13.0, *) {
+            // use the same background color as for cells and esp. the first archive-link cell
+            // to make things appear less outstanding.
+            //
+            // TODO: this initally also sets the color of the "navigation area",
+            // however, when opening+closing a chat, it is a blurry grey.
+            // the inconsistency seems to be releated to the line
+            //   navigationController?.navigationBar.scrollEdgeAppearance = navigationController?.navigationBar.standardAppearance
+            // in ChatViewController.swift - removing this, the color is preserved at the cost of more flickering ...
+            // this needs more love :)
+            self.view.backgroundColor = UIColor.systemBackground
+        }
     }
 
     required init?(coder _: NSCoder) {

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -11,23 +11,22 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
     }
 
     private enum CellTags: Int {
-        case profile = 0
-        case showArchive = 1
-        case showEmails = 2
-        case blockedContacts = 3
-        case notifications = 4
-        case receiptConfirmation = 5
-        case autocryptPreferences = 6
-        case sendAutocryptMessage = 7
-        case exportBackup = 8
-        case advanced = 9
-        case help = 10
-        case autodel = 11
-        case mediaQuality = 12
-        case downloadOnDemand = 13
-        case videoChat = 14
-        case connectivity = 15
-        case selectBackground = 16
+        case profile
+        case showEmails
+        case blockedContacts
+        case notifications
+        case receiptConfirmation
+        case autocryptPreferences
+        case sendAutocryptMessage
+        case exportBackup
+        case advanced
+        case help
+        case autodel
+        case mediaQuality
+        case downloadOnDemand
+        case videoChat
+        case connectivity
+        case selectBackground
     }
 
     private var dcContext: DcContext
@@ -49,14 +48,6 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
         let cellViewModel = ProfileViewModel(context: dcContext)
         cell.updateCell(cellViewModel: cellViewModel)
         cell.tag = CellTags.profile.rawValue
-        cell.accessoryType = .disclosureIndicator
-        return cell
-    }()
-
-    private lazy var showArchiveCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.tag = CellTags.showArchive.rawValue
-        cell.textLabel?.text = String.localized("chat_archived_chats_title")
         cell.accessoryType = .disclosureIndicator
         return cell
     }()
@@ -228,7 +219,7 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
         let preferencesSection = SectionConfigs(
             headerTitle: String.localized("pref_chats_and_media"),
             footerTitle: String.localized("pref_read_receipts_explain"),
-            cells: [showArchiveCell, showEmailsCell, blockedContactsCell, mediaQualityCell, downloadOnDemandCell,
+            cells: [showEmailsCell, blockedContactsCell, mediaQualityCell, downloadOnDemandCell,
                     autodelCell, videoChatInstanceCell, notificationCell, receiptConfirmationCell]
         )
         let appearanceSection = SectionConfigs(
@@ -344,7 +335,6 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
 
         switch cellTag {
         case .profile: showEditSettingsController()
-        case .showArchive: showArchivedCharts()
         case .showEmails: showClassicMail()
         case .blockedContacts: showBlockedContacts()
         case .autodel: showAutodelOptions()
@@ -567,11 +557,6 @@ internal final class SettingsViewController: UITableViewController, ProgressAler
     private func showVideoChatInstance() {
         let videoInstanceController = VideoChatInstanceViewController(dcContext: dcContext)
         navigationController?.pushViewController(videoInstanceController, animated: true)
-    }
-
-    private func showArchivedCharts() {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-        appDelegate.appCoordinator.showArchivedChats()
     }
 
     private func showBlockedContacts() {

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -253,7 +253,7 @@ class ContactCell: UITableViewCell {
     }
 
     func setStatusIndicators(unreadCount: Int, status: Int, visibility: Int32, isLocationStreaming: Bool, isMuted: Bool, isContactRequest: Bool, isArchiveLink: Bool) {
-        unreadMessageCounter.backgroundColor = isMuted || isArchiveLink ? .gray : DcColors.unreadBadge
+        unreadMessageCounter.backgroundColor = isMuted || isArchiveLink ? DcColors.unreadBadgeMuted : DcColors.unreadBadge
 
         if isLargeText {
             unreadMessageCounter.setCount(unreadCount)

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -334,7 +334,9 @@ class ContactCell: UITableViewCell {
             let visibility = chat.visibility
             isArchived = visibility == DC_CHAT_VISIBILITY_ARCHIVED
             // text bold if chat contains unread messages - otherwise hightlight search results if needed
-            if chatData.unreadMessages > 0 {
+            if chatData.chatId == DC_CHAT_ID_ARCHIVED_LINK {
+                titleLabel.text = cellViewModel.title
+            } else if chatData.unreadMessages > 0 {
                 titleLabel.attributedText = cellViewModel.title.bold(fontSize: titleLabel.font.pointSize)
             } else {
                 titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -336,6 +336,10 @@ class ContactCell: UITableViewCell {
             // text bold if chat contains unread messages - otherwise hightlight search results if needed
             if chatData.chatId == DC_CHAT_ID_ARCHIVED_LINK {
                 titleLabel.text = cellViewModel.title
+                // for archived links, move unread counter to top line (bottom line is not used)
+                // this hack is also the reason we do not reuse the archive-link together with the normal chats
+                bottomlineStackView.removeArrangedSubview(unreadMessageCounter)
+                toplineStackView.addArrangedSubview(unreadMessageCounter)
             } else if chatData.unreadMessages > 0 {
                 titleLabel.attributedText = cellViewModel.title.bold(fontSize: titleLabel.font.pointSize)
             } else {

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -252,11 +252,12 @@ class ContactCell: UITableViewCell {
         avatar.setName(name)
     }
 
-    func setStatusIndicators(unreadCount: Int, status: Int, visibility: Int32, isLocationStreaming: Bool, isMuted: Bool, isContactRequest: Bool) {
+    func setStatusIndicators(unreadCount: Int, status: Int, visibility: Int32, isLocationStreaming: Bool, isMuted: Bool, isContactRequest: Bool, isArchiveLink: Bool) {
+        unreadMessageCounter.backgroundColor = isMuted || isArchiveLink ? .gray : DcColors.unreadBadge
+
         if isLargeText {
             unreadMessageCounter.setCount(unreadCount)
             unreadMessageCounter.isHidden = unreadCount == 0 || isContactRequest
-            unreadMessageCounter.backgroundColor = isMuted ? .gray : .red
             pinnedIndicator.isHidden = true
             deliveryStatusIndicator.isHidden = true
             archivedIndicator.isHidden = true
@@ -266,14 +267,14 @@ class ContactCell: UITableViewCell {
 
         if visibility == DC_CHAT_VISIBILITY_ARCHIVED {
             pinnedIndicator.isHidden = true
-            unreadMessageCounter.isHidden = true
+            unreadMessageCounter.setCount(unreadCount)
+            unreadMessageCounter.isHidden = isContactRequest || unreadCount <= 0
             deliveryStatusIndicator.isHidden = true
             archivedIndicator.isHidden = false
         } else if unreadCount > 0 {
             pinnedIndicator.isHidden = !(visibility == DC_CHAT_VISIBILITY_PINNED)
             unreadMessageCounter.setCount(unreadCount)
             unreadMessageCounter.isHidden = isContactRequest
-            unreadMessageCounter.backgroundColor = isMuted ? .gray : DcColors.unreadBadge
             deliveryStatusIndicator.isHidden = true
             archivedIndicator.isHidden = true
         } else {
@@ -358,7 +359,8 @@ class ContactCell: UITableViewCell {
                                 visibility: visibility,
                                 isLocationStreaming: chat.isSendingLocations,
                                 isMuted: chat.isMuted,
-                                isContactRequest: isContactRequest)
+                                isContactRequest: isContactRequest,
+                                isArchiveLink: chatData.chatId == DC_CHAT_ID_ARCHIVED_LINK)
 
         case .contact(let contactData):
             let contact = cellViewModel.dcContext.getContact(id: contactData.contactId)
@@ -376,7 +378,8 @@ class ContactCell: UITableViewCell {
                                 visibility: 0,
                                 isLocationStreaming: false,
                                 isMuted: false,
-                                isContactRequest: false)
+                                isContactRequest: false,
+                                isArchiveLink: false)
         case .profile:
             let contact = cellViewModel.dcContext.getContact(id: Int(DC_CONTACT_ID_SELF))
             titleLabel.text = cellViewModel.title
@@ -394,7 +397,8 @@ class ContactCell: UITableViewCell {
             visibility: 0,
             isLocationStreaming: false,
             isMuted: false,
-            isContactRequest: false)
+            isContactRequest: false,
+            isArchiveLink: false)
         }
 
         accessibilityLabel = (titleLabel.text != nil ? ((titleLabel.text ?? "")+"\n") : "")

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -244,6 +244,12 @@ class ChatListViewModel: NSObject {
         pinChat(chatId: chatId, pinned: pinned, notifyListener: true)
     }
 
+    func archiveLinkPositionToggle(chatId: Int) {
+        let archiveLinkBottom = dcContext.getConfigBool("archive_link_bottom")
+        dcContext.setConfigBool("archive_link_bottom", !archiveLinkBottom)
+        self.dcContext.setChatVisibility(chatId: Int(DC_CHAT_ID_ARCHIVED_LINK), visibility: DC_CHAT_VISIBILITY_NORMAL)
+    }
+
     func pinChat(chatId: Int, pinned: Bool, notifyListener: Bool = false) {
         self.dcContext.setChatVisibility(chatId: chatId, visibility: pinned ? DC_CHAT_VISIBILITY_NORMAL : DC_CHAT_VISIBILITY_PINNED)
         updateChatList(notifyListener: notifyListener)

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -244,12 +244,6 @@ class ChatListViewModel: NSObject {
         pinChat(chatId: chatId, pinned: pinned, notifyListener: true)
     }
 
-    func archiveLinkPositionToggle(chatId: Int) {
-        let archiveLinkBottom = dcContext.getConfigBool("archive_link_bottom")
-        dcContext.setConfigBool("archive_link_bottom", !archiveLinkBottom)
-        self.dcContext.setChatVisibility(chatId: Int(DC_CHAT_ID_ARCHIVED_LINK), visibility: DC_CHAT_VISIBILITY_NORMAL)
-    }
-
     func pinChat(chatId: Int, pinned: Bool, notifyListener: Bool = false) {
         self.dcContext.setChatVisibility(chatId: chatId, visibility: pinned ? DC_CHAT_VISIBILITY_NORMAL : DC_CHAT_VISIBILITY_PINNED)
         updateChatList(notifyListener: notifyListener)


### PR DESCRIPTION
- move "archive" link up, similar to whatsapp and telegram
- show the number of unread chats inside the archive, also similar to whatsapp and telegram
- remove "archive" option from the settings

that avoids messages being missed when archiving a muted chat or muting an archived chat. 

moreover, this ensures _inner_ consistency (up to now, the reasonably accessible archive-link is at different places in all UI - settings, menu, drawer) and _outer_ consistency with whatsapp/telegram.

there are also some visual tweaks in this pr:

- use a more muted gray - the gray before has the same saturation as the colored one and did not really look "muted"
- show the "archive link" more like on whatsapp/telegram, with an icon
- slightly lighter background color for pinned chats so that they better overall
- use a shorter label ("Archived" instead of "Archived Chats"), inspired by whatsapp

<img width=320 src=https://user-images.githubusercontent.com/9800740/210594335-9f1edd6a-11b8-478b-a4bb-cf0f8684db9a.jpg>

todo:

- this pr depends on https://github.com/deltachat/deltachat-core-rust/pull/3918 , which needs to be merged first
- ~~if the unread counter is shown beside the archive, the layout is vertically unaligned~~ EDIT: done
- ~~maybe the "archive link" can be less in height (2/3rd or so)~~ EDIT: done

there were lots of experiments done before, if interested, see the commit history  here and in the core :) for the idea of setting the summary to the names of the archice chats: this contercarates the idea of archiving sth. to get it "out of sight" - instead you eg. still see the name etc. of course, one  could again deal with that, however, the simple whatsapp approach of just showing an unread counter seems to be much simpler and not worse here.

once this is settled, we should propagate the new colors and ui to the other apps.