### PR TITLE
use more generic placeholder for email addresses

### DIFF
--- a/deltachat-ios/View/TextFieldCell.swift
+++ b/deltachat-ios/View/TextFieldCell.swift
@@ -164,7 +164,7 @@ class TextFieldCell: UITableViewCell {
     }
 
     static func makeEmailCell(delegate: UITextFieldDelegate? = nil) -> TextFieldCell {
-        let cell = TextFieldCell(description: String.localized("email_address"), placeholder: "you@example.org")
+        let cell = TextFieldCell(description: String.localized("email_address"), placeholder: "name@example.org")
         cell.textField.keyboardType = .emailAddress
         // switch off quicktype
         cell.textField.autocorrectionType = .no


### PR DESCRIPTION
the corresponding string is used in account-setup as well as in add-contact. 'you@example.org' does not fit in the latter.
'name@example.org' fits in both.

came over that when discussing https://github.com/deltachat/deltachat-android/pull/2844

at some point, we can also make the string translatable, but this is another pr and needs a settled thing before :)