### PR TITLE
use 'display name' for verified by

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -326,7 +326,7 @@ class ContactDetailViewController: UITableViewController {
             } else {
                 verifiedByCell.accessoryType = .disclosureIndicator
                 verifiedInfo = String.localizedStringWithFormat(String.localized("verified_by"),
-                                                                viewModel.context.getContact(id: verifierId).nameNAddr)
+                                                                viewModel.context.getContact(id: verifierId).displayName)
             }
             verifiedByCell.textLabel?.text = verifiedInfo
         }


### PR DESCRIPTION
always showing the email address as well
is over the top and clutters UI -
you can tap the row to get more information and '>' shows even that you can tap.

counterpart of https://github.com/deltachat/deltachat-android/pull/2831 that also contains for reasonings