### PR TITLE
factor out notification token handling

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -376,7 +376,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let notifyToken = tokenParts.joined()
         logger.info("Notifications: Token: \(notifyToken)")
         self.notifyToken = notifyToken
-        dcAccounts.setNotifyToken(token: notifyToken)
+        dcAccounts.setPushToken(token: notifyToken)
     }
 
     // `didFailToRegisterForRemoteNotificationsWithError` is called by iOS

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -373,33 +373,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // we pass the received token to the app's notification server then.
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
-        let tokenString = tokenParts.joined()
-
-        let endpoint = "https://notifications.delta.chat/register"
-
-        logger.info("Notifications: POST token: \(tokenString) to \(endpoint)")
-
-        if let url = URL(string: endpoint) {
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            let body = "{ \"token\": \"\(tokenString)\" }"
-            request.httpBody = body.data(using: String.Encoding.utf8)
-            let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
-                if let error = error {
-                    logger.error("Notifications: cannot POST to notification server: \(error)")
-                    return
-                }
-                if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode == 200 {
-                    logger.info("Notifications: request to notification server succeeded")
-                } else {
-                    logger.error("Notifications: request to notification server failed: \(String(describing: response)), \(String(describing: data))")
-                }
-                self.notifyToken = tokenString
-            }
-            task.resume()
-        } else {
-            logger.error("Notifications: cannot create URL for token: \(tokenString)")
-        }
+        let notifyToken = tokenParts.joined()
+        logger.info("Notifications: Token: \(notifyToken)")
+        self.notifyToken = notifyToken
+        dcAccounts.setNotifyToken(token: notifyToken)
     }
 
     // `didFailToRegisterForRemoteNotificationsWithError` is called by iOS

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -373,7 +373,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // we pass the received token to the app's notification server then.
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
-        let notifyToken = tokenParts.joined()
+        #if DEBUG
+            let notifyToken = "sandbox:" + tokenParts.joined()
+        #else
+            let notifyToken = tokenParts.joined()
+        #endif
         logger.info("Notifications: Token: \(notifyToken)")
         self.notifyToken = notifyToken
         dcAccounts.setPushToken(token: notifyToken)

--- a/deltachat-ios/Controller/ConnectivityViewController.swift
+++ b/deltachat-ios/Controller/ConnectivityViewController.swift
@@ -123,7 +123,7 @@ class ConnectivityViewController: WebViewViewController {
                 .appending(String.localized("connectivity_low_power_mode"))
         }
 
