### PR TITLE
Fix wrong gallery and files counter

### DIFF
--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -118,6 +118,9 @@ class ContactDetailViewModel {
     }
 
     var galleryItemMessageIds: [Int] {
+        if chatId == 0 {
+            return []
+        }
         return context.getChatMedia(
             chatId: chatId,
             messageType: DC_MSG_IMAGE,
@@ -127,6 +130,9 @@ class ContactDetailViewModel {
     }
 
     var documentItemMessageIds: [Int] {
+        if chatId == 0 {
+            return []
+        }
         return context.getChatMedia(
             chatId: chatId,
             messageType: DC_MSG_FILE,


### PR DESCRIPTION
Show 'none' in media and file cells of chat/contact profile, if contact profile's chatId is 0. 
Fixes incorrect files and gallery counter in profiles

Fixes #1779