### PR TITLE
remove jitsi meet from default video chat instances

### DIFF
--- a/deltachat-ios/Controller/Settings/VideoChatInstanceViewController.swift
+++ b/deltachat-ios/Controller/Settings/VideoChatInstanceViewController.swift
@@ -31,7 +31,6 @@ class VideoChatInstanceViewController: UITableViewController {
     private var dcContext: DcContext
 
     private static let predefinedOptions = [
-        PredefinedOption(label: "Jitsi", url: "https://meet.jit.si/$ROOM"),
         PredefinedOption(label: "Systemli", url: "https://meet.systemli.org/$ROOM"),
         PredefinedOption(label: "Autistici", url: "https://vc.autistici.org/$ROOM"),
     ]


### PR DESCRIPTION
because they now require sign in, see deltachat/deltachat-desktop#3366

closes #1915
