### PR TITLE
do not add "Changelog" for new accounts

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -134,9 +134,14 @@ class ChatListViewController: UITableViewController {
 
         // update messages - for new messages, do not reuse or modify strings but create new ones.
         // it is not needed to keep all past update messages, however, when deleted, also the strings should be deleted.
-        let msg = dcContext.newMessage(viewType: DC_MSG_TEXT)
-        msg.text = String.localized("update_1_42_common") + "\n\n" + String.localized("more_info_desktop") +  ": https://get.delta.chat/#changelogs"
-        dcContext.addDeviceMessage(label: "update_1_42b_ios", msg: msg)
+        let deviceMsgLabel = "update_1_42b_ios2"
+        if !dcAccounts.isJustAdded(id: dcContext.id) {
+            let msg = dcContext.newMessage(viewType: DC_MSG_TEXT)
+            msg.text = String.localized("update_1_42_common") + "\n\n" + String.localized("more_info_desktop") +  ": https://get.delta.chat/#changelogs"
+            dcContext.addDeviceMessage(label: deviceMsgLabel, msg: msg)
+        } else {
+            dcContext.addDeviceMessage(label: deviceMsgLabel, msg: nil)
+        }
 
         if dcContext.isAnyDatabaseEncrypted() {
             let msg = dcContext.newMessage(viewType: DC_MSG_TEXT)

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -135,7 +135,7 @@ class ChatListViewController: UITableViewController {
         // update messages - for new messages, do not reuse or modify strings but create new ones.
         // it is not needed to keep all past update messages, however, when deleted, also the strings should be deleted.
         let deviceMsgLabel = "update_1_42b_ios2"
-        if !dcAccounts.isJustAdded(id: dcContext.id) {
+        if !dcAccounts.isFreshlyAdded(id: dcContext.id) {
             let msg = dcContext.newMessage(viewType: DC_MSG_TEXT)
             msg.text = String.localized("update_1_42_common") + "\n\n" + String.localized("more_info_desktop") +  ": https://get.delta.chat/#changelogs"
             dcContext.addDeviceMessage(label: deviceMsgLabel, msg: msg)

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -12,6 +12,7 @@ public class DcAccounts {
     public var fetchSemaphore: DispatchSemaphore?
 
     private var encryptedDatabases: [Int: Bool] = [:]
+    private var justAdded: [Int: Bool] = [:]
 
     public init() {}
 
@@ -26,12 +27,17 @@ public class DcAccounts {
     public func add() -> Int {
         let accountId = Int(dc_accounts_add_account(accountsPointer))
         get(id: accountId).setConfig("verified_one_on_one_chats", "1")
+        justAdded[accountId] = true
         return accountId
     }
 
     public func get(id: Int) -> DcContext {
         let contextPointer = dc_accounts_get_account(accountsPointer, UInt32(id))
         return DcContext(contextPointer: contextPointer)
+    }
+
+    public func isJustAdded(id: Int) -> Bool {
+        return justAdded[id] ?? false
     }
 
     public func getAll() -> [Int] {

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -12,7 +12,7 @@ public class DcAccounts {
     public var fetchSemaphore: DispatchSemaphore?
 
     private var encryptedDatabases: [Int: Bool] = [:]
-    private var justAdded: [Int: Bool] = [:]
+    private var freshlyAddedAccountIds: [Int] = []
 
     public init() {}
 
@@ -27,7 +27,7 @@ public class DcAccounts {
     public func add() -> Int {
         let accountId = Int(dc_accounts_add_account(accountsPointer))
         get(id: accountId).setConfig("verified_one_on_one_chats", "1")
-        justAdded[accountId] = true
+        freshlyAddedAccountIds.append(accountId)
         return accountId
     }
 
@@ -36,8 +36,8 @@ public class DcAccounts {
         return DcContext(contextPointer: contextPointer)
     }
 
-    public func isJustAdded(id: Int) -> Bool {
-        return justAdded[id] ?? false
+    public func isFreshlyAdded(id: Int) -> Bool {
+        return freshlyAddedAccountIds.contains(id)
     }
 
     public func getAll() -> [Int] {

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -504,8 +504,8 @@ public class DcContext {
     }
 
     @discardableResult
-    public func addDeviceMessage(label: String?, msg: DcMsg) -> Int {
-        return Int(dc_add_device_msg(contextPointer, label, msg.cptr))
+    public func addDeviceMessage(label: String?, msg: DcMsg?) -> Int {
+        return Int(dc_add_device_msg(contextPointer, label, msg?.cptr ?? nil))
     }
 
     public func getProviderFromEmailWithDns(addr: String) -> DcProvider? {


### PR DESCRIPTION
on new installations or accounts,
the "What's new?" messages only clutter the device messages with unimportant information
(either the user is new to the app, so everyrhing is new and nothing is changed, or an existing user has created a new account, they have seen the changelog anyways)

in other words,
the changelog will be added only for updates.

when reading https://c.delta.chat/classdc__context__t.html#a1a2aad98bd23c1d21ee42374e241f389 , this was always the gist, however, somehow forgotten or removed on the way :)

technically, it was easier to track the creation in an array, as the user flow from creation to finally addind the device message is a bit too complicated to pass flags around.

counterpart of https://github.com/deltachat/deltachat-android/pull/2935 and https://github.com/deltachat/deltachat-desktop/issues/3637