### PR TITLE
handle ogg attachments as ordinary files

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -1167,6 +1167,11 @@ public class DcMsg {
         return nil
     }
 
+    public var isUnsupportedMediaFile: Bool {
+        let fileMime = filemime
+        return filemime == "audio/ogg"
+    }
+
     public var filename: String? {
         if let cString = dc_msg_get_filename(messagePointer) {
             let str = String(cString: cString)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -775,10 +775,15 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         case DC_MSG_WEBXDC:
                 cell = tableView.dequeueReusableCell(withIdentifier: "webxdc", for: indexPath) as? WebxdcCell ?? WebxdcCell()
         case DC_MSG_AUDIO, DC_MSG_VOICE:
-            let audioMessageCell: AudioMessageCell = tableView.dequeueReusableCell(withIdentifier: "audio",
-                                                                                      for: indexPath) as? AudioMessageCell ?? AudioMessageCell()
-            audioController.update(audioMessageCell, with: message.id)
-            cell = audioMessageCell
+            if message.isUnsupportedMediaFile {
+                cell = tableView.dequeueReusableCell(withIdentifier: "file", for: indexPath) as? FileTextCell ?? FileTextCell()
+            } else {
+                let audioMessageCell: AudioMessageCell = tableView.dequeueReusableCell(
+                    withIdentifier: "audio",
+                    for: indexPath) as? AudioMessageCell ?? AudioMessageCell()
+                audioController.update(audioMessageCell, with: message.id)
+                cell = audioMessageCell
+            }
         default:
             cell = tableView.dequeueReusableCell(withIdentifier: "text", for: indexPath) as? TextMessageCell ?? TextMessageCell()
         }

--- a/deltachat-ios/Chat/Views/FileView.swift
+++ b/deltachat-ios/Chat/Views/FileView.swift
@@ -98,7 +98,7 @@ public class FileView: UIView {
     public func configure(message: DcMsg) {
         if message.type == DC_MSG_WEBXDC {
            configureWebxdc(message: message)
-        } else if message.type == DC_MSG_FILE {
+        } else if message.type == DC_MSG_FILE || message.isUnsupportedMediaFile {
             configureFile(message: message)
         } else {
             logger.error("Configuring message failed")


### PR DESCRIPTION
closes #1789 


Appearantly ogg are considered audio files in core. so we have to double check the exact mimetype and sort them out. This MR allows to add more audio protocols that are unsupported on iOS. That having said, I've tested FLAC that is supported. 