### PR TITLE
remove meet.jit.si as predefined videochat instance 

### DIFF
--- a/deltachat-ios/Controller/Settings/VideoChatInstanceViewController.swift
+++ b/deltachat-ios/Controller/Settings/VideoChatInstanceViewController.swift
@@ -31,7 +31,6 @@ class VideoChatInstanceViewController: UITableViewController {
     private var dcContext: DcContext
 
     private static let predefinedOptions = [
-        PredefinedOption(label: "Jitsi", url: "https://meet.jit.si/$ROOM"),
         PredefinedOption(label: "Systemli", url: "https://meet.systemli.org/$ROOM"),
         PredefinedOption(label: "Autistici", url: "https://vc.autistici.org/$ROOM"),
     ]
@@ -167,7 +166,7 @@ class VideoChatInstanceViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return String.localized("videochat_instance_explain_2") + "\n\n" + String.localized("videochat_instance_example")
+        return String.localized("videochat_instance_explain_2")
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
meet.jit.si requires a login now and is no longer usable ad-hoc; adapt explanation string

