### PR TITLE
update mute icon on CHAT_MODIFIED

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -617,6 +617,12 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                         self.messageInputBar.isHidden = true
                     }
                 }
+
+                let oldMuted = self.navigationItem.rightBarButtonItems?.contains(self.muteItem)
+                let newMuted = self.dcChat.isMuted
+                if oldMuted != newMuted {
+                    self.updateTitle()
+                }
             }
         }
 


### PR DESCRIPTION
check if an update is needed,
if so, call updateTitle()

nb: updateTitle() is done on viewWillAppear(),
however, self.dcChat is not always up to date at that point, this is not changed by this pr:
in general, we should aim to avoid updates on subsequent shows anyway and let all updates be driven by events
as this makes navigation between controller much faster and also allows the state to be changed by other reasons.

i assume, #1810 will pull in the existing event handlers at some point,
so this pr should not make #1810 harder and can be merged independently