### PR TITLE
start qr-code-reader in background as adviced by logged system warning

### DIFF
--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -174,9 +174,11 @@ class QrCodeReaderController: UIViewController {
     // MARK: - actions
     func startSession() {
         #if targetEnvironment(simulator)
-        // ignore if run from simulator
+            // ignore if run from simulator
         #else
-        captureSession.startRunning()
+            DispatchQueue.global(qos: .userInteractive).async {
+                self.captureSession.startRunning()
+            }
         #endif
     }
 


### PR DESCRIPTION
the warning reads sth as
"[AVCaptureSession startRunning] should be called from background thread. Calling it on the main thread can lead to UI unresponsiveness"

closes #1836