### PR TITLE
disable "mark all read" button when it does nothing

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -661,6 +661,7 @@ class ChatListController: UITableViewController {
                 navigationItem.setLeftBarButton(nil, animated: true)
                 navigationItem.setRightBarButton(markArchivedReadButton, animated: true)
             }
+            updateMarkArchivedReadButton()
         } else {
             titleView.text = DcUtils.getConnectivityString(dcContext: dcContext, connectedString: String.localized("pref_chats"))
             if !handleMultiSelectionTitle() {
@@ -674,7 +675,6 @@ class ChatListController: UITableViewController {
         }
         titleView.isUserInteractionEnabled = !tableView.isEditing
         titleView.sizeToFit()
-        updateMarkArchivedReadButton()
     }
 
     func handleMultiSelectionTitle() -> Bool {
@@ -704,7 +704,9 @@ class ChatListController: UITableViewController {
                 self.handleEmptyStateLabel()
             }
         }
-        updateMarkArchivedReadButton()
+        if isArchive {
+            updateMarkArchivedReadButton()
+        }
     }
     
     func updateMarkArchivedReadButton(){

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -674,6 +674,7 @@ class ChatListController: UITableViewController {
         }
         titleView.isUserInteractionEnabled = !tableView.isEditing
         titleView.sizeToFit()
+        updateMarkArchivedReadButton()
     }
 
     func handleMultiSelectionTitle() -> Bool {
@@ -703,6 +704,11 @@ class ChatListController: UITableViewController {
                 self.handleEmptyStateLabel()
             }
         }
+        updateMarkArchivedReadButton()
+    }
+    
+    func updateMarkArchivedReadButton(){
+        self.markArchivedReadButton.isEnabled = dcContext.getUnreadMessages(chatId: Int(DC_CHAT_ID_ARCHIVED_LINK)) != 0
     }
 
     private func handleEmptyStateLabel() {


### PR DESCRIPTION
This also helps with understanding what it does,
because you can now only click it if there are messages that can be marked as read.

Basically it disables the button if there are no unread archived chats.

<img width="511" alt="Bildschirmfoto 2023-06-05 um 21 12 10" src="https://github.com/deltachat/deltachat-ios/assets/18725968/9c06c548-83ab-42a1-a12e-006e0ed25d5d">
<img width="511" alt="Bildschirmfoto 2023-06-05 um 21 11 52" src="https://github.com/deltachat/deltachat-ios/assets/18725968/52126766-f318-4ded-a2e6-2f37b7ad73bf">
