### PR TITLE
immedite feedback when tapping chat title

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1384,7 +1384,11 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         if tableView.isEditing {
             return
         }
-        showChatDetail(chatId: chatId)
+        titleView.setEnabled(false) // immedidate feedback
+        DispatchQueue.main.async { // opening controller in next loop allows the system to render the immedidate feedback
+            self.showChatDetail(chatId: self.chatId)
+            self.titleView.setEnabled(true)
+        }
     }
 
     @objc private func clipperButtonPressed() {

--- a/deltachat-ios/Controller/ChatListController.swift
+++ b/deltachat-ios/Controller/ChatListController.swift
@@ -282,9 +282,11 @@ class ChatListController: UITableViewController {
 
     @objc
     public func onNavigationTitleTapped() {
-        logger.debug("on navigation title tapped")
-        let connectivityViewController = ConnectivityViewController(dcContext: dcContext)
-        navigationController?.pushViewController(connectivityViewController, animated: true)
+        titleView.isEnabled = false // immedidate feedback
+        DispatchQueue.main.async { // opening controller in next loop allows the system to render the immedidate feedback
+            self.navigationController?.pushViewController(ConnectivityViewController(dcContext: self.dcContext), animated: true)
+            self.titleView.isEnabled = true
+        }
     }
 
     // MARK: - configuration

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -61,4 +61,9 @@ class ChatTitleView: UIStackView {
         subtitleLabel.text = subtitle
         subtitleLabel.textColor = DcColors.defaultTextColor.withAlphaComponent(0.95)
     }
+
+    func setEnabled(_ enabled: Bool) {
+        titleLabel.isEnabled = enabled
+        subtitleLabel.isEnabled = enabled
+    }
 }


### PR DESCRIPTION
iOS usually shows immediate feedback when tapping a button, eg. disable the button for a moment (you can see that on many "back" or "ok" buttons)

for the "title bar taps", this was just missing (still good to speed up loading, however, even then it is good to give immeduate feedback before animation starts)