### PR TITLE
fix sharing videos

### DIFF
--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -247,6 +247,14 @@ extension ShareViewController: ShareAttachmentDelegate {
 
     func onAttachmentChanged() {
         DispatchQueue.main.async {
+            if let shareAttachment = self.shareAttachment,
+               let error = shareAttachment.error {
+                shareAttachment.error = nil
+                logger.error(error)
+                let alert = UIAlertController(title: nil, message: error, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: nil))
+                self.present(alert, animated: true, completion: nil)
+            }
             self.validateContent()
         }
     }

--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -251,10 +251,11 @@ extension ShareViewController: ShareAttachmentDelegate {
         DispatchQueue.main.async {
             if let shareAttachment = self.shareAttachment,
                let error = shareAttachment.error {
-                shareAttachment.error = nil
                 logger.error(error)
                 let alert = UIAlertController(title: nil, message: error, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: nil))
+                alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: { _ in
+                    self.quit()
+                }))
                 self.present(alert, animated: true, completion: nil)
             }
             self.validateContent()

--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -19,7 +19,6 @@ class ShareViewController: SLComposeServiceViewController {
     var selectedChat: DcChat?
     var shareAttachment: ShareAttachment?
     var isAccountConfigured: Bool = true
-    var isLoading: Bool = false
 
     var previewImageHeightConstraint: NSLayoutConstraint?
     var previewImageWidthConstraint: NSLayoutConstraint?
@@ -126,6 +125,9 @@ class ShareViewController: SLComposeServiceViewController {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
             self.shareAttachment = ShareAttachment(dcContext: self.dcContext, inputItems: self.extensionContext?.inputItems, delegate: self)
+            DispatchQueue.main.async {
+                self.validateContent()
+            }
         }
     }
 
