### PR TITLE
use menu- instead of reload-icon

### DIFF
--- a/deltachat-ios/Controller/FullMessageViewController.swift
+++ b/deltachat-ios/Controller/FullMessageViewController.swift
@@ -5,9 +5,14 @@ import DcCore
 class FullMessageViewController: WebViewViewController {
 
     var loadButton: UIBarButtonItem {
-        let button = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.refresh, target: self, action: #selector(showLoadOptions))
+        let image: UIImage?
+        if #available(iOS 13.0, *) {
+            image = UIImage(systemName: "ellipsis.circle")
+        } else {
+            image = UIImage(named: "ic_more")
+        }
+        let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(showLoadOptions))
         button.accessibilityLabel = String.localized("load_remote_content")
-        button.tintColor = DcColors.primary
         return button
     }
 


### PR DESCRIPTION
the idea of the "reload" icon was
"oh, my images are missing, i hit reload, maybe they appear then", however, this idea did not really work out,
we we figured out by seveial user discussions :)

(the old icon is also read as "sync", which is even more confusing)

just use the menu icon, i think, this will lead to fewer questions (also, we may add more options that way :)

closes #1803 