### PR TITLE
use correct add-second-device confirmation title

### DIFF
--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -268,7 +268,7 @@ internal final class SettingsViewController: UITableViewController {
     }
 
     private func showBackupProviderViewController() {
-        let alert = UIAlertController(title: String.localized("multidevice_receiver_title"), message: String.localized("multidevice_this_creates_a_qr_code"), preferredStyle: .alert)
+        let alert = UIAlertController(title: String.localized("multidevice_title"), message: String.localized("multidevice_this_creates_a_qr_code"), preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         alert.addAction(UIAlertAction(
             title: String.localized("perm_continue"),


### PR DESCRIPTION
in the setting, the title of the confirmation dialog should read "add second device",
not "add as second device"