### PR TITLE
use core for checking email addresses

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -1546,3 +1546,7 @@ func strToBool(_ value: String?) -> Bool {
 
     return false
 }
+
+public func mayBeValidAddr(email: String) -> Bool {
+    return dc_may_be_valid_addr(email) != 0
+}

--- a/deltachat-ios/Controller/NewContactController.swift
+++ b/deltachat-ios/Controller/NewContactController.swift
@@ -15,7 +15,7 @@ class NewContactController: UITableViewController {
     var onContactSaved: ((Int) -> Void)?
 
     func contactIsValid() -> Bool {
-        return Utils.isValid(email: model.email)
+        return mayBeValidAddr(email: model.email)
     }
 
     var model: (name: String, email: String) = ("", "") {

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -4,24 +4,10 @@ import DcCore
 
 struct Utils {
 
-    static func isValid(email: String) -> Bool {
-        let emailRegEx = "(?:[a-z0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[a-z0-9!#$%\\&'*+/=?\\^_`{|}"
-            + "~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\"
-            + "x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-"
-            + "z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5"
-            + "]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-"
-            + "9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21"
-            + "-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
-
-        let emailTest = NSPredicate(format: "SELF MATCHES[c] %@", emailRegEx)
-        return emailTest.evaluate(with: email)
-    }
-
-
     static func isEmail(url: URL) -> Bool {
         let mailScheme = "mailto"
         if let scheme = url.scheme {
-            return mailScheme == scheme && isValid(email: url.absoluteString.substring(mailScheme.count + 1, url.absoluteString.count))
+            return mailScheme == scheme && mayBeValidAddr(email: url.absoluteString.substring(mailScheme.count + 1, url.absoluteString.count))
         }
         return false
     }


### PR DESCRIPTION
might be that core is less strict,
however, many strict rules also have to turn out to be wrong in the past :)

dc_may_be_valid_addr() is also used at least on android, is in any case it is good to have the same behavoir.

picking up things from https://github.com/deltachat/deltachat-ios/pull/1920