### PR TITLE
make 'troubleshooting' available for add-as-second-device

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -27,7 +27,8 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
             let qrReader = QrCodeReaderController(title: String.localized("multidevice_receiver_title"),
                         addHints: "➊ " + String.localized("multidevice_same_network_hint") + "\n\n"
                             +     "➋ " + String.localized("multidevice_open_settings_on_other_device") + "\n\n"
-                            +     String.localized("multidevice_experimental_hint"))
+                            +     String.localized("multidevice_experimental_hint"),
+                        showTroubleshooting: true)
             qrReader.delegate = self
             self.qrCodeReader = qrReader
             self.navigationController?.pushViewController(qrReader, animated: true)


### PR DESCRIPTION
this PR adds a menu button to the upper right corner of the "Add as Second Device" screen; it is already available for the side showing the QR code ("Add Second Device"), but it is good to have it on both sides.

<img width=250 src=https://github.com/deltachat/deltachat-ios/assets/9800740/d15cea14-2722-4a44-91af-e15d34092b23> &nbsp;  <img width=250 src=https://github.com/deltachat/deltachat-ios/assets/9800740/7085981e-ccc0-472d-8400-4f221a1a88b7>

tbh, i thought it is already there, came over this while playing around with https://github.com/deltachat/deltachat-desktop/issues/3676 :)