### PR TITLE
try out migrating to os_log for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,22 @@ If you want to import/export a backup this is the location you want to put it (i
 ```
 ~/Library/Containers/98CC2CD0-7DED-4E02-9C0A-B4FF287AA877/Data/Documents
 ```
+
+
+## Accssing the Logs
+
+Use the macOS Console app. (maybe some tool from libimobile device can also read the log)
+Select your device (you need to plugin in your phone), then paste this in the seach field to only show messages from deltachat:
+```
+prozesspfad:deltachat-ios
+```
+
+
+These symbols are used and you can use them for filtering.
+```
+📡 - events
+📡accountId - also events but replace accountId with the id you are interessted in
+🚨📡 - error events
+⚠️📡 - warn events
+ℹ️📡 - info events
+```

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -6,6 +6,7 @@ import DcCore
 import SDWebImageWebPCoder
 import Intents
 import SDWebImageSVGKitPlugin
+import OSLog
 
 let logger = SimpleLogger()
 
@@ -603,11 +604,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             guard let self = self else { return }
             let eventHandler = DcEventHandler(dcAccounts: self.dcAccounts)
             let eventEmitter = self.dcAccounts.getEventEmitter()
+            os_log("📡⬆️ EventHandler started ⬆️📡", log: .default, type: .info)
             while true {
                 guard let event = eventEmitter.getNextEvent() else { break }
                 eventHandler.handleEvent(event: event)
             }
-            logger.info("⬅️ event emitter finished")
+            os_log("📡⬇️ EventHandler shutdown ⬇️📡", log: .default, type: .info)
         }
     }
 


### PR DESCRIPTION
with this old syntax I'm not so sure about it, if you mess up the formatting string you get a runtime crash.
maybe we should rather use a library until we can upgrade the target to iOS 14. (see #1973)
