### PR TITLE
use core background fetch, use .default qos

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -156,15 +156,17 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_CONNECTIVITY_CHANGED:
-            if let sem = dcAccounts.fetchSemaphore, dcAccounts.isAllWorkDone() {
-                sem.signal()
-            }
             if accountId != dcAccounts.getSelected().id {
                 return
             }
             logger.info("📡[\(accountId)] connectivity changed")
             DispatchQueue.main.async {
                 NotificationCenter.default.post(name: eventConnectivityChanged, object: nil)
+            }
+
+        case DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE:
+            if let sem = dcAccounts.fetchSemaphore {
+                sem.signal()
             }
 
         case DC_EVENT_WEBXDC_STATUS_UPDATE:

--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -138,7 +138,7 @@ class ShareAttachment {
                 _ = self.addDcMsg(path: url.relativePath, viewType: DC_MSG_VIDEO)
                 self.delegate?.onAttachmentChanged()
                 if self.imageThumbnail == nil {
-                    DispatchQueue.global(qos: .background).async {
+                    DispatchQueue.global().async {
                         self.imageThumbnail = DcUtils.generateThumbnailFromVideo(url: url)
                         DispatchQueue.main.async {
                             self.delegate?.onThumbnailChanged()

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -501,9 +501,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             }
             let diff = CFAbsoluteTimeGetCurrent() - start
 
-            // wait for DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE,
-            // marking the end of events needed to being processed.
-            // as IO was not started, random events caused by other reasons are not added.
+            // wait for DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE;
+            // without IO being started, more events that could interfere with shutdown are not added
             _ = self.dcAccounts.fetchSemaphore?.wait(timeout: .now() + 20)
             self.dcAccounts.fetchSemaphore = nil
             let diff2 = CFAbsoluteTimeGetCurrent() - start

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -132,7 +132,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 // maybeNetwork() shall not be called in ui thread;
                 // Reachability::reachabilityChanged uses DispatchQueue.main.async only
                 logger.info("network: reachable \(reachability.connection.description)")
-                DispatchQueue.global(qos: .background).async { [weak self] in
+                DispatchQueue.global().async { [weak self] in
                     guard let self else { return }
                     self.dcAccounts.maybeNetwork()
                     if self.notifyToken == nil &&
@@ -145,7 +145,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             
             reachability.whenUnreachable = { _ in
                 logger.info("network: not reachable")
-                DispatchQueue.global(qos: .background).async { [weak self] in
+                DispatchQueue.global().async { [weak self] in
                     self?.dcAccounts.maybeNetworkLost()
                 }
             }
@@ -233,7 +233,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         applicationInForeground = true
         dcAccounts.startIo()
 
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global().async { [weak self] in
             guard let self else { return }
             if let reachability = self.reachability {
                 if reachability.connection != .unavailable {
@@ -484,7 +484,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         pushToDebugArray("1")
 
         // move work to non-main thread to not block UI (otherwise, in case we get suspended, the app is blocked totally)
-        // (we are using `qos: default` as `qos: .background` or `main.asyncAfter` may be delayed by tens of minutes)
+        // (we are using `qos: default` as `qos: .background` may be delayed by tens of minutes)
         DispatchQueue.global().async { [weak self] in
             guard let self else { completionHandler?(.failed); return }
 
@@ -588,7 +588,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             return
         }
         eventHandlerActive = true
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global().async { [weak self] in
             guard let self else { return }
             let eventHandler = DcEventHandler(dcAccounts: self.dcAccounts)
             let eventEmitter = self.dcAccounts.getEventEmitter()

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -525,7 +525,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
         // things that do not affect the chatview
         // and are delayed after the view is displayed
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global().async { [weak self] in
             guard let self else { return }
             self.dcContext.marknoticedChat(chatId: self.chatId)
         }
@@ -959,7 +959,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
            let indexPaths = tableView.indexPathsForVisibleRows {
                 let visibleMessagesIds = indexPaths.map { UInt32(messageIds[$0.row]) }
                 if !visibleMessagesIds.isEmpty {
-                    DispatchQueue.global(qos: .background).async { [weak self] in
+                    DispatchQueue.global().async { [weak self] in
                         self?.dcContext.markSeenMessages(messageIds: visibleMessagesIds)
                     }
                 }

--- a/deltachat-ios/Controller/ConnectivityViewController.swift
+++ b/deltachat-ios/Controller/ConnectivityViewController.swift
@@ -25,7 +25,7 @@ class ConnectivityViewController: WebViewViewController {
                 self.loadHtml()
             }
             isLowDataMode = monitor.currentPath.isConstrained
-            monitor.start(queue: DispatchQueue.global(qos: .background))
+            monitor.start(queue: DispatchQueue.global())
             self.connectivityMonitor = monitor
         }
     }

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -71,6 +71,10 @@ public class DcAccounts {
         dc_accounts_stop_io(accountsPointer)
     }
 
+    public func backgroundFetch(timeout: UInt64) -> Bool {
+        return dc_accounts_background_fetch(accountsPointer, timeout) == 1
+    }
+
     public func select(id: Int) -> Bool {
         return dc_accounts_select_account(accountsPointer, UInt32(id)) == 1
     }

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -59,10 +59,6 @@ public class DcAccounts {
         dc_accounts_maybe_network_lost(accountsPointer)
     }
 
-    public func isAllWorkDone() -> Bool {
-        return dc_accounts_all_work_done(accountsPointer) != 0
-    }
-
     public func startIo() {
         dc_accounts_start_io(accountsPointer)
     }

--- a/deltachat-ios/Extensions/UIImageView+Extensions.swift
+++ b/deltachat-ios/Extensions/UIImageView+Extensions.swift
@@ -6,7 +6,7 @@ extension UIImageView {
     func loadVideoThumbnail(from url: URL, placeholderImage: UIImage?, completionHandler: ((UIImage?) -> Void)?) {
 
         self.image = placeholderImage
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue.global().async {
             let thumbnailImage = DcUtils.generateThumbnailFromVideo(url: url)
             DispatchQueue.main.async { [weak self] in
                 self?.image = thumbnailImage

--- a/deltachat-ios/Handler/DeviceContactsHandler.swift
+++ b/deltachat-ios/Handler/DeviceContactsHandler.swift
@@ -42,7 +42,7 @@ class DeviceContactsHandler {
 
     private func fetchContactsWithEmailFromDevice(completionHandler: @escaping ([CNContact]) -> Void) {
 
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue.global().async {
             let keys = [CNContactFamilyNameKey, CNContactGivenNameKey, CNContactEmailAddressesKey]
 
             var fetchedContacts: [CNContact] = []

--- a/deltachat-ios/Helper/FileHelper.swift
+++ b/deltachat-ios/Helper/FileHelper.swift
@@ -63,7 +63,7 @@ public class FileHelper {
 
     public static func deleteFile(atPath: String?) {
         if Thread.isMainThread {
-            DispatchQueue.global(qos: .background).async {
+            DispatchQueue.global().async {
                 deleteFile(atPath)
             }
         } else {

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -42,7 +42,7 @@ public class NotificationManager {
     }
     
     public static func removeNotificationsForChat(dcContext: DcContext, chatId: Int) {
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue.global().async {
             NotificationManager.removePendingNotificationsFor(dcContext: dcContext, chatId: chatId)
             NotificationManager.removeDeliveredNotificationsFor(dcContext: dcContext, chatId: chatId)
             NotificationManager.updateApplicationIconBadge()
@@ -70,7 +70,7 @@ public class NotificationManager {
                 logger.info("notification background task will end soon")
             }
 
-            DispatchQueue.global(qos: .background).async { [weak self] in
+            DispatchQueue.global().async { [weak self] in
                 guard let self else { return }
                 if let ui = notification.userInfo,
                    let chatId = ui["chat_id"] as? Int,


### PR DESCRIPTION
this PR aims to improve the existing background fetch further by:

- use the new `[dc_accounts_background_fetch()`](https://github.com/deltachat/deltachat-core-rust/pull/5104) api which was explicitly made for this purpose 

- changing qos ("quality of service") of background task to `.default` instead of `.background` - while the latter sounds as if it is correct, it was probably never the intention as  `.background` may be delayed by a loooong time [according to stackoverflow](https://stackoverflow.com/questions/53141829/performance-of-background-queue-in-swift) - but also by our [own observations](https://github.com/deltachat/deltachat-ios/blob/main/deltachat-ios/AppDelegate.swift#L487) (in theory, there is also `.utility`, however, finer granulation is probably not needed, i assume anyways that there is some additional per-app-weight)

the "one second sleep" is untouched for now, in fact, you'll see some core activity between "finishing fetch" and "fetch done", at least in the simulator, maybe in "real background" where re-start IO is not needed, it is really superfluous. also, in theory, swift could have started short-living threads from events need to finish. so, let's do not have too many moving targets and leave that as is for now