### PR TITLE
fix some images not shown in gallery

### DIFF
--- a/deltachat-ios/Helper/ImageFormat.swift
+++ b/deltachat-ios/Helper/ImageFormat.swift
@@ -48,17 +48,12 @@ extension ImageFormat {
         return .unknown
     }
 
-
-    // Theoretically, SDAnimatedImage should be able to read data of all kinds of images.
-    // In practive, JPG files haven't been read correctly, for now we're using SDAnimatedImage
-    // only for file formats that support animated content.
     static func loadImageFrom(data: Data) -> UIImage? {
-        switch ImageFormat.get(from: data) {
-        case .gif, .png, .webp, .heic:
-            return SDAnimatedImage(data: data)
-        default:
-            return UIImage(data: data)
+        if let image = SDAnimatedImage(data: data) {
+            return image
         }
+        // use UIImage if SDAnimatedImage failes (known for some JPG, see #1911, SDAnimatedImageView does probably sth. similar)
+        return UIImage(data: data)
     }
 
     static func loadImageFrom(url: URL) -> UIImage? {

--- a/deltachat-ios/Model/GalleryItem.swift
+++ b/deltachat-ios/Model/GalleryItem.swift
@@ -75,38 +75,47 @@ class GalleryItem: ContextMenuItem {
     }
 
     private func loadImageThumbnail(from url: URL) {
-        DispatchQueue.global(qos: .userInteractive).async {
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
             if let image = ImageFormat.loadImageFrom(url: url) {
                 DispatchQueue.main.async { [weak self] in
                     self?.thumbnailImage = image
                 }
             } else {
                 logger.error("cannot load image thumbnail for \(url)")
+                self?.setLoadingFailedPlaceholder()
             }
         }
     }
 
     private func loadVideoThumbnail(from url: URL) {
-        DispatchQueue.global(qos: .userInteractive).async {
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
             if let image = DcUtils.generateThumbnailFromVideo(url: url) {
                 DispatchQueue.main.async { [weak self] in
                     self?.thumbnailImage = image
                 }
             } else {
                 logger.error("cannot load video thumbnail for \(url)")
+                self?.setLoadingFailedPlaceholder()
             }
         }
     }
 
     private func loadWebxdcThumbnail(from message: DcMsg) {
-        DispatchQueue.global(qos: .userInteractive).async {
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
             if let image = message.getWebxdcPreviewImage() {
                 DispatchQueue.main.async { [weak self] in
                     self?.thumbnailImage = image
                 }
             } else {
                 logger.error("cannot load webxdc thumbnail for \(message.file ?? "ErrName")")
+                self?.setLoadingFailedPlaceholder()
             }
+        }
+    }
+
+    private func setLoadingFailedPlaceholder() {
+        DispatchQueue.main.async { [weak self] in
+            self?.thumbnailImage = UIImage(named: "ic_error_36pt")?.sd_tintedImage(with: .gray)
         }
     }
 }

--- a/deltachat-ios/Model/GalleryItem.swift
+++ b/deltachat-ios/Model/GalleryItem.swift
@@ -78,29 +78,34 @@ class GalleryItem: ContextMenuItem {
         DispatchQueue.global(qos: .userInteractive).async {
             if let image = ImageFormat.loadImageFrom(url: url) {
                 DispatchQueue.main.async { [weak self] in
-                        self?.thumbnailImage = image
+                    self?.thumbnailImage = image
                 }
+            } else {
+                logger.error("cannot load image thumbnail for \(url)")
             }
         }
     }
 
     private func loadVideoThumbnail(from url: URL) {
         DispatchQueue.global(qos: .userInteractive).async {
-            if let thumbnailImage = DcUtils.generateThumbnailFromVideo(url: url) {
+            if let image = DcUtils.generateThumbnailFromVideo(url: url) {
                 DispatchQueue.main.async { [weak self] in
-                    self?.thumbnailImage = thumbnailImage
+                    self?.thumbnailImage = image
                 }
+            } else {
+                logger.error("cannot load video thumbnail for \(url)")
             }
         }
     }
 
     private func loadWebxdcThumbnail(from message: DcMsg) {
         DispatchQueue.global(qos: .userInteractive).async {
-            let image = message.getWebxdcPreviewImage()
-            if let image = image {
+            if let image = message.getWebxdcPreviewImage() {
                 DispatchQueue.main.async { [weak self] in
                     self?.thumbnailImage = image
                 }
+            } else {
+                logger.error("cannot load webxdc thumbnail for \(message.file ?? "ErrName")")
             }
         }
     }


### PR DESCRIPTION
with this PR, images can be loaded in gallery that failed before.

not sure about the _why_, however, SDAnimagedImage seems to fail sometimes where UIImage succeeded - maybe also the other way round, images are complicated in hard.

the failing images where always rendered in the bubbles btw - but there we did not use SDAnimagedImage directly - but SDAnimagedImageView - might be that that wrapper also calls UIImage if in doubt.

anyways, the nice bears (test images that were failing before) are rendered correctly now :)

![Screenshot 2023-12-14 at 23 55 34](https://github.com/deltachat/deltachat-ios/assets/9800740/23c90731-ec62-4f82-84c2-cecf7efe8e0b)

closes #1911