### PR TITLE
move 'Password and Account' one level up

### DIFF
--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -11,13 +11,7 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     private let section1Status = 2
     private let section1RowCount = 3
 
-    private let section2 = 1
-    private let section2AccountSettings = 0
-    private let section2RowCount = 1
-
-    private let sectionCount = 2
-
-    private let tagAccountSettingsCell = 1
+    private let sectionCount = 1
 
     private lazy var mediaPicker: MediaPicker? = {
         let mediaPicker = MediaPicker(dcContext: dcContext, navigationController: navigationController)
@@ -29,14 +23,6 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
         let cell = MultilineTextFieldCell(description: String.localized("pref_default_status_label"),
                                           multilineText: dcContext.selfstatus,
                                           placeholder: String.localized("pref_default_status_label"))
-        return cell
-    }()
-
-    private lazy var accountSettingsCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("pref_password_and_account_settings")
-        cell.accessoryType = .disclosureIndicator
-        cell.tag = tagAccountSettingsCell
         return cell
     }()
 
@@ -85,9 +71,8 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if section == section1 {
             return section1RowCount
-        } else {
-            return section2RowCount
         }
+        return 0
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -100,29 +85,17 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
             case section1Status:
                 return statusCell
             default:
-               return UITableViewCell()
+                break
             }
-        } else {
-            return accountSettingsCell
         }
+        return UITableViewCell()
     }
 
     override func tableView(_: UITableView, titleForFooterInSection section: Int) -> String? {
         if section == section1 {
             return String.localized("pref_who_can_see_profile_explain")
-        } else {
-            return nil
         }
-    }
-
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let cell = tableView.cellForRow(at: indexPath) else { return }
-        if cell.tag == tagAccountSettingsCell {
-            tableView.deselectRow(at: indexPath, animated: false)
-            guard let nc = navigationController else { return }
-            let accountSetupVC = AccountSetupController(dcAccounts: dcAccounts, editView: true)
-            nc.pushViewController(accountSetupVC, animated: true)
-        }
+        return nil
     }
 
     // MARK: - actions

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -146,7 +146,7 @@ internal final class SettingsViewController: UITableViewController {
         let preferencesSection = SectionConfigs(
             headerTitle: nil,
             footerTitle: nil,
-            cells: [chatsAndMediaCell, notificationCell, selectBackgroundCell, addAnotherDeviceCell, connectivityCell, passwordAndAccountCell, advancedCell]
+            cells: [chatsAndMediaCell, notificationCell, selectBackgroundCell, addAnotherDeviceCell, passwordAndAccountCell, connectivityCell, advancedCell]
         )
         let helpSection = SectionConfigs(
             headerTitle: nil,

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -16,6 +16,7 @@ internal final class SettingsViewController: UITableViewController {
         case addAnotherDevice
         case notifications
         case selectBackground
+        case passwordAndAccount
         case advanced
         case help
         case connectivity
@@ -72,6 +73,17 @@ internal final class SettingsViewController: UITableViewController {
         cell.textLabel?.text = String.localized("multidevice_title")
         if #available(iOS 16.0, *) {
             cell.imageView?.image = UIImage(systemName: "macbook.and.iphone") // added in ios16
+        }
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }()
+
+    private lazy var passwordAndAccountCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        cell.tag = CellTags.passwordAndAccount.rawValue
+        cell.textLabel?.text = String.localized("pref_password_and_account_settings")
+        if #available(iOS 16.0, *) {
+            cell.imageView?.image = UIImage(systemName: "server.rack") // added in ios14
         }
         cell.accessoryType = .disclosureIndicator
         return cell
@@ -134,7 +146,7 @@ internal final class SettingsViewController: UITableViewController {
         let preferencesSection = SectionConfigs(
             headerTitle: nil,
             footerTitle: nil,
-            cells: [chatsAndMediaCell, notificationCell, selectBackgroundCell, addAnotherDeviceCell, connectivityCell, advancedCell]
+            cells: [chatsAndMediaCell, notificationCell, selectBackgroundCell, addAnotherDeviceCell, connectivityCell, passwordAndAccountCell, advancedCell]
         )
         let helpSection = SectionConfigs(
             headerTitle: nil,
@@ -223,6 +235,7 @@ internal final class SettingsViewController: UITableViewController {
         case .advanced: showAdvanced()
         case .help: showHelp()
         case .connectivity: showConnectivity()
+        case .passwordAndAccount: showPasswordAndAccount()
         case .selectBackground: selectBackground()
         }
     }
@@ -290,6 +303,10 @@ internal final class SettingsViewController: UITableViewController {
 
     private func showConnectivity() {
         navigationController?.pushViewController(ConnectivityViewController(dcContext: dcContext), animated: true)
+    }
+
+    private func showPasswordAndAccount() {
+        navigationController?.pushViewController(AccountSetupController(dcAccounts: dcAccounts, editView: true), animated: true)
     }
 
     private func selectBackground() {

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -146,12 +146,12 @@ internal final class SettingsViewController: UITableViewController {
         let preferencesSection = SectionConfigs(
             headerTitle: nil,
             footerTitle: nil,
-            cells: [chatsAndMediaCell, notificationCell, selectBackgroundCell, addAnotherDeviceCell, passwordAndAccountCell, connectivityCell, advancedCell]
+            cells: [chatsAndMediaCell, notificationCell, selectBackgroundCell, addAnotherDeviceCell, passwordAndAccountCell, advancedCell]
         )
         let helpSection = SectionConfigs(
             headerTitle: nil,
             footerTitle: appNameAndVersion,
-            cells: [helpCell]
+            cells: [connectivityCell, helpCell]
         )
 
         return [profileSection, preferencesSection, helpSection]


### PR DESCRIPTION
(an idea that came out of recent desktop discussions)

this aligns to desktop, to help
and also to to many other messengers
that have 'Account' settings somewhere in the settings - and not in the 'Profile'.

still, it is tuned down by using a position further down and by using an "standard, unobtrusive" icon

<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/a36087db-0bbc-462c-9a37-ac9a20c12c93>


EDIT: moved account related items (add second device, password and account) together

EDIT: grouped "info" things together
