### PR TITLE
snappier qr-code and all-media tabs

### DIFF
--- a/deltachat-ios/Controller/AllMediaViewController.swift
+++ b/deltachat-ios/Controller/AllMediaViewController.swift
@@ -132,8 +132,16 @@ extension AllMediaViewController: UIPageViewControllerDataSource, UIPageViewCont
         return nil
     }
 
+    func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
+        if let viewController = pendingViewControllers.first {
+            let i = getIndexFromObject(viewController)
+            segmentControl.selectedSegmentIndex = i
+            prevIndex = i
+        }
+    }
+
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
-        if let viewControllers = viewControllers, let viewController = viewControllers.first, completed {
+        if let viewController = previousViewControllers.first, !completed {
             let i = getIndexFromObject(viewController)
             segmentControl.selectedSegmentIndex = i
             prevIndex = i

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -175,12 +175,20 @@ extension QrPageController: UIPageViewControllerDataSource, UIPageViewController
         return nil
     }
 
+    func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
+        if pendingViewControllers.first is QrViewController {
+            qrSegmentControl.selectedSegmentIndex = 0
+        } else {
+            qrSegmentControl.selectedSegmentIndex = 1
+        }
+    }
+
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
-        if completed {
+        if !completed {
             if previousViewControllers.first is QrViewController {
-                qrSegmentControl.selectedSegmentIndex = 1
-            } else {
                 qrSegmentControl.selectedSegmentIndex = 0
+            } else {
+                qrSegmentControl.selectedSegmentIndex = 1
             }
         }
     }


### PR DESCRIPTION
this pr starts the tab-change-animation already
when the user starts dragging the page.

this feels much snappier,
however, requires to revert the selection if the user aborts the dragging.

looking at the api, i think, this is also the gist.

targets https://github.com/deltachat/deltachat-ios/issues/1845