### PR TITLE
Add 'Scan QR Code' button to 'New Chat'

### DIFF
--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -6,10 +6,11 @@ class NewChatViewController: UITableViewController {
     private let dcContext: DcContext
 
     private let sectionNew = 0
-    private let sectionNewRowNewContact = 0
+    private let sectionNewRowScanQRCode = 0
     private let sectionNewRowNewGroup = 1
     private let sectionNewRowBroadcastList = 2
-    private var sectionNewRowCount: Int { return UserDefaults.standard.bool(forKey: "broadcast_lists") ? 3 : 2 }
+    private let sectionNewRowNewContact = 3
+    private var sectionNewRowCount: Int { return UserDefaults.standard.bool(forKey: "broadcast_lists") ? 4 : 3 }
 
     private let sectionImportedContacts = 1
 
@@ -143,6 +144,8 @@ class NewChatViewController: UITableViewController {
             let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
             if let actionCell = cell as? ActionCell {
                 switch row {
+                case sectionNewRowScanQRCode:
+                    actionCell.actionTitle = String.localized("qrscan_title")
                 case sectionNewRowNewGroup:
                     actionCell.actionTitle = String.localized("menu_new_group")
                 case sectionNewRowBroadcastList:
@@ -184,7 +187,11 @@ class NewChatViewController: UITableViewController {
         let section = indexPath.section
 
         if section == sectionNew {
-            if row == sectionNewRowNewGroup {
+            if row == sectionNewRowScanQRCode {
+                if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                    appDelegate.appCoordinator.presentQrCodeController()
+                }
+            } else if row == sectionNewRowNewGroup {
                 showNewGroupController()
             } else if row == sectionNewRowBroadcastList {
                 showNewGroupController(createBroadcast: true)


### PR DESCRIPTION
The "New Chat" dialog is the main way we're offering to create new chats. With chatmail getting more into focus,
scanning a QR code becomes more important
and is now available directly from "New Chat" as well

<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/2fa7bcec-e2a7-4efd-bbf5-cb0cfc4b74ad>


closes #2036