### PR TITLE
disable 'Add to Home Screen' for iOS 16+

### DIFF
--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -392,8 +392,13 @@ class WebxdcViewController: WebViewViewController {
         let alert = UIAlertController(title: webxdcName + " – " + String.localized("webxdc_app"),
                                       message: nil,
                                       preferredStyle: .safeActionSheet)
-        let addToHomescreenAction = UIAlertAction(title: String.localized("add_to_home_screen"), style: .default, handler: addToHomeScreen(_:))
-        alert.addAction(addToHomescreenAction)
+        if #available(iOS 16, *) {
+            dcContext.logger?.info("cannot add shortcut as passing data: urls to local server was disabled by apple on on iOS 16")
+        } else {
+            let addToHomescreenAction = UIAlertAction(title: String.localized("add_to_home_screen"), style: .default, handler: addToHomeScreen(_:))
+            alert.addAction(addToHomescreenAction)
+        }
+
         if sourceCodeUrl != nil {
             let sourceCodeAction = UIAlertAction(title: String.localized("source_code"), style: .default, handler: openUrl(_:))
             alert.addAction(sourceCodeAction)


### PR DESCRIPTION
this pr disables 'Add to Home Screen' for iOS 16+ and is an alternative to https://github.com/deltachat/deltachat-ios/pull/1939 (which disables 'Add to Home Screen'  for all iOS)

closes https://github.com/deltachat/deltachat-ios/issues/1880 ,   which also shows some alternatives to removal on iOS 16+, however it is unclear what is working and/or requires lots of work; this time is spend better in other areas acurrently