### PR TITLE
separate tabs for apps and audio

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -276,6 +276,24 @@ public class DcContext {
         return !getChatMedia(chatId: chatId, messageType: DC_MSG_WEBXDC, messageType2: 0, messageType3: 0).isEmpty
     }
 
+    public func getAllMediaCount(chatId: Int) -> String {
+        let max = 500
+        var c = getChatMedia(chatId: chatId, messageType: DC_MSG_IMAGE, messageType2: DC_MSG_GIF, messageType3: DC_MSG_VIDEO).count
+        if c < max {
+            c += getChatMedia(chatId: chatId, messageType: DC_MSG_AUDIO, messageType2: DC_MSG_VOICE, messageType3: 0).count
+        }
+        if c < max {
+            c += getChatMedia(chatId: chatId, messageType: DC_MSG_FILE, messageType2: DC_MSG_WEBXDC, messageType3: 0).count
+        }
+        if c == 0 {
+            return String.localized("none")
+        } else if c >= max {
+            return "\(max)+"
+        } else {
+            return "\(c)"
+        }
+    }
+
     @discardableResult
     public func createChatByContactId(contactId: Int) -> Int {
         return Int(dc_create_chat_by_contact_id(contextPointer, UInt32(contactId)))

--- a/deltachat-ios/Controller/AllMediaViewController.swift
+++ b/deltachat-ios/Controller/AllMediaViewController.swift
@@ -11,10 +11,12 @@ class AllMediaViewController: UIPageViewController {
     }
 
     private let dcContext: DcContext
+    private let chatId: Int
     private var prevIndex: Int = 0
 
     private func getPages() -> [Page] {
-        let webxdcReallyInUse = dcContext.getChatMedia(chatId: 0, messageType: DC_MSG_WEBXDC, messageType2: 0, messageType3: 0).count > 5
+        let webxdcReallyInUse = dcContext.getChatMedia(chatId: chatId, messageType: DC_MSG_WEBXDC, messageType2: 0, messageType3: 0).count
+                                    >= (chatId == 0 ? 5 : 1)
         pages.append(Page(
             headerTitle: String.localized("files"),
             type1: DC_MSG_FILE, type2: webxdcReallyInUse ? 0 : DC_MSG_WEBXDC, type3: 0
@@ -45,8 +47,9 @@ class AllMediaViewController: UIPageViewController {
         return control
     }()
 
-    init(dcAccounts: DcAccounts) {
-        self.dcContext = dcAccounts.getSelected()
+    init(dcContext: DcContext, chatId: Int = 0) {
+        self.dcContext = dcContext
+        self.chatId = chatId
         super.init(transitionStyle: .scroll, navigationOrientation: .horizontal, options: [:])
         self.pages = self.getPages()
     }
@@ -88,10 +91,10 @@ class AllMediaViewController: UIPageViewController {
     // MARK: - factory
     private func makeViewController(_ page: Page) -> UIViewController {
         if page.type1 == DC_MSG_IMAGE {
-            let allMedia = dcContext.getChatMedia(chatId: 0, messageType: page.type1, messageType2: page.type2, messageType3: page.type3)
-            return GalleryViewController(context: dcContext, chatId: 0, mediaMessageIds: allMedia.reversed())
+            let allMedia = dcContext.getChatMedia(chatId: chatId, messageType: page.type1, messageType2: page.type2, messageType3: page.type3)
+            return GalleryViewController(context: dcContext, chatId: chatId, mediaMessageIds: allMedia.reversed())
         } else {
-            return FilesViewController(context: dcContext, chatId: 0, type1: page.type1, type2: page.type2, type3: page.type3)
+            return FilesViewController(context: dcContext, chatId: chatId, type1: page.type1, type2: page.type2, type3: page.type3)
         }
     }
 }

--- a/deltachat-ios/Controller/AllMediaViewController.swift
+++ b/deltachat-ios/Controller/AllMediaViewController.swift
@@ -11,22 +11,15 @@ class AllMediaViewController: UIPageViewController {
     }
 
     private let dcContext: DcContext
-    private var everHadWebxdc: Bool = false
     private var prevIndex: Int = 0
 
-    private func hasWebxdc() -> Bool {
-        if !everHadWebxdc {
-            everHadWebxdc = dcContext.hasWebxdc(chatId: 0)
-        }
-        return everHadWebxdc
-    }
-
     private func getPages() -> [Page] {
+        let webxdcReallyInUse = dcContext.getChatMedia(chatId: 0, messageType: DC_MSG_WEBXDC, messageType2: 0, messageType3: 0).count > 5
         pages.append(Page(
             headerTitle: String.localized("files"),
-            type1: DC_MSG_FILE, type2: 0, type3: 0
+            type1: DC_MSG_FILE, type2: webxdcReallyInUse ? 0 : DC_MSG_WEBXDC, type3: 0
         ))
-        if hasWebxdc() {
+        if webxdcReallyInUse {
             pages.append(Page(
                 headerTitle: String.localized("webxdc_apps"),
                 type1: DC_MSG_WEBXDC, type2: 0, type3: 0

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -27,6 +27,9 @@ class ContactDetailViewController: UITableViewController {
     private lazy var ephemeralMessagesCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.textLabel?.text = String.localized("ephemeral_messages")
+        if #available(iOS 13.0, *) {
+            cell.imageView?.image = UIImage(systemName: "timer") // added in ios13
+        }
         cell.accessoryType = .disclosureIndicator
         return cell
     }()
@@ -66,20 +69,12 @@ class ContactDetailViewController: UITableViewController {
         return cell
     }()
 
-    private lazy var galleryCell: UITableViewCell = {
+    private lazy var allMediaCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("images_and_videos")
-        cell.accessoryType = .disclosureIndicator
-        if viewModel.chatId == 0 {
-            cell.isUserInteractionEnabled = false
-            cell.textLabel?.isEnabled = false
+        cell.textLabel?.text = String.localized("menu_all_media")
+        if #available(iOS 13.0, *) {
+            cell.imageView?.image = UIImage(systemName: "photo.on.rectangle") // added in ios13
         }
-        return cell
-    }()
-
-    private lazy var documentsCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized(viewModel.hasWebxdc ? "files_and_webxdx_apps" : "files")
         cell.accessoryType = .disclosureIndicator
         if viewModel.chatId == 0 {
             cell.isUserInteractionEnabled = false
@@ -168,10 +163,8 @@ class ContactDetailViewController: UITableViewController {
         switch cellType {
         case .chatOptions:
             switch viewModel.chatOptionFor(row: row) {
-            case .documents:
-                return documentsCell
-            case .gallery:
-                return galleryCell
+            case .allMedia:
+                return allMediaCell
             case .ephemeralMessages:
                 return ephemeralMessagesCell
             case .startChat:
@@ -305,8 +298,7 @@ class ContactDetailViewController: UITableViewController {
 
     private func updateCellValues() {
         ephemeralMessagesCell.detailTextLabel?.text = String.localized(viewModel.chatIsEphemeral ? "on" : "off")
-        galleryCell.detailTextLabel?.text = String.numberOrNone(viewModel.galleryItemMessageIds.count)
-        documentsCell.detailTextLabel?.text = String.numberOrNone(viewModel.documentItemMessageIds.count)
+        allMediaCell.detailTextLabel?.text = viewModel.chatId == 0 ? String.localized("none") : viewModel.context.getAllMediaCount(chatId: viewModel.chatId)
         statusCell.setText(text: viewModel.contact.status)
     }
 
@@ -335,10 +327,8 @@ class ContactDetailViewController: UITableViewController {
     private func handleChatOption(indexPath: IndexPath) {
         let action = viewModel.chatOptionFor(row: indexPath.row)
         switch action {
-        case .documents:
-            showDocuments()
-        case .gallery:
-            showGallery()
+        case .allMedia:
+            showAllMedia()
         case .ephemeralMessages:
             showEphemeralMessagesController()
         case .startChat:
@@ -468,16 +458,8 @@ class ContactDetailViewController: UITableViewController {
         navigationController?.pushViewController(editContactController, animated: true)
     }
 
-    private func showDocuments() {
-        let title = String.localized(viewModel.hasWebxdc ? "files_and_webxdx_apps" : "files")
-        let fileGalleryController = FilesViewController(context: viewModel.context, chatId: viewModel.chatId, type1: DC_MSG_FILE, type2: DC_MSG_AUDIO, type3: DC_MSG_WEBXDC, title: title)
-        navigationController?.pushViewController(fileGalleryController, animated: true)
-    }
-
-    private func showGallery() {
-        let messageIds: [Int] = viewModel.galleryItemMessageIds.reversed()
-        let galleryController = GalleryViewController(context: viewModel.context, chatId: viewModel.chatId, mediaMessageIds: messageIds)
-        navigationController?.pushViewController(galleryController, animated: true)
+    private func showAllMedia() {
+        navigationController?.pushViewController(AllMediaViewController(dcContext: viewModel.context, chatId: viewModel.chatId), animated: true)
     }
 
     private func showSearch() {

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -146,7 +146,7 @@ extension FilesViewController: UITableViewDelegate, UITableViewDataSource {
             return UITableViewCell()
         }
         let msg = dcContext.getMessage(id: fileMessageIds[indexPath.row])
-        cell.update(msg: msg)
+        cell.update(msg: msg, dcContext: dcContext)
         return cell
     }
 

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -4,6 +4,8 @@ import LinkPresentation
 
 class FilesViewController: UIViewController {
 
+    public let type1: Int32
+
     private var fileMessageIds: [Int]
     private let dcContext: DcContext
     private let chatId: Int
@@ -19,7 +21,13 @@ class FilesViewController: UIViewController {
 
     private lazy var emptyStateView: EmptyStateLabel = {
         let label = EmptyStateLabel()
-        label.text = String.localized(chatId == 0 ? "tab_all_media_empty_hint" : "tab_docs_empty_hint")
+        if chatId == 0 {
+            label.text = String.localized("tab_all_media_empty_hint")
+        } else if type1 == DC_MSG_AUDIO {
+            label.text = String.localized("tab_audio_empty_hint")
+        } else {
+            label.text = String.localized("tab_docs_empty_hint")
+        }
         label.isHidden = true
         return label
     }()
@@ -59,6 +67,7 @@ class FilesViewController: UIViewController {
         self.dcContext = context
         self.fileMessageIds = dcContext.getChatMedia(chatId: chatId, messageType: type1, messageType2: type2, messageType3: type3).reversed()
         self.chatId = chatId
+        self.type1 = type1
         super.init(nibName: nil, bundle: nil)
         self.title = title
     }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -48,7 +48,7 @@ class AppCoordinator {
     }
 
     private func createAllMediaNavigationController() -> UINavigationController {
-        let root = AllMediaViewController(dcAccounts: dcAccounts)
+        let root = AllMediaViewController(dcContext: dcAccounts.getSelected())
         let nav = UINavigationController(rootViewController: root)
         let settingsImage = UIImage(named: "photo.on.rectangle")
         nav.tabBarItem = UITabBarItem(title: String.localized("menu_all_media"), image: settingsImage, tag: chatsTab)

--- a/deltachat-ios/Extensions/String+Extension.swift
+++ b/deltachat-ios/Extensions/String+Extension.swift
@@ -74,14 +74,6 @@ extension String {
         }
     }
 
-    static func numberOrNone(_ number: Int) -> String {
-        if number == 0 {
-            return String.localized("none")
-        } else {
-            return "\(number)"
-        }
-    }
-
     // required for jumbomoji logic
     // thanks to https://stackoverflow.com/a/39425959
     var containsOnlyEmoji: Bool {

--- a/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
+++ b/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
@@ -75,8 +75,10 @@ class DocumentGalleryFileCell: UITableViewCell {
     }
 
     // MARK: - update
-    func update(msg: DcMsg) {
-        if msg.type == DC_MSG_WEBXDC {
+    func update(msg: DcMsg, dcContext: DcContext) {
+        if msg.type == DC_MSG_VOICE {
+            updateVoiceMsg(msg: msg, dcContext: dcContext)
+        } else if msg.type == DC_MSG_WEBXDC {
             updateWebxdcMsg(msg: msg)
         } else {
             updateFileMsg(msg: msg)
@@ -89,6 +91,14 @@ class DocumentGalleryFileCell: UITableViewCell {
         }
         title.text = msg.filename
         subtitle.text = msg.getPrettyFileSize()
+    }
+
+    private func updateVoiceMsg(msg: DcMsg, dcContext: DcContext) {
+        if let fileUrl = msg.fileURL {
+            generateThumbnailFor(url: fileUrl, placeholder: UIImage(named: "ic_attach_file_36pt")?.maskWithColor(color: DcColors.grayTextColor))
+        }
+        title.text = msg.getSenderName(dcContext.getContact(id: msg.fromContactId))
+        subtitle.text = msg.formattedSentDate()
     }
 
     private func updateWebxdcMsg(msg: DcMsg) {

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -13,8 +13,7 @@ class ContactDetailViewModel {
     }
 
     enum ChatOption {
-        case gallery
-        case documents
+        case allMedia
         case ephemeralMessages
         case startChat
     }
@@ -72,7 +71,7 @@ class ContactDetailViewModel {
         sections.append(.chatActions)
 
         if chatId != 0 {
-            chatOptions = [.documents, .gallery]
+            chatOptions = [.allMedia]
             if !isDeviceTalk {
                 chatOptions.append(.ephemeralMessages)
             }
@@ -88,7 +87,7 @@ class ContactDetailViewModel {
             }
             chatActions.append(.deleteChat)
         } else {
-            chatOptions = [.documents, .gallery, .startChat]
+            chatOptions = [.allMedia, .startChat]
             chatActions = [.showEncrInfo, .copyToClipboard, .blockContact]
         }
     }
@@ -120,34 +119,6 @@ class ContactDetailViewModel {
     var chatIsEphemeral: Bool {
         return chatId != 0 && context.getChatEphemeralTimer(chatId: chatId) > 0
     }
-
-    var galleryItemMessageIds: [Int] {
-        if chatId == 0 {
-            return []
-        }
-        return context.getChatMedia(
-            chatId: chatId,
-            messageType: DC_MSG_IMAGE,
-            messageType2: DC_MSG_GIF,
-            messageType3: DC_MSG_VIDEO
-        )
-    }
-
-    var documentItemMessageIds: [Int] {
-        if chatId == 0 {
-            return []
-        }
-        return context.getChatMedia(
-            chatId: chatId,
-            messageType: DC_MSG_FILE,
-            messageType2: DC_MSG_AUDIO,
-            messageType3: DC_MSG_WEBXDC
-        )
-    }
-
-    lazy var hasWebxdc: Bool = {
-        return context.hasWebxdc(chatId: chatId)
-    }()
 
     var numberOfSections: Int {
         return sections.count


### PR DESCRIPTION
- this pr adds separate tabs for "Apps" and for "Audio" to the new "All Media" view.

- moreover, with this pr, voice messages in the galleries are shown for the first time; this pr adds some basic layout for them (audio cells could need some more love, but well, what not)

- for webxdc: they gets a separate tab only if there are at least a handful apps - otherwise, it is integrated in "Files" for now.

- the same "All Media" is also used for group and contact profiles now

- icons added to group and contact profiles

interestingly, despite all additions, this pr _removes_ lines instead of adding new ones :)

_global view:_

<img width=250 src=https://user-images.githubusercontent.com/9800740/235657631-25a33678-0b30-41c0-8caf-2b8e770a9555.PNG>

_profiles:_

<img width=250 src=https://user-images.githubusercontent.com/9800740/235674066-74108e1d-845c-4762-86a5-f00fcf681196.jpg> <img width=250 src=https://user-images.githubusercontent.com/9800740/235674079-03c8ff3d-14f1-4093-aa12-960200d6352c.PNG>

"all media" should be read in context - also for the "global view" it is only all of the account, so, i think, the wording is okay.

whatsapp/ios uses a similar UI btw, so also no overall global tab area (which would require some more refactoring, and i am not sure if that is worth the effort - or if it is even better)