### PR TITLE
use translucent qr-code title bar

### DIFF
--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -74,6 +74,10 @@ class QrPageController: UIPageViewController {
             animated: true,
             completion: nil
         )
+
+        if #available(iOS 13, *) {
+            self.navigationController?.navigationBar.scrollEdgeAppearance = self.navigationController?.navigationBar.standardAppearance
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -101,7 +105,7 @@ class QrPageController: UIPageViewController {
         } else {
             let qrCodeReaderController = makeQRReader()
             self.qrCodeReaderController = qrCodeReaderController
-            setViewControllers([qrCodeReaderController], direction: .forward, animated: false, completion: nil)
+            setViewControllers([qrCodeReaderController], direction: .forward, animated: true, completion: nil)
         }
     }
 


### PR DESCRIPTION
the old, totally transparent title bar led to more or less unreadable tabs, depending on what is shown to the camera.

after figuring out the translucent thingie at #1843, this is a nice improvement for the other view using a tabbar in the title.

moreover, this pr adds an animation for both tabs, things really seem to be fast enough,
also, the system seem to do UIViewController creation in parallel anyways.

before/after - it is not always that bad, but you get the idea:

<img width=280 src=https://user-images.githubusercontent.com/9800740/235149069-c462eaa5-7cec-40d1-b794-aca9fde93142.PNG> &nbsp; <img width=280 src=https://user-images.githubusercontent.com/9800740/235149132-b4a4089d-bc6e-46c9-b731-b710affbcc72.PNG>

finally, i have to clean my screen
