### PR TITLE
focus on name and avatar in guaranteed-e2ee chats

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1029,7 +1029,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             navigationItem.title = String.localized(stringID: "n_selected", count: cnt)
             self.navigationItem.setLeftBarButton(cancelButton, animated: true)
         } else {
-            var subtitle = ""
+            let subtitle: String?
             let chatContactIds = dcChat.getContactIds(dcContext)
             if dcChat.isMailinglist {
                 subtitle = String.localized("mailing_list")
@@ -1041,8 +1041,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 subtitle = String.localized("device_talk_subtitle")
             } else if dcChat.isSelfTalk {
                 subtitle = String.localized("chat_self_talk_subtitle")
-            } else if chatContactIds.count >= 1 {
+            } else if !dcChat.isProtected && chatContactIds.count >= 1 {
                 subtitle = dcContext.getContact(id: chatContactIds[0]).email
+            } else {
+                subtitle = nil
             }
 
             titleView.updateTitleView(title: dcChat.name, subtitle: subtitle, isVerified: dcChat.isProtected)

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -58,8 +58,14 @@ class ChatTitleView: UIStackView {
         titleLabel.text = title
         titleLabel.textColor = DcColors.defaultTextColor
         verifiedView.isHidden = !isVerified
-        subtitleLabel.text = subtitle
-        subtitleLabel.textColor = DcColors.defaultTextColor.withAlphaComponent(0.95)
+
+        if let subtitle = subtitle {
+            subtitleLabel.text = subtitle
+            subtitleLabel.textColor = DcColors.defaultTextColor.withAlphaComponent(0.95)
+            subtitleLabel.isHidden = false
+        } else {
+            subtitleLabel.isHidden = true
+        }
     }
 
     func setEnabled(_ enabled: Bool) {

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -59,7 +59,7 @@ class ChatTitleView: UIStackView {
         titleLabel.textColor = DcColors.defaultTextColor
         verifiedView.isHidden = !isVerified
 
-        if let subtitle = subtitle {
+        if let subtitle {
             subtitleLabel.text = subtitle
             subtitleLabel.textColor = DcColors.defaultTextColor.withAlphaComponent(0.95)
             subtitleLabel.isHidden = false


### PR DESCRIPTION
this PR hides the email address from the chat's title bar for guaranteeedd e2ee one-to-one chats.

this affects chatmail contacts and delta-to-delta contacts mainly, for classic email usage, things stay the same mostly.

to be clear: the email address will stay in profile (one tap away) and there are no ideas to change that.

for reasons and discussion,
see https://github.com/deltachat/deltachat-android/pull/2916 , to sum up:
- protects against "over the shoulder surveillance", a real-world issue reported
- the address is not meaningful for chatmail. featuring chatmail is importing for future users, esp. <30yo ones considering email a "thing of the past that can't possible bring any good" :)
- act similar to other messengers, not showing the "handle" for known contacts
- focus are shift to name and avatar, not clutterung UI, making guaranteed e2ee more outstanding
- impersonation won't become worse, you could always use trustworthy looking but wrong addresses. removing the address may even improve here as other aspects (chat history etc.) may get more into focus.
- prepare for AEAP and the idea of multilple addresses per account

closes #2037