### PR TITLE
align options ephemeral options to android/desktop for consistency

### DIFF
--- a/deltachat-ios/Controller/EphemeralMessagesViewController.swift
+++ b/deltachat-ios/Controller/EphemeralMessagesViewController.swift
@@ -32,7 +32,20 @@ class EphemeralMessagesViewController: UITableViewController {
         self.dcContext = dcContext
         self.chatId = chatId
         super.init(style: .grouped)
-        self.currentIndex = self.options.index(of: dcContext.getChatEphemeralTimer(chatId: chatId)) ?? 0
+
+        // select option close to the timespan (that may no be available as an option eg. in case option have changed)
+        self.currentIndex = 0
+        let timespan = dcContext.getChatEphemeralTimer(chatId: chatId)
+        if timespan > 0 {
+            self.currentIndex = options.count - 1
+            for i in 2...options.count - 1 {
+                if timespan < options[i] {
+                    self.currentIndex = i - 1
+                    break
+                }
+            }
+        }
+
         self.title = String.localized("ephemeral_messages")
         hidesBottomBarWhenPushed = true
 

--- a/deltachat-ios/Controller/EphemeralMessagesViewController.swift
+++ b/deltachat-ios/Controller/EphemeralMessagesViewController.swift
@@ -7,7 +7,7 @@ class EphemeralMessagesViewController: UITableViewController {
     var currentIndex: Int = 0
 
     private lazy var options: [Int] = {
-        return [0, Time.thirtySeconds, Time.oneMinute, Time.oneHour, Time.oneDay, Time.oneWeek, Time.fourWeeks]
+        return [0, Time.oneMinute, Time.fiveMinutes, Time.thirtyMinutes, Time.oneHour, Time.oneDay, Time.oneWeek, Time.fiveWeeks]
     }()
 
     private lazy var cancelButton: UIBarButtonItem = {
@@ -52,18 +52,20 @@ class EphemeralMessagesViewController: UITableViewController {
         switch val {
         case 0:
             return String.localized("off")
-        case Time.thirtySeconds:
-            return String.localized("after_30_seconds")
         case Time.oneMinute:
             return String.localized("after_1_minute")
+        case Time.fiveMinutes:
+            return String.localized("after_5_minutes")
+        case Time.thirtyMinutes:
+            return String.localized("after_30_minutes")
         case Time.oneHour:
             return String.localized("autodel_after_1_hour")
         case Time.oneDay:
             return String.localized("autodel_after_1_day")
         case Time.oneWeek:
             return String.localized("autodel_after_1_week")
-        case Time.fourWeeks:
-            return String.localized("autodel_after_4_weeks")
+        case Time.fiveWeeks:
+            return String.localized("after_5_weeks")
         default:
             return "Err"
         }

--- a/deltachat-ios/Helper/Constants.swift
+++ b/deltachat-ios/Helper/Constants.swift
@@ -20,15 +20,13 @@ struct Constants {
 }
 
 struct Time {
-    static let thirtySeconds = 30
     static let oneMinute = 60
-    static let twoMinutes = 2 * 60
     static let fiveMinutes = 5 * 60
-    static let thirtyMinutes = 30 * 6
+    static let thirtyMinutes = 30 * 60
     static let oneHour = 60 * 60
     static let twoHours = 2 * 60 * 60
     static let sixHours = 6 * 60 * 60
     static let oneDay = 24 * 60 * 60
     static let oneWeek = 7 * 24 * 60 * 60
-    static let fourWeeks = 4 * 7 * 24 * 60 * 60
+    static let fiveWeeks = 5 * 7 * 24 * 60 * 60
 }


### PR DESCRIPTION
- add "5 minutes", "30 minutes", remove "30 seconds", see https://github.com/deltachat/deltachat-android/pull/1780 for reasoning
- change "4 weeks" to "5 weeks", see https://github.com/deltachat/deltachat-android/pull/1786 for reasoning
- for timespans, that are not available as options, chose the smaller one just before (before, we've always shown "off" which was much worse)

closes #2000