### PR TITLE
sum up all fresh messages in app-icon

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -612,7 +612,7 @@ class ChatListViewController: UITableViewController {
     }
     
     private func updateAccountButton() {
-        let unreadMessages = getUnreadCounterOfOtherAccounts()
+        let unreadMessages = dcAccounts.getFreshMessageCount(skipCurrent: true)
         accountButtonAvatar.setUnreadMessageCount(unreadMessages)
         if unreadMessages > 0 {
             accountButtonAvatar.accessibilityLabel = "\(String.localized("switch_account")): \(String.localized(stringID: "n_messages", count: unreadMessages))"
@@ -627,20 +627,6 @@ class ChatListViewController: UITableViewController {
         if let image = contact.profileImage {
             accountButtonAvatar.setImage(image)
         }
-    }
-    
-    private func getUnreadCounterOfOtherAccounts() -> Int {
-        var unreadCount = 0
-        let selectedAccountId = dcAccounts.getSelected().id
-        
-        for accountId in dcAccounts.getAll() {
-            if accountId == selectedAccountId {
-                continue
-            }
-            unreadCount += dcAccounts.get(id: accountId).getFreshMessages().count
-        }
-        
-        return unreadCount
     }
     
     @objc private func accountButtonTapped() {

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -246,7 +246,7 @@ internal final class SettingsViewController: UITableViewController {
             NotificationManager.removeAllNotifications()
         }
         UserDefaults.standard.synchronize()
-        NotificationManager.updateApplicationIconBadge(dcContext: dcContext, reset: !sender.isOn)
+        NotificationManager.updateApplicationIconBadge(forceZero: !sender.isOn)
     }
 
     // MARK: - updates

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -239,7 +239,7 @@ class AppCoordinator {
         // the applicationIconBadgeNumber is remembered by the system even on reinstalls (just tested on ios 13.3.1),
         // to avoid appearing an old number of a previous installation, we reset the counter manually.
         // but even when this changes in ios, we need the reset as we allow account-deletion also in-app.
-        NotificationManager.updateApplicationIconBadge(dcContext: dcAccounts.getSelected(), reset: true)
+        NotificationManager.updateApplicationIconBadge(forceZero: true)
     }
 
     func presentTabBarController() {

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -110,6 +110,17 @@ public class DcAccounts {
         }
     }
 
+    public func getFreshMessageCount(skipCurrent: Bool = false) -> Int {
+        var freshCount = 0
+        let skipId = skipCurrent ? getSelected().id : -1
+        for accountId in getAll() {
+            if accountId != skipId {
+                freshCount += get(id: accountId).getFreshMessages().count
+            }
+        }
+        return freshCount
+    }
+
     @discardableResult
     public func blockingCall(method: String, params: [AnyObject]) -> Data? {
         if let paramsData = try? JSONSerialization.data(withJSONObject: params),


### PR DESCRIPTION
with this PR, the app icon shows the sum of the unread (fresh) messages of all accounts,  making multi account usage and fast switching more usable.

<img width=120 src=https://github.com/deltachat/deltachat-ios/assets/9800740/eab15a25-ebe8-4291-b285-47a5d4b60abf>

closes #2045