### PR TITLE
move 'pinned' indicator right for cleaner UI

### DIFF
--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -30,9 +30,9 @@ class ContactCell: UITableViewCell {
             verifiedIndicator,
             spacerView,
             mutedIndicator,
-            pinnedIndicator,
+            locationStreamingIndicator,
             timeLabel,
-            locationStreamingIndicator])
+            pinnedIndicator])
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.spacing = 4


### PR DESCRIPTION
'pinned' chats are always shown together below each other; moving the 'pinned' indicator to the same position in each chat makes the UI a little less cluttered and nicer
(all pinned indicators will form a column if you will)

<img width=280 src=https://github.com/deltachat/deltachat-ios/assets/9800740/8a279c07-105d-4de4-a27e-e21b14a0661d>

this PR is an outcome of the feature-proposal at https://support.delta.chat/t/three-small-changes-to-make-delta-chat-better/2886 