### PR TITLE
adapt empty-view layout to overall style

### DIFF
--- a/deltachat-ios/View/EmptyStateLabel.swift
+++ b/deltachat-ios/View/EmptyStateLabel.swift
@@ -7,8 +7,9 @@ class EmptyStateLabel: PaddingTextView {
         super.init()
         backgroundColor = DcColors.systemMessageBackgroundColor
         label.textColor = DcColors.systemMessageFontColor
-        layer.cornerRadius = 5
+        layer.cornerRadius = 16
         label.clipsToBounds = true
+        label.textAlignment = .center
         paddingTop = 15
         paddingBottom = 15
         paddingLeading = 15


### PR DESCRIPTION
reusing corner radius of the bubbles
and centering as info-messages
(the empty-view is sort of an info message as well).

this is also roughly in sync with the layout on desktop and android.

<img width=270 src=https://user-images.githubusercontent.com/9800740/235943953-892dbbf6-d09d-4b94-9c56-5217e37c5479.PNG> &nbsp; &nbsp; <img width= 270 src=https://user-images.githubusercontent.com/9800740/235943985-a1d02337-10c8-4c0e-8223-7c3a6b5d4d07.PNG>
