### PR TITLE
do not exist apps unexpectedly

### DIFF
--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -411,19 +411,23 @@ extension WebxdcViewController: WKScriptMessageHandler {
             _ = dcContext.sendWebxdcStatusUpdate(msgId: messageId, payload: payloadString, description: description)
 
         case .sendToChat:
-            guard let dict = message.body as? [String: AnyObject] else {
-                logger.error("failed to parse sendToChat parameters \(message.body)")
-                return
-            }
-            let base64 = dict["base64"] as? String
-            let data = base64 != nil ? Data(base64Encoded: base64 ?? "") : nil
-            RelayHelper.shared.setForwardMessage(text: dict["text"] as? String, fileData: data, fileName: dict["name"] as? String)
+            let alert = UIAlertController(title: String.localized("chat_share_with_title"), message: nil, preferredStyle: .safeActionSheet)
+            alert.addAction(UIAlertAction(title: String.localized("select_chat"), style: .default, handler: { _ in
+                if let dict = message.body as? [String: AnyObject] {
+                    let base64 = dict["base64"] as? String
+                    let data = base64 != nil ? Data(base64Encoded: base64 ?? "") : nil
+                    RelayHelper.shared.setForwardMessage(text: dict["text"] as? String, fileData: data, fileName: dict["name"] as? String)
 
-            if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-               let rootController = appDelegate.appCoordinator.tabBarController.selectedViewController as? UINavigationController {
-                appDelegate.appCoordinator.showTab(index: appDelegate.appCoordinator.chatsTab)
-                rootController.popToRootViewController(animated: false)
-            }
+                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+                       let rootController = appDelegate.appCoordinator.tabBarController.selectedViewController as? UINavigationController {
+                        appDelegate.appCoordinator.showTab(index: appDelegate.appCoordinator.chatsTab)
+                        rootController.popToRootViewController(animated: false)
+                    }
+                }
+            }))
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+            self.present(alert, animated: true, completion: nil)
+
 
         default:
             logger.debug("another method was called")

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -1001,3 +1001,4 @@
 "backup_successful_explain_ios" = "You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.";
 "location_denied" = "Location access denied";
 "location_denied_explain_ios" = "In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".";
+"select_chat" = "Select Chat";

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -9,4 +9,5 @@
     <string name="backup_successful_explain_ios">You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.</string>
     <string name="location_denied">Location access denied</string>
     <string name="location_denied_explain_ios">In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".</string>
+    <string name="select_chat">Select Chat</string>
 </resources>


### PR DESCRIPTION
the current "forward" implementation does not allow to "cancel" the action and return to the app (as on android).
this results in apps being terminated quite unexpectedly and undoable, which is esp. surprising if the user taps around to check functinalities or hits a "Share" button accidentally.

this pr adds a little dialog as the next better approach; (i also thought about explaining more in the message, however, this is also not what we're doing on android, so this is out of scope)

<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/e79526f0-c3fb-43ac-b47d-63864574bee8>

for desktop, we need sth. like that or as on android as well
