### PR TITLE
set a default label for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Report something that isn't working.
 title: ''
 assignees: ''
-
+labels: bug
 ---
 
 <!--
@@ -12,8 +12,8 @@ This is a bug report tracker. New features are discussed in the forum: https://s
 Please fill out as much of this form as you can (leaving out stuff that is not applicable is ok).
 -->
 
-- Device:
 - iOS version:
+- Device:
 - Delta Chat version:
 - Expected behavior:
 - Actual behavior:
@@ -23,7 +23,7 @@ Please fill out as much of this form as you can (leaving out stuff that is not a
 
 <!--
 Debug logs can be accessed from within the Delta Chat app 
-at "Settings / Advanced / View log / Console" and "Custom variables";
+at "Settings / Advanced / View log";
 alternatively, use Xcode.
 
 Logs may contain private data 


### PR DESCRIPTION
the default label "bug" also makes it more obvious for users that it's only bug reporting.

moreover, adapt ordering to android, update log position.

counterpart to https://github.com/deltachat/deltachat-android/pull/2727