### PR TITLE
Revert "truncate subtitle as needed"

### DIFF
--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -37,6 +37,7 @@ class ChatTitleView: UIView {
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         subtitleLabel.font = UIFont.systemFont(ofSize: 12)
         subtitleLabel.textAlignment = .center
+        subtitleLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         return subtitleLabel
     }()
 


### PR DESCRIPTION
This reverts commit 82e99b4c36f67057c91a30ebd86183660a761249 which creates larger issues than it aims to fix:


<img width=200 src=https://github.com/deltachat/deltachat-ios/assets/9800740/e59fecc2-c88d-4487-9886-f891de70d4e4> <img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/b286f7af-3e08-4eb9-8ec0-1e4da07c3ef0>
_too much space left of verified, too larger verified, address truncated too soon if name is short_

closes #1942 
reopens #1899 

