### PR TITLE
swap 'Gallery' and 'Files' tab

### DIFF
--- a/deltachat-ios/Controller/AllMediaViewController.swift
+++ b/deltachat-ios/Controller/AllMediaViewController.swift
@@ -7,8 +7,8 @@ class AllMediaViewController: UIPageViewController {
 
     private lazy var segmentControl: UISegmentedControl = {
         let control = UISegmentedControl(
-            items: [String.localized("images_and_videos"),
-                    dcContext.hasWebxdc(chatId: 0) ? String.localized("files_and_webxdx_apps") : String.localized("files")]
+            items: [dcContext.hasWebxdc(chatId: 0) ? String.localized("files_and_webxdx_apps") : String.localized("files"),
+                    String.localized("images_and_videos")]
         )
         control.tintColor = DcColors.primary
         control.addTarget(self, action: #selector(segmentControlChanged), for: .valueChanged)
@@ -33,7 +33,7 @@ class AllMediaViewController: UIPageViewController {
         navigationItem.titleView = segmentControl
 
         setViewControllers(
-            [makeGalleryViewController()],
+            [makeFilesViewController()],
             direction: .forward,
             animated: true,
             completion: nil
@@ -58,9 +58,9 @@ class AllMediaViewController: UIPageViewController {
     // MARK: - actions
     @objc private func segmentControlChanged(_ sender: UISegmentedControl) {
         if sender.selectedSegmentIndex == 0 {
-            setViewControllers([makeGalleryViewController()], direction: .reverse, animated: true, completion: nil)
+            setViewControllers([makeFilesViewController()], direction: .reverse, animated: true, completion: nil)
         } else {
-            setViewControllers([makeFilesViewController()], direction: .forward, animated: true, completion: nil)
+            setViewControllers([makeGalleryViewController()], direction: .forward, animated: true, completion: nil)
         }
     }
 
@@ -79,22 +79,22 @@ class AllMediaViewController: UIPageViewController {
 // MARK: - UIPageViewControllerDataSource, UIPageViewControllerDelegate
 extension AllMediaViewController: UIPageViewControllerDataSource, UIPageViewControllerDelegate {
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        if viewController is GalleryViewController {
+        if viewController is DocumentGalleryController {
             return nil
         }
-        return makeGalleryViewController()
+        return makeFilesViewController()
     }
 
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        if viewController is GalleryViewController {
-            return makeFilesViewController()
+        if viewController is DocumentGalleryController {
+            return makeGalleryViewController()
         }
         return nil
     }
 
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         if completed {
-            if previousViewControllers.first is GalleryViewController {
+            if previousViewControllers.first is DocumentGalleryController {
                 segmentControl.selectedSegmentIndex = 1
             } else {
                 segmentControl.selectedSegmentIndex = 0

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -299,22 +299,22 @@ class GroupChatDetailViewController: UIViewController {
         self.editBarButtonItem.isEnabled = chat.isMailinglist || chat.canSend
 
         if chat.isMailinglist {
-            self.chatOptions = [.gallery, .documents]
+            self.chatOptions = [.documents, .gallery]
             self.memberManagementRows = 0
             self.chatActions = [.archiveChat, .copyToClipboard, .deleteChat]
             self.groupHeader.showMuteButton(show: true)
         } else if chat.isBroadcast {
-            self.chatOptions = [.gallery, .documents]
+            self.chatOptions = [.documents, .gallery]
             self.memberManagementRows = 1
             self.chatActions = [.archiveChat, .deleteChat]
             self.groupHeader.showMuteButton(show: false)
         } else if chat.canSend {
-            self.chatOptions = [.gallery, .documents, .ephemeralMessages]
+            self.chatOptions = [.documents, .gallery, .ephemeralMessages]
             self.memberManagementRows = 2
             self.chatActions = [.archiveChat, .leaveGroup, .deleteChat]
             self.groupHeader.showMuteButton(show: true)
         } else {
-            self.chatOptions = [.gallery, .documents]
+            self.chatOptions = [.documents, .gallery]
             self.memberManagementRows = 0
             self.chatActions = [.archiveChat, .deleteChat]
             self.groupHeader.showMuteButton(show: true)

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -72,7 +72,7 @@ class ContactDetailViewModel {
         sections.append(.chatActions)
 
         if chatId != 0 {
-            chatOptions = [.gallery, .documents]
+            chatOptions = [.documents, .gallery]
             if !isDeviceTalk {
                 chatOptions.append(.ephemeralMessages)
             }
@@ -88,7 +88,7 @@ class ContactDetailViewModel {
             }
             chatActions.append(.deleteChat)
         } else {
-            chatOptions = [.gallery, .documents, .startChat]
+            chatOptions = [.documents, .gallery, .startChat]
             chatActions = [.showEncrInfo, .copyToClipboard, .blockContact]
         }
     }


### PR DESCRIPTION
that way, two taps in different areas are required, making it harder to show maybe private images accidentally.

these two clicks is also how android works since some time in Delta Chat - and even longer in Delta Lab - without complains in that direction.

all this is meant only as a minor precaution against accidental taps, not as something that helps if someone plays around with unlocked phone for minutes. for that, we have ephemeral messages.