### PR TITLE
truncate subtitle as needed

### DIFF
--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -37,7 +37,6 @@ class ChatTitleView: UIView {
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         subtitleLabel.font = UIFont.systemFont(ofSize: 12)
         subtitleLabel.textAlignment = .center
-        subtitleLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         return subtitleLabel
     }()
 


### PR DESCRIPTION
[`setContentCompressionResistancePriority()`](https://developer.apple.com/documentation/uikit/uiview/1622526-setcontentcompressionresistancep) does not make sense here, the outer avatar and back-button should have a higher priority (which seem to be fine by just using defaults here)

closes https://github.com/deltachat/deltachat-ios/issues/1899