### PR TITLE
update reaction view on DC_EVENT_REACTIONS_CHANGED

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -70,7 +70,7 @@ public class DcEventHandler {
         case DC_EVENT_IMAP_CONNECTED, DC_EVENT_SMTP_CONNECTED:
             logger.info("📡[\(accountId)] network: \(event.data2String)")
 
-        case DC_EVENT_MSGS_CHANGED, DC_EVENT_MSG_READ, DC_EVENT_MSG_DELIVERED, DC_EVENT_MSG_FAILED:
+        case DC_EVENT_MSGS_CHANGED, DC_EVENT_REACTIONS_CHANGED, DC_EVENT_MSG_READ, DC_EVENT_MSG_DELIVERED, DC_EVENT_MSG_FAILED:
             if accountId != dcAccounts.getSelected().id {
                 return
             }


### PR DESCRIPTION
handling of this event was just missing.
for simplicity, the event is handled that in the same way as the other more explicit events;
if really needed, we can optimize updates later.

this should also prepare for sending reactions,
as DC_EVENT_REACTIONS_CHANGED is also emitted for self-reactions (so, one can just call sendReaction(), no need to update anything)