### PR TITLE
share webxdc's

### DIFF
--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -284,7 +284,10 @@ extension FilesViewController {
 
     func shareAttachment(of indexPath: IndexPath) {
         let msgId = fileMessageIds[indexPath.row]
-        let message = dcContext.getMessage(id: msgId)
+        FilesViewController.share(message: dcContext.getMessage(id: msgId), parentViewController: self, sourceView: self.view)
+    }
+
+    public static func share(message: DcMsg, parentViewController: UIViewController, sourceView: UIView) {
         let activityVC: UIActivityViewController
         guard let fileURL = message.fileURL else { return }
         let objectsToShare: [Any]
@@ -301,8 +304,8 @@ extension FilesViewController {
 
         activityVC = UIActivityViewController(activityItems: objectsToShare, applicationActivities: nil)
         activityVC.excludedActivityTypes = [.copyToPasteboard]
-        activityVC.popoverPresentationController?.sourceView = self.view
-        self.present(activityVC, animated: true, completion: nil)
+        activityVC.popoverPresentationController?.sourceView = sourceView
+        parentViewController.present(activityVC, animated: true, completion: nil)
     }
 }
 

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -403,6 +403,10 @@ class WebxdcViewController: WebViewViewController {
             let sourceCodeAction = UIAlertAction(title: String.localized("source_code"), style: .default, handler: openUrl(_:))
             alert.addAction(sourceCodeAction)
         }
+
+        let shareAction = UIAlertAction(title: String.localized("menu_share"), style: .default, handler: shareWebxdc(_:))
+        alert.addAction(shareAction)
+
         let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil)
         alert.addAction(cancelAction)
         self.present(alert, animated: true, completion: nil)
@@ -417,6 +421,9 @@ class WebxdcViewController: WebViewViewController {
            let url = URL(string: sourceCodeUrl) {
             UIApplication.shared.open(url)
         }
+    }
+
+    private func shareWebxdc(_ action: UIAlertAction) {
     }
 }
 

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -424,6 +424,7 @@ class WebxdcViewController: WebViewViewController {
     }
 
     private func shareWebxdc(_ action: UIAlertAction) {
+        FilesViewController.share(message: dcContext.getMessage(id: messageId), parentViewController: self, sourceView: self.view)
     }
 }
 


### PR DESCRIPTION
this PR adds the option "Share" to the webxdc's menu; the options are the same as long-tapping a webxdc in the galleries.

closes #1983

<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/bebc1428-8130-4608-b714-d12e38f85763>

