### PR TITLE
share and copy invite-links

### DIFF
--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -307,9 +307,11 @@ extension FilesViewController {
         parentViewController.present(activityVC, animated: true, completion: nil)
     }
 
-    public static func share(text: String, parentViewController: UIViewController) {
-        let activityVC = UIActivityViewController(activityItems: [text], applicationActivities: nil)
-        parentViewController.present(activityVC, animated: true, completion: nil)
+    public static func share(url: String, parentViewController: UIViewController) {
+        if let url = URL(string: url) {
+            let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+            parentViewController.present(activityVC, animated: true, completion: nil)
+        }
     }
 }
 

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -288,7 +288,6 @@ extension FilesViewController {
     }
 
     public static func share(message: DcMsg, parentViewController: UIViewController, sourceView: UIView) {
-        let activityVC: UIActivityViewController
         guard let fileURL = message.fileURL else { return }
         let objectsToShare: [Any]
         if message.type == DC_MSG_WEBXDC {
@@ -302,9 +301,14 @@ extension FilesViewController {
             objectsToShare = [fileURL]
         }
 
-        activityVC = UIActivityViewController(activityItems: objectsToShare, applicationActivities: nil)
+        let activityVC = UIActivityViewController(activityItems: objectsToShare, applicationActivities: nil)
         activityVC.excludedActivityTypes = [.copyToPasteboard]
         activityVC.popoverPresentationController?.sourceView = sourceView
+        parentViewController.present(activityVC, animated: true, completion: nil)
+    }
+
+    public static func share(text: String, parentViewController: UIViewController) {
+        let activityVC = UIActivityViewController(activityItems: [text], applicationActivities: nil)
         parentViewController.present(activityVC, animated: true, completion: nil)
     }
 }

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -112,6 +112,7 @@ class QrPageController: UIPageViewController {
     @objc private func showMoreOptions() {
         let alert = UIAlertController(title: String.localized("qr_code"), message: nil, preferredStyle: .safeActionSheet)
         if qrSegmentControl.selectedSegmentIndex == 0 {
+            alert.addAction(UIAlertAction(title: String.localized("menu_share"), style: .default, handler: share(_:)))
             alert.addAction(UIAlertAction(title: String.localized("menu_copy_to_clipboard"), style: .default, handler: copyToClipboard(_:)))
             alert.addAction(UIAlertAction(title: String.localized("withdraw_qr_code"), style: .default, handler: withdrawQrCode(_:)))
         } else {
@@ -121,8 +122,14 @@ class QrPageController: UIPageViewController {
         self.present(alert, animated: true, completion: nil)
     }
 
+    @objc func share(_ action: UIAlertAction) {
+        if let inviteLink = Utils.getInviteLink(context: dcContext, chatId: 0) {
+            FilesViewController.share(text: inviteLink, parentViewController: self)
+        }
+    }
+
     @objc func copyToClipboard(_ action: UIAlertAction) {
-        UIPasteboard.general.string = Utils.getInviteLink(context: dcContext)
+        UIPasteboard.general.string = Utils.getInviteLink(context: dcContext, chatId: 0)
     }
 
     @objc func withdrawQrCode(_ action: UIAlertAction) {

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -122,7 +122,7 @@ class QrPageController: UIPageViewController {
     }
 
     @objc func copyToClipboard(_ action: UIAlertAction) {
-        UIPasteboard.general.string = dcContext.getSecurejoinQr(chatId: 0)
+        UIPasteboard.general.string = Utils.getInviteLink(context: dcContext)
     }
 
     @objc func withdrawQrCode(_ action: UIAlertAction) {

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -124,7 +124,7 @@ class QrPageController: UIPageViewController {
 
     @objc func share(_ action: UIAlertAction) {
         if let inviteLink = Utils.getInviteLink(context: dcContext, chatId: 0) {
-            FilesViewController.share(text: inviteLink, parentViewController: self)
+            FilesViewController.share(url: inviteLink, parentViewController: self)
         }
     }
 

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -94,7 +94,7 @@ class QrViewController: UIViewController {
 
     @objc func share(_ action: UIAlertAction) {
         if let inviteLink = Utils.getInviteLink(context: dcContext, chatId: chatId) {
-            FilesViewController.share(text: inviteLink, parentViewController: self)
+            FilesViewController.share(url: inviteLink, parentViewController: self)
         }
     }
 

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -92,7 +92,7 @@ class QrViewController: UIViewController {
     }
 
     @objc func copyToClipboard(_ action: UIAlertAction) {
-        UIPasteboard.general.string = dcContext.getSecurejoinQr(chatId: chatId)
+        UIPasteboard.general.string = Utils.getInviteLink(context: dcContext, chatId: chatId)
     }
 
     @objc func withdrawQrCode(_ action: UIAlertAction) {

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -85,10 +85,17 @@ class QrViewController: UIViewController {
     // MARK: - actions
     @objc private func showMoreOptions() {
         let alert = UIAlertController(title: String.localized("qrshow_title"), message: nil, preferredStyle: .safeActionSheet)
+        alert.addAction(UIAlertAction(title: String.localized("menu_share"), style: .default, handler: share(_:)))
         alert.addAction(UIAlertAction(title: String.localized("menu_copy_to_clipboard"), style: .default, handler: copyToClipboard(_:)))
         alert.addAction(UIAlertAction(title: String.localized("withdraw_qr_code"), style: .default, handler: withdrawQrCode(_:)))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         self.present(alert, animated: true, completion: nil)
+    }
+
+    @objc func share(_ action: UIAlertAction) {
+        if let inviteLink = Utils.getInviteLink(context: dcContext, chatId: chatId) {
+            FilesViewController.share(text: inviteLink, parentViewController: self)
+        }
     }
 
     @objc func copyToClipboard(_ action: UIAlertAction) {

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -3,6 +3,7 @@ import UIKit
 import DcCore
 
 struct Utils {
+    private static let inviteDomain = "i.delta.chat"
 
     static func isEmail(url: URL) -> Bool {
         let mailScheme = "mailto"
@@ -39,5 +40,17 @@ struct Utils {
         // iOS 11 and 12
         let window = UIApplication.shared.keyWindow
         return window?.safeAreaInsets.bottom ?? 0
+    }
+
+    public static func getInviteLink(context: DcContext, chatId: Int = 0) -> String? {
+        // convert `OPENPGP4FPR:FPR#a=ADDR&n=NAME&...` to `https://i.delta.chat/#FPR&a=ADDR&n=NAME&...`
+        if var data = context.getSecurejoinQr(chatId: chatId), let range = data.range(of: "#") {
+            data.replaceSubrange(range, with: "&")
+            if let range = data.range(of: "OPENPGP4FPR:") {
+                data.replaceSubrange(range, with: "https://" + inviteDomain + "/#")
+                return data
+            }
+        }
+        return nil
     }
 }

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -42,7 +42,7 @@ struct Utils {
         return window?.safeAreaInsets.bottom ?? 0
     }
 
-    public static func getInviteLink(context: DcContext, chatId: Int = 0) -> String? {
+    public static func getInviteLink(context: DcContext, chatId: Int) -> String? {
         // convert `OPENPGP4FPR:FPR#a=ADDR&n=NAME&...` to `https://i.delta.chat/#FPR&a=ADDR&n=NAME&...`
         if var data = context.getSecurejoinQr(chatId: chatId), let range = data.range(of: "#") {
             data.replaceSubrange(range, with: "&")


### PR DESCRIPTION
this PR let the **Copy to Clipboard** option of the 'QR Show' dialogs copy an invite-link instead of an openpgp4fpr-link (invite links are much more useful outside delta chat as they can be tapped and also show instructions about how to install delta chat)

moreover, this PR adds the option **Share** to the 'QR Show' dialogs, so that one can directly send the invite-links eg. via other messengers

<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/46752a8a-b355-4449-8c74-b3b60607adf6> <img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/a4d32f30-f344-42f9-ba8e-62ec387f39ff>

on the receiving side, both, invite-links as well as openpgp4fpr-links can be pasted since https://github.com/deltachat/deltachat-core-rust/pull/5219 , as external protocol, for now openpgp4fpr is supported (which is shown on the invite page)

closes #2057 