### PR TITLE
show error when trying to send locations but access is not granted

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1647,7 +1647,16 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
             return
         }
-        appDelegate.locationManager.shareLocation(chatId: self.chatId, duration: seconds)
+        if !appDelegate.locationManager.shareLocation(chatId: self.chatId, duration: seconds) {
+            let alert = UIAlertController(title: String.localized("location_denied"), message: String.localized("location_denied_explain_ios"), preferredStyle: .alert)
+            if let appSettings = URL(string: UIApplication.openSettingsURLString) {
+                alert.addAction(UIAlertAction(title: String.localized("open_settings"), style: .default, handler: { _ in
+                        UIApplication.shared.open(appSettings, options: [:], completionHandler: nil)
+                }))
+            }
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+            navigationController?.present(alert, animated: true, completion: nil)
+        }
     }
 
     func updateMessage(_ msg: DcMsg) {

--- a/deltachat-ios/Helper/LocationManager.swift
+++ b/deltachat-ios/Helper/LocationManager.swift
@@ -29,7 +29,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
         dcContext = dcAccounts.getSelected()
     }
 
-    func shareLocation(chatId: Int, duration: Int) {
+    func shareLocation(chatId: Int, duration: Int) -> Bool {
         if duration > 0 {
             var authStatus: CLAuthorizationStatus
             if #available(iOS 14.0, *) {
@@ -43,18 +43,21 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
                 chatIdLocationRequest = chatId
                 durationLocationRequest = duration
                 locationManager.requestAlwaysAuthorization()
+                return true
             case .authorizedAlways, .authorizedWhenInUse:
                 dcContext.sendLocationsToChat(chatId: chatId, seconds: duration)
                 locationManager.startUpdatingLocation()
-            default:
-                // TODO: show an alert to inform the user why nothing works :)
-                logger.info("Location permission was rejected.")
+                return true
+            case .restricted, .denied:
+                logger.error("Location permission rejected: \(authStatus)")
+                return false
             }
         } else {
             dcContext.sendLocationsToChat(chatId: chatId, seconds: duration)
             if !dcContext.isSendingLocationsToChat(chatId: 0) {
                 locationManager.stopUpdatingLocation()
             }
+            return true
         }
     }
 

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -999,3 +999,5 @@
 "add_encrypted_account" = "Add encrypted account";
 "backup_successful" = "Backup successful";
 "backup_successful_explain_ios" = "You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.";
+"location_denied" = "Location access denied";
+"location_denied_explain_ios" = "In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".";

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -7,4 +7,6 @@
     <string name="add_encrypted_account">Add encrypted account</string>
     <string name="backup_successful">Backup successful</string>
     <string name="backup_successful_explain_ios">You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.</string>
+    <string name="location_denied">Location access denied</string>
+    <string name="location_denied_explain_ios">In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".</string>
 </resources>


### PR DESCRIPTION
show detailed error and instructions when location access is not granted; just came over this, this was just missing (we are in that state when the user disabled location access at some point for all apps or for Delta Chat)

before, the app failed silently, without giving the user a hint how to fix the issue.

<img width="380" alt="Screenshot 2023-05-29 at 19 44 43" src="https://github.com/deltachat/deltachat-ios/assets/9800740/303b52fa-8fff-40a6-953a-2e0f59056f1d">
