### PR TITLE
Force-layout titleView (#2053)

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1074,6 +1074,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             }
 
             titleView.updateTitleView(title: dcChat.name, subtitle: subtitle, isVerified: dcChat.isProtected)
+            titleView.layoutIfNeeded()
             navigationItem.titleView = titleView
             self.navigationItem.setLeftBarButton(nil, animated: true)
         }


### PR DESCRIPTION
This is a little workaround to make the UIStackView in the navigationItem.titleView look great again on iOS 16. Affected were especially chats with a subtitle. Please run it on an iOS 16-simulator to see that it's fixed. iOS 17 wasn't affected, but this PR doesn't break it (fingers crossed 🤞. jk.). And it looks like this:

![2053](https://github.com/deltachat/deltachat-ios/assets/2580019/056dccb0-5667-4503-a5b0-3062746dee03)

Fixes #2053.

----

On a side note: I couldn't debug on the iOS 16-simulator. Breakpoints were turned of automatically by Xcode. Very strange, to be honest.