### PR TITLE
try to fix notifications

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -18,6 +18,10 @@ public class DcAccounts {
         dc_accounts_unref(accountsPointer)
         accountsPointer = nil
     }
+    
+    public func isOpen() -> Bool {
+        return accountsPointer != nil
+    }
 
     public func migrate(dbLocation: String) -> Int {
         return Int(dc_accounts_migrate_account(accountsPointer, dbLocation))

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -14,6 +14,7 @@ protocol ShareAttachmentDelegate: class {
 }
 
 class ShareAttachment {
+
     weak var delegate: ShareAttachmentDelegate?
     let dcContext: DcContext
     let thumbnailSize = CGFloat(96)

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -14,7 +14,6 @@ protocol ShareAttachmentDelegate: class {
 }
 
 class ShareAttachment {
-
     weak var delegate: ShareAttachmentDelegate?
     let dcContext: DcContext
     let thumbnailSize = CGFloat(96)

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -566,7 +566,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             self.pushToDebugArray(String(format: "3/%.3fs", Double(Date().timeIntervalSince1970)-nowTimestamp))
 
             if !self.appIsInForeground() {
-                self.dcAccounts.stopIo()
                 // to avoid 0xdead10cc exceptions, we need to make sure there are no locks on files.
                 self.closeDB()
             }

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -570,6 +570,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 self.closeDB()
             }
 
+            // to avoid 0xdead10cc exceptions, scheduled jobs need to be done before we get suspended;
+            // we increase the probabilty that this happens by waiting a moment before calling completionHandler()
+            usleep(1_000_000)
             logger.info("⬅️ fetch done")
             completionHandler(.newData)
             if backgroundTask != .invalid {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -560,9 +560,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 self.closeDB()
             }
 
-            // to avoid 0xdead10cc exceptions, scheduled jobs need to be done before we get suspended;
-            // we increase the probabilty that this happens by waiting a moment before calling completionHandler()
-            usleep(1_000_000)
             logger.info("⬅️ fetch done")
             completionHandler(.newData)
             if backgroundTask != .invalid {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -331,7 +331,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     private var shouldShutdownEventLoop: Bool = false
-    private var eventShutdownSemaphore = DispatchSemaphore(value: 1)
+    private var eventShutdownSemaphore = DispatchSemaphore(value: 0)
     private func closeDB() {
         shouldShutdownEventLoop = true
         dcAccounts.stopIo() // stopIo will generate atleast one event to the event handler can shut down


### PR DESCRIPTION
- don't use logger from context outside of context -> r10s did that in #1994
- context wrapper objects that are created for each event can not be used to save state so I commented out those non working statements -> now also in https://github.com/deltachat/deltachat-ios/pull/1976
- try to add real shutdown for event handler and closing the db (#1979)

Does not crash as often anymore, but:
- [ ] delay after waking up / unsuspeding, link2xt said probably because of missing cache, also might just be sqlcipher taking long to open the db
- [X] events are not received by the UI anymore, althrough I sucessfully restarted the handler that the events are printed to the console.
- [ ] there is a performance warning because I wait in the main thread for the event thread to finish: "Thread Performance Checker: Thread running at QOS_CLASS_USER_INTERACTIVE waiting on a lower QoS thread running at QOS_CLASS_BACKGROUND. Investigate ways to avoid priority inversions"
- [X] TODO: eventHandlerActive boolean should proabably be an atomic? -> seems to be not necessary
- [ ] it wastes time when going in the background, sometimes just waits while doing nothing, https://github.com/deltachat/deltachat-core-rust/issues/4420 could be useful here. - though keeping open a bit for the case that user comes back to the app is a feature, not a bug

## Also See

- https://github.com/deltachat/deltachat-core-rust/issues/4420


closes #1979
closes #1830
closes #1202 (basically the same as #1979)

if crashes still continue, we should open new, on-point issues
