### PR TITLE
'encrypted accounts' are 'highly' experimental

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -218,11 +218,13 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
     }
 
     @objc private func moreButtonPressed() {
-        let alert = UIAlertController(title: "Encrypted Account (experimental)",
-                                      message: "Do you want to encrypt your account database? This cannot be undone.",
+        let alert = UIAlertController(title: "Encrypt Database (highly experimental, use at your own risk)",
+                                      message: "Encrypting your database will slow down your accout and notifications. "
+                                          + "This cannot be undone and is usually not needed on iOS "
+                                          + "as the system already protects and sandboxes the database.",
                                       preferredStyle: .safeActionSheet)
-        let encryptedAccountAction = UIAlertAction(title: "Create encrypted account", style: .default, handler: switchToEncrypted(_:))
-        let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .destructive, handler: nil)
+        let encryptedAccountAction = UIAlertAction(title: "Use Non-Recommended Database Encryption", style: .default, handler: switchToEncrypted(_:))
+        let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil)
         alert.addAction(encryptedAccountAction)
         alert.addAction(cancelAction)
         self.present(alert, animated: true, completion: nil)
@@ -241,7 +243,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
                 logger.error("Failed to open account database for account \(dcContext.id)")
                 return
             }
-            self.navigationItem.title = String.localized("add_encrypted_account")
+            self.navigationItem.title = "Encrypt database"
         } catch KeychainError.unhandledError(let message, let status) {
             logger.error("Keychain error. Failed to create encrypted account. \(message). Error status: \(status)")
         } catch {

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -219,7 +219,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
 
     @objc private func moreButtonPressed() {
         let alert = UIAlertController(title: "Encrypt Database (highly experimental, use at your own risk)",
-                                      message: "Encrypting your database will slow down your accout and notifications. "
+                                      message: "Encrypting your database will slow down the app and notifications. "
                                           + "This cannot be undone and is usually not needed on iOS "
                                           + "as the system already protects and sandboxes the database.",
                                       preferredStyle: .safeActionSheet)

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -1024,7 +1024,6 @@
 "update_1_42_android" = "Watch out for more improvements in camera, voice messages, backup-all, screen reader, per-account wallpapers, gallery select-all, webxdc landscape … or read them at %1$@";
 "connectivity_low_data_mode" = "Disabled by system's \"Low Data Mode\".";
 "connectivity_low_power_mode" = "Disabled by system's \"Low Power Mode\".";
-"add_encrypted_account" = "Add encrypted account";
 "backup_successful" = "Backup successful";
 "backup_successful_explain_ios" = "You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.";
 "location_denied" = "Location access denied";


### PR DESCRIPTION
this pr picks up the wording from android,
underlining the 'experimental' and 'use at your own risk' aspects.

moreover,
possible slowness and notification issues are mentioned.

closes #1989 


<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/375ca0fa-b8f0-42c9-b36f-9f10de999a59>
