### PR TITLE
fix out of bounds error in search

### DIFF
--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -103,7 +103,7 @@ class ChatListViewModel: NSObject {
     }
 
     func cellDataFor(section: Int, row: Int) -> AvatarCellViewModel {
-        if showSearchResults {
+        if showSearchResults && !searchResultSections.isEmpty {
             switch searchResultSections[section] {
             case .chats:
                 return makeChatCellViewModel(index: row, searchText: searchText)


### PR DESCRIPTION
I came across this error while testing the search field on mac.
could have something to do with pressing backspace when the search field is empty
