### PR TITLE
Send Reactions

### DIFF
--- a/DcCore/DcCore/Extensions/UIView+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UIView+Extensions.swift
@@ -7,19 +7,19 @@ public extension UIView {
         self.layer.borderWidth = 2
     }
 
-    func alignLeadingToAnchor(_ anchor: NSLayoutXAxisAnchor, paddingLeading: CGFloat = 0.0, priority: UILayoutPriority? = .none) {
+    func alignLeadingToAnchor(_ anchor: NSLayoutXAxisAnchor, paddingLeading: CGFloat = 0.0, priority: UILayoutPriority = .required) {
         _ = constraintAlignLeadingToAnchor(anchor, paddingLeading: paddingLeading, priority: priority)
     }
 
-    func alignTrailingToAnchor(_ anchor: NSLayoutXAxisAnchor, paddingTrailing: CGFloat = 0.0, priority: UILayoutPriority? = .none) {
+    func alignTrailingToAnchor(_ anchor: NSLayoutXAxisAnchor, paddingTrailing: CGFloat = 0.0, priority: UILayoutPriority = .required) {
         _ = constraintAlignTrailingToAnchor(anchor, paddingTrailing: paddingTrailing, priority: priority)
     }
 
-    func alignTopToAnchor(_ anchor: NSLayoutYAxisAnchor, paddingTop: CGFloat = 0.0, priority: UILayoutPriority? = .none) {
+    func alignTopToAnchor(_ anchor: NSLayoutYAxisAnchor, paddingTop: CGFloat = 0.0, priority: UILayoutPriority = .required) {
         _ = constraintAlignTopToAnchor(anchor, paddingTop: paddingTop, priority: priority)
     }
 
-    func alignBottomToAnchor(_ anchor: NSLayoutYAxisAnchor, paddingBottom: CGFloat = 0.0, priority: UILayoutPriority? = .none) {
+    func alignBottomToAnchor(_ anchor: NSLayoutYAxisAnchor, paddingBottom: CGFloat = 0.0, priority: UILayoutPriority = .required) {
         _ = constraintAlignBottomToAnchor(anchor, paddingBottom: paddingBottom, priority: priority)
     }
 
@@ -30,38 +30,30 @@ public extension UIView {
         alignBottomToAnchor(view.bottomAnchor, paddingBottom: paddingBottom ?? 0.0)
     }
 
-    func constraintAlignLeadingToAnchor(_ anchor: NSLayoutXAxisAnchor, paddingLeading: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignLeadingToAnchor(_ anchor: NSLayoutXAxisAnchor, paddingLeading: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = self.leadingAnchor.constraint(equalTo: anchor, constant: paddingLeading)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         constraint.isActive = true
         return constraint
     }
 
-    func constraintAlignTrailingToAnchor(_ anchor: NSLayoutXAxisAnchor, paddingTrailing: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignTrailingToAnchor(_ anchor: NSLayoutXAxisAnchor, paddingTrailing: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = self.trailingAnchor.constraint(equalTo: anchor, constant: -paddingTrailing)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         constraint.isActive = true
         return constraint
     }
 
-    func constraintAlignTopToAnchor(_ anchor: NSLayoutYAxisAnchor, paddingTop: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignTopToAnchor(_ anchor: NSLayoutYAxisAnchor, paddingTop: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = self.topAnchor.constraint(equalTo: anchor, constant: paddingTop)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         constraint.isActive = true
         return constraint
     }
 
-    func constraintAlignBottomToAnchor(_ anchor: NSLayoutYAxisAnchor, paddingBottom: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignBottomToAnchor(_ anchor: NSLayoutYAxisAnchor, paddingBottom: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = self.bottomAnchor.constraint(equalTo: anchor, constant: -paddingBottom)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         constraint.isActive = true
         return constraint
     }
@@ -70,7 +62,7 @@ public extension UIView {
         return constraintAlignTopTo(view, paddingTop: 0.0)
     }
 
-    func constraintAlignTopTo(_ view: UIView, paddingTop: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignTopTo(_ view: UIView, paddingTop: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .top,
@@ -79,17 +71,15 @@ public extension UIView {
             attribute: .top,
             multiplier: 1.0,
             constant: paddingTop)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
-    
+
     /**
      ensure the top of self is aligned with or lower than another view
      can be used in conjunction with constraintAlignCenterY
      */
-    func constraintAlignTopMaxTo(_ view: UIView, paddingTop: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignTopMaxTo(_ view: UIView, paddingTop: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .top,
@@ -98,13 +88,11 @@ public extension UIView {
             attribute: .top,
             multiplier: 1.0,
             constant: paddingTop)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintAlignBottomTo(_ view: UIView, paddingBottom: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignBottomTo(_ view: UIView, paddingBottom: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .bottom,
@@ -113,13 +101,11 @@ public extension UIView {
             attribute: .bottom,
             multiplier: 1.0,
             constant: -paddingBottom)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintAlignBottomMaxTo(_ view: UIView, paddingBottom: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignBottomMaxTo(_ view: UIView, paddingBottom: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .bottom,
@@ -128,13 +114,11 @@ public extension UIView {
             attribute: .bottom,
             multiplier: 1.0,
             constant: -paddingBottom)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintAlignLeadingTo(_ view: UIView, paddingLeading: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignLeadingTo(_ view: UIView, paddingLeading: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .leading,
@@ -143,16 +127,14 @@ public extension UIView {
             attribute: .leading,
             multiplier: 1.0,
             constant: paddingLeading)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
     /**
-        allows to align leading to the leading of another view but allows left side shrinking
+     allows to align leading to the leading of another view but allows left side shrinking
      */
-    func constraintAlignLeadingMaxTo(_ view: UIView, paddingLeading: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignLeadingMaxTo(_ view: UIView, paddingLeading: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .leading,
@@ -161,13 +143,11 @@ public extension UIView {
             attribute: .leading,
             multiplier: 1.0,
             constant: paddingLeading)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintAlignTrailingTo(_ view: UIView, paddingTrailing: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignTrailingTo(_ view: UIView, paddingTrailing: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .trailing,
@@ -176,16 +156,14 @@ public extension UIView {
             attribute: .trailing,
             multiplier: 1.0,
             constant: -paddingTrailing)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
     /**
-        allows to align trailing to the trailing of another view but allows right side shrinking
+     allows to align trailing to the trailing of another view but allows right side shrinking
      */
-    func constraintAlignTrailingMaxTo(_ view: UIView, paddingTrailing: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintAlignTrailingMaxTo(_ view: UIView, paddingTrailing: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .trailing,
@@ -194,13 +172,11 @@ public extension UIView {
             attribute: .trailing,
             multiplier: 1.0,
             constant: -paddingTrailing)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintToBottomOf(_ view: UIView, paddingTop: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintToBottomOf(_ view: UIView, paddingTop: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .top,
@@ -209,13 +185,11 @@ public extension UIView {
             attribute: .bottom,
             multiplier: 1.0,
             constant: paddingTop)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintToTrailingOf(_ view: UIView, paddingLeading: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintToTrailingOf(_ view: UIView, paddingLeading: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .leading,
@@ -224,13 +198,11 @@ public extension UIView {
             attribute: .trailing,
             multiplier: 1.0,
             constant: paddingLeading)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintTrailingToLeadingOf(_ view: UIView, paddingTrailing: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintTrailingToLeadingOf(_ view: UIView, paddingTrailing: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,
             attribute: .trailing,
@@ -239,53 +211,43 @@ public extension UIView {
             attribute: .leading,
             multiplier: 1.0,
             constant: -paddingTrailing)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintCenterXTo(_ view: UIView, paddingX: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintCenterXTo(_ view: UIView, paddingX: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
-                                  attribute: .centerX,
-                                  relatedBy: .equal,
-                                  toItem: view,
-                                  attribute: .centerX,
-                                  multiplier: 1.0,
-                                  constant: paddingX)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+                                            attribute: .centerX,
+                                            relatedBy: .equal,
+                                            toItem: view,
+                                            attribute: .centerX,
+                                            multiplier: 1.0,
+                                            constant: paddingX)
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintCenterYTo(_ view: UIView, paddingY: CGFloat = 0.0, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintCenterYTo(_ view: UIView, paddingY: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
-                                  attribute: .centerY,
-                                  relatedBy: .equal,
-                                  toItem: view,
-                                  attribute: .centerY,
-                                  multiplier: 1.0,
-                                  constant: paddingY)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+                                            attribute: .centerY,
+                                            relatedBy: .equal,
+                                            toItem: view,
+                                            attribute: .centerY,
+                                            multiplier: 1.0,
+                                            constant: paddingY)
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintHeightTo(_ height: CGFloat, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintHeightTo(_ height: CGFloat, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = heightAnchor.constraint(equalToConstant: height)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
-    func constraintWidthTo(_ width: CGFloat, priority: UILayoutPriority? = .none) -> NSLayoutConstraint {
+    func constraintWidthTo(_ width: CGFloat, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = widthAnchor.constraint(equalToConstant: width)
-        if let priority = priority {
-            constraint.priority = priority
-        }
+        constraint.priority = priority
         return constraint
     }
 
@@ -336,36 +298,36 @@ public extension UIView {
 
         var constraints = [NSLayoutConstraint]()
 
-        if let top = top {
+        if let top {
             let constraint = topAnchor.constraint(equalTo: top, constant: topConstant)
             constraint.identifier = "top"
             constraints.append(constraint)
         }
-        if let left = left {
+        if let left {
             let constraint = leftAnchor.constraint(equalTo: left, constant: leftConstant)
             constraint.identifier = "left"
             constraints.append(constraint)
         }
 
-        if let bottom = bottom {
+        if let bottom {
             let constraint = bottomAnchor.constraint(equalTo: bottom, constant: -bottomConstant)
             constraint.identifier = "bottom"
             constraints.append(constraint)
         }
 
-        if let right = right {
+        if let right {
             let constraint = rightAnchor.constraint(equalTo: right, constant: -rightConstant)
             constraint.identifier = "right"
             constraints.append(constraint)
         }
 
-        if let centerY = centerY {
+        if let centerY {
             let constraint = centerYAnchor.constraint(equalTo: centerY, constant: centerYConstant)
             constraint.identifier = "centerY"
             constraints.append(constraint)
         }
 
-        if let centerX = centerX {
+        if let centerX {
             let constraint = centerXAnchor.constraint(equalTo: centerX, constant: centerXConstant)
             constraint.identifier = "centerX"
             constraints.append(constraint)

--- a/DcShare/Controller/SendingController.swift
+++ b/DcShare/Controller/SendingController.swift
@@ -85,7 +85,7 @@ class SendingController: UIViewController {
 
     private func sendMessage() {
         DispatchQueue.global(qos: .utility).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             for dcMsg in self.dcMsgs {
                 self.dcContext.sendMsgSync(chatId: self.chatId, msg: dcMsg)
             }

--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -123,7 +123,7 @@ class ShareViewController: SLComposeServiceViewController {
         }
         selectedChat = dcContext.getChat(chatId: chatId)
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.shareAttachment = ShareAttachment(dcContext: self.dcContext, inputItems: self.extensionContext?.inputItems, delegate: self)
             DispatchQueue.main.async {
                 self.validateContent()
@@ -264,7 +264,7 @@ extension ShareViewController: ShareAttachmentDelegate {
 
     func onThumbnailChanged() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             if let preview = self.preview {
                 preview.image = self.shareAttachment?.thumbnail ?? nil
             }

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		B2C42570265C325C00B95377 /* MultilineLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C4256F265C325C00B95377 /* MultilineLabelCell.swift */; };
 		B2D4B63B29C38D1900B47DA8 /* ChatsAndMediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4B63A29C38D1900B47DA8 /* ChatsAndMediaViewController.swift */; };
 		B2F899E129F96A67003797D5 /* AllMediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F899E029F96A67003797D5 /* AllMediaViewController.swift */; };
+		D80F62792B59D1CC00877059 /* SendReactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F62782B59D1CC00877059 /* SendReactionsView.swift */; };
 		D84AED242B55E8EB00D753F6 /* ReactionsOverviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84AED232B55E8EB00D753F6 /* ReactionsOverviewViewController.swift */; };
 		D84AED272B566C0700D753F6 /* ReactionsOverviewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84AED262B566C0700D753F6 /* ReactionsOverviewTableViewCell.swift */; };
 		D8FB03FD2B4EF20700A355F8 /* ReactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FB03FC2B4EF20700A355F8 /* ReactionsView.swift */; };
@@ -564,6 +565,7 @@
 		B2F899E029F96A67003797D5 /* AllMediaViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllMediaViewController.swift; sourceTree = "<group>"; };
 		B9CDCE77DAE9389E205F094C /* Pods-DcShare.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DcShare.release.xcconfig"; path = "Target Support Files/Pods-DcShare/Pods-DcShare.release.xcconfig"; sourceTree = "<group>"; };
 		D30610767F4AF8040B739987 /* Pods-deltachat-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-deltachat-ios.debug.xcconfig"; path = "Target Support Files/Pods-deltachat-ios/Pods-deltachat-ios.debug.xcconfig"; sourceTree = "<group>"; };
+		D80F62782B59D1CC00877059 /* SendReactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendReactionsView.swift; sourceTree = "<group>"; };
 		D84AED232B55E8EB00D753F6 /* ReactionsOverviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionsOverviewViewController.swift; sourceTree = "<group>"; };
 		D84AED262B566C0700D753F6 /* ReactionsOverviewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionsOverviewTableViewCell.swift; sourceTree = "<group>"; };
 		D8FB03FC2B4EF20700A355F8 /* ReactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionsView.swift; sourceTree = "<group>"; };
@@ -736,6 +738,7 @@
 		30FDB6B224D18E390066C48D /* Chat */ = {
 			isa = PBXGroup;
 			children = (
+				D80F62772B59D1B800877059 /* Send Reaction */,
 				D84AED252B566BF700D753F6 /* Reactions */,
 				3008CB7524F95B6D00E6A617 /* AudioController.swift */,
 				30FDB6F824D1C1000066C48D /* ChatViewController.swift */,
@@ -1047,6 +1050,14 @@
 				30DAF71B275901610073C154 /* BackgroundOptionsViewController.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		D80F62772B59D1B800877059 /* Send Reaction */ = {
+			isa = PBXGroup;
+			children = (
+				D80F62782B59D1CC00877059 /* SendReactionsView.swift */,
+			);
+			path = "Send Reaction";
 			sourceTree = "<group>";
 		};
 		D84AED252B566BF700D753F6 /* Reactions */ = {
@@ -1448,6 +1459,7 @@
 				AEE6EC3F2282C59C00EDC689 /* GroupMembersViewController.swift in Sources */,
 				B26B3BC7236DC3DC008ED35A /* SwitchCell.swift in Sources */,
 				AEE700252438E0E500D6992E /* ProgressAlertHandler.swift in Sources */,
+				D80F62792B59D1CC00877059 /* SendReactionsView.swift in Sources */,
 				30E348E524F6647D005C93D1 /* FileTextCell.swift in Sources */,
 				30238CFD28A5028300EF14AC /* WebxdcGridCell.swift in Sources */,
 				3080A036277DE30100E74565 /* NSMutableAttributedString+Extensions.swift in Sources */,

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -133,7 +133,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 // Reachability::reachabilityChanged uses DispatchQueue.main.async only
                 logger.info("network: reachable \(reachability.connection.description)")
                 DispatchQueue.global(qos: .background).async { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     self.dcAccounts.maybeNetwork()
                     if self.notifyToken == nil &&
                         self.dcAccounts.getSelected().isConfigured() &&
@@ -215,7 +215,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         dcAccounts.startIo()
 
         DispatchQueue.global(qos: .background).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             if let reachability = self.reachability {
                 if reachability.connection != .unavailable {
                     self.dcAccounts.maybeNetwork()
@@ -329,7 +329,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // https://developer.apple.com/documentation/usernotifications/asking_permission_to_use_notifications
     func registerForNotifications() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.notifyToken = nil
             UNUserNotificationCenter.current().delegate = self
@@ -467,7 +467,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // move work to non-main thread to not block UI (otherwise, in case we get suspended, the app is blocked totally)
         // (we are using `qos: default` as `qos: .background` or `main.asyncAfter` may be delayed by tens of minutes)
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { completionHandler?(.failed); return }
+            guard let self else { completionHandler?(.failed); return }
 
             // we're in background, run IO for a little time
             self.dcAccounts.startIo()
@@ -572,7 +572,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
         eventHandlerActive = true
         DispatchQueue.global(qos: .background).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let eventHandler = DcEventHandler(dcAccounts: self.dcAccounts)
             let eventEmitter = self.dcAccounts.getEventEmitter()
             logger.info("➡️ event emitter started")

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1867,15 +1867,24 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         container.spacing = 10
         container.axis = .vertical
         container.backgroundColor = .clear
+        container.alignment = .leading
 
-        sendReactionsView.widthAnchor.constraint(lessThanOrEqualTo: container.widthAnchor).isActive = true
+        messageSnapshotView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            sendReactionsView.widthAnchor.constraint(lessThanOrEqualTo: container.widthAnchor),
+            messageSnapshotView.widthAnchor.constraint(equalToConstant: messageSnapshotView.frame.width),
+        ])
 
-        let centerPoint = cell.convert(messageSnapshotView.center, to: tableView)
+        var centerPoint = cell.convert(messageSnapshotView.center, to: tableView)
+        centerPoint.y -= 20
+        centerPoint.x += 6
         let previewTarget = UIPreviewTarget(container: tableView, center: centerPoint)
 
         let parameters = UIPreviewParameters()
         parameters.backgroundColor = .clear
-        return UITargetedPreview(view: container, parameters: parameters, target: previewTarget)
+        let preview = UITargetedPreview(view: container, parameters: parameters, target: previewTarget)
+
+        return preview
     }
 
     @available(iOS 13.0, *)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1861,6 +1861,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         guard let cell = tableView.cellForRow(at: indexPath) as? BaseMessageCell,
               let messageSnapshotView = cell.messageBackgroundContainer.snapshotView(afterScreenUpdates: false) else { return nil }
 
+        cell.messageBackgroundContainer.isHidden = (reactionsHidden == false)
+        cell.reactionsView.isHidden = (reactionsHidden == false)
+
         let myReactions = dcContext.getMessageReactions(messageId: messageId.integerValue)?.reactions.filter { $0.isFromSelf } ?? []
 
         let sendReactionsView = SendReactionsView(messageId: messageId as String, myReactions: myReactions)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1851,7 +1851,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
               let messageSnapshotView = cell.messageBackgroundContainer.snapshotView(afterScreenUpdates: false)
         else { return nil }
 
-        let sendReactionsView = SendReactionsView(messageId: messageId as String)
+        let myReactions = dcContext.getMessageReactions(messageId: messageId.integerValue)?.reactions.filter { $0.isFromSelf } ?? []
+
+        let sendReactionsView = SendReactionsView(messageId: messageId as String, myReactions: myReactions)
         sendReactionsView.delegate = self
         sendReactionsView.translatesAutoresizingMaskIntoConstraints = false
         sendReactionsView.layoutIfNeeded()

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -181,7 +181,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             imageName: "doc.on.doc",
             action: #selector(BaseMessageCell.messageCopy),
             onPerform: { [weak self] indexPath in
-                guard let self = self else { return }
+                guard let self else { return }
                 let id = self.messageIds[indexPath.row]
                 self.copyToClipboard(ids: [id])
             }
@@ -194,7 +194,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             imageName: "info",
             action: #selector(BaseMessageCell.messageInfo),
             onPerform: { [weak self] indexPath in
-                guard let self = self else { return }
+                guard let self else { return }
                 let msg = self.dcContext.getMessage(id: self.messageIds[indexPath.row])
                 let msgViewController = MessageInfoViewController(dcContext: self.dcContext, message: msg)
                 if let ctrl = self.navigationController {
@@ -212,7 +212,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             action: #selector(BaseMessageCell.messageDelete),
             onPerform: { [weak self] indexPath in
                 DispatchQueue.main.async { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     self.tableView.becomeFirstResponder()
                     let msg = self.dcContext.getMessage(id: self.messageIds[indexPath.row])
                     self.askToDeleteMessage(id: msg.id)
@@ -227,7 +227,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             imageName: "ic_forward_white_36pt",
             action: #selector(BaseMessageCell.messageForward),
             onPerform: { [weak self] indexPath in
-                guard let self = self else { return }
+                guard let self else { return }
                 let msg = self.dcContext.getMessage(id: self.messageIds[indexPath.row])
                 RelayHelper.shared.setForwardMessage(messageId: msg.id)
                 self.navigationController?.popViewController(animated: true)
@@ -255,7 +255,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             imageName: "arrowshape.turn.up.left",
             action: #selector(BaseMessageCell.messageReplyPrivately),
             onPerform: { [weak self] indexPath in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.replyPrivatelyToMessage(at: indexPath)
             }
         )
@@ -268,7 +268,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             action: #selector(BaseMessageCell.messageSelectMore),
             onPerform: { indexPath in
                 DispatchQueue.main.async { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     let messageId = self.messageIds[indexPath.row]
                     self.setEditing(isEditing: true, selectedAtIndexPath: indexPath)
                     if UIAccessibility.isVoiceOverRunning {
@@ -345,7 +345,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         // Binding to the tableView will enable interactive dismissal
         keyboardManager?.bind(to: tableView)
         keyboardManager?.on(event: .didChangeFrame) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             if self.isInitial {
                 self.isInitial = false
                 return
@@ -354,7 +354,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 self.scrollToBottom()
             }
         }.on(event: .willChangeFrame) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             if self.isLastRowVisible() && !self.tableView.isDragging && !self.tableView.isDecelerating && self.highlightedMsg == nil  && !self.isInitial {
                 self.scrollToBottom()
             }
@@ -399,7 +399,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             // reload table
             DispatchQueue.main.async { [weak self] in
-                guard let self = self,
+                guard let self,
                       let appDelegate = UIApplication.shared.delegate as? AppDelegate
                 else { return }
                 
@@ -448,19 +448,19 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 self?.scrollToMessage(msgId: msgId, animated: false)
             }, completion: { [weak self] finished in
                 if finished {
-                    guard let self = self else { return }
+                    guard let self else { return }
                     self.highlightedMsg = nil
                     self.updateScrollDownButtonVisibility()
                 }
             })
         } else {
             UIView.animate(withDuration: 0.1, delay: 0, options: .allowAnimatedContent, animations: { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 if self.isInitial {
                     self.scrollToLastUnseenMessage()
                 }
             }, completion: { [weak self] finished in
-                guard let self = self else { return }
+                guard let self else { return }
                 if finished {
                     self.updateScrollDownButtonVisibility()
                 }
@@ -493,7 +493,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         // things that do not affect the chatview
         // and are delayed after the view is displayed
         DispatchQueue.global(qos: .background).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.dcContext.marknoticedChat(chatId: self.chatId)
         }
 
@@ -553,6 +553,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             object: nil,
             queue: OperationQueue.main
         ) { [weak self] notification in
+
             guard let self, let ui = notification.userInfo else { return }
             let chatId = ui["chat_id"] as? Int ?? 0
             if chatId == 0 || chatId == self.chatId {
@@ -596,7 +597,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             forName: eventChatModified,
             object: nil, queue: OperationQueue.main
         ) { [weak self] notification in
-            guard let self = self, let ui = notification.userInfo else { return }
+            guard let self, let ui = notification.userInfo else { return }
             if self.chatId == ui["chat_id"] as? Int {
                 self.dcChat = self.dcContext.getChat(chatId: self.chatId)
                 if self.dcChat.canSend {
@@ -620,7 +621,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             forName: eventEphemeralTimerModified,
             object: nil, queue: OperationQueue.main
         ) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             self.updateTitle()
         }
 
@@ -658,14 +659,14 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         let lastSectionVisibleBeforeTransition = self.isLastRowVisible(checkTopCellPostion: true, checkBottomCellPosition: true, allowPartialVisibility: true)
         coordinator.animate(
             alongsideTransition: { [weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.navigationItem.setRightBarButton(self.badgeItem, animated: true)
                 if lastSectionVisibleBeforeTransition {
                     self.scrollToBottom(animated: false)
                 }
             },
             completion: {[weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.updateTitle()
                 if lastSectionVisibleBeforeTransition {
                     DispatchQueue.main.async { [weak self] in
@@ -1153,7 +1154,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     private func scrollToBottom(animated: Bool, focusOnVoiceOver: Bool = false) {
         if !messageIds.isEmpty {
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 let numberOfRows = self.tableView.numberOfRows(inSection: 0)
                 if numberOfRows > 0 {
                     self.scrollToRow(at: IndexPath(row: numberOfRows - 1, section: 0),
@@ -1167,7 +1168,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func scrollToLastUnseenMessage() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             if let markerMessageIndex = self.messageIds.firstIndex(of: Int(DC_MSG_ID_MARKER1)) {
                 let indexPath = IndexPath(row: markerMessageIndex, section: 0)
                 self.scrollToRow(at: indexPath, animated: false)
@@ -1183,7 +1184,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func scrollToMessage(msgId: Int, animated: Bool = true, scrollToText: Bool = false) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             guard let index = self.messageIds.firstIndex(of: msgId) else {
                 return
             }
@@ -1229,7 +1230,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     // notification doesn't cause VoiceOver to readout the cell mutliple times.
     private func forceVoiceOverFocussingCell(at indexPath: IndexPath, postingFinished: (() -> Void)?) {
         DispatchQueue.global(qos: .userInteractive).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             for _ in 1...4 {
                 DispatchQueue.main.async {
                     UIAccessibility.post(notification: .layoutChanged, argument: self.tableView.cellForRow(at: indexPath))
@@ -1435,7 +1436,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         let title = String.localized(stringID: "ask_delete_chat", count: 1)
         confirmationAlert(title: title, actionTitle: String.localized("delete"), actionStyle: .destructive,
                           actionHandler: { [weak self] _ in
-                            guard let self = self else { return }
+                            guard let self else { return }
                             // remove message observers early to avoid careless calls to dcContext methods
                             self.removeObservers()
                             self.dcContext.deleteChat(chatId: self.chatId)
@@ -1543,7 +1544,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         } else {
             AVCaptureDevice.requestAccess(for: .video, completionHandler: { (granted: Bool) in
                 DispatchQueue.main.async { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     if granted {
                         self.mediaPicker?.showCamera()
                     } else {
@@ -1642,7 +1643,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                                style: .default,
                                handler: { _ in
                                 DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                                    guard let self = self else { return }
+                                    guard let self else { return }
                                     let messageId = self.dcContext.sendVideoChatInvitation(chatId: self.chatId)
                                     let inviteMessage = self.dcContext.getMessage(id: messageId)
                                     if let url = NSURL(string: inviteMessage.getVideoChatUrl()) {
@@ -1681,7 +1682,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func sendTextMessage(text: String, quoteMessage: DcMsg?) {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let message = self.dcContext.newMessage(viewType: DC_MSG_TEXT)
             message.text = text
             if let quoteMessage = quoteMessage {
@@ -1703,7 +1704,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     private func stageDocument(url: NSURL) {
         keepKeyboard = true
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.draft.setAttachment(viewType: url.pathExtension == "xdc" ? DC_MSG_WEBXDC : DC_MSG_FILE, path: url.relativePath)
             self.configureDraftArea(draft: self.draft)
             self.focusInputTextView()
@@ -1714,7 +1715,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     private func stageVideo(url: NSURL) {
         keepKeyboard = true
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.draft.setAttachment(viewType: DC_MSG_VIDEO, path: url.relativePath)
             self.configureDraftArea(draft: self.draft)
             self.focusInputTextView()
@@ -1733,7 +1734,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func stageImage(_ image: UIImage) {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             if let pathInCachesDir = ImageFormat.saveImage(image: image, directory: .cachesDirectory) {
                 DispatchQueue.main.async {
                     if pathInCachesDir.suffix(4).contains(".gif") {
@@ -1751,7 +1752,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func sendImage(_ image: UIImage, message: String? = nil) {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             if let path = ImageFormat.saveImage(image: image, directory: .cachesDirectory) {
                 self.sendAttachmentMessage(viewType: DC_MSG_IMAGE, filePath: path, message: message)
                 FileHelper.deleteFile(atPath: path)
@@ -1761,7 +1762,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func sendSticker(_ image: UIImage) {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             if let path = ImageFormat.saveImage(image: image, directory: .cachesDirectory) {
                 self.sendAttachmentMessage(viewType: DC_MSG_STICKER, filePath: path, message: nil)
                 FileHelper.deleteFile(atPath: path)
@@ -1781,7 +1782,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func sendVoiceMessage(url: NSURL) {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let msg = self.dcContext.newMessage(viewType: DC_MSG_VOICE)
             if let quoteMessage =  self.draft.quoteMessage {
                 msg.quoteMessage = quoteMessage
@@ -1875,7 +1876,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             identifier: NSString(string: "\(messageId)"),
             previewProvider: nil,
             actionProvider: { [weak self] _ in
-                guard let self = self else {
+                guard let self else {
                     return nil
                 }
                 if self.dcContext.getMessage(id: messageId).isInfo {
@@ -2335,11 +2336,11 @@ extension ChatViewController: UISearchResultsUpdating {
         debounceTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { _ in
             let searchText = searchController.searchBar.text ?? ""
             DispatchQueue.global(qos: .userInteractive).async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 let resultIds = self.dcContext.searchMessages(chatId: self.chatId, searchText: searchText)
                 DispatchQueue.main.async { [weak self] in
 
-                guard let self = self else { return }
+                guard let self else { return }
                     self.searchMessageIds = resultIds
                     self.searchResultIndex = self.searchMessageIds.isEmpty ? 0 : self.searchMessageIds.count - 1
                     self.searchAccessoryBar.isEnabled = !resultIds.isEmpty
@@ -2422,7 +2423,7 @@ extension ChatViewController: QLPreviewControllerDelegate {
 
     func previewController(_ controller: QLPreviewController, didUpdateContentsOf previewItem: QLPreviewItem) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.draftArea.reload(draft: self.draft)
         }
     }
@@ -2464,7 +2465,7 @@ extension ChatViewController: ChatInputTextViewPasteDelegate {
 extension ChatViewController: WebxdcSelectorDelegate {
     func onWebxdcFromFilesSelected(url: NSURL) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.tableView.becomeFirstResponder()
             self.onDocumentSelected(url: url)
         }
@@ -2473,7 +2474,7 @@ extension ChatViewController: WebxdcSelectorDelegate {
     func onWebxdcSelected(msgId: Int) {
         keepKeyboard = true
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let message = self.dcContext.getMessage(id: msgId)
             if let filename = message.fileURL {
                 let nsdata = NSData(contentsOf: filename)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1872,31 +1872,46 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             sendReactionsView.alpha = 0.0
         }
 
-        let width = max(messageSnapshotView.frame.width, sendReactionsView.frame.width)
-        let height = messageSnapshotView.frame.height + 10 + sendReactionsView.frame.height
+        let container: UIView
+        let yDelta: CGFloat
 
-        let container = UIStackView(frame: CGRect(0, cell.bounds.minY, width, height))
-        container.addArrangedSubview(sendReactionsView)
-        container.addArrangedSubview(messageSnapshotView)
-        container.spacing = 10
-        container.axis = .vertical
-        container.backgroundColor = .clear
+        if dcChat.canSend {
+            let width = max(messageSnapshotView.frame.width, sendReactionsView.frame.width)
+            let height = messageSnapshotView.frame.height + 10 + sendReactionsView.frame.height
 
-        messageSnapshotView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            sendReactionsView.widthAnchor.constraint(lessThanOrEqualTo: container.widthAnchor),
-            messageSnapshotView.widthAnchor.constraint(equalToConstant: messageSnapshotView.frame.width),
-        ])
+            let stackView = UIStackView(frame: CGRect(0, cell.bounds.minY, width, height))
+            stackView.addArrangedSubview(sendReactionsView)
+            stackView.addArrangedSubview(messageSnapshotView)
+            stackView.spacing = 10
+            stackView.axis = .vertical
+            stackView.backgroundColor = .clear
+
+            messageSnapshotView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                sendReactionsView.widthAnchor.constraint(lessThanOrEqualTo: stackView.widthAnchor),
+                messageSnapshotView.widthAnchor.constraint(equalToConstant: messageSnapshotView.frame.width),
+            ])
+
+            if message.isFromCurrentSender {
+                stackView.alignment = .trailing
+            } else {
+                stackView.alignment = .leading
+            }
+
+            container = stackView
+            yDelta = -24
+        } else {
+            container = messageSnapshotView
+            yDelta = 0
+        }
 
         var centerPoint = cell.convert(cell.messageBackgroundContainer.frame.origin, to: tableView)
-        centerPoint.y += 0.5 * cell.messageBackgroundContainer.frame.height - 24
+        centerPoint.y += 0.5 * cell.messageBackgroundContainer.frame.height + yDelta
 
         if message.isFromCurrentSender {
             centerPoint.x = cell.frame.width - 0.5 * container.frame.width - 6
-            container.alignment = .trailing
         } else {
             centerPoint.x = (container.center.x + cell.messageBackgroundContainer.frame.minX)
-            container.alignment = .leading
         }
 
         let previewTarget = UIPreviewTarget(container: tableView, center: centerPoint)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2559,10 +2559,17 @@ extension ChatViewController: ChatDropInteractionDelegate {
 
 // MARK: - SendReactionsViewDelegate
 extension ChatViewController: SendReactionsViewDelegate {
-    func reactionButtonTapped(_ view: SendReactionsView, reaction: DefaultReactions, messageId: String) {
+    func reactionButtonTapped(_ view: SendReactionsView, reaction: DefaultReactions, myReactions: [DcReaction], messageId: String) {
         guard let messageId = Int(messageId) else { return }
 
+        let myEmojis = myReactions.map { $0.emoji }
+
+        if myEmojis.contains(reaction.emoji) {
+            dcContext.sendReaction(messageId: messageId, reaction: nil)
+        } else {
+            dcContext.sendReaction(messageId: messageId, reaction: reaction.emoji)
+        }
+
         // TODO: Dismiss Menu
-        dcContext.sendReaction(messageId: messageId, reaction: reaction.emoji)
     }
 }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -703,11 +703,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }
 
     /// UITableView methods
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
     override func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
         return messageIds.count
     }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2570,6 +2570,11 @@ extension ChatViewController: SendReactionsViewDelegate {
             dcContext.sendReaction(messageId: messageId, reaction: reaction.emoji)
         }
 
-        // TODO: Dismiss Menu
+        if #available(iOS 14.0, *) {
+            tableView.contextMenuInteraction?.dismissMenu()
+        } else {
+            // Fallback on earlier versions
+            dismiss(animated: false)
+        }
     }
 }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1843,6 +1843,16 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     @available(iOS 13.0, *)
     override func tableView(_ tableView: UITableView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        return targetedPreview(for: configuration, reactionsHidden: false)
+    }
+
+    @available(iOS 13.0, *)
+    override func tableView(_ tableView: UITableView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        return targetedPreview(for: configuration, reactionsHidden: true)
+    }
+
+    @available(iOS 13.0, *)
+    private func targetedPreview(for configuration: UIContextMenuConfiguration, reactionsHidden: Bool) -> UITargetedPreview? {
         guard let messageId = configuration.identifier as? NSString else { return nil }
         guard let index = messageIds.firstIndex(of: messageId.integerValue) else { return nil }
         let indexPath = IndexPath(row: index, section: 0)
@@ -1857,6 +1867,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         sendReactionsView.delegate = self
         sendReactionsView.translatesAutoresizingMaskIntoConstraints = false
         sendReactionsView.layoutIfNeeded()
+        
+        if reactionsHidden {
+            sendReactionsView.alpha = 0.0
+        }
 
         let width = max(messageSnapshotView.frame.width, sendReactionsView.frame.width)
         let height = messageSnapshotView.frame.height + 10 + sendReactionsView.frame.height
@@ -1894,18 +1908,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         return preview
     }
 
-    @available(iOS 13.0, *)
-    override func tableView(_ tableView: UITableView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
-        guard let messageId = configuration.identifier as? NSString else { return nil }
-        guard let index = messageIds.firstIndex(of: messageId.integerValue) else { return nil }
-        let indexPath = IndexPath(row: index, section: 0)
-
-        guard let cell = tableView.cellForRow(at: indexPath) as? BaseMessageCell else { return nil }
-
-        let parameters = UIPreviewParameters()
-        parameters.backgroundColor = .clear
-        return UITargetedPreview(view: cell.messageBackgroundContainer, parameters: parameters)
-    }
 
     // context menu for iOS 13+
     @available(iOS 13, *)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1846,10 +1846,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         guard let messageId = configuration.identifier as? NSString else { return nil }
         guard let index = messageIds.firstIndex(of: messageId.integerValue) else { return nil }
         let indexPath = IndexPath(row: index, section: 0)
+        let message = dcContext.getMessage(id: messageId.integerValue)
 
         guard let cell = tableView.cellForRow(at: indexPath) as? BaseMessageCell,
-              let messageSnapshotView = cell.messageBackgroundContainer.snapshotView(afterScreenUpdates: false)
-        else { return nil }
+              let messageSnapshotView = cell.messageBackgroundContainer.snapshotView(afterScreenUpdates: false) else { return nil }
 
         let myReactions = dcContext.getMessageReactions(messageId: messageId.integerValue)?.reactions.filter { $0.isFromSelf } ?? []
 
@@ -1867,7 +1867,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         container.spacing = 10
         container.axis = .vertical
         container.backgroundColor = .clear
-        container.alignment = .leading
 
         messageSnapshotView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -1875,9 +1874,17 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             messageSnapshotView.widthAnchor.constraint(equalToConstant: messageSnapshotView.frame.width),
         ])
 
-        var centerPoint = cell.convert(messageSnapshotView.center, to: tableView)
-        centerPoint.y -= 20
-        centerPoint.x += 6
+        var centerPoint = cell.convert(cell.messageBackgroundContainer.frame.origin, to: tableView)
+        centerPoint.y += 0.5 * cell.messageBackgroundContainer.frame.height - 24
+
+        if message.isFromCurrentSender {
+            centerPoint.x = cell.frame.width - 0.5 * container.frame.width - 6
+            container.alignment = .trailing
+        } else {
+            centerPoint.x = (container.center.x + cell.messageBackgroundContainer.frame.minX)
+            container.alignment = .leading
+        }
+
         let previewTarget = UIPreviewTarget(container: tableView, center: centerPoint)
 
         let parameters = UIPreviewParameters()

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarAccessoryView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarAccessoryView.swift
@@ -418,15 +418,15 @@ open class InputBarAccessoryView: UIView {
 
     private func setupKeyboardEvents() {
         keyboardManager.on(event: .willChangeFrame, do: {  [weak self] (notification) in
-            guard let self = self else { return }
+            guard let self else { return }
             self.keyboardHeight = notification.endFrame.height - self.intrinsicContentSize.height
             self.delegate?.inputBar(self, didAdaptToKeyboard: self.keyboardHeight)
         }).on(event: .didChangeFrame, do: {  [weak self] (notification) in
-            guard let self = self else { return }
+            guard let self else { return }
             self.keyboardHeight = notification.endFrame.height - self.intrinsicContentSize.height
             self.delegate?.inputBar(self, didAdaptToKeyboard: self.keyboardHeight)
         }).on(event: .didShow, do: { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             if UIApplication.shared.statusBarOrientation.isLandscape && UIDevice.current.userInterfaceIdiom == .phone {
                 self.orientationDidChange()
             }

--- a/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
+++ b/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
@@ -1,0 +1,108 @@
+import UIKit
+
+enum DefaultReactions: CaseIterable {
+    case thumbsUp
+    case thumbsDown
+    case heart
+    case haha
+
+    var emoji: String {
+        switch self {
+        case .thumbsUp: return "👍"
+        case .thumbsDown: return "👎"
+        case .heart: return "❤️"
+        case .haha: return "😀"
+        }
+    }
+}
+
+protocol SendReactionsViewDelegate: AnyObject {
+    func reactionButtonTapped(_ view: SendReactionsView, reaction: DefaultReactions, messageId: String)
+}
+
+class SendReactionsView: UIView {
+    weak var delegate: SendReactionsViewDelegate?
+    
+    private let messageId: String
+    private let contentStackView: UIStackView
+    private let thumbsUpReactionButton: UIButton
+    private let thumbsDownReactionButton: UIButton
+    private let heartReactionButton: UIButton
+    private let hahaReactionButton: UIButton
+
+    init(messageId: String) {
+        self.messageId = messageId
+
+        thumbsUpReactionButton = UIButton()
+        thumbsDownReactionButton = UIButton()
+        heartReactionButton = UIButton()
+        hahaReactionButton = UIButton()
+
+        [thumbsUpReactionButton, thumbsDownReactionButton, heartReactionButton, hahaReactionButton].forEach {
+            if #available(iOS 13, *) {
+                $0.backgroundColor = .systemBackground
+            } else {
+                $0.backgroundColor = .white
+            }
+
+            $0.layer.cornerRadius = 8
+            $0.contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 16)
+            $0.titleEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: -8)
+        }
+
+        contentStackView = UIStackView(arrangedSubviews: [thumbsUpReactionButton, thumbsDownReactionButton, heartReactionButton, hahaReactionButton])
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.axis = .horizontal
+
+        contentStackView.spacing = 12
+
+        super.init(frame: .zero)
+
+        addSubview(contentStackView)
+
+        thumbsUpReactionButton.setTitle(DefaultReactions.thumbsUp.emoji, for: .normal)
+        thumbsUpReactionButton.addTarget(self, action: #selector(SendReactionsView.thumbsUpReactionButtonsButtonPressed(_:)), for: .touchUpInside)
+        thumbsDownReactionButton.setTitle(DefaultReactions.thumbsDown.emoji, for: .normal)
+        thumbsDownReactionButton.addTarget(self, action: #selector(SendReactionsView.thumbsDownReactionButtonsButtonPressed(_:)), for: .touchUpInside)
+        heartReactionButton.setTitle(DefaultReactions.heart.emoji, for: .normal)
+        heartReactionButton.addTarget(self, action: #selector(SendReactionsView.heartReactionButtonsButtonPressed(_:)), for: .touchUpInside)
+        hahaReactionButton.setTitle(DefaultReactions.haha.emoji, for: .normal)
+        hahaReactionButton.addTarget(self, action: #selector(SendReactionsView.hahaReactionButtonsButtonPressed(_:)), for: .touchUpInside)
+
+        setupCostraints()
+
+        backgroundColor = .clear
+        layer.cornerRadius = 15
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setupCostraints() {
+        let constraints = [
+            contentStackView.topAnchor.constraint(equalTo: topAnchor),
+            contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            trailingAnchor.constraint(greaterThanOrEqualTo: contentStackView.trailingAnchor),
+            bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor)
+        ]
+
+        NSLayoutConstraint.activate(constraints)
+    }
+
+    // MARK: - Actions
+
+    @objc func thumbsUpReactionButtonsButtonPressed(_ sender: Any) {
+        delegate?.reactionButtonTapped(self, reaction: .thumbsUp, messageId: messageId)
+    }
+
+    @objc func thumbsDownReactionButtonsButtonPressed(_ sender: Any) {
+        delegate?.reactionButtonTapped(self, reaction: .thumbsDown, messageId: messageId)
+    }
+
+    @objc func heartReactionButtonsButtonPressed(_ sender: Any) {
+        delegate?.reactionButtonTapped(self, reaction: .heart, messageId: messageId)
+    }
+
+    @objc func hahaReactionButtonsButtonPressed(_ sender: Any) {
+        delegate?.reactionButtonTapped(self, reaction: .haha, messageId: messageId)
+    }
+}

--- a/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
+++ b/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import DcCore
 
 enum DefaultReactions: CaseIterable {
     case thumbsUp
@@ -24,30 +25,48 @@ class SendReactionsView: UIView {
     weak var delegate: SendReactionsViewDelegate?
     
     private let messageId: String
+    let myReactions: [DcReaction]
+
     private let contentStackView: UIStackView
     private let thumbsUpReactionButton: UIButton
     private let thumbsDownReactionButton: UIButton
     private let heartReactionButton: UIButton
     private let hahaReactionButton: UIButton
 
-    init(messageId: String) {
+    init(messageId: String, myReactions: [DcReaction]) {
         self.messageId = messageId
+        self.myReactions = myReactions
 
         thumbsUpReactionButton = UIButton()
         thumbsDownReactionButton = UIButton()
         heartReactionButton = UIButton()
         hahaReactionButton = UIButton()
 
-        [thumbsUpReactionButton, thumbsDownReactionButton, heartReactionButton, hahaReactionButton].forEach {
+        let myEmojis = myReactions.map { $0.emoji }
+
+        [
+            (button: thumbsUpReactionButton, reaction: DefaultReactions.thumbsUp),
+            (button: thumbsDownReactionButton, reaction: DefaultReactions.thumbsDown),
+            (button: heartReactionButton, reaction: DefaultReactions.heart),
+            (button: hahaReactionButton, reaction: DefaultReactions.haha)
+        ].forEach {
             if #available(iOS 13, *) {
-                $0.backgroundColor = .systemBackground
+                if myEmojis.contains($0.reaction.emoji) {
+                    $0.button.backgroundColor = DcColors.messagePrimaryColor
+                } else {
+                    $0.button.backgroundColor = .systemBackground
+                }
             } else {
-                $0.backgroundColor = .white
+                if myEmojis.contains($0.reaction.emoji) {
+                    $0.button.backgroundColor = DcColors.messagePrimaryColor
+                } else {
+                    $0.button.backgroundColor = .white
+                }
             }
 
-            $0.layer.cornerRadius = 8
-            $0.contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 16)
-            $0.titleEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: -8)
+            $0.button.layer.cornerRadius = 8
+            $0.button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 16)
+            $0.button.titleEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: -8)
         }
 
         contentStackView = UIStackView(arrangedSubviews: [thumbsUpReactionButton, thumbsDownReactionButton, heartReactionButton, hahaReactionButton])

--- a/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
+++ b/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
@@ -67,6 +67,8 @@ class SendReactionsView: UIView {
             $0.button.layer.cornerRadius = 8
             $0.button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 16)
             $0.button.titleEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: -8)
+            $0.button.setTitle($0.reaction.emoji, for: .normal)
+
         }
 
         contentStackView = UIStackView(arrangedSubviews: [thumbsUpReactionButton, thumbsDownReactionButton, heartReactionButton, hahaReactionButton])
@@ -79,13 +81,9 @@ class SendReactionsView: UIView {
 
         addSubview(contentStackView)
 
-        thumbsUpReactionButton.setTitle(DefaultReactions.thumbsUp.emoji, for: .normal)
         thumbsUpReactionButton.addTarget(self, action: #selector(SendReactionsView.thumbsUpReactionButtonsButtonPressed(_:)), for: .touchUpInside)
-        thumbsDownReactionButton.setTitle(DefaultReactions.thumbsDown.emoji, for: .normal)
         thumbsDownReactionButton.addTarget(self, action: #selector(SendReactionsView.thumbsDownReactionButtonsButtonPressed(_:)), for: .touchUpInside)
-        heartReactionButton.setTitle(DefaultReactions.heart.emoji, for: .normal)
         heartReactionButton.addTarget(self, action: #selector(SendReactionsView.heartReactionButtonsButtonPressed(_:)), for: .touchUpInside)
-        hahaReactionButton.setTitle(DefaultReactions.haha.emoji, for: .normal)
         hahaReactionButton.addTarget(self, action: #selector(SendReactionsView.hahaReactionButtonsButtonPressed(_:)), for: .touchUpInside)
 
         setupCostraints()

--- a/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
+++ b/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
@@ -13,7 +13,7 @@ enum DefaultReactions: CaseIterable {
         case .thumbsUp: return "👍"
         case .thumbsDown: return "👎"
         case .heart: return "❤️"
-        case .haha: return "😀"
+        case .haha: return "😂"
         case .sad: return "🙁"
         }
     }

--- a/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
+++ b/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
@@ -18,7 +18,7 @@ enum DefaultReactions: CaseIterable {
 }
 
 protocol SendReactionsViewDelegate: AnyObject {
-    func reactionButtonTapped(_ view: SendReactionsView, reaction: DefaultReactions, messageId: String)
+    func reactionButtonTapped(_ view: SendReactionsView, reaction: DefaultReactions, myReactions: [DcReaction], messageId: String)
 }
 
 class SendReactionsView: UIView {
@@ -108,18 +108,18 @@ class SendReactionsView: UIView {
     // MARK: - Actions
 
     @objc func thumbsUpReactionButtonsButtonPressed(_ sender: Any) {
-        delegate?.reactionButtonTapped(self, reaction: .thumbsUp, messageId: messageId)
+        delegate?.reactionButtonTapped(self, reaction: .thumbsUp, myReactions: myReactions, messageId: messageId)
     }
 
     @objc func thumbsDownReactionButtonsButtonPressed(_ sender: Any) {
-        delegate?.reactionButtonTapped(self, reaction: .thumbsDown, messageId: messageId)
+        delegate?.reactionButtonTapped(self, reaction: .thumbsDown, myReactions: myReactions, messageId: messageId)
     }
 
     @objc func heartReactionButtonsButtonPressed(_ sender: Any) {
-        delegate?.reactionButtonTapped(self, reaction: .heart, messageId: messageId)
+        delegate?.reactionButtonTapped(self, reaction: .heart, myReactions: myReactions, messageId: messageId)
     }
 
     @objc func hahaReactionButtonsButtonPressed(_ sender: Any) {
-        delegate?.reactionButtonTapped(self, reaction: .haha, messageId: messageId)
+        delegate?.reactionButtonTapped(self, reaction: .haha, myReactions: myReactions, messageId: messageId)
     }
 }

--- a/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
+++ b/deltachat-ios/Chat/Send Reaction/SendReactionsView.swift
@@ -6,6 +6,7 @@ enum DefaultReactions: CaseIterable {
     case thumbsDown
     case heart
     case haha
+    case sad
 
     var emoji: String {
         switch self {
@@ -13,6 +14,7 @@ enum DefaultReactions: CaseIterable {
         case .thumbsDown: return "👎"
         case .heart: return "❤️"
         case .haha: return "😀"
+        case .sad: return "🙁"
         }
     }
 }
@@ -32,6 +34,7 @@ class SendReactionsView: UIView {
     private let thumbsDownReactionButton: UIButton
     private let heartReactionButton: UIButton
     private let hahaReactionButton: UIButton
+    private let sadReactionButton: UIButton
 
     init(messageId: String, myReactions: [DcReaction]) {
         self.messageId = messageId
@@ -41,6 +44,7 @@ class SendReactionsView: UIView {
         thumbsDownReactionButton = UIButton()
         heartReactionButton = UIButton()
         hahaReactionButton = UIButton()
+        sadReactionButton = UIButton()
 
         let myEmojis = myReactions.map { $0.emoji }
 
@@ -48,7 +52,8 @@ class SendReactionsView: UIView {
             (button: thumbsUpReactionButton, reaction: DefaultReactions.thumbsUp),
             (button: thumbsDownReactionButton, reaction: DefaultReactions.thumbsDown),
             (button: heartReactionButton, reaction: DefaultReactions.heart),
-            (button: hahaReactionButton, reaction: DefaultReactions.haha)
+            (button: hahaReactionButton, reaction: DefaultReactions.haha),
+            (button: sadReactionButton, reaction: DefaultReactions.sad),
         ].forEach {
             if #available(iOS 13, *) {
                 if myEmojis.contains($0.reaction.emoji) {
@@ -68,10 +73,9 @@ class SendReactionsView: UIView {
             $0.button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 16)
             $0.button.titleEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: -8)
             $0.button.setTitle($0.reaction.emoji, for: .normal)
-
         }
 
-        contentStackView = UIStackView(arrangedSubviews: [thumbsUpReactionButton, thumbsDownReactionButton, heartReactionButton, hahaReactionButton])
+        contentStackView = UIStackView(arrangedSubviews: [thumbsUpReactionButton, thumbsDownReactionButton, heartReactionButton, hahaReactionButton, sadReactionButton])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .horizontal
 
@@ -85,6 +89,7 @@ class SendReactionsView: UIView {
         thumbsDownReactionButton.addTarget(self, action: #selector(SendReactionsView.thumbsDownReactionButtonsButtonPressed(_:)), for: .touchUpInside)
         heartReactionButton.addTarget(self, action: #selector(SendReactionsView.heartReactionButtonsButtonPressed(_:)), for: .touchUpInside)
         hahaReactionButton.addTarget(self, action: #selector(SendReactionsView.hahaReactionButtonsButtonPressed(_:)), for: .touchUpInside)
+        sadReactionButton.addTarget(self, action: #selector(SendReactionsView.sadReactionButtonsButtonPressed(_:)), for: .touchUpInside)
 
         setupCostraints()
 
@@ -121,5 +126,9 @@ class SendReactionsView: UIView {
 
     @objc func hahaReactionButtonsButtonPressed(_ sender: Any) {
         delegate?.reactionButtonTapped(self, reaction: .haha, myReactions: myReactions, messageId: messageId)
+    }
+
+    @objc func sadReactionButtonsButtonPressed(_ sender: Any) {
+        delegate?.reactionButtonTapped(self, reaction: .sad, myReactions: myReactions, messageId: messageId)
     }
 }

--- a/deltachat-ios/Chat/Views/Cells/AudioMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/AudioMessageCell.swift
@@ -54,7 +54,7 @@ public class AudioMessageCell: BaseMessageCell {
         }
         
         delegate?.getAudioDuration(messageId: messageId, successHandler: { [weak self] messageId, duration in
-            if let self = self,
+            if let self,
                messageId == self.messageId {
                 self.audioPlayerView.setDuration(duration: duration)
             }

--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -162,7 +162,7 @@ public class BaseMessageCell: UITableViewCell {
         return StatusView()
     }()
 
-    private lazy var messageBackgroundContainer: BackgroundContainer = {
+    lazy var messageBackgroundContainer: BackgroundContainer = {
         let container = BackgroundContainer()
         container.image = UIImage(color: UIColor.blue)
         container.contentMode = .scaleToFill

--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -172,7 +172,7 @@ public class BaseMessageCell: UITableViewCell {
         return container
     }()
 
-    private let reactionsView: ReactionsView
+    let reactionsView: ReactionsView
 
     private var showSelectionBackground: Bool
 

--- a/deltachat-ios/Chat/Views/MediaPreview.swift
+++ b/deltachat-ios/Chat/Views/MediaPreview.swift
@@ -54,7 +54,7 @@ class MediaPreview: DraftPreview {
                 let thumbnailImage = DcUtils.generateThumbnailFromVideo(url: URL(fileURLWithPath: path, isDirectory: false))
                 if let thumbnailImage = thumbnailImage {
                     DispatchQueue.main.async { [weak self] in
-                        guard let self = self else { return }
+                        guard let self else { return }
                         self.contentImageView.image = thumbnailImage
                         self.setAspectRatio(image: thumbnailImage)
                         self.delegate?.onAttachmentAdded()

--- a/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
+++ b/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
@@ -52,10 +52,6 @@ class CertificateCheckController: UITableViewController {
 
     // MARK: - Table view data source
 
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return options.count
     }

--- a/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
+++ b/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
@@ -52,11 +52,7 @@ class SecuritySettingsController: UITableViewController {
     }
 
     // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return options.count
     }

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -19,11 +19,11 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
     private lazy var welcomeView: WelcomeContentView = {
         let view = WelcomeContentView()
         view.onLogin = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.showAccountSetupController()
         }
         view.onAddSecondDevice  = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let qrReader = QrCodeReaderController(title: String.localized("multidevice_receiver_title"),
                         addHints: "➊ " + String.localized("multidevice_same_network_hint") + "\n\n"
                             +     "➋ " + String.localized("multidevice_open_settings_on_other_device") + "\n\n"
@@ -33,14 +33,14 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
             self.navigationController?.pushViewController(qrReader, animated: true)
         }
         view.onScanQRCode  = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let qrReader = QrCodeReaderController(title: String.localized("scan_invitation_code"))
             qrReader.delegate = self
             self.qrCodeReader = qrReader
             self.navigationController?.pushViewController(qrReader, animated: true)
         }
         view.onImportBackup = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.restoreBackup()
         }
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -72,7 +72,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         super.init(nibName: nil, bundle: nil)
         self.navigationItem.title = String.localized(canCancel ? "add_account" : "welcome_desktop")
         onProgressSuccess = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let profileInfoController = ProfileInfoViewController(context: self.dcContext)
             profileInfoController.onClose = {
                 if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
@@ -164,7 +164,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
                                      onSuccess: self.handleLoginSuccess)
             showProgressAlert(title: String.localized("login_header"), dcContext: self.dcContext)
             DispatchQueue.global().async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 let success = self.dcContext.setConfigFromQR(qrCode: qrCode)
                 DispatchQueue.main.async {
                     if success {
@@ -254,7 +254,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
             object: nil,
             queue: nil
         ) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             if let ui = notification.userInfo {
                 if let error = ui["error"] as? Bool, error {
                     UIApplication.shared.isIdleTimerDisabled = false
@@ -321,7 +321,7 @@ extension WelcomeViewController: QrCodeReaderDelegate {
             title: String.localized("ok"),
             style: .default,
             handler: { [weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.dismissQRReader()
                 self.createAccountFromQRCode(qrCode: qrCode)
             }
@@ -331,7 +331,7 @@ extension WelcomeViewController: QrCodeReaderDelegate {
             title: String.localized("cancel"),
             style: .cancel,
             handler: { [weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.dismissQRReader()
                 // if an injected accountCode exists, the WelcomeViewController was only opened to handle that
                 // cancelling the action should also dismiss the whole controller
@@ -359,7 +359,7 @@ extension WelcomeViewController: QrCodeReaderDelegate {
              title: String.localized("ok"),
              style: .default,
              handler: { [weak self] _ in
-                 guard let self = self else { return }
+                 guard let self else { return }
                  if self.dcAccounts.getSelected().isConfigured() {
                      UserDefaults.standard.setValue(self.dcAccounts.getSelected().id, forKey: Constants.Keys.lastSelectedAccountKey)
                      _ = self.dcAccounts.add()
@@ -372,7 +372,7 @@ extension WelcomeViewController: QrCodeReaderDelegate {
                      self.showProgressAlert(title: String.localized("multidevice_receiver_title"), dcContext: self.dcContext)
                      self.dcAccounts.stopIo()
                      DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                         guard let self = self else { return }
+                         guard let self else { return }
                          logger.info("##### receiveBackup() with qr: \(qrCode)")
                          let res = self.dcContext.receiveBackup(qrCode: qrCode)
                          logger.info("##### receiveBackup() done with result: \(res)")
@@ -402,7 +402,7 @@ extension WelcomeViewController: QrCodeReaderDelegate {
             title: String.localized("ok"),
             style: .default,
             handler: { [weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 if self.accountCode != nil {
                     // if an injected accountCode exists, the WelcomeViewController was only opened to handle that
                     // if the action failed the whole controller should be dismissed

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -162,12 +162,12 @@ class AccountSwitchViewController: UITableViewController {
         let prefs = UserDefaults.standard
         let confirm1 = UIAlertController(title: String.localized("delete_account_ask"), message: nil, preferredStyle: .safeActionSheet)
         confirm1.addAction(UIAlertAction(title: String.localized("delete_account"), style: .destructive, handler: { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             let account = self.dcAccounts.get(id: accountId)
             let confirm2 = UIAlertController(title: account.displaynameAndAddr,
                 message: String.localized("forget_login_confirmation_desktop"), preferredStyle: .alert)
             confirm2.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { [weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 appDelegate.locationManager.disableLocationStreamingInAllChats()
                 self.dcAccounts.stopIo()
                 _ = self.dcAccounts.remove(id: accountId)

--- a/deltachat-ios/Controller/AddGroupMembersViewController.swift
+++ b/deltachat-ios/Controller/AddGroupMembersViewController.swift
@@ -126,7 +126,7 @@ class AddGroupMembersViewController: GroupMembersViewController {
         let newContactController = NewContactController(dcContext: dcContext, searchResult: searchText)
         newContactController.createChatOnSave = false
         newContactController.onContactSaved = { [weak self] contactId in
-            guard let self = self else { return }
+            guard let self else { return }
             self.contactIds = self.loadMemberCandidates()
             if self.contactIds.contains(contactId) {
                 self.selectedContactIds.insert(contactId)

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -305,7 +305,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         let audioSession = AVAudioSession.sharedInstance()
         audioSession.requestRecordPermission({ granted in
             DispatchQueue.main.async { [weak self] in
-                if let self = self {
+                if let self {
                     self.noRecordingPermissionView.alpha = granted ? 0.0 : 1.0
                     self.waveFormView.alpha = granted ? 1.0 : 0.0
                     self.doneButton.isEnabled = granted

--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -96,7 +96,7 @@ class BackupTransferViewController: UIViewController {
         triggerLocalNetworkPrivacyAlert()
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.dcAccounts.stopIo()
             self.dcBackupProvider = DcBackupProvider(self.dcContext)
             DispatchQueue.main.async {
@@ -116,7 +116,7 @@ class BackupTransferViewController: UIViewController {
                                  + "\n\n➋ " + String.localized("multidevice_install_dc_on_other_device")
                                  + "\n\n➌ " + String.localized("multidevice_tap_scan_on_other_device")
                 DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     self.dcBackupProvider?.wait()
                 }
             }
@@ -140,7 +140,7 @@ class BackupTransferViewController: UIViewController {
         } else {
             UIApplication.shared.isIdleTimerDisabled = true
             imexObserver = NotificationCenter.default.addObserver(forName: eventImexProgress, object: nil, queue: nil) { [weak self] notification in
-                guard let self = self, let ui = notification.userInfo, let permille = ui["progress"] as? Int else { return }
+                guard let self, let ui = notification.userInfo, let permille = ui["progress"] as? Int else { return }
                 if self.isFinishing { return }
                 var statusLineText: String?
                 var hideQrCode = false
@@ -257,7 +257,7 @@ class BackupTransferViewController: UIViewController {
         }))
         if !self.qrContentView.isHidden {
             alert.addAction(UIAlertAction(title: String.localized("menu_copy_to_clipboard"), style: .default, handler: { [weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.warnAboutCopiedQrCodeOnAbort = true
                 UIPasteboard.general.string = self.dcBackupProvider?.getQr()
             }))

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -95,11 +95,11 @@ class ChatListViewController: UITableViewController {
         self.isArchive = isArchive
         super.init(style: .plain)
         DispatchQueue.global(qos: .userInteractive).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.viewModel = ChatListViewModel(dcContext: self.dcContext, isArchive: isArchive)
             self.viewModel?.onChatListUpdate = self.handleChatListUpdate
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 if !isArchive {
                     self.navigationItem.searchController = self.searchController
                     self.searchController.searchResultsUpdater = self.viewModel
@@ -204,7 +204,7 @@ class ChatListViewController: UITableViewController {
             forName: eventMsgsChangedReadDeliveredFailed,
             object: nil,
             queue: nil) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
                let viewModel = self.viewModel,
                viewModel.searchActive,
@@ -704,7 +704,7 @@ class ChatListViewController: UITableViewController {
             handleEmptyStateLabel()
         } else {
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.tableView.reloadData()
                 self.handleEmptyStateLabel()
             }
@@ -740,7 +740,7 @@ class ChatListViewController: UITableViewController {
         stopTimer()
         timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             
-            guard let self = self,
+            guard let self,
                   let appDelegate = UIApplication.shared.delegate as? AppDelegate
             else { return }
             
@@ -809,7 +809,7 @@ class ChatListViewController: UITableViewController {
             preferredStyle: .safeActionSheet
         )
         alert.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { [weak self] _ in
-            guard let self = self, let viewModel = self.viewModel else { return }
+            guard let self, let viewModel = self.viewModel else { return }
             viewModel.deleteChats(indexPaths: self.tableView.indexPathsForSelectedRows)
             self.setLongTapEditing(false)
         }))
@@ -822,7 +822,7 @@ class ChatListViewController: UITableViewController {
                                       message: nil,
                                       preferredStyle: .safeActionSheet)
         alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             self.createAndShowNewChat(contactId: contactId, email: address)
         }))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in

--- a/deltachat-ios/Controller/ConnectivityViewController.swift
+++ b/deltachat-ios/Controller/ConnectivityViewController.swift
@@ -20,7 +20,7 @@ class ConnectivityViewController: WebViewViewController {
         if #available(iOS 13.0, *) {
             let monitor = NWPathMonitor()
             monitor.pathUpdateHandler = { [weak self] path in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.isLowDataMode = path.isConstrained
                 self.loadHtml()
             }
@@ -155,7 +155,7 @@ class ConnectivityViewController: WebViewViewController {
 
     private func loadHtml() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             // `UIApplication.shared` needs to be called from main thread
             var hasNotifyToken = false
             if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
@@ -165,7 +165,7 @@ class ConnectivityViewController: WebViewViewController {
 
             // do the remaining things in background thread
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 var html = self.dcContext.getConnectivityHtml()
                     .replacingOccurrences(of: "</style>", with:
                         """

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -251,7 +251,7 @@ class ContactDetailViewController: UITableViewController {
             forName: eventContactsChanged,
             object: nil,
             queue: OperationQueue.main) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             if let ui = notification.userInfo,
                self.viewModel.contactId == ui["contact_id"] as? Int {
                 self.updateHeader()
@@ -261,7 +261,7 @@ class ContactDetailViewController: UITableViewController {
             forName: eventIncomingMsg,
             object: nil,
             queue: OperationQueue.main) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             if let ui = notification.userInfo,
                let chatId = ui["chat_id"] as? Int {
                 if self.viewModel.getSharedChatIds().contains(chatId) {
@@ -574,7 +574,7 @@ extension ContactDetailViewController: MultilineLabelCellDelegate {
             let alert = UIAlertController(title: String.localizedStringWithFormat(String.localized("ask_start_chat_with"), email),
                                           message: nil, preferredStyle: .safeActionSheet)
             alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { [weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 let chatId = self.viewModel.context.createChatByContactId(contactId: contactId)
                 if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
                     appDelegate.appCoordinator.showChat(chatId: chatId, clearViewControllerStack: true)

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -76,10 +76,6 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
         }
     }
 
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return editRows.count
     }

--- a/deltachat-ios/Controller/EphemeralMessagesViewController.swift
+++ b/deltachat-ios/Controller/EphemeralMessagesViewController.swift
@@ -96,12 +96,7 @@ class EphemeralMessagesViewController: UITableViewController {
         navigationController?.popViewControllers(viewsToPop: 2, animated: true)
     }
 
-
     // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return options.count

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -166,7 +166,7 @@ class FilesViewController: UIViewController {
         let ids: [Int]
         ids = self.dcContext.getChatMedia(chatId: self.chatId, messageType: self.type1, messageType2: self.type2, messageType3: self.type3).reversed()
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.fileMessageIds = ids
             self.emptyStateView.isHidden = !ids.isEmpty
             self.tableView.reloadData()

--- a/deltachat-ios/Controller/FullMessageViewController.swift
+++ b/deltachat-ios/Controller/FullMessageViewController.swift
@@ -141,7 +141,7 @@ class FullMessageViewController: WebViewViewController {
 
     private func loadHtml() {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let html = self.dcContext.getMsgHtml(msgId: self.messageId)
             DispatchQueue.main.async {
                 self.webView.loadHTMLString(html, baseURL: nil)

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -185,7 +185,7 @@ class GalleryViewController: UIViewController {
         let ids: [Int]
         ids = self.dcContext.getChatMedia(chatId: self.chatId, messageType: DC_MSG_IMAGE, messageType2: DC_MSG_GIF, messageType3: DC_MSG_VIDEO).reversed()
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.galleryItemCache = [:]
             self.mediaMessageIds = ids
             self.emptyStateView.isHidden = !ids.isEmpty

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -227,7 +227,7 @@ class GroupChatDetailViewController: UIViewController {
             forName: eventIncomingMsg,
             object: nil,
             queue: OperationQueue.main) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             if let ui = notification.userInfo,
                self.chatId == ui["chat_id"] as? Int {
                 self.updateMediaCellValues()
@@ -237,7 +237,7 @@ class GroupChatDetailViewController: UIViewController {
             forName: eventEphemeralTimerModified,
             object: nil,
             queue: OperationQueue.main) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             if let ui = notification.userInfo,
                self.chatId == ui["chat_id"] as? Int {
                 self.updateEphemeralTimerCellValue()
@@ -247,7 +247,7 @@ class GroupChatDetailViewController: UIViewController {
             forName: eventChatModified,
             object: nil,
             queue: OperationQueue.main) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             if let ui = notification.userInfo,
                self.chatId == ui["chat_id"] as? Int {
                 self.updateHeader()
@@ -378,7 +378,7 @@ class GroupChatDetailViewController: UIViewController {
     private func showAddGroupMember(chatId: Int) {
         let groupMemberViewController = AddGroupMembersViewController(dcContext: dcContext, chatId: chatId)
         groupMemberViewController.onMembersSelected = { [weak self] memberIds in
-            guard let self = self else { return }
+            guard let self else { return }
             let chat = self.dcContext.getChat(chatId: chatId)
             var chatMembersToRemove = chat.getContactIds(self.dcContext)
             chatMembersToRemove.removeAll(where: { memberIds.contains($0)})
@@ -614,7 +614,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             getGroupMemberIdFor(row) != DC_CONTACT_ID_SELF {
             // action set for members except for current user
             let delete = UITableViewRowAction(style: .destructive, title: String.localized("remove_desktop")) { [weak self] _, indexPath in
-                guard let self = self else { return }
+                guard let self else { return }
                 let contact = self.getGroupMember(at: row)
                 let title = String.localizedStringWithFormat(String.localized(self.chat.isBroadcast ?
                                      "ask_remove_from_broadcast" :

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -208,7 +208,7 @@ class NewChatViewController: UITableViewController {
             let contactId = contactIdByRow(indexPath.row)
 
             let edit = UITableViewRowAction(style: .normal, title: String.localized("info")) { [weak self] _, _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 if self.searchController.isActive {
                     self.searchController.dismiss(animated: false) {
                         self.showContactDetail(contactId: contactId)
@@ -219,7 +219,7 @@ class NewChatViewController: UITableViewController {
             }
 
             let delete = UITableViewRowAction(style: .destructive, title: String.localized("delete")) { [weak self] _, _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 let contactId = self.contactIdByRow(indexPath.row)
                 self.askToDeleteContact(contactId: contactId, indexPath: indexPath)
             }

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -240,7 +240,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
         // swipe to delete
         if sections[indexPath.section] == .members, groupContactIds[indexPath.row] != DC_CONTACT_ID_SELF {
             let delete = UITableViewRowAction(style: .destructive, title: String.localized("remove_desktop")) { [weak self] _, indexPath in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.removeGroupContactFromList(at: indexPath)
             }
             delete.backgroundColor = UIColor.systemRed
@@ -327,7 +327,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
                                                                preselected: preselectedMembers,
                                                                isBroadcast: createBroadcast)
         newGroupController.onMembersSelected = { [weak self] memberIds in
-            guard let self = self else { return }
+            guard let self else { return }
             var memberIds = memberIds
             if !self.createBroadcast {
                 memberIds.insert(Int(DC_CONTACT_ID_SELF))

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -54,7 +54,7 @@ class QrCodeReaderController: UIViewController {
             self.setupQRCodeScanner()
         } else {
             AVCaptureDevice.requestAccess(for: .video, completionHandler: {  [weak self] (granted: Bool) in
-                guard let self = self else { return }
+                guard let self else { return }
                 DispatchQueue.main.async {
                     if granted {
                         self.setupQRCodeScanner()
@@ -127,7 +127,7 @@ class QrCodeReaderController: UIViewController {
     
     private func showCameraWarning() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let text = String.localized("chat_camera_unavailable")
             logger.error(text)
             self.infoLabel.textColor = DcColors.defaultTextColor

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -129,7 +129,7 @@ class QrPageController: UIPageViewController {
         let alert = UIAlertController(title: String.localized("withdraw_verifycontact_explain"), message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .default))
         alert.addAction(UIAlertAction(title: String.localized("withdraw_qr_code"), style: .destructive, handler: { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             guard let code = dcContext.getSecurejoinQr(chatId: 0) else { return }
             guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
             _ = self.dcContext.setConfigFromQR(qrCode: code)
@@ -280,7 +280,7 @@ extension QrPageController: QrCodeReaderDelegate {
                                           preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .default))
             alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: { [weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 let success = self.dcContext.setConfigFromQR(qrCode: code)
                 if !success {
                     logger.warning("Could not set webrtc instance from QR code.")

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -101,7 +101,7 @@ class QrViewController: UIViewController {
                                       message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .default))
         alert.addAction(UIAlertAction(title: String.localized("withdraw_qr_code"), style: .destructive, handler: { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             guard let code = dcContext.getSecurejoinQr(chatId: self.chatId) else { return }
             _ = self.dcContext.setConfigFromQR(qrCode: code)
             self.navigationController?.popViewController(animated: true)

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -186,7 +186,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         addProgressAlertListener(dcAccounts: dcAccounts, progressName: eventImexProgress) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.progressAlert?.dismiss(animated: true)
         }
     }
@@ -275,7 +275,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         let broadcastLists = UserDefaults.standard.bool(forKey: "broadcast_lists")
         alert.addAction(UIAlertAction(title: (broadcastLists ? "✔︎ " : "") + String.localized("broadcast_lists"),
                                       style: .default, handler: { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             UserDefaults.standard.set(!broadcastLists, forKey: "broadcast_lists")
             if !broadcastLists {
                 let alert = UIAlertController(title: "Thanks for trying out the experimental feature 🧪 \"Broadcast Lists\"!",
@@ -291,7 +291,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         let locationStreaming = UserDefaults.standard.bool(forKey: "location_streaming")
         let title = (locationStreaming ? "✔︎ " : "") + String.localized("pref_on_demand_location_streaming")
         alert.addAction(UIAlertAction(title: title, style: .default, handler: { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             UserDefaults.standard.set(!locationStreaming, forKey: "location_streaming")
             if !locationStreaming {
                 let alert = UIAlertController(title: "Thanks for trying out the experimental feature 🧪 \"Location streaming\"",

--- a/deltachat-ios/Controller/Settings/AutodelOptionsViewController.swift
+++ b/deltachat-ios/Controller/Settings/AutodelOptionsViewController.swift
@@ -101,11 +101,7 @@ class AutodelOptionsViewController: UITableViewController {
     }
 
     // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return autodelOptions.count
     }

--- a/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
+++ b/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
@@ -146,7 +146,7 @@ internal final class ChatsAndMediaViewController: UITableViewController, Progres
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         addProgressAlertListener(dcAccounts: dcAccounts, progressName: eventImexProgress) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.progressAlert?.dismiss(animated: true) {
                 let alert = UIAlertController(

--- a/deltachat-ios/Controller/Settings/DownloadOnDemandViewController.swift
+++ b/deltachat-ios/Controller/Settings/DownloadOnDemandViewController.swift
@@ -44,11 +44,7 @@ class DownloadOnDemandViewController: UITableViewController {
     }
 
     // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return options.count
     }

--- a/deltachat-ios/Controller/Settings/EmailOptionsViewController.swift
+++ b/deltachat-ios/Controller/Settings/EmailOptionsViewController.swift
@@ -40,11 +40,6 @@ class EmailOptionsViewController: UITableViewController {
     }
 
     // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return options.count
     }

--- a/deltachat-ios/Controller/Settings/MediaQualityViewController.swift
+++ b/deltachat-ios/Controller/Settings/MediaQualityViewController.swift
@@ -38,11 +38,6 @@ class MediaQualityViewController: UITableViewController {
     }
 
     // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return options.count
     }

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -170,7 +170,7 @@ internal final class SettingsViewController: UITableViewController {
         connectivityChangedObserver = NotificationCenter.default.addObserver(forName: eventConnectivityChanged,
                                                                              object: nil,
                                                                              queue: nil) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             self.connectivityCell.detailTextLabel?.text = DcUtils.getConnectivityString(dcContext: self.dcContext,
                                                                                         connectedString: String.localized("connectivity_connected"))
         }
@@ -273,7 +273,7 @@ internal final class SettingsViewController: UITableViewController {
             title: String.localized("perm_continue"),
             style: .default,
             handler: { [weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.navigationController?.pushViewController(BackupTransferViewController(dcAccounts: self.dcAccounts), animated: true)
             }
         ))

--- a/deltachat-ios/Controller/Settings/VideoChatInstanceViewController.swift
+++ b/deltachat-ios/Controller/Settings/VideoChatInstanceViewController.swift
@@ -82,11 +82,7 @@ class VideoChatInstanceViewController: UITableViewController {
     }
 
     // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return self.predefinedCells.count + 2
     }

--- a/deltachat-ios/Controller/WebViewViewController.swift
+++ b/deltachat-ios/Controller/WebViewViewController.swift
@@ -156,7 +156,7 @@ class WebViewViewController: UIViewController, WKNavigationDelegate {
 
     private func updateAccessoryBar() {
         handleSearchResultCount { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             logger.debug("found \(result) elements")
             self.searchAccessoryBar.isEnabled = result > 0
             self.handleCurrentlySelected { [weak self] position in

--- a/deltachat-ios/Controller/WebxdcSelector.swift
+++ b/deltachat-ios/Controller/WebxdcSelector.swift
@@ -105,7 +105,7 @@ class WebxdcSelector: UIViewController {
     func deduplicateWebxdcs() {
         var deduplicatedMessageHashes: [String: Int] = [:]
         DispatchQueue.global(qos: .userInteractive).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let mediaMessageIds = dcContext.getChatMedia(chatId: 0, messageType: DC_MSG_WEBXDC, messageType2: 0, messageType3: 0).reversed()
             for id in mediaMessageIds {
                 guard let filename = self.dcContext.getMessage(id: id).fileURL else { continue }

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -287,7 +287,7 @@ class WebxdcViewController: WebViewViewController {
             object: nil,
             queue: OperationQueue.main
         ) { [weak self] notification in
-            guard let self = self, let messageId = notification.userInfo?["message_id"] as? Int else { return }
+            guard let self, let messageId = notification.userInfo?["message_id"] as? Int else { return }
             if messageId == self.messageId {
                 self.updateWebxdc()
             }
@@ -298,7 +298,7 @@ class WebxdcViewController: WebViewViewController {
             object: nil,
             queue: OperationQueue.main
         ) { [weak self] notification in
-            guard let self = self, let messageId = notification.userInfo?["message_id"] as? Int else { return }
+            guard let self, let messageId = notification.userInfo?["message_id"] as? Int else { return }
             if messageId == self.messageId {
                 self.refreshWebxdcInfo()
             }
@@ -365,7 +365,7 @@ class WebxdcViewController: WebViewViewController {
     
     private func loadHtml() {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let url = URL(string: "\(self.INTERNALSCHEMA)://acc\(self.dcContext.id)-msg\(self.messageId).localhost/index.html")
             let urlRequest = URLRequest(url: url!)
             DispatchQueue.main.async {

--- a/deltachat-ios/Handler/DeviceContactsHandler.swift
+++ b/deltachat-ios/Handler/DeviceContactsHandler.swift
@@ -86,7 +86,7 @@ class DeviceContactsHandler {
             contactListDelegate?.accessDenied()
         case .restricted, .notDetermined:
             store.requestAccess(for: .contacts) { [weak self] granted, _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 if granted {
                     DispatchQueue.main.async {
                         self.addContactsToCore()

--- a/deltachat-ios/Handler/ProgressAlertHandler.swift
+++ b/deltachat-ios/Handler/ProgressAlertHandler.swift
@@ -77,7 +77,7 @@ extension ProgressAlertHandler {
             object: nil,
             queue: nil
         ) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             if let ui = notification.userInfo {
                 if ui["error"] as? Bool ?? false {
                     dcAccounts.startIo()

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -71,7 +71,7 @@ public class NotificationManager {
             }
 
             DispatchQueue.global(qos: .background).async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 if let ui = notification.userInfo,
                    let chatId = ui["chat_id"] as? Int,
                    let messageId = ui["message_id"] as? Int,
@@ -128,7 +128,7 @@ public class NotificationManager {
             forName: eventMsgsNoticed,
             object: nil, queue: OperationQueue.main
         ) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             if !UserDefaults.standard.bool(forKey: "notifications_disabled"),
                let ui = notification.userInfo,
                let chatId = ui["chat_id"] as? Int {


### PR DESCRIPTION
Adds a view to send emoji-reactions. When you can't send a message in that very chat, you also won't be able to send an emoji-reaction. Please note, that this works only for iOS 13+.

For now, there are five default emojis: 👍, 👎, ❤️, ~😀~ 😂, 🙁. It is planned for the foreseable future to add an Emoji-selection. Your own reactions are visually marked. If you tap them again, your reaction disappears. And it looks like this on iPad:

## Screenshots

![1728_ipad](https://github.com/deltachat/deltachat-ios/assets/2580019/23f265d6-59f1-403b-a867-5eee0184c76d)

On iPhone, it looks like this:

![1728_iphone](https://github.com/deltachat/deltachat-ios/assets/2580019/952298b3-1fb9-48cb-9f78-868eac59fd80)

The different blurry backgrounds come from the operating system (AFAIK). Another change is that only the message-bubble is highlighted, not the entire cell anymore. I also sneaked in some cleanups (see `UIView+Extensions`).

Closes #1728.