### PR TITLE
show existing saved-messages hint in profile

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -308,7 +308,7 @@ class ContactDetailViewController: UITableViewController {
     private func updateCellValues() {
         ephemeralMessagesCell.detailTextLabel?.text = String.localized(viewModel.chatIsEphemeral ? "on" : "off")
         allMediaCell.detailTextLabel?.text = viewModel.chatId == 0 ? String.localized("none") : viewModel.context.getAllMediaCount(chatId: viewModel.chatId)
-        statusCell.setText(text: viewModel.contact.status)
+        statusCell.setText(text: viewModel.isSavedMessages ? String.localized("saved_messages_explain") : viewModel.contact.status)
     }
 
     // MARK: - actions

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -173,7 +173,7 @@ class ContactDetailViewModel {
     func footerFor(section: Int) -> String? {
         switch sections[section] {
         case .chatOptions:
-            if isSavedMessages {
+            if isSavedMessages || isDeviceTalk {
                 return nil
             } else if lastSeen == 0 {
                 return String.localized("last_seen_unknown")

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -164,7 +164,7 @@ class ContactDetailViewModel {
     func titleFor(section: Int) -> String? {
         switch sections[section] {
         case .chatOptions: return nil
-        case .statusArea: return String.localized("pref_default_status_label")
+        case .statusArea: return (isSavedMessages || isDeviceTalk) ? nil : String.localized("pref_default_status_label")
         case .sharedChats: return String.localized("profile_shared_chats")
         case .chatActions: return nil
         }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -60,10 +60,9 @@ class ContactDetailViewModel {
 
         let dcContact = context.getContact(id: contactId)
         self.lastSeen = dcContact.lastSeen
-        if !self.isSavedMessages {
-            if !dcContact.status.isEmpty {
-                sections.append(.statusArea)
-            }
+
+        if self.isSavedMessages || !dcContact.status.isEmpty {
+            sections.append(.statusArea)
         }
 
         if sharedChats.length > 0 && !isSavedMessages && !isDeviceTalk {


### PR DESCRIPTION
a little, cheap help. inspired by https://github.com/deltachat/deltachat-desktop/pull/3234

<img width="320" alt="Screenshot 2023-05-29 at 00 43 57" src="https://github.com/deltachat/deltachat-ios/assets/9800740/b5b3892a-9f3b-48b8-b095-d1af89969e3b">

moreover, this pr hides "last seen" for device messages and hides the label "Signature Text" for both, device messages and saved messages (the label does not make much sense for the explanation)
