### PR TITLE
prep 1.35.0 testflight  ✈️

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Delta Chat iOS Changelog
 
+## v1.35.0 Testflight
+2023-02
+
+* show non-deltachat emails by default for new installations
+* add jumbomoji support: messages containing only emoji shown bigger
+* verified marker shown right of the chat names now
+* show hint on successful backups
+* add option to copy QR codes to the clipboard
+* show full messages: do not load remote content for requests automatically
+* improve freeing of unused space
+* cache DNS results for SMTP connections
+* use read/write timeouts instead of per-command timeouts for SMTP
+* prefer TLS over STARTTLS during autoconfiguration
+* fix Securejoin for multiple devices on a joining side
+* fix closing of database files, allowing proper shutdowns
+* fix some database transactons
+* fix a problem with Gmail where (auto-)deleted messages would get archived instead of deleted.
+  Move them to the Trash folder for Gmail which auto-deletes trashed messages in 30 days
+* fix: clear config cache after backup import. This bug sometimes resulted in the import to seemingly work at first
+* speed up connections to the database
+* improve logging
+* update translations
+* update to core110
+
+
 ## v1.34.12
 2023-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * prefer TLS over STARTTLS during autoconfiguration
 * fix Securejoin for multiple devices on a joining side
 * fix closing of database files, allowing proper shutdowns
-* fix some database transactons
+* fix some database transactions
 * fix a problem with Gmail where (auto-)deleted messages would get archived instead of deleted.
   Move them to the Trash folder for Gmail which auto-deletes trashed messages in 30 days
 * fix: clear config cache after backup import. This bug sometimes resulted in the import to seemingly work at first

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -1793,13 +1793,13 @@
 				CODE_SIGN_ENTITLEMENTS = DcShare/DcShare.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = DcShare/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.34.12;
+				MARKETING_VERSION = 1.35.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.delta.DcShare;
@@ -1818,13 +1818,13 @@
 				CODE_SIGN_ENTITLEMENTS = DcShare/DcShare.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = DcShare/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.34.12;
+				MARKETING_VERSION = 1.35.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.delta.DcShare;
 				PRODUCT_NAME = "Delta Chat";
@@ -1960,7 +1960,7 @@
 				CODE_SIGN_ENTITLEMENTS = "deltachat-ios/deltachat-ios.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -1977,7 +1977,7 @@
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/release",
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/debug",
 				);
-				MARKETING_VERSION = 1.34.12;
+				MARKETING_VERSION = 1.35.0;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-isystem",
@@ -2030,7 +2030,7 @@
 				CODE_SIGN_ENTITLEMENTS = "deltachat-ios/deltachat-ios.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -2047,7 +2047,7 @@
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/release",
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/target/universal/debug",
 				);
-				MARKETING_VERSION = 1.34.12;
+				MARKETING_VERSION = 1.35.0;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-isystem",


### PR DESCRIPTION
with chance, this improves crashes for testflight, cmp. https://github.com/deltachat/deltachat-ios/issues/1202#issuecomment-1435329483 (these crashes are not present in regular releases)