### PR TITLE
fix webxdc.js that broken after adding importFiles()

### DIFF
--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -164,7 +164,7 @@ class WebxdcViewController: WebViewViewController {
                 }
 
                 webkit.messageHandlers.sendToChat.postMessage(data);
-            }
+            },
 
             importFiles: (filters) => {
                 var element = document.createElement("input");


### PR DESCRIPTION
there was just a comma missing, that broke _some_ apps (for whatever reason, not _all_ apps)

ftr: in theory, adding a trailing comma is always a good idea, make adding things easier.
however, JavaScript and JSON is a mess here:
the former allows adding a trailing comma, the latter does not allow that - resulting in devs using both often to not add the comma.