### PR TITLE
try to enable service worker on iOS

### DIFF
--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -221,6 +221,12 @@ class WebxdcViewController: WebViewViewController {
         
         config.mediaTypesRequiringUserActionForPlayback = []
         config.allowsInlineMediaPlayback = true
+    
+        if #available(iOS 14.0, *) {
+            config.limitsNavigationsToAppBoundDomains = true
+        } else {
+            // Fallback on earlier versions
+        }
 
         if #available(iOS 13.0, *) {
             preferences.isFraudulentWebsiteWarningEnabled = true
@@ -251,6 +257,11 @@ class WebxdcViewController: WebViewViewController {
         super.viewDidLoad()
         navigationItem.rightBarButtonItem = moreButton
         refreshWebxdcInfo()
+        if #available(iOS 16.4, *) {
+            self.webView.isInspectable = true
+        } else {
+            // Fallback on earlier versions
+        }
     }
 
     override func willMove(toParent parent: UIViewController?) {

--- a/deltachat-ios/Info.plist
+++ b/deltachat-ios/Info.plist
@@ -108,5 +108,9 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>WKAppBoundDomains</key>
+	<array>
+		<string>localhost</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
I get the function to show up, but to make it work we either need a way to intercept/replace https: scheme or a way to mark our webxdc scheme as allowed origin for service workers like we do in electron (but I can not find any working api for that)

The error I get now is:
```
Unhandled Promise Rejection: TypeError: serviceWorker.register() must be called with a script URL whose protocol is either HTTP or HTTPS
```

My guess is that gecko view for iOS comes sooner than a the api for the iOS webkit web view.