@@ -135,7 +137,7 @@ class ShareViewController: SLComposeServiceViewController {
 
     override func isContentValid() -> Bool {
         // Do validation of contentText and/or NSExtensionContext attachments here
-        return  isAccountConfigured && !isLoading && (!(contentText?.isEmpty ?? true) || !(self.shareAttachment?.isEmpty ?? true))
+        return  isAccountConfigured && (!(contentText?.isEmpty ?? true) || !(self.shareAttachment?.isEmpty ?? true))
     }
 
     private func setupNavigationBar() {
@@ -266,14 +268,5 @@ extension ShareViewController: ShareAttachmentDelegate {
                 preview.image = self.shareAttachment?.thumbnail ?? nil
             }
         }
-    }
-
-    func onLoadingStarted() {
-        isLoading = true
-    }
-
-    func onLoadingFinished() {
-        isLoading = false
-        self.validateContent()
     }
 }

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -84,9 +84,7 @@ class ShareAttachment {
             }
             if let result = result {
                 let path = ImageFormat.saveImage(image: result, directory: .cachesDirectory)
-                let msg = self.dcContext.newMessage(viewType: DC_MSG_GIF)
-                msg.setFile(filepath: path)
-                self.messages.append(msg)
+                _ = self.addDcMsg(path: path, viewType: DC_MSG_GIF)
                 self.delegate?.onAttachmentChanged()
                 if self.imageThumbnail == nil {
                     self.imageThumbnail = result
@@ -117,9 +115,7 @@ class ShareAttachment {
             }
             if let result = result,
                let path = ImageFormat.saveImage(image: result, directory: .cachesDirectory) {
-                let msg = self.dcContext.newMessage(viewType: DC_MSG_IMAGE)
-                msg.setFile(filepath: path)
-                self.messages.append(msg)
+                _ = self.addDcMsg(path: path, viewType: DC_MSG_IMAGE)
                 self.delegate?.onAttachmentChanged()
                 if self.imageThumbnail == nil {
                     self.imageThumbnail = ImageFormat.scaleDownImage(NSURL(fileURLWithPath: path), toMax: self.thumbnailSize)

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -5,9 +5,11 @@ import UIKit
 import QuickLookThumbnailing
 import SDWebImage
 
-// the share extension allows a max. of 120 mb ram (the app allows 2gb);
-// assume we need 2/3rd for processing in UI and core
-let maxAttachmentBytes = 40 * 1024 * 1024
+// iOS allows max. 120mb ram for extenstions (2000mb for apps).
+// by copying memory around, this is easily exceeded.
+// the following 12mb were tested to work on an iphone7 -
+// where 15mb already result in "high watermark memory limit exceeded" crash.
+let maxAttachmentBytes = 12 * 1024 * 1024
 
 protocol ShareAttachmentDelegate: class {
     func onAttachmentChanged()

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -13,8 +13,6 @@ protocol ShareAttachmentDelegate: class {
     func onAttachmentChanged()
     func onThumbnailChanged()
     func onUrlShared(url: URL)
-    func onLoadingStarted()
-    func onLoadingFinished()
 }
 
 class ShareAttachment {
@@ -48,13 +46,11 @@ class ShareAttachment {
 
     private func createMessages() {
         guard let items = inputItems as? [NSExtensionItem] else { return }
-        delegate?.onLoadingStarted()
         for item in items {
             if let attachments = item.attachments {
                 createMessageFromDataRepresentation(attachments)
             }
         }
-        delegate?.onLoadingFinished()
     }
 
     private func createMessageFromDataRepresentation(_ attachments: [NSItemProvider]) {

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -136,7 +136,7 @@ class ShareAttachment {
         item.loadItem(forTypeIdentifier: kUTTypeMovie as String, options: nil) { data, error in
             switch data {
             case let url as URL:
-                _ = self.addDcMsg(url: url, viewType: DC_MSG_VIDEO)
+                _ = self.addDcMsg(path: url.relativePath, viewType: DC_MSG_VIDEO)
                 self.delegate?.onAttachmentChanged()
                 if self.imageThumbnail == nil {
                     DispatchQueue.global(qos: .background).async {
@@ -169,7 +169,7 @@ class ShareAttachment {
             switch data {
             case let url as URL:
                 if url.pathExtension == "xdc" {
-                    let webxdcMsg = self.addDcMsg(url: url, viewType: DC_MSG_WEBXDC)
+                    let webxdcMsg = self.addDcMsg(path: url.relativePath, viewType: DC_MSG_WEBXDC)
                     if self.imageThumbnail == nil {
                         self.imageThumbnail = webxdcMsg.getWebxdcPreviewImage()?
                             .scaleDownImage(toMax: self.thumbnailSize,
@@ -177,7 +177,7 @@ class ShareAttachment {
                         self.delegate?.onThumbnailChanged()
                     }
                 } else {
-                    _ = self.addDcMsg(url: url, viewType: viewType)
+                    _ = self.addDcMsg(path: url.relativePath, viewType: viewType)
                 }
                 self.delegate?.onAttachmentChanged()
                 if self.imageThumbnail == nil {
@@ -192,9 +192,9 @@ class ShareAttachment {
         }
     }
 
-    private func addDcMsg(url: URL, viewType: Int32) -> DcMsg {
+    private func addDcMsg(path: String?, viewType: Int32) -> DcMsg {
         let msg = dcContext.newMessage(viewType: viewType)
-        msg.setFile(filepath: url.relativePath)
+        msg.setFile(filepath: path)
         self.messages.append(msg)
         return msg
     }

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -193,11 +193,11 @@ class ShareAttachment {
         let msg = dcContext.newMessage(viewType: viewType)
         msg.setFile(filepath: path)
         let bytes = msg.filesize
+        logger.info("share \(path ?? "ErrPath") with \(bytes) bytes")
         if bytes > maxAttachmentBytes {
-            self.error = "For large files, open Delta Chat and attach the file there"
+            self.error = "File is too large for sharing.\n\nOpen Delta Chat directly and attach the file there."
             return nil
         }
-        logger.info("adding \(path ?? "ErrPath") with \(bytes) bytes")
         self.messages.append(msg)
         return msg
     }
@@ -236,10 +236,10 @@ class ShareAttachment {
                 case let url as URL:
                     delegate.onUrlShared(url: url)
                 default:
-                    logger.error("Unexpected data: \(type(of: data))")
+                    self.error = "Unexpected data: \(type(of: data))"
                 }
                 if let error = error {
-                    logger.error("Could not share URL: \(error.localizedDescription)")
+                    self.error = error.localizedDescription
                 }
             }
         }


### PR DESCRIPTION
this PR shows all errors that happen during sharing and also raises an error if the file to be shared is very probably to large.

in this case, we suggest to send the file from the app directly (which will work better as we have a 2000mb instead of a 120mb memory limit there).

the check is done for all files, not only for videos.

closes #2021