### PR TITLE
use contact_is_verified() on no-chat-profiles for green checkmark

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -305,7 +305,7 @@ class ContactDetailViewController: UITableViewController {
             } else {
                 headerCell.setBackupImage(name: viewModel.contact.displayName, color: viewModel.contact.color)
             }
-            headerCell.setGreenCheckmark(greenCheckmark: viewModel.isProtected)
+            headerCell.setGreenCheckmark(greenCheckmark: viewModel.greenCheckmark)
             headerCell.setMuted(isMuted: viewModel.chatIsMuted)
             headerCell.showMuteButton(show: true)
         }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -38,7 +38,7 @@ class ContactDetailViewModel {
     let chatId: Int
     let isSavedMessages: Bool
     let isDeviceTalk: Bool
-    let isProtected: Bool
+    let greenCheckmark: Bool
     var lastSeen: Int64
     private var sharedChats: DcChatlist
     private var sections: [ProfileSections] = []
@@ -49,21 +49,21 @@ class ContactDetailViewModel {
         self.context = dcContext
         self.contactId = contactId
         self.chatId = dcContext.getChatIdByContactId(contactId: contactId)
+        let dcContact = context.getContact(id: contactId)
         if chatId != 0 {
             let dcChat = dcContext.getChat(chatId: chatId)
             isSavedMessages = dcChat.isSelfTalk
             isDeviceTalk = dcChat.isDeviceTalk
-            isProtected = dcChat.isProtected
+            greenCheckmark = dcChat.isProtected
         } else {
             isSavedMessages = false
             isDeviceTalk = false
-            isProtected = false
+            greenCheckmark = dcContact.isVerified
         }
         self.sharedChats = context.getChatlist(flags: 0, queryString: nil, queryId: contactId)
 
         sections.append(.chatOptions)
 
-        let dcContact = context.getContact(id: contactId)
         self.lastSeen = dcContact.lastSeen
 
         if self.isSavedMessages || !dcContact.status.isEmpty {


### PR DESCRIPTION
this change only affects contact-profiles without an existing 1to1-chat; in this case, use contact_is_verified() to add the green-checkmark. this matches member-lists as well as new-contact-list and is sort of prediction for how a new 1to1-chats would look like

counterpart of https://github.com/deltachat/deltachat-android/pull/2837