### PR TITLE
remove unused, not working debug variables from context

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -112,8 +112,6 @@ public class DcContext {
 
     public var logger: Logger?
     var contextPointer: OpaquePointer?
-    public var lastWarningString: String = "" // temporary thing to get a grip on some weird errors
-    public var maxConfigureProgress: Int = 0 // temporary thing to get a grip on some weird errors
     private var anyWebxdcSeen: Bool = false
 
     public init(contextPointer: OpaquePointer?, logger: Logger?) {
@@ -494,8 +492,6 @@ public class DcContext {
     }
 
     public func configure() {
-        maxConfigureProgress = 0
-        lastWarningString = ""
         dc_configure(contextPointer)
     }
 

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -41,11 +41,9 @@ public class DcEventHandler {
 
         case DC_EVENT_WARNING:
             let s = event.data2String
-            dcContext.lastWarningString = s
             dcContext.logger?.warning("event: \(s)")
 
         case DC_EVENT_CONFIGURE_PROGRESS:
-            dcContext.maxConfigureProgress = max(dcContext.maxConfigureProgress, Int(data1))
             dcContext.logger?.info("configure progress: \(Int(data1)) \(Int(data2))")
             let nc = NotificationCenter.default
             DispatchQueue.main.async {

--- a/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
@@ -574,8 +574,6 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
                         if let reachability = appDelegate.reachability, reachability.connection == .unavailable {
                             errorMessage = String.localized("login_error_no_internet_connection")
                         }
-                    } else {
-                        errorMessage = "\(errorMessage ?? "no message")\n\n(warning=\(self.dcContext.lastWarningString) (progress=\(self.dcContext.maxConfigureProgress))"
                     }
                     self.updateProgressAlert(error: errorMessage)
                 } else if let done = ui["done"] as? Bool, done {


### PR DESCRIPTION
closes #1975 (read Explanation on that issue)
