### PR TITLE
more in-app help

### DIFF
--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -253,9 +253,7 @@ class BackupTransferViewController: UIViewController {
     @objc private func moreButtonPressed() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
         alert.addAction(UIAlertAction(title: String.localized("troubleshooting"), style: .default, handler: { _ in
-            if let url = URL(string: "https://delta.chat/en/help#multiclient") {
-                UIApplication.shared.open(url)
-            }
+            self.navigationController?.pushViewController(HelpViewController(dcContext: self.dcContext, fragment: "#multiclient"), animated: true)
         }))
         if !self.qrContentView.isHidden {
             alert.addAction(UIAlertAction(title: String.localized("menu_copy_to_clipboard"), style: .default, handler: { [weak self] _ in

--- a/deltachat-ios/Controller/HelpViewController.swift
+++ b/deltachat-ios/Controller/HelpViewController.swift
@@ -4,7 +4,10 @@ import DcCore
 
 class HelpViewController: WebViewViewController {
 
-    override init(dcContext: DcContext) {
+    let fragment: String?
+
+    init(dcContext: DcContext, fragment: String? = nil) {
+        self.fragment = fragment
         super.init(dcContext: dcContext)
         self.allowSearch = true
     }
@@ -39,6 +42,13 @@ class HelpViewController: WebViewViewController {
             DispatchQueue.main.async {
                 self?.webView.loadFileURL(url, allowingReadAccessTo: url)
             }
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        if let fragment = self.fragment {
+            let scrollToFragmentScript = "window.location.hash = '\(fragment)';"
+            webView.evaluateJavaScript(scrollToFragmentScript, completionHandler: nil)
         }
     }
 


### PR DESCRIPTION
this pr prepares for opening verified-chats-help in-app, see https://github.com/deltachat/deltachat-android/issues/2829 

- allow opening in-app help at given fragment
- use multi-device-troubleshouting in-app-help