### PR TITLE
clone groups and broadcasts

### DIFF
--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -18,6 +18,7 @@ class GroupChatDetailViewController: UIViewController {
 
     enum ChatAction {
         case archiveChat
+        case cloneChat
         case leaveGroup
         case clearChat
         case deleteChat
@@ -92,6 +93,13 @@ class GroupChatDetailViewController: UIViewController {
     private lazy var archiveChatCell: ActionCell = {
         let cell = ActionCell()
         cell.actionTitle = chat.isArchived ? String.localized("menu_unarchive_chat") :  String.localized("menu_archive_chat")
+        cell.actionColor = UIColor.systemBlue
+        return cell
+    }()
+
+    private lazy var cloneChatCell: ActionCell = {
+        let cell = ActionCell()
+        cell.actionTitle = String.localized("clone_chat")
         cell.actionColor = UIColor.systemBlue
         return cell
     }()
@@ -279,12 +287,12 @@ class GroupChatDetailViewController: UIViewController {
         } else if chat.isBroadcast {
             self.chatOptions = [.allMedia]
             self.memberManagementRows = 1
-            self.chatActions = [.archiveChat, .clearChat, .deleteChat]
+            self.chatActions = [.archiveChat, .cloneChat, .clearChat, .deleteChat]
             self.groupHeader.showMuteButton(show: false)
         } else if chat.canSend {
             self.chatOptions = [.allMedia, .ephemeralMessages]
             self.memberManagementRows = 2
-            self.chatActions = [.archiveChat, .leaveGroup, .clearChat, .deleteChat]
+            self.chatActions = [.archiveChat, .cloneChat, .leaveGroup, .clearChat, .deleteChat]
             self.groupHeader.showMuteButton(show: true)
         } else {
             self.chatOptions = [.allMedia]
@@ -505,6 +513,8 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             switch chatActions[row] {
             case .archiveChat:
                 return archiveChatCell
+            case .cloneChat:
+                return cloneChatCell
             case .leaveGroup:
                 return leaveGroupCell
             case .clearChat:
@@ -551,6 +561,8 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             case .archiveChat:
                 tableView.deselectRow(at: indexPath, animated: true) // animated as no other elements pop up
                 toggleArchiveChat()
+            case .cloneChat:
+                tableView.deselectRow(at: indexPath, animated: false)
             case .leaveGroup:
                 tableView.deselectRow(at: indexPath, animated: false)
                 showLeaveGroupConfirmationAlert()

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -563,6 +563,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 toggleArchiveChat()
             case .cloneChat:
                 tableView.deselectRow(at: indexPath, animated: false)
+                navigationController?.pushViewController(NewGroupController(dcContext: dcContext, createBroadcast: chat.isBroadcast, templateChatId: chatId), animated: true)
             case .leaveGroup:
                 tableView.deselectRow(at: indexPath, animated: false)
                 showLeaveGroupConfirmationAlert()

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -2,7 +2,6 @@ import UIKit
 import DcCore
 
 class NewGroupController: UITableViewController, MediaPickerDelegate {
-    var groupName: String = ""
 
     var doneButton: UIBarButtonItem!
     var contactIdsForGroup: Set<Int>
@@ -119,6 +118,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     }
 
     @objc func doneButtonPressed() {
+        guard let groupName = groupNameCell.textField.text else { return }
         let groupChatId: Int
         if createBroadcast {
             groupChatId = dcContext.createBroadcastList()
@@ -247,8 +247,6 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     }
 
     private func updateGroupName(textView: UITextField) {
-        let name = textView.text ?? ""
-        groupName = name
         checkDoneButton()
     }
 

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -93,6 +93,10 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
         }
         if let templateChat = self.templateChat {
             groupNameCell.textField.text = templateChat.name
+            if !createBroadcast, let image = templateChat.profileImage {
+                avatarSelectionCell = AvatarSelectionCell(image: image)
+                changeGroupImage = image
+            }
         }
         doneButton = UIBarButtonItem(title: String.localized("create"), style: .done, target: self, action: #selector(doneButtonPressed))
         navigationItem.rightBarButtonItem = doneButton

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -7,6 +7,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
     var doneButton: UIBarButtonItem!
     var contactIdsForGroup: Set<Int>
     var groupContactIds: [Int]
+    let templateChat: DcChat?
 
     private var changeGroupImage: UIImage?
     private var deleteGroupImage: Bool = false
@@ -55,7 +56,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
         return cell
     }()
 
-    init(dcContext: DcContext, createBroadcast: Bool) {
+    init(dcContext: DcContext, createBroadcast: Bool, templateChatId: Int? = nil) {
         self.createBroadcast = createBroadcast
         self.dcContext = dcContext
         self.sections = [.details, .invite, .members]
@@ -67,6 +68,14 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
             self.detailsRows = [.name, .avatar]
             self.inviteRows = [.addMembers]
             self.contactIdsForGroup = [Int(DC_CONTACT_ID_SELF)]
+        }
+        if let templateChatId = templateChatId {
+            templateChat = dcContext.getChat(chatId: templateChatId)
+            if let templateChat = templateChat {
+                self.contactIdsForGroup = Set(templateChat.getContactIds(dcContext))
+            }
+        } else {
+            templateChat = nil
         }
         self.groupContactIds = Array(contactIdsForGroup)
         super.init(style: .grouped)
@@ -82,6 +91,9 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
             title = String.localized("new_broadcast_list")
         } else {
             title = String.localized("menu_new_group")
+        }
+        if let templateChat = self.templateChat {
+            groupNameCell.textField.text = templateChat.name
         }
         doneButton = UIBarButtonItem(title: String.localized("create"), style: .done, target: self, action: #selector(doneButtonPressed))
         navigationItem.rightBarButtonItem = doneButton


### PR DESCRIPTION
this pr adds a "Clone Chat" function to the profiles of groups and broadcast lists.

tapping the button opens the normal "Create Group" resp. "Create Broadcast" dialog with member list, name and avatar preset

<img width=280 src=https://github.com/deltachat/deltachat-ios/assets/9800740/9f2b18fa-f406-4c32-acaf-9eab1be77b4d>

counterpart of https://github.com/deltachat/deltachat-android/issues/2786