### PR TITLE
reduce dependency on context in event loop

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -25,6 +25,7 @@ public class DcEventHandler {
         let id = event.id
         let data1 = event.data1Int
         let data2 = event.data2Int
+        let accountId = event.accountId
         let dcContext = dcAccounts.get(id: event.accountId)
 
         if id >= DC_EVENT_ERROR && id <= 499 {
@@ -85,7 +86,7 @@ public class DcEventHandler {
             dcContext.logger?.warning("network: \(event.data2String)")
 
         case DC_EVENT_MSGS_CHANGED, DC_EVENT_MSG_READ, DC_EVENT_MSG_DELIVERED, DC_EVENT_MSG_FAILED:
-            if dcContext.id != dcAccounts.getSelected().id {
+            if accountId != dcAccounts.getSelected().id {
                 return
             }
             dcContext.logger?.info("change: \(id)")
@@ -105,7 +106,7 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_MSGS_NOTICED:
-            if dcContext.id != dcAccounts.getSelected().id {
+            if accountId != dcAccounts.getSelected().id {
                 return
             }
             let nc = NotificationCenter.default
@@ -120,7 +121,7 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_CHAT_MODIFIED:
-            if dcContext.id != dcAccounts.getSelected().id {
+            if accountId != dcAccounts.getSelected().id {
                 return
             }
             dcContext.logger?.info("chat modified: \(id)")
@@ -135,7 +136,7 @@ public class DcEventHandler {
                 )
             }
         case DC_EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED:
-            if dcContext.id != dcAccounts.getSelected().id {
+            if accountId != dcAccounts.getSelected().id {
                 return
             }
             dcContext.logger?.info("chat ephemeral timer modified: \(id)")
@@ -158,7 +159,7 @@ public class DcEventHandler {
                         userInfo: nil)
             }
             
-            if dcContext.id != dcAccounts.getSelected().id {
+            if accountId != dcAccounts.getSelected().id {
                 return
             }
             
@@ -178,7 +179,7 @@ public class DcEventHandler {
             dcContext.logger?.info("network: \(event.data2String)")
 
         case DC_EVENT_SECUREJOIN_INVITER_PROGRESS:
-            if dcContext.id != dcAccounts.getSelected().id {
+            if accountId != dcAccounts.getSelected().id {
                 return
             }
             dcContext.logger?.info("securejoin inviter progress \(data1)")
@@ -197,7 +198,7 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_CONTACTS_CHANGED:
-            if dcContext.id != dcAccounts.getSelected().id {
+            if accountId != dcAccounts.getSelected().id {
                 return
             }
             dcContext.logger?.info("contact changed: \(data1)")
@@ -216,7 +217,7 @@ public class DcEventHandler {
             if let sem = dcAccounts.fetchSemaphore, dcAccounts.isAllWorkDone() {
                 sem.signal()
             }
-            if dcContext.id != dcAccounts.getSelected().id {
+            if accountId != dcAccounts.getSelected().id {
                 return
             }
             dcContext.logger?.info("network: DC_EVENT_CONNECTIVITY_CHANGED: \(dcContext.getConnectivity())")
@@ -230,7 +231,7 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_WEBXDC_STATUS_UPDATE:
-            if dcContext.id != dcAccounts.getSelected().id {
+            if accountId != dcAccounts.getSelected().id {
                 return
             }
             dcContext.logger?.info("webxdc: update!")

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -220,7 +220,7 @@ public class DcEventHandler {
             if accountId != dcAccounts.getSelected().id {
                 return
             }
-            dcContext.logger?.info("network: DC_EVENT_CONNECTIVITY_CHANGED: \(self.dcAccounts.get(id: accountId).getConnectivity())")
+            dcContext.logger?.info("network: DC_EVENT_CONNECTIVITY_CHANGED")
             DispatchQueue.main.async {
                 let nc = NotificationCenter.default
                 nc.post(

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -77,7 +77,7 @@ public class DcEventHandler {
                         "progress": Int(data1),
                         "error": Int(data1) == 0,
                         "done": Int(data1) == 1000,
-                        "errorMessage": dcContext.lastErrorString as Any,
+                        "errorMessage": self.dcAccounts.get(id: accountId).lastErrorString,
                     ]
                 )
             }
@@ -220,7 +220,7 @@ public class DcEventHandler {
             if accountId != dcAccounts.getSelected().id {
                 return
             }
-            dcContext.logger?.info("network: DC_EVENT_CONNECTIVITY_CHANGED: \(dcContext.getConnectivity())")
+            dcContext.logger?.info("network: DC_EVENT_CONNECTIVITY_CHANGED: \(self.dcAccounts.get(id: accountId).getConnectivity())")
             DispatchQueue.main.async {
                 let nc = NotificationCenter.default
                 nc.post(

--- a/docs/uiview-layout.md
+++ b/docs/uiview-layout.md
@@ -115,6 +115,13 @@ a tricky part (see eg. [3]) seems to be to hold the correct type of references t
   child-class and a makeCoordinator() called by SwiftUI:
   https://developer.apple.com/tutorials/swiftui/interfacing-with-uikit
 
+- rules of thumb to minimze impact of **logging:**
+  - only log vars that are anyway there, do not calculate or get vars only for logging
+  - do only log relevant information
+  - logging is there to help on issues.
+	to not decelerate things, there is no strict format or depth buerocracy.
+	logging may be adapted, also temporary, different areas may have different depths etc.
+
 
 ## notification system
 


### PR DESCRIPTION
- use `accountid` from `event.accountId` for "is this the selected account?" checks
- load context when needed.


The context loading at the beginning now is only still there because of the logger situation (#1973) and #1976