### PR TITLE
prepare 1.40.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Delta Chat iOS Changelog
 
+## v1.40.3
+2023-10
+
+* fix a crash when opening the connectivity view on newer iOS versions
+* minimum system version is iOS 12 now
+* using core119
+
+
 ## v1.40.2
 2023-10
 

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -2037,7 +2037,7 @@
 				CODE_SIGN_ENTITLEMENTS = "deltachat-ios/deltachat-ios.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -2056,7 +2056,7 @@
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/deltachat-ffi",
 					"$(PROJECT_DIR)/deltachat-ios/libraries",
 				);
-				MARKETING_VERSION = 1.40.2;
+				MARKETING_VERSION = 1.40.3;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-isystem",
@@ -2110,7 +2110,7 @@
 				CODE_SIGN_ENTITLEMENTS = "deltachat-ios/deltachat-ios.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -2129,7 +2129,7 @@
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/deltachat-ffi",
 					"$(PROJECT_DIR)/deltachat-ios/libraries",
 				);
-				MARKETING_VERSION = 1.40.2;
+				MARKETING_VERSION = 1.40.3;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-isystem",


### PR DESCRIPTION
this fixes a crash probably introduced by one of the last ios updates, see https://github.com/deltachat/deltachat-ios/issues/1930