### PR TITLE
remove superfluous files grouping

### DIFF
--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -11,7 +11,7 @@ class FilesViewController: UIViewController {
     private let chatId: Int
 
     private lazy var tableView: UITableView = {
-        let table = UITableView(frame: .zero, style: .grouped)
+        let table = UITableView(frame: .zero, style: .plain)
         table.register(DocumentGalleryFileCell.self, forCellReuseIdentifier: DocumentGalleryFileCell.reuseIdentifier)
         table.dataSource = self
         table.delegate = self


### PR DESCRIPTION
we have no grouping currently.
the `.grouped` style only led
to some large gray border atop of the list,
looking a little lost that way.

moreover, the background fits the background of the gallery now,
this looks better esp. on empty pages.