### PR TITLE
add more context to dialogs shown after `sendToChat()`

### DIFF
--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -654,7 +654,7 @@ class ChatListController: UITableViewController {
         titleView.accessibilityHint = String.localized("a11y_connectivity_hint")
         if RelayHelper.shared.isForwarding() {
             // multi-select is not allowed during forwarding
-            titleView.text = RelayHelper.shared.forwardIds != nil ? String.localized("forward_to") : String.localized("chat_share_with_title")
+            titleView.text = RelayHelper.shared.dialogTitle
             if !isArchive {
                 navigationItem.setLeftBarButton(cancelButton, animated: true)
             }

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -423,7 +423,7 @@ extension WebxdcViewController: WKScriptMessageHandler {
                 alert.addAction(UIAlertAction(title: String.localized("select_chat"), style: .default, handler: { _ in
                     let base64 = dict["base64"] as? String
                     let data = base64 != nil ? Data(base64Encoded: base64 ?? "") : nil
-                    RelayHelper.shared.setForwardMessage(text: dict["text"] as? String, fileData: data, fileName: dict["name"] as? String)
+                    RelayHelper.shared.setForwardMessage(dialogTitle: title, text: dict["text"] as? String, fileData: data, fileName: dict["name"] as? String)
 
                     if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
                        let rootController = appDelegate.appCoordinator.tabBarController.selectedViewController as? UINavigationController {

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -411,9 +411,16 @@ extension WebxdcViewController: WKScriptMessageHandler {
             _ = dcContext.sendWebxdcStatusUpdate(msgId: messageId, payload: payloadString, description: description)
 
         case .sendToChat:
-            let alert = UIAlertController(title: String.localized("chat_share_with_title"), message: nil, preferredStyle: .safeActionSheet)
-            alert.addAction(UIAlertAction(title: String.localized("select_chat"), style: .default, handler: { _ in
-                if let dict = message.body as? [String: AnyObject] {
+            if let dict = message.body as? [String: AnyObject] {
+                let title: String
+                if let name = dict["name"] as? String {
+                    title = String.localizedStringWithFormat(String.localized("send_file_to"), name)
+                } else {
+                    title = String.localized("send_message_to")
+                }
+
+                let alert = UIAlertController(title: title, message: nil, preferredStyle: .safeActionSheet)
+                alert.addAction(UIAlertAction(title: String.localized("select_chat"), style: .default, handler: { _ in
                     let base64 = dict["base64"] as? String
                     let data = base64 != nil ? Data(base64Encoded: base64 ?? "") : nil
                     RelayHelper.shared.setForwardMessage(text: dict["text"] as? String, fileData: data, fileName: dict["name"] as? String)
@@ -423,11 +430,10 @@ extension WebxdcViewController: WKScriptMessageHandler {
                         appDelegate.appCoordinator.showTab(index: appDelegate.appCoordinator.chatsTab)
                         rootController.popToRootViewController(animated: false)
                     }
-                }
-            }))
-            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
-            self.present(alert, animated: true, completion: nil)
-
+                }))
+                alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+                self.present(alert, animated: true, completion: nil)
+            }
 
         default:
             logger.debug("another method was called")

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -5,6 +5,8 @@ class RelayHelper {
     static var shared: RelayHelper = RelayHelper()
     private static var dcContext: DcContext?
 
+    var dialogTitle: String = ""
+
     var forwardIds: [Int]?
     var forwardText: String?
     var forwardFileData: Data?
@@ -28,8 +30,9 @@ class RelayHelper {
 
     // forwarding messages
 
-    func setForwardMessage(text: String?, fileData: Data?, fileName: String?) {
+    func setForwardMessage(dialogTitle: String, text: String?, fileData: Data?, fileName: String?) {
         finishRelaying()
+        self.dialogTitle = dialogTitle
         self.forwardText = text
         self.forwardFileData = fileData
         self.forwardFileName = fileName
@@ -37,11 +40,13 @@ class RelayHelper {
 
     func setForwardMessage(messageId: Int) {
         finishRelaying()
+        self.dialogTitle = String.localized("forward_to")
         self.forwardIds = [messageId]
     }
 
     func setForwardMessages(messageIds: [Int]) {
         finishRelaying()
+        self.dialogTitle = String.localized("forward_to")
         if !messageIds.isEmpty {
             self.forwardIds = messageIds
         }
@@ -59,6 +64,7 @@ class RelayHelper {
     }
 
     func finishRelaying() {
+        dialogTitle = ""
         forwardIds = nil
         forwardText = nil
         forwardFileData = nil


### PR DESCRIPTION
the title shows one of the strings discussed at https://github.com/deltachat/deltachat-android/pull/2592

<img width=300 src=https://github.com/deltachat/deltachat-ios/assets/9800740/88f57b16-4c47-4dad-9f84-2d07c1639cff>
