### PR TITLE
improve sharing large images

### DIFF
--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -111,7 +111,6 @@ class ShareAttachment {
                 result = ImageFormat.loadImageFrom(url: url)
             default:
                 logger.error("Unexpected data: \(type(of: data))")
-                result = nil
             }
             if let result = result,
                let path = ImageFormat.saveImage(image: result, directory: .cachesDirectory) {

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -80,7 +80,7 @@ class ShareAttachment {
             case let url as URL:
                 result = SDAnimatedImage(contentsOfFile: url.path)
             default:
-                logger.debug("Unexpected data: \(type(of: data))")
+                logger.error("Unexpected data: \(type(of: data))")
             }
             if let result = result {
                 let path = ImageFormat.saveImage(image: result, directory: .cachesDirectory)
@@ -110,7 +110,7 @@ class ShareAttachment {
             case let url as URL:
                 result = ImageFormat.loadImageFrom(url: url)
             default:
-                logger.debug("Unexpected data: \(type(of: data))")
+                logger.error("Unexpected data: \(type(of: data))")
                 result = nil
             }
             if let result = result,
@@ -146,7 +146,7 @@ class ShareAttachment {
 
                 }
             default:
-                logger.debug("Unexpected data: \(type(of: data))")
+                logger.error("Unexpected data: \(type(of: data))")
             }
             if let error = error {
                 logger.error("Could not load share item as video: \(error.localizedDescription)")
@@ -182,7 +182,7 @@ class ShareAttachment {
                     self.generateThumbnailRepresentations(url: url)
                 }
             default:
-                logger.debug("Unexpected data: \(type(of: data))")
+                logger.error("Unexpected data: \(type(of: data))")
             }
             if let error = error {
                 logger.error("Could not load share item: \(error.localizedDescription)")
@@ -231,7 +231,7 @@ class ShareAttachment {
                 case let url as URL:
                     delegate.onUrlShared(url: url)
                 default:
-                    logger.debug("Unexpected data: \(type(of: data))")
+                    logger.error("Unexpected data: \(type(of: data))")
                 }
                 if let error = error {
                     logger.error("Could not share URL: \(error.localizedDescription)")

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -108,7 +108,10 @@ class ShareAttachment {
             case let data as Data:
                 result = ImageFormat.loadImageFrom(data: data)
             case let url as URL:
-                result = ImageFormat.loadImageFrom(url: url)
+                if let nsurl = NSURL(string: url.absoluteString) {
+                    // scaleDownImage() uses less memory than core and avoids exhausing the 120 mb memory restriction of extensions (see #1330)
+                    result = ImageFormat.scaleDownImage(nsurl, toMax: 1280)
+                }
             default:
                 logger.error("Unexpected data: \(type(of: data))")
             }


### PR DESCRIPTION
the reason that sharing (mostly) panoramas does not work is that they are pretty large  - sth. as 16382 x 3690 pixels, needing 180+ mb pixel data in  core before recoding - where [extensions are limited to 120 mb by iOS.](https://duckduckgo.com/?q=RESOURCE_TYPE_MEMORY+high+watermark+memory+limit+exceeded)

this PR uses UI to scale images to "1280 pixels max width or height", so that  scaling in core should not be needed most times. scaling in UI consumes less memory - or that memory is not counted to the 120 mb.

closes #1330
closes https://github.com/deltachat/deltachat-core-rust/issues/2681

<img width=300 src=https://github.com/deltachat/deltachat-ios/assets/9800740/7baced39-c62a-4e2f-8863-d3cc25a6f39e>

