### PR TITLE
allow pinning/archiving of message search results

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -503,7 +503,7 @@ class ChatListController: UITableViewController {
             return []
         }
 
-        if chatId==DC_CHAT_ID_ARCHIVED_LINK || viewModel.isMessageSearchResult(indexPath: indexPath) {
+        if chatId==DC_CHAT_ID_ARCHIVED_LINK {
             return []
             // returning nil may result in a default delete action,
             // see https://forums.developer.apple.com/thread/115030
@@ -525,12 +525,15 @@ class ChatListController: UITableViewController {
         }
         pinAction.backgroundColor = UIColor.systemGreen
 
-        let deleteAction = UITableViewRowAction(style: .normal, title: String.localized("delete")) { [weak self] _, _ in
-            self?.showDeleteChatConfirmationAlert(chatId: chatId)
+        if viewModel.isMessageSearchResult(indexPath: indexPath) {
+            return [archiveAction, pinAction]
+        } else {
+            let deleteAction = UITableViewRowAction(style: .normal, title: String.localized("delete")) { [weak self] _, _ in
+                self?.showDeleteChatConfirmationAlert(chatId: chatId)
+            }
+            deleteAction.backgroundColor = UIColor.systemRed
+            return [archiveAction, pinAction, deleteAction]
         }
-        deleteAction.backgroundColor = UIColor.systemRed
-
-        return [archiveAction, pinAction, deleteAction]
     }
 
     override func setEditing(_ editing: Bool, animated: Bool) {


### PR DESCRIPTION
the message search results are shown as chat items, including indicators about pinning, archived etc.
there are no good reasons that you cannot eg. unpin a chat found by message search;
it is pretty clear that this is about chats and not messages - and if not, it is easily undoable.

concrete example:
you receive a message where you can remember some words of, more messages arrive, you search for the words you remember and want to pin the chat to come back to that (eg. just now "new project language requested - korean")

targets #1869