### PR TITLE
detailed error message on 'cannot encrypt'

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -735,6 +735,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         dcContext.setStockTranslation(id: DC_STR_CHAT_PROTECTION_ENABLED, localizationKey: "chat_protection_enabled_tap_to_learn_more")
         dcContext.setStockTranslation(id: DC_STR_CHAT_PROTECTION_DISABLED, localizationKey: "chat_protection_broken_tap_to_learn_more")
         dcContext.setStockTranslation(id: DC_STR_NEW_GROUP_SEND_FIRST_MESSAGE, localizationKey: "chat_new_group_hint")
+        dcContext.setStockTranslation(id: DC_STR_MESSAGE_ADD_MEMBER, localizationKey: "member_x_added")
+        dcContext.setStockTranslation(id: DC_STR_INVALID_UNENCRYPTED_MAIL, localizationKey: "invalid_unencrypted_tap_to_learn_more")
     }
 
     func appIsInForeground() -> Bool {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -984,6 +984,8 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 showProtectionEnabledDialog()
             case DC_INFO_PROTECTION_DISABLED:
                 showProtectionBrokenDialog()
+            case DC_INFO_INVALID_UNENCRYPTED_MAIL:
+                showInvalidUnencryptedDialog()
             default:
                 break
             }
@@ -1591,6 +1593,20 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         let alert = UIAlertController(title: String.localized("chat_protection_enabled_explanation"), message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: String.localized("learn_more"), style: .default, handler: { _ in
             self.navigationController?.pushViewController(HelpViewController(dcContext: self.dcContext, fragment: "#e2eeguarantee"), animated: true)
+        }))
+        alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: nil))
+        navigationController?.present(alert, animated: true, completion: nil)
+    }
+
+    private func showInvalidUnencryptedDialog() {
+        let alert = UIAlertController(title: String.localized("invalid_unencrypted_explanation"), message: nil, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: String.localized("learn_more"), style: .default, handler: { _ in
+            self.navigationController?.pushViewController(HelpViewController(dcContext: self.dcContext, fragment: "#howtoe2ee"), animated: true)
+        }))
+        alert.addAction(UIAlertAction(title: String.localized("qrscan_title"), style: .default, handler: { _ in
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                appDelegate.appCoordinator.presentQrCodeController()
+            }
         }))
         alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: nil))
         navigationController?.present(alert, animated: true, completion: nil)


### PR DESCRIPTION
providers may not allow to send unencrypted messages. for this case, this PR adds a more detailed error message including away for the user to fix the situation.

<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/a49e9164-b1fd-4ffb-89fc-f7e0efd4fa32> <img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/b888be0b-ced7-441f-aa53-ab2b30d90789>

closes #2054 