### PR TITLE
use core email validation function

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -1546,3 +1546,7 @@ func strToBool(_ value: String?) -> Bool {
 
     return false
 }
+
+public func isValidEmail(email: String) -> Bool{
+    return dc_may_be_valid_addr(email) != 0
+}

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -5,16 +5,7 @@ import DcCore
 struct Utils {
 
     static func isValid(email: String) -> Bool {
-        let emailRegEx = "(?:[a-z0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[a-z0-9!#$%\\&'*+/=?\\^_`{|}"
-            + "~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\"
-            + "x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-"
-            + "z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5"
-            + "]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-"
-            + "9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21"
-            + "-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
-
-        let emailTest = NSPredicate(format: "SELF MATCHES[c] %@", emailRegEx)
-        return emailTest.evaluate(with: email)
+        return isValidEmail(email: email)
     }
 
 


### PR DESCRIPTION
closes #1918

The core email validation function should be improved to be atleast as good as the regex that is replaced by this pr, before merging 
this pr.
