### PR TITLE
use core background fetch

### DIFF
--- a/DcCore/DcCore/DC/Wrapper.swift
+++ b/DcCore/DcCore/DC/Wrapper.swift
@@ -10,7 +10,6 @@ public class DcAccounts {
     /// The ID is created in the apple developer portal and can be changed there.
     let applicationGroupIdentifier = "group.chat.delta.ios"
     var accountsPointer: OpaquePointer?
-    public var fetchSemaphore: DispatchSemaphore?
 
     public init() {
     }
@@ -65,6 +64,10 @@ public class DcAccounts {
 
     public func stopIo() {
         dc_accounts_stop_io(accountsPointer)
+    }
+    
+    public func backgroundFetch(timeout: UInt64) -> Bool {
+        return dc_accounts_background_fetch(accountsPointer, timeout) == 1
     }
 
     public func select(id: Int) -> Bool {

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -213,9 +213,6 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_CONNECTIVITY_CHANGED:
-            if let sem = dcAccounts.fetchSemaphore, dcAccounts.isAllWorkDone() {
-                sem.signal()
-            }
             if accountId != dcAccounts.getSelected().id {
                 return
             }

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -507,11 +507,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
             // we're in background, run IO for a little time
             self.addDebugFetchTimestamp()
+            let start = CFAbsoluteTimeGetCurrent()
             // this pauses io/scheduler so we don't need start/stop io here
             if !self.dcAccounts.backgroundFetch(timeout: 20) {
                 logger.info("⬅️ error or timeout on backgroundFetch")
                 self.pushToDebugArray(String("error or timeout on backgroundFetch"))
             }
+            let diff = CFAbsoluteTimeGetCurrent() - start
+            logger.info("⏰ background fetch took: \(diff) s")
 
             logger.info("⬅️ finishing fetch")
             self.pushToDebugArray(String(format: "3/%.3fs", Double(Date().timeIntervalSince1970)-nowTimestamp))


### PR DESCRIPTION
use https://github.com/deltachat/deltachat-core-rust/pull/5104 instead of the semaphore that waited for the event.
I was conservative with removing code, maybe we can remove even more code now, because we now only have one blocking core call that has 
timeout built-in.
