### PR TITLE
move 'cancel' to the right on app selector

### DIFF
--- a/deltachat-ios/Controller/WebxdcSelector.swift
+++ b/deltachat-ios/Controller/WebxdcSelector.swift
@@ -49,14 +49,14 @@ class WebxdcSelector: UIViewController {
         return label
     }()
 
-    private lazy var leftBarBtn: UIBarButtonItem = {
+    private lazy var cancelButton: UIBarButtonItem = {
         let btn = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel,
                                                              target: self,
                                                action: #selector(cancelAction))
         return btn
     }()
 
-    private lazy var rightBarBtn: UIBarButtonItem = {
+    private lazy var filesButton: UIBarButtonItem = {
         let btn = UIBarButtonItem(title: String.localized("files"),
                                   style: .plain,
                                   target: self,
@@ -88,8 +88,8 @@ class WebxdcSelector: UIViewController {
         super.viewDidLoad()
         setupSubviews()
         title = String.localized("webxdc_apps")
-        navigationItem.setLeftBarButton(leftBarBtn, animated: false)
-        navigationItem.setRightBarButton(rightBarBtn, animated: false)
+        navigationItem.setLeftBarButton(filesButton, animated: false)
+        navigationItem.setRightBarButton(cancelButton, animated: false)
         if mediaMessageIds.isEmpty {
             emptyStateView.isHidden = false
         }


### PR DESCRIPTION
unless "cancel" is paired with "done", "save", "ok" or similar _and_ there is another button, it should go to the right as the primary action of a dialog (ppl tap there to move forward, to get rid of things etc.)

cmp. other apps or eg. https://bigmedium.com/ideas/ios-button-placement.html or apples human interface guidelines (which seem less specific wrt ios)