-        if pushState != DC_PUSH_HEARTBEAT {
+        if pushState == DC_PUSH_CONNECTED {
             return "<span class=\"green dot\"></span>"
                 .appending(title)
                 .appending(String.localized("connectivity_connected"))

--- a/deltachat-ios/Controller/ConnectivityViewController.swift
+++ b/deltachat-ios/Controller/ConnectivityViewController.swift
@@ -64,7 +64,7 @@ class ConnectivityViewController: WebViewViewController {
     // this method needs to be run from a background thread
     private func getNotificationStatus(backgroundRefreshStatus: UIBackgroundRefreshStatus) -> String {
         let connectiviy = self.dcContext.getConnectivity()
-        let notifyState = dcContext.getNotifyState()
+        let pushState = dcContext.getPushState()
         let title = " <b>" + String.localized("pref_notifications") + ":</b> "
         let notificationsEnabledInDC = !UserDefaults.standard.bool(forKey: "notifications_disabled")
         var notificationsEnabledInSystem = false
@@ -105,7 +105,7 @@ class ConnectivityViewController: WebViewViewController {
                 .appending(String.localized("bg_app_refresh_disabled"))
         }
 
-        if notifyState == .notConnected || connectiviy == DC_CONNECTIVITY_NOT_CONNECTED {
+        if pushState == DC_PUSH_NOT_CONNECTED || connectiviy == DC_CONNECTIVITY_NOT_CONNECTED {
             return "<span class=\"red dot\"></span>"
                 .appending(title)
                 .appending(String.localized("connectivity_not_connected"))
@@ -123,7 +123,7 @@ class ConnectivityViewController: WebViewViewController {
                 .appending(String.localized("connectivity_low_power_mode"))
         }
 
-        if notifyState == .push {
+        if pushState != DC_PUSH_HEARTBEAT {
             return "<span class=\"green dot\"></span>"
                 .appending(title)
                 .appending(String.localized("connectivity_connected"))

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -71,6 +71,29 @@ public class DcAccounts {
         return dc_accounts_background_fetch(accountsPointer, timeout) == 1
     }
 
+    public func setNotifyToken(token: String) {
+        if let url = URL(string: "https://notifications.delta.chat/register") {
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            let body = "{ \"token\": \"\(token)\" }"
+            request.httpBody = body.data(using: String.Encoding.utf8)
+            let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+                if let error = error {
+                    logger.error("Notifications: cannot POST to notification server: \(error)")
+                    return
+                }
+                if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode == 200 {
+                    logger.info("Notifications: request to notification server succeeded")
+                } else {
+                    logger.error("Notifications: request to notification server failed: \(String(describing: response)), \(String(describing: data))")
+                }
+            }
+            task.resume()
+        } else {
+            logger.error("Notifications: cannot create URL for token: \(token)")
+        }
+    }
+
     public func select(id: Int) -> Bool {
         return dc_accounts_select_account(accountsPointer, UInt32(id)) == 1
     }

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -71,32 +71,8 @@ public class DcAccounts {
         return dc_accounts_background_fetch(accountsPointer, timeout) == 1
     }
 
-    public var notifyTokenPassedToServer: Bool = false // will be moved to core
-
-    public func setNotifyToken(token: String) {
-        // implementation will be moved to core
-        self.notifyTokenPassedToServer = false
-        if let url = URL(string: "https://notifications.delta.chat/register") {
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            let body = "{ \"token\": \"\(token)\" }"
-            request.httpBody = body.data(using: String.Encoding.utf8)
-            let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
-                if let error = error {
-                    logger.error("Notifications: cannot POST to notification server: \(error)")
-                    return
-                }
-                if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode == 200 {
-                    logger.info("Notifications: request to notification server succeeded")
-                    self.notifyTokenPassedToServer = true
-                } else {
-                    logger.error("Notifications: request to notification server failed: \(String(describing: response)), \(String(describing: data))")
-                }
-            }
-            task.resume()
-        } else {
-            logger.error("Notifications: cannot create URL for token: \(token)")
-        }
+    public func setPushToken(token: String) {
+        dc_accounts_set_push_device_token(accountsPointer, token)
     }
 
     public func select(id: Int) -> Bool {

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -71,7 +71,11 @@ public class DcAccounts {
         return dc_accounts_background_fetch(accountsPointer, timeout) == 1
     }
 
+    public var notifyTokenPassedToServer: Bool = false // will be moved to core
+
     public func setNotifyToken(token: String) {
+        // implementation will be moved to core
+        self.notifyTokenPassedToServer = false
         if let url = URL(string: "https://notifications.delta.chat/register") {
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
@@ -84,6 +88,7 @@ public class DcAccounts {
                 }
                 if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode == 200 {
                     logger.info("Notifications: request to notification server succeeded")
+                    self.notifyTokenPassedToServer = true
                 } else {
                     logger.error("Notifications: request to notification server failed: \(String(describing: response)), \(String(describing: data))")
                 }

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -1,5 +1,11 @@
 import UIKit
 
+public enum DcNotifyState: Error {
+    // will be moved to core
+    case notConnected
+    case push
+    case heartbeat
+}
 
 /// An object representing a single account
 ///
@@ -299,6 +305,11 @@ public class DcContext {
             return info
         }
         return "ErrGetInfo"
+    }
+
+    public func getNotifyState() -> DcNotifyState {
+        // implementation will be moved to core
+        return DcAccounts.shared.notifyTokenPassedToServer ? .heartbeat : .notConnected
     }
 
     public func getContactEncrInfo(contactId: Int) -> String {

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -1,12 +1,5 @@
 import UIKit
 
-public enum DcNotifyState: Error {
-    // will be moved to core
-    case notConnected
-    case push
-    case heartbeat
-}
-
 /// An object representing a single account
 ///
 /// See [dc_context_t Class Reference](https://c.delta.chat/classdc__context__t.html)
@@ -307,9 +300,8 @@ public class DcContext {
         return "ErrGetInfo"
     }
 
-    public func getNotifyState() -> DcNotifyState {
-        // implementation will be moved to core
-        return DcAccounts.shared.notifyTokenPassedToServer ? .heartbeat : .notConnected
+    public func getPushState() -> Int32 {
+        return dc_get_push_state(contextPointer)
     }
 
     public func getContactEncrInfo(contactId: Int) -> String {


### PR DESCRIPTION
this PR moves the handling of the notification token to DcAccounts and DcContext objects using the new core API that supports **real push notifications** (correct core PR needs to be  checked out at deltachat-ios/libraries/deltachat-core-rust  manually to make this PR work)

Overview of related PRs:
- notifiers PR: https://github.com/deltachat/notifiers/pull/17 (adding endpoint to receive notifications from chatmail server)
- chatmail PR: https://github.com/deltachat/chatmail/pull/201 (adding metadata server to register device tokens for notifications and sending them to notifiers)
- core PR: https://github.com/deltachat/deltachat-core-rust/pull/5286 (adding APIs to set tokens and register them with chatmail servers or fallback heartbeat notifications)
- this iOS PR: https://github.com/deltachat/deltachat-ios/pull/2080 (using new core APIs)

EDIT:  apart from the expected issues wrt "mute chat" and "mute all" the PRs play well together and things are working nicely (idea for "mute all" is to drop that switch and just open system notifications setting where you can "mute all" as well. or, if per-account-mute is needed, a revoke api. for "mute chat", maybe this is doable by a notification service exetension as well; i started a branch with that. that could also be used for "mute all". we'll see :) both, however should not block merging this pr)


~~there are two new API that will be replaced by the following core implementation soon:~~
~~- `dc_accounts_set_notify_token(token)` - passes the token received from apple to the core. core will forward it to supported (chatmail) server or, as a fallback, use it for heartbeat. as we have only one token for all accounts, core will do that for all accounts.  the method may be called on every app start as the tokens may be short-living. the function may take a while (we should decide if UI needs to call it in a thread or core does that) there is no need for a return value, UI will check the state using the following method.~~
~~- `dc_context_get_notify_state(context)` - returns NOT_CONNECTED (0), HEARTBEAT (1) or PUSH (2) - this is a per-context method as some accounts may use chatmail while others not. the method is used by the UI mainly to show the state to the user~~
~~the PR adapts flow and connectivity view already to these new calls, however, still uses a "dummy" UI implementation. i also did this PR to make myself clear what is actually and really needed for UI :) (@hpk42 and me are first thinking that we can just use a set_config(), however, this does not work nicely as the token is same for all accounts)~~
~~@link2xt @zeitschlag if this roughly makes sense  to you, i suggest to merge this PR already in, we can then focus on the core~~ EDIT: we decided to go for changing core directly

