### PR TITLE
sticky search result headers

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -93,7 +93,7 @@ class ChatListController: UITableViewController {
         self.dcContext = dcContext
         self.dcAccounts = dcAccounts
         self.isArchive = isArchive
-        super.init(style: .grouped)
+        super.init(style: .plain)
         DispatchQueue.global(qos: .userInteractive).async { [weak self] in
             guard let self = self else { return }
             self.viewModel = ChatListViewModel(dcContext: self.dcContext, isArchive: isArchive)


### PR DESCRIPTION
let the headlines "123 chats", "234 contacts", "345 messages" not scroll away.

this makes the context of swiping action even a bit clearer, targets #1869