### PR TITLE
experimenting with device owner verification for "add second device"

### DIFF
--- a/deltachat-ios/Info.plist
+++ b/deltachat-ios/Info.plist
@@ -106,6 +106,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Creates a QR code that the second device can scan to copy the account</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>


### PR DESCRIPTION
works in general, however, needs some more love wrt wording and the different authentication methods, that, unfortunately, all seem have their own flow and dialogs.

maybe also always show the existing alert beforehand. and the strings should also fit for backup and exporting keys (seems, one cannot give different reasons if it is picked up from Info.plist which is the approach from newer os)

postponed, however. it was 10 minutes to get to this state, but needs some more hours of love to be really ready :)

btw, a good guide is at https://www.hackingwithswift.com/read/28/4/touch-to-activate-touch-id-face-id-and-localauthentication