### PR TITLE
prefer pasteboard.hasImages over pasteboard.image != nil

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2026,10 +2026,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }
 
     private func copyToClipboard(ids: [Int]) {
-        let pasteboard = UIPasteboard.general
-        pasteboard.string = ""
         var stringsToCopy = ""
-
         if ids.count > 1 {
             let sortedIds = ids.sorted()
             var lastSenderId: Int = -1
@@ -2063,7 +2060,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 stringsToCopy.append("\(msgSummary)")
             }
         }
-        pasteboard.string = stringsToCopy
+        UIPasteboard.general.string = stringsToCopy
     }
 }
 

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputTextView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputTextView.swift
@@ -236,7 +236,7 @@ open class InputTextView: UITextView {
     
     open override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         
-        if action == NSSelectorFromString("paste:") && UIPasteboard.general.image != nil {
+        if action == NSSelectorFromString("paste:") && UIPasteboard.general.hasImages {
             return isImagePasteEnabled
         }
         return super.canPerformAction(action, withSender: sender)

--- a/deltachat-ios/Chat/Views/ChatInputTextView.swift
+++ b/deltachat-ios/Chat/Views/ChatInputTextView.swift
@@ -16,7 +16,7 @@ public class ChatInputTextView: InputTextView {
 
     // MARK: - Image Paste Support
     open override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        if action == NSSelectorFromString("paste:") && UIPasteboard.general.image != nil {
+        if action == NSSelectorFromString("paste:") && UIPasteboard.general.hasImages {
             return true
         }
         return super.canPerformAction(action, withSender: sender)

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -322,8 +322,7 @@ class ContactDetailViewController: UITableViewController {
             showEncrInfoAlert()
         case .copyToClipboard:
             tableView.deselectRow(at: indexPath, animated: true)
-            let pasteboard = UIPasteboard.general
-            pasteboard.string = viewModel.contact.email
+            UIPasteboard.general.string = viewModel.contact.email
         case .blockContact:
             tableView.deselectRow(at: indexPath, animated: false)
             toggleBlockContact()

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -597,8 +597,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 showDeleteChatConfirmationAlert()
             case .copyToClipboard:
                 tableView.deselectRow(at: indexPath, animated: false)
-                let pasteboard = UIPasteboard.general
-                pasteboard.string = chat.getMailinglistAddr()
+                UIPasteboard.general.string = chat.getMailinglistAddr()
 
             }
         }


### PR DESCRIPTION
this has performance advantages
and also the "has"-properties should not trigger a "User pasted from clipboard" warning
(if i understood https://developer.apple.com/documentation/uikit/uipasteboard correctly)

moreover, this pr does some cleanup.

closes #1528