### PR TITLE
reuse existing ephemeral icon

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -28,7 +28,7 @@ class ContactDetailViewController: UITableViewController {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.textLabel?.text = String.localized("ephemeral_messages")
         if #available(iOS 13.0, *) {
-            cell.imageView?.image = UIImage(systemName: "timer") // added in ios13
+            cell.imageView?.image = UIImage(named: "ephemeral_timer")?.withTintColor(UIColor.systemBlue)
         }
         cell.accessoryType = .disclosureIndicator
         return cell

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -126,17 +126,6 @@ class GroupChatDetailViewController: UIViewController {
         return cell
     }()
 
-    private lazy var searchCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("search")
-        cell.accessoryType = .disclosureIndicator
-        if chatId == 0 {
-            cell.isUserInteractionEnabled = false
-            cell.textLabel?.isEnabled = false
-        }
-        return cell
-    }()
-
     init(chatId: Int, dcContext: DcContext) {
         self.dcContext = dcContext
         self.chatId = chatId

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -82,7 +82,7 @@ class GroupChatDetailViewController: UIViewController {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.textLabel?.text = String.localized("ephemeral_messages")
         if #available(iOS 13.0, *) {
-            cell.imageView?.image = UIImage(systemName: "timer") // added in ios13
+            cell.imageView?.image = UIImage(named: "ephemeral_timer")?.withTintColor(UIColor.systemBlue)
         }
         cell.accessoryType = .disclosureIndicator
         return cell


### PR DESCRIPTION
we already have an ephemeral icon,
that is also used across systems;
use that icon for the profile button.
(however, still do that only for ios>=13
as the other images are available only with ios>=13 and is it better to show no image at all for ios12 (this is no worsening as before we also had no icons at all))

<img width=320 src=https://user-images.githubusercontent.com/9800740/235917722-8a2dd934-1330-47d2-b64c-4b07fd9b3e6d.jpg>
