### PR TITLE
give instructions how to play unsupported video formats

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2147,7 +2147,7 @@ extension ChatViewController: BaseMessageCellDelegate {
         }
     }
 
-    @objc func imageTapped(indexPath: IndexPath) {
+    @objc func imageTapped(indexPath: IndexPath, previewError: Bool) {
         if handleUIMenu() || handleSelection(indexPath: indexPath) {
             return
         }
@@ -2155,7 +2155,16 @@ extension ChatViewController: BaseMessageCellDelegate {
         if message.type == DC_MSG_WEBXDC {
             showWebxdcViewFor(message: message)
         } else if message.type != DC_MSG_STICKER {
-            showMediaGalleryFor(message: message)
+            if previewError && message.type == DC_MSG_VIDEO {
+                let alert = UIAlertController(title: "To play this video, share to apps as VLC on the following page.", message: nil, preferredStyle: .safeActionSheet)
+                alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .default, handler: { _ in
+                    self.showMediaGalleryFor(message: message)
+                }))
+                alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+                present(alert, animated: true, completion: nil)
+            } else {
+                showMediaGalleryFor(message: message)
+            }
         }
     }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2155,6 +2155,8 @@ extension ChatViewController: BaseMessageCellDelegate {
         if message.type == DC_MSG_WEBXDC {
             showWebxdcViewFor(message: message)
         } else if message.type != DC_MSG_STICKER {
+            // prefer previewError over QLPreviewController.canPreview().
+            // (the latter returns `true` for .webm - which is not wrong as _something_ is shown, even if the video cannot be played)
             if previewError && message.type == DC_MSG_VIDEO {
                 let alert = UIAlertController(title: "To play this video, share to apps as VLC on the following page.", message: nil, preferredStyle: .safeActionSheet)
                 alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .default, handler: { _ in

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1580,11 +1580,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         mediaPicker?.showPhotoVideoLibrary()
     }
 
-    private func showMediaGallery(currentIndex: Int, msgIds: [Int]) {
-        let previewController = PreviewController(dcContext: dcContext, type: .multi(msgIds, currentIndex))
-        navigationController?.pushViewController(previewController, animated: true)
-    }
-
     private func webxdcButtonPressed(_ action: UIAlertAction) {
         showWebxdcSelector()
     }
@@ -1927,19 +1922,11 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         navigationController?.pushViewController(webxdcViewController, animated: true)
     }
 
-    func showMediaGalleryFor(indexPath: IndexPath) {
-        let messageId = messageIds[indexPath.row]
-        let message = dcContext.getMessage(id: messageId)
-        if message.type != DC_MSG_STICKER {
-            showMediaGalleryFor(message: message)
-        }
-    }
-
     func showMediaGalleryFor(message: DcMsg) {
-
         let msgIds = dcContext.getChatMedia(chatId: chatId, messageType: Int32(message.type), messageType2: 0, messageType3: 0)
         let index = msgIds.firstIndex(of: message.id) ?? 0
-        showMediaGallery(currentIndex: index, msgIds: msgIds)
+
+        navigationController?.pushViewController(PreviewController(dcContext: dcContext, type: .multi(msgIds, index)), animated: true)
     }
 
     private func didTapAsm(msg: DcMsg, orgText: String) {
@@ -2167,8 +2154,8 @@ extension ChatViewController: BaseMessageCellDelegate {
         let message = dcContext.getMessage(id: messageIds[indexPath.row])
         if message.type == DC_MSG_WEBXDC {
             showWebxdcViewFor(message: message)
-        } else {
-            showMediaGalleryFor(indexPath: indexPath)
+        } else if message.type != DC_MSG_STICKER {
+            showMediaGalleryFor(message: message)
         }
     }
 

--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -616,7 +616,7 @@ public protocol BaseMessageCellDelegate: class {
     func commandTapped(command: String, indexPath: IndexPath) // `/command`
     func phoneNumberTapped(number: String, indexPath: IndexPath)
     func urlTapped(url: URL, indexPath: IndexPath) // url is eg. `https://foo.bar`
-    func imageTapped(indexPath: IndexPath)
+    func imageTapped(indexPath: IndexPath, previewError: Bool)
     func avatarTapped(indexPath: IndexPath)
     func textTapped(indexPath: IndexPath)
     func quoteTapped(indexPath: IndexPath)

--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -103,7 +103,7 @@ class ImageTextCell: BaseMessageCell {
 
     @objc func onImageTapped() {
         if let tableView = self.superview as? UITableView, let indexPath = tableView.indexPath(for: self) {
-            baseDelegate?.imageTapped(indexPath: indexPath)
+            baseDelegate?.imageTapped(indexPath: indexPath, previewError: imageView?.image == nil)
         }
     }
 

--- a/deltachat-ios/Chat/Views/Cells/WebxdcCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/WebxdcCell.swift
@@ -14,7 +14,7 @@ public class WebxdcCell: FileTextCell {
 
     @objc func onImageTapped() {
         if let tableView = self.superview as? UITableView, let indexPath = tableView.indexPath(for: self) {
-            baseDelegate?.imageTapped(indexPath: indexPath)
+            baseDelegate?.imageTapped(indexPath: indexPath, previewError: false)
         }
     }
 


### PR DESCRIPTION
this first commit reduces unneeded code complexity and removes one full message-db load.

the second commit shows an alert with instructions in case a video-preview could not be generated (with high chance, also Preview will fail to play the file)

<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/59f40593-3767-48b6-81f8-e3cb3ff392e2>

closes https://github.com/deltachat/deltachat-ios/issues/1909

of course, this can be improved further, however, regarding that .webm video is not an officially supported format, this seems good enough and already a good improvement, giving the ppl an idea how to play that at all (it was not even clear to me :)