### PR TITLE
embed and fix reaction picker code

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,7 +44,6 @@ function_parameter_count:
 
 file_length:
   warning: 2000
-  error: 3000
   ignore_comment_only_lines: true
 
 cyclomatic_complexity:

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -199,6 +199,32 @@
 		B2172F3C29C125F2002C289E /* AdvancedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2172F3B29C125F2002C289E /* AdvancedViewController.swift */; };
 		B259D64329B771D5008FB706 /* BackupTransferViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B259D64229B771D5008FB706 /* BackupTransferViewController.swift */; };
 		B26B3BC7236DC3DC008ED35A /* SwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26B3BC6236DC3DC008ED35A /* SwitchCell.swift */; };
+		B2B6833C2B8E010300FA2349 /* MCEmojiPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B682EE2B8E010300FA2349 /* MCEmojiPickerViewModel.swift */; };
+		B2B6833D2B8E010300FA2349 /* MCEmojiPickerLocalizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = B2B682F12B8E010300FA2349 /* MCEmojiPickerLocalizable.strings */; };
+		B2B6833E2B8E010300FA2349 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B6831C2B8E010300FA2349 /* UIColor+Extension.swift */; };
+		B2B6833F2B8E010300FA2349 /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B6831D2B8E010300FA2349 /* Bundle+Extension.swift */; };
+		B2B683402B8E010300FA2349 /* Double+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B6831E2B8E010300FA2349 /* Double+Extension.swift */; };
+		B2B683412B8E010300FA2349 /* UICollectionReusableView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B6831F2B8E010300FA2349 /* UICollectionReusableView+Extension.swift */; };
+		B2B683422B8E010300FA2349 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683202B8E010300FA2349 /* View+Extension.swift */; };
+		B2B683432B8E010300FA2349 /* NSNotification.Name+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683212B8E010300FA2349 /* NSNotification.Name+Extension.swift */; };
+		B2B683442B8E010300FA2349 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683222B8E010300FA2349 /* Array+Extension.swift */; };
+		B2B683452B8E010300FA2349 /* MCEmojiCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683242B8E010300FA2349 /* MCEmojiCategory.swift */; };
+		B2B683462B8E010300FA2349 /* MCEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683252B8E010300FA2349 /* MCEmoji.swift */; };
+		B2B683472B8E010300FA2349 /* MCPickerArrowDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683262B8E010300FA2349 /* MCPickerArrowDirection.swift */; };
+		B2B683482B8E010300FA2349 /* MCEmojiPickerRepresentableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683282B8E010300FA2349 /* MCEmojiPickerRepresentableController.swift */; };
+		B2B683492B8E010300FA2349 /* MCEmojiPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683292B8E010300FA2349 /* MCEmojiPickerViewController.swift */; };
+		B2B6834A2B8E010300FA2349 /* MCEmojiCategoryIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B6832C2B8E010300FA2349 /* MCEmojiCategoryIconView.swift */; };
+		B2B6834B2B8E010300FA2349 /* MCTouchableEmojiCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B6832D2B8E010300FA2349 /* MCTouchableEmojiCategoryView.swift */; };
+		B2B6834C2B8E010300FA2349 /* MCEmojiSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B6832E2B8E010300FA2349 /* MCEmojiSectionHeader.swift */; };
+		B2B6834D2B8E010300FA2349 /* MCEmojiSkinTonePickerBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683302B8E010300FA2349 /* MCEmojiSkinTonePickerBackgroundView.swift */; };
+		B2B6834E2B8E010300FA2349 /* MCEmojiSkinTonePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683312B8E010300FA2349 /* MCEmojiSkinTonePickerView.swift */; };
+		B2B6834F2B8E010300FA2349 /* MCEmojiSkinTonePickerContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683322B8E010300FA2349 /* MCEmojiSkinTonePickerContainerView.swift */; };
+		B2B683502B8E010300FA2349 /* MCEmojiPreviewBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683342B8E010300FA2349 /* MCEmojiPreviewBackgroundView.swift */; };
+		B2B683512B8E010300FA2349 /* MCEmojiPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683352B8E010300FA2349 /* MCEmojiPreviewView.swift */; };
+		B2B683522B8E010300FA2349 /* MCEmojiCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683362B8E010300FA2349 /* MCEmojiCollectionViewCell.swift */; };
+		B2B683532B8E010300FA2349 /* MCEmojiPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683372B8E010300FA2349 /* MCEmojiPickerView.swift */; };
+		B2B683542B8E010300FA2349 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B683392B8E010300FA2349 /* Observable.swift */; };
+		B2B683552B8E010300FA2349 /* MCUnicodeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B6833B2B8E010300FA2349 /* MCUnicodeManager.swift */; };
 		B2C42570265C325C00B95377 /* MultilineLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C4256F265C325C00B95377 /* MultilineLabelCell.swift */; };
 		B2D4B63B29C38D1900B47DA8 /* ChatsAndMediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4B63A29C38D1900B47DA8 /* ChatsAndMediaViewController.swift */; };
 		B2F899E129F96A67003797D5 /* AllMediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F899E029F96A67003797D5 /* AllMediaViewController.swift */; };
@@ -553,6 +579,71 @@
 		B2AB4B5B27EBE19D0003BE47 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B2AB4B5C27EBE19D0003BE47 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B2AB4B5D27EBE19D0003BE47 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fi; path = fi.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		B2B682EE2B8E010300FA2349 /* MCEmojiPickerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiPickerViewModel.swift; sourceTree = "<group>"; };
+		B2B682F22B8E010300FA2349 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B682F32B8E010300FA2349 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B682F42B8E010300FA2349 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B682F52B8E010300FA2349 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B682F62B8E010300FA2349 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/MCEmojiPickerLocalizable.strings"; sourceTree = "<group>"; };
+		B2B682F72B8E010300FA2349 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B682F82B8E010300FA2349 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B682F92B8E010300FA2349 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B682FA2B8E010300FA2349 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/MCEmojiPickerLocalizable.strings"; sourceTree = "<group>"; };
+		B2B682FB2B8E010300FA2349 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B682FC2B8E010300FA2349 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/MCEmojiPickerLocalizable.strings"; sourceTree = "<group>"; };
+		B2B682FD2B8E010300FA2349 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B682FE2B8E010300FA2349 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B682FF2B8E010300FA2349 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/MCEmojiPickerLocalizable.strings"; sourceTree = "<group>"; };
+		B2B683002B8E010300FA2349 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683012B8E010300FA2349 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683022B8E010300FA2349 /* fr-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "fr-CA"; path = "fr-CA.lproj/MCEmojiPickerLocalizable.strings"; sourceTree = "<group>"; };
+		B2B683032B8E010300FA2349 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683042B8E010300FA2349 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683052B8E010300FA2349 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683062B8E010300FA2349 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683072B8E010300FA2349 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MCEmojiPickerLocalizable.strings"; sourceTree = "<group>"; };
+		B2B683082B8E010300FA2349 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683092B8E010300FA2349 /* en-AU */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-AU"; path = "en-AU.lproj/MCEmojiPickerLocalizable.strings"; sourceTree = "<group>"; };
+		B2B6830A2B8E010300FA2349 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B6830B2B8E010300FA2349 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B6830C2B8E010300FA2349 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/MCEmojiPickerLocalizable.strings"; sourceTree = "<group>"; };
+		B2B6830D2B8E010300FA2349 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B6830E2B8E010300FA2349 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B6830F2B8E010300FA2349 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683102B8E010300FA2349 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683112B8E010300FA2349 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683122B8E010300FA2349 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683132B8E010300FA2349 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683142B8E010300FA2349 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/MCEmojiPickerLocalizable.strings"; sourceTree = "<group>"; };
+		B2B683152B8E010300FA2349 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683162B8E010300FA2349 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683172B8E010300FA2349 /* hi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hi; path = hi.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683182B8E010300FA2349 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/MCEmojiPickerLocalizable.strings; sourceTree = "<group>"; };
+		B2B683192B8E010300FA2349 /* en-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-IN"; path = "en-IN.lproj/MCEmojiPickerLocalizable.strings"; sourceTree = "<group>"; };
+		B2B6831C2B8E010300FA2349 /* UIColor+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		B2B6831D2B8E010300FA2349 /* Bundle+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Extension.swift"; sourceTree = "<group>"; };
+		B2B6831E2B8E010300FA2349 /* Double+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Double+Extension.swift"; sourceTree = "<group>"; };
+		B2B6831F2B8E010300FA2349 /* UICollectionReusableView+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionReusableView+Extension.swift"; sourceTree = "<group>"; };
+		B2B683202B8E010300FA2349 /* View+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
+		B2B683212B8E010300FA2349 /* NSNotification.Name+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSNotification.Name+Extension.swift"; sourceTree = "<group>"; };
+		B2B683222B8E010300FA2349 /* Array+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
+		B2B683242B8E010300FA2349 /* MCEmojiCategory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiCategory.swift; sourceTree = "<group>"; };
+		B2B683252B8E010300FA2349 /* MCEmoji.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmoji.swift; sourceTree = "<group>"; };
+		B2B683262B8E010300FA2349 /* MCPickerArrowDirection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCPickerArrowDirection.swift; sourceTree = "<group>"; };
+		B2B683282B8E010300FA2349 /* MCEmojiPickerRepresentableController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiPickerRepresentableController.swift; sourceTree = "<group>"; };
+		B2B683292B8E010300FA2349 /* MCEmojiPickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiPickerViewController.swift; sourceTree = "<group>"; };
+		B2B6832C2B8E010300FA2349 /* MCEmojiCategoryIconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiCategoryIconView.swift; sourceTree = "<group>"; };
+		B2B6832D2B8E010300FA2349 /* MCTouchableEmojiCategoryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCTouchableEmojiCategoryView.swift; sourceTree = "<group>"; };
+		B2B6832E2B8E010300FA2349 /* MCEmojiSectionHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiSectionHeader.swift; sourceTree = "<group>"; };
+		B2B683302B8E010300FA2349 /* MCEmojiSkinTonePickerBackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiSkinTonePickerBackgroundView.swift; sourceTree = "<group>"; };
+		B2B683312B8E010300FA2349 /* MCEmojiSkinTonePickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiSkinTonePickerView.swift; sourceTree = "<group>"; };
+		B2B683322B8E010300FA2349 /* MCEmojiSkinTonePickerContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiSkinTonePickerContainerView.swift; sourceTree = "<group>"; };
+		B2B683342B8E010300FA2349 /* MCEmojiPreviewBackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiPreviewBackgroundView.swift; sourceTree = "<group>"; };
+		B2B683352B8E010300FA2349 /* MCEmojiPreviewView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiPreviewView.swift; sourceTree = "<group>"; };
+		B2B683362B8E010300FA2349 /* MCEmojiCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiCollectionViewCell.swift; sourceTree = "<group>"; };
+		B2B683372B8E010300FA2349 /* MCEmojiPickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCEmojiPickerView.swift; sourceTree = "<group>"; };
+		B2B683392B8E010300FA2349 /* Observable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
+		B2B6833B2B8E010300FA2349 /* MCUnicodeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCUnicodeManager.swift; sourceTree = "<group>"; };
 		B2B9BC1026245F2200F35832 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B2B9BC1126245F2200F35832 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B2B9BC1226245F2200F35832 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = cs; path = cs.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -822,6 +913,7 @@
 		7A9FB1421FB061E2001FEA36 /* deltachat-ios */ = {
 			isa = PBXGroup;
 			children = (
+				B2B682EC2B8E010300FA2349 /* MCEmojiPicker */,
 				AE57C07E2552BBC0003CFE70 /* Model */,
 				304219D7244072E600516852 /* DC */,
 				AE1988AA23EB3C7600B4CD5F /* Assets */,
@@ -1052,6 +1144,143 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		B2B682EC2B8E010300FA2349 /* MCEmojiPicker */ = {
+			isa = PBXGroup;
+			children = (
+				B2B682ED2B8E010300FA2349 /* ViewModel */,
+				B2B682EF2B8E010300FA2349 /* Resources */,
+				B2B6831A2B8E010300FA2349 /* Common */,
+				B2B683232B8E010300FA2349 /* Model */,
+				B2B683272B8E010300FA2349 /* View */,
+				B2B683382B8E010300FA2349 /* Bindings */,
+				B2B6833A2B8E010300FA2349 /* Services */,
+			);
+			path = MCEmojiPicker;
+			sourceTree = "<group>";
+		};
+		B2B682ED2B8E010300FA2349 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				B2B682EE2B8E010300FA2349 /* MCEmojiPickerViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		B2B682EF2B8E010300FA2349 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				B2B682F02B8E010300FA2349 /* Localization */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		B2B682F02B8E010300FA2349 /* Localization */ = {
+			isa = PBXGroup;
+			children = (
+				B2B682F12B8E010300FA2349 /* MCEmojiPickerLocalizable.strings */,
+			);
+			path = Localization;
+			sourceTree = "<group>";
+		};
+		B2B6831A2B8E010300FA2349 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				B2B6831B2B8E010300FA2349 /* Extensions */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		B2B6831B2B8E010300FA2349 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B2B6831C2B8E010300FA2349 /* UIColor+Extension.swift */,
+				B2B6831D2B8E010300FA2349 /* Bundle+Extension.swift */,
+				B2B6831E2B8E010300FA2349 /* Double+Extension.swift */,
+				B2B6831F2B8E010300FA2349 /* UICollectionReusableView+Extension.swift */,
+				B2B683202B8E010300FA2349 /* View+Extension.swift */,
+				B2B683212B8E010300FA2349 /* NSNotification.Name+Extension.swift */,
+				B2B683222B8E010300FA2349 /* Array+Extension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		B2B683232B8E010300FA2349 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				B2B683242B8E010300FA2349 /* MCEmojiCategory.swift */,
+				B2B683252B8E010300FA2349 /* MCEmoji.swift */,
+				B2B683262B8E010300FA2349 /* MCPickerArrowDirection.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		B2B683272B8E010300FA2349 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				B2B683282B8E010300FA2349 /* MCEmojiPickerRepresentableController.swift */,
+				B2B683292B8E010300FA2349 /* MCEmojiPickerViewController.swift */,
+				B2B6832A2B8E010300FA2349 /* Views */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		B2B6832A2B8E010300FA2349 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				B2B6832B2B8E010300FA2349 /* EmojiCategoryView */,
+				B2B6832E2B8E010300FA2349 /* MCEmojiSectionHeader.swift */,
+				B2B6832F2B8E010300FA2349 /* EmojiSkinTonePickerView */,
+				B2B683332B8E010300FA2349 /* EmojiPreviewView */,
+				B2B683362B8E010300FA2349 /* MCEmojiCollectionViewCell.swift */,
+				B2B683372B8E010300FA2349 /* MCEmojiPickerView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		B2B6832B2B8E010300FA2349 /* EmojiCategoryView */ = {
+			isa = PBXGroup;
+			children = (
+				B2B6832C2B8E010300FA2349 /* MCEmojiCategoryIconView.swift */,
+				B2B6832D2B8E010300FA2349 /* MCTouchableEmojiCategoryView.swift */,
+			);
+			path = EmojiCategoryView;
+			sourceTree = "<group>";
+		};
+		B2B6832F2B8E010300FA2349 /* EmojiSkinTonePickerView */ = {
+			isa = PBXGroup;
+			children = (
+				B2B683302B8E010300FA2349 /* MCEmojiSkinTonePickerBackgroundView.swift */,
+				B2B683312B8E010300FA2349 /* MCEmojiSkinTonePickerView.swift */,
+				B2B683322B8E010300FA2349 /* MCEmojiSkinTonePickerContainerView.swift */,
+			);
+			path = EmojiSkinTonePickerView;
+			sourceTree = "<group>";
+		};
+		B2B683332B8E010300FA2349 /* EmojiPreviewView */ = {
+			isa = PBXGroup;
+			children = (
+				B2B683342B8E010300FA2349 /* MCEmojiPreviewBackgroundView.swift */,
+				B2B683352B8E010300FA2349 /* MCEmojiPreviewView.swift */,
+			);
+			path = EmojiPreviewView;
+			sourceTree = "<group>";
+		};
+		B2B683382B8E010300FA2349 /* Bindings */ = {
+			isa = PBXGroup;
+			children = (
+				B2B683392B8E010300FA2349 /* Observable.swift */,
+			);
+			path = Bindings;
+			sourceTree = "<group>";
+		};
+		B2B6833A2B8E010300FA2349 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				B2B6833B2B8E010300FA2349 /* MCUnicodeManager.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		D80F62772B59D1B800877059 /* Send Reaction */ = {
 			isa = PBXGroup;
 			children = (
@@ -1211,6 +1440,16 @@
 				ro,
 				bqi,
 				vi,
+				he,
+				"zh-HK",
+				"en-GB",
+				"es-419",
+				"fr-CA",
+				ms,
+				"en-AU",
+				th,
+				hi,
+				"en-IN",
 			);
 			mainGroup = 7A9FB1371FB061E2001FEA36;
 			productRefGroup = 7A9FB1411FB061E2001FEA36 /* Products */;
@@ -1245,6 +1484,7 @@
 				AE1988A723EB382A00B4CD5F /* Help in Resources */,
 				3060119C22DDE24000C1CE6F /* Localizable.strings in Resources */,
 				7A9FB14E1FB061E2001FEA36 /* LaunchScreen.storyboard in Resources */,
+				B2B6833D2B8E010300FA2349 /* MCEmojiPickerLocalizable.strings in Resources */,
 				306011B622E5E7FB00C1CE6F /* Localizable.stringsdict in Resources */,
 				7A9FB14B1FB061E2001FEA36 /* Assets.xcassets in Resources */,
 			);
@@ -1406,6 +1646,9 @@
 				78ED839421D5AF8A00243125 /* QrCodeView.swift in Sources */,
 				30CE137828D9C40800158DF4 /* ChatDropInteraction.swift in Sources */,
 				D84AED242B55E8EB00D753F6 /* ReactionsOverviewViewController.swift in Sources */,
+				B2B6833F2B8E010300FA2349 /* Bundle+Extension.swift in Sources */,
+				B2B683462B8E010300FA2349 /* MCEmoji.swift in Sources */,
+				B2B6834A2B8E010300FA2349 /* MCEmojiCategoryIconView.swift in Sources */,
 				3059620E234614E700C80F33 /* DcContact+Extension.swift in Sources */,
 				30DED713292EE4280040835D /* LogViewController.swift in Sources */,
 				AED423D7249F580700B6B2BB /* BlockedContactsViewController.swift in Sources */,
@@ -1416,10 +1659,14 @@
 				30AAD71B2762869600DE3DC1 /* SelectableCell.swift in Sources */,
 				AE9DAF0F22C278C6004C9591 /* ChatTitleView.swift in Sources */,
 				AE4AEE3522B1030D000AA495 /* PreviewController.swift in Sources */,
+				B2B6833C2B8E010300FA2349 /* MCEmojiPickerViewModel.swift in Sources */,
 				D84AED272B566C0700D753F6 /* ReactionsOverviewTableViewCell.swift in Sources */,
 				7070FB9B2101ECBB000DC258 /* NewGroupController.swift in Sources */,
+				B2B683482B8E010300FA2349 /* MCEmojiPickerRepresentableController.swift in Sources */,
+				B2B683512B8E010300FA2349 /* MCEmojiPreviewView.swift in Sources */,
 				3080A037277DE30100E74565 /* UITextView+Extensions.swift in Sources */,
 				3080A027277DE12D00E74565 /* InputBarButtonItem.swift in Sources */,
+				B2B683412B8E010300FA2349 /* UICollectionReusableView+Extension.swift in Sources */,
 				30238CFB28A501C300EF14AC /* WebxdcSelector.swift in Sources */,
 				AE57C084255310BB003CFE70 /* ContextMenuController.swift in Sources */,
 				304219D92440734A00516852 /* DcMsg+Extension.swift in Sources */,
@@ -1429,6 +1676,8 @@
 				30734326249A280B00BF9AD1 /* MediaQualityViewController.swift in Sources */,
 				3080A01C277DDB8A00E74565 /* InputBarAccessoryViewDelegate.swift in Sources */,
 				30FDB70524D1C1000066C48D /* ChatViewController.swift in Sources */,
+				B2B683402B8E010300FA2349 /* Double+Extension.swift in Sources */,
+				B2B683442B8E010300FA2349 /* Array+Extension.swift in Sources */,
 				3080A013277DDABA00E74565 /* KeyboardNotification.swift in Sources */,
 				AE52EA20229EB9F000C586C9 /* EditGroupViewController.swift in Sources */,
 				AE18F294228C602A0007B1BE /* SecuritySettingsController.swift in Sources */,
@@ -1436,11 +1685,13 @@
 				AE39D323249CFC1A007346A1 /* FilesViewController.swift in Sources */,
 				AE8DD451249D1DFB009A4BC1 /* DocumentGalleryFileCell.swift in Sources */,
 				3095A351237DD1F700AB07F7 /* MediaPicker.swift in Sources */,
+				B2B683452B8E010300FA2349 /* MCEmojiCategory.swift in Sources */,
 				B21005DB23383664004C70C5 /* EmailOptionsViewController.swift in Sources */,
 				AEC67A1C241CE9E4007DDBE1 /* AppStateRestorer.swift in Sources */,
 				3008CB7224F93EB900E6A617 /* AudioMessageCell.swift in Sources */,
 				302E1BB4252B5AB4008F4264 /* PlayButtonView.swift in Sources */,
 				303492AD2577CAC300A523D0 /* FileView.swift in Sources */,
+				B2B683502B8E010300FA2349 /* MCEmojiPreviewBackgroundView.swift in Sources */,
 				7AE0A5491FC42F65005ECB4B /* NewChatViewController.swift in Sources */,
 				AE77838F23E4276D0093EABD /* ContactCellViewModel.swift in Sources */,
 				B20462E62440C99600367A57 /* AutodelOptionsViewController.swift in Sources */,
@@ -1451,6 +1702,7 @@
 				D8975E412B7285ED00E5EB9F /* ContextMenuProvider.swift in Sources */,
 				30DDCBE928FCA1FA00465D22 /* PartialScreenPresentationController.swift in Sources */,
 				30A4149724F6EFBE00EC91EB /* InfoMessageCell.swift in Sources */,
+				B2B6834B2B8E010300FA2349 /* MCTouchableEmojiCategoryView.swift in Sources */,
 				302B84C6239676F0001C261F /* AvatarHelper.swift in Sources */,
 				AE77838D23E32ED20093EABD /* ContactDetailViewModel.swift in Sources */,
 				3080A02D277DE26000E74565 /* HorizontalEdgePadding.swift in Sources */,
@@ -1458,6 +1710,7 @@
 				3010968926838A050032CBA0 /* VideoInviteCell.swift in Sources */,
 				303492CB257A814200A523D0 /* DraftArea.swift in Sources */,
 				AEE6EC3F2282C59C00EDC689 /* GroupMembersViewController.swift in Sources */,
+				B2B6834C2B8E010300FA2349 /* MCEmojiSectionHeader.swift in Sources */,
 				B26B3BC7236DC3DC008ED35A /* SwitchCell.swift in Sources */,
 				AEE700252438E0E500D6992E /* ProgressAlertHandler.swift in Sources */,
 				D80F62792B59D1CC00877059 /* SendReactionsView.swift in Sources */,
@@ -1466,11 +1719,14 @@
 				3080A036277DE30100E74565 /* NSMutableAttributedString+Extensions.swift in Sources */,
 				307A82CC25B8D26700748B57 /* ChatEditingBar.swift in Sources */,
 				30703B6D27AA80FF00BDADE6 /* WebxdcCell.swift in Sources */,
+				B2B683432B8E010300FA2349 /* NSNotification.Name+Extension.swift in Sources */,
 				303492952565AABC00A523D0 /* DraftModel.swift in Sources */,
 				78E45E3A21D3CFBC00D4B15E /* SettingsViewController.swift in Sources */,
 				3080A021277DE09900E74565 /* InputStackView.swift in Sources */,
 				B259D64329B771D5008FB706 /* BackupTransferViewController.swift in Sources */,
+				B2B683472B8E010300FA2349 /* MCPickerArrowDirection.swift in Sources */,
 				AE8519EA2272FDCA00ED86F0 /* DeviceContactsHandler.swift in Sources */,
+				B2B6833E2B8E010300FA2349 /* UIColor+Extension.swift in Sources */,
 				302E592426A5CF4800DD4F58 /* ConnectivityViewController.swift in Sources */,
 				78ED838321D5379000243125 /* TextFieldCell.swift in Sources */,
 				305702A124C6453700D84EFC /* TypeAlias.swift in Sources */,
@@ -1499,7 +1755,9 @@
 				3008CB7624F95B6D00E6A617 /* AudioController.swift in Sources */,
 				3080A035277DE30100E74565 /* String+Extensions.swift in Sources */,
 				302B84CE2397F6CD001C261F /* URL+Extension.swift in Sources */,
+				B2B683422B8E010300FA2349 /* View+Extension.swift in Sources */,
 				7A9FB1441FB061E2001FEA36 /* AppDelegate.swift in Sources */,
+				B2B6834D2B8E010300FA2349 /* MCEmojiSkinTonePickerBackgroundView.swift in Sources */,
 				30C7D5EE28F47E620078D24C /* MessageCounter.swift in Sources */,
 				30E83EFD289BF32C0035614C /* ShortcutManager.swift in Sources */,
 				305501742798CDE1008FD5CA /* WebxdcViewController.swift in Sources */,
@@ -1511,6 +1769,7 @@
 				303492A5257546B400A523D0 /* DraftPreview.swift in Sources */,
 				305961D02346125100C80F33 /* NSAttributedString+Extensions.swift in Sources */,
 				21D6C941260623F500D0755A /* NotificationManager.swift in Sources */,
+				B2B6834F2B8E010300FA2349 /* MCEmojiSkinTonePickerContainerView.swift in Sources */,
 				3080A023277DE09900E74565 /* SeparatorLine.swift in Sources */,
 				302B84C72396770B001C261F /* RelayHelper.swift in Sources */,
 				B2172F3C29C125F2002C289E /* AdvancedViewController.swift in Sources */,
@@ -1526,6 +1785,7 @@
 				AEFBE22F23FEF23D0045327A /* ProviderInfoCell.swift in Sources */,
 				AE6EC5242497663200A400E4 /* UIImageView+Extensions.swift in Sources */,
 				30F8817624DA97DA0023780E /* BackgroundContainer.swift in Sources */,
+				B2B683492B8E010300FA2349 /* MCEmojiPickerViewController.swift in Sources */,
 				3067AA4C2666310E00525036 /* ChatInputTextView.swift in Sources */,
 				30DDCBEB28FCA21800465D22 /* AccountSwitchViewController.swift in Sources */,
 				3080A02C277DE26000E74565 /* NSConstraintLayoutSet.swift in Sources */,
@@ -1534,22 +1794,27 @@
 				B20462E42440A4A600367A57 /* AutodelOverviewViewController.swift in Sources */,
 				305962102346154D00C80F33 /* String+Extension.swift in Sources */,
 				789E879621D6CB58003ED1C5 /* QrCodeReaderController.swift in Sources */,
+				B2B683522B8E010300FA2349 /* MCEmojiCollectionViewCell.swift in Sources */,
 				305961D22346125100C80F33 /* CGRect+Extensions.swift in Sources */,
 				3057029B24C6441300D84EFC /* EmptyStateLabel.swift in Sources */,
 				30260CA7238F02F700D8D52C /* MultilineTextFieldCell.swift in Sources */,
 				70B8882E2091B8550074812E /* ContactCell.swift in Sources */,
+				B2B6834E2B8E010300FA2349 /* MCEmojiSkinTonePickerView.swift in Sources */,
 				305961CD2346125100C80F33 /* UIEdgeInsets+Extensions.swift in Sources */,
 				30EF7324252FF15F00E2C54A /* MessageLabel.swift in Sources */,
 				30C0D49D237C4908008E2A0E /* CertificateCheckController.swift in Sources */,
 				3080A034277DE30100E74565 /* NSNotification+Extensions.swift in Sources */,
+				B2B683532B8E010300FA2349 /* MCEmojiPickerView.swift in Sources */,
 				3080A01B277DDB8A00E74565 /* InputPlugin.swift in Sources */,
 				304F769525DD237B0094B5E2 /* WebViewViewController.swift in Sources */,
 				7092474120B3869500AF8799 /* ContactDetailViewController.swift in Sources */,
+				B2B683542B8E010300FA2349 /* Observable.swift in Sources */,
 				304F769925DD23D70094B5E2 /* FullMessageViewController.swift in Sources */,
 				AE0AA952247800E700D42A7F /* GalleryCell.swift in Sources */,
 				3080A028277DE12D00E74565 /* InputBarSendButton.swift in Sources */,
 				AE0AA958247834A400D42A7F /* Date+Extension.swift in Sources */,
 				307D822E241669C7006D2490 /* LocationManager.swift in Sources */,
+				B2B683552B8E010300FA2349 /* MCUnicodeManager.swift in Sources */,
 				21D54500299415B9008B54D5 /* Character+Extentions.swift in Sources */,
 				30238CFF28A5554C00EF14AC /* FileHelper.swift in Sources */,
 				AE851AD0227DF50900ED86F0 /* GroupChatDetailViewController.swift in Sources */,
@@ -1753,6 +2018,53 @@
 				7A9FB14D1FB061E2001FEA36 /* Base */,
 			);
 			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		B2B682F12B8E010300FA2349 /* MCEmojiPickerLocalizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B2B682F22B8E010300FA2349 /* de */,
+				B2B682F32B8E010300FA2349 /* he */,
+				B2B682F42B8E010300FA2349 /* ar */,
+				B2B682F52B8E010300FA2349 /* el */,
+				B2B682F62B8E010300FA2349 /* zh-Hans */,
+				B2B682F72B8E010300FA2349 /* ja */,
+				B2B682F82B8E010300FA2349 /* en */,
+				B2B682F92B8E010300FA2349 /* uk */,
+				B2B682FA2B8E010300FA2349 /* zh-HK */,
+				B2B682FB2B8E010300FA2349 /* nb */,
+				B2B682FC2B8E010300FA2349 /* en-GB */,
+				B2B682FD2B8E010300FA2349 /* es */,
+				B2B682FE2B8E010300FA2349 /* da */,
+				B2B682FF2B8E010300FA2349 /* es-419 */,
+				B2B683002B8E010300FA2349 /* it */,
+				B2B683012B8E010300FA2349 /* sk */,
+				B2B683022B8E010300FA2349 /* fr-CA */,
+				B2B683032B8E010300FA2349 /* ms */,
+				B2B683042B8E010300FA2349 /* sv */,
+				B2B683052B8E010300FA2349 /* cs */,
+				B2B683062B8E010300FA2349 /* ko */,
+				B2B683072B8E010300FA2349 /* zh-Hant */,
+				B2B683082B8E010300FA2349 /* hu */,
+				B2B683092B8E010300FA2349 /* en-AU */,
+				B2B6830A2B8E010300FA2349 /* tr */,
+				B2B6830B2B8E010300FA2349 /* pl */,
+				B2B6830C2B8E010300FA2349 /* pt-BR */,
+				B2B6830D2B8E010300FA2349 /* vi */,
+				B2B6830E2B8E010300FA2349 /* ru */,
+				B2B6830F2B8E010300FA2349 /* fr */,
+				B2B683102B8E010300FA2349 /* fi */,
+				B2B683112B8E010300FA2349 /* id */,
+				B2B683122B8E010300FA2349 /* nl */,
+				B2B683132B8E010300FA2349 /* th */,
+				B2B683142B8E010300FA2349 /* pt-PT */,
+				B2B683152B8E010300FA2349 /* ro */,
+				B2B683162B8E010300FA2349 /* hr */,
+				B2B683172B8E010300FA2349 /* hi */,
+				B2B683182B8E010300FA2349 /* ca */,
+				B2B683192B8E010300FA2349 /* en-IN */,
+			);
+			name = MCEmojiPickerLocalizable.strings;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/deltachat-ios/MCEmojiPicker/Bindings/Observable.swift
+++ b/deltachat-ios/MCEmojiPicker/Bindings/Observable.swift
@@ -1,0 +1,58 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+/// Simple implementation of the observer pattern.
+final class Observable<T> {
+    
+    // MARK: - Public Properties
+    
+    public typealias Listener = (T) -> Void
+    
+    /// Holds the current value of the observable.
+    ///
+    /// The `didSet` block ensures that the `Listener` closure is called whenever the value changes.
+    public var value: T {
+        didSet {
+            listeners.forEach { $0(value) }
+        }
+    }
+    
+    // MARK: - Private Properties
+    
+    /// Holds a closure that will be called whenever the value changes.
+    private var listeners = [Listener]()
+    
+    // MARK: - Initializers
+    
+    init(value: T) {
+        self.value = value
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Allows you to set the `Listener` closure.
+    public func bind(_ listener: @escaping Listener) {
+        self.listeners.append(listener)
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/Common/Extensions/Array+Extension.swift
+++ b/deltachat-ios/MCEmojiPicker/Common/Extensions/Array+Extension.swift
@@ -1,0 +1,48 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+extension Array where Element == Int {
+    /// Converts hex values into emoji.
+    ///
+    /// This example shows that one emoji can consist of either one hex value or several.
+    /// ```
+    /// print([0x1F600].emoji()) // "😀"
+    /// print([0x1F635, 0x200D, 0x1F4AB].emoji()) // "😵‍💫"
+    /// ```
+    /// But if you put hex values not related to one emoji in one array. You will get a string of several emojis.
+    /// ```
+    /// print([0x1F600, 0x1F635, 0x200D, 0x1F4AB].emoji()) // "😀😵‍💫"
+    /// ```
+    func emoji() -> String {
+        return self
+            // Converting hex value into a 32-bit integer representation of emoji in the Unicode table.
+            .map({ UnicodeScalar($0) })
+            // Removing the optional.
+            .compactMap({ $0 })
+            // Converting a 32-bit integer to a character for correct representation.
+            .map({ String($0) })
+            // Combine all the received values to get the final emoji.
+            .joined()
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/Common/Extensions/Bundle+Extension.swift
+++ b/deltachat-ios/MCEmojiPicker/Common/Extensions/Bundle+Extension.swift
@@ -1,0 +1,40 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+/// In SPM, the parameter `Bundle.module` is used to access resources, but in CocoaPods this is done differently.
+/// In order for the library to support both dependency managers, it is necessary to add a similar parameter to the CocoaPods version.
+///
+/// To do this, a check has been added before the extension.
+#if !SWIFT_PACKAGE
+extension Bundle {
+    /// Resources bundle.
+    static var module: Bundle {
+        let path = Bundle(for: MCUnicodeManager.self).path(
+            forResource: "MCEmojiPicker",
+            ofType: "bundle"
+        ) ?? ""
+        return Bundle(path: path) ?? Bundle.main
+    }
+}
+#endif

--- a/deltachat-ios/MCEmojiPicker/Common/Extensions/Double+Extension.swift
+++ b/deltachat-ios/MCEmojiPicker/Common/Extensions/Double+Extension.swift
@@ -1,0 +1,48 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+extension Double {
+    /// Angle `270°` in radians.
+    static let downAngle: CGFloat = 1.5 * Double.pi
+    /// Angle `180°` in radians.
+    static let leftAngle: CGFloat = Double.pi
+    /// Angle `90°` in radians.
+    static let upAngle: CGFloat = Double.pi / 2
+    /// Angle `0°` in radians.
+    static let rightAngle: CGFloat = 0.0
+    
+    /// Used to increase various sizes (fonts, heights and widths).
+    /// - Parameter isOnlyToIncrease: Responsible for whether the value will decrease if the screen size is smaller than the default.
+    func fit(isOnlyToIncrease: Bool = true) -> Double {
+        let defaultScreenSize = CGSize(width: 375, height: 812)
+        let currentScreenSize = UIScreen.main.bounds.size
+        // Check the type of the current device, if it is not a phone, return the original value.
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return self }
+        var scale = 1.0
+        if isOnlyToIncrease && currentScreenSize.height > defaultScreenSize.height || !isOnlyToIncrease {
+            scale = currentScreenSize.height / defaultScreenSize.height
+        }
+        return self * scale
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/Common/Extensions/NSNotification.Name+Extension.swift
+++ b/deltachat-ios/MCEmojiPicker/Common/Extensions/NSNotification.Name+Extension.swift
@@ -1,0 +1,27 @@
+// The MIT License (MIT)
+//
+// Copyright © 2023 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+extension NSNotification.Name {
+    static let MCEmojiPickerDidDisappear = NSNotification.Name("MCEmojiPickerDidDisappear")
+}

--- a/deltachat-ios/MCEmojiPicker/Common/Extensions/UICollectionReusableView+Extension.swift
+++ b/deltachat-ios/MCEmojiPicker/Common/Extensions/UICollectionReusableView+Extension.swift
@@ -1,0 +1,30 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+extension UICollectionReusableView {
+    /// Converts the class name to a string.
+    static var reuseIdentifier: String {
+        return String(describing: self)
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/Common/Extensions/UIColor+Extension.swift
+++ b/deltachat-ios/MCEmojiPicker/Common/Extensions/UIColor+Extension.swift
@@ -1,0 +1,53 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+extension UIColor {
+    /// Background color for `MCEmojiPickerView`.
+    ///
+    /// This is a standard color from UIKit - `.systemGroupedBackground`.
+    static let popoverBackgroundColor = UIColor(
+        light:  UIColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1.0),
+        dark: UIColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 1.0)
+    )
+    /// Background color for `MCEmojiSkinTonePickerBackgroundView` and `MCEmojiPreviewView`.
+    ///
+    /// The colors were taken from similar iOS elements.
+    static let previewAndSkinToneBackgroundViewColor = UIColor(
+        light: UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0),
+        dark: UIColor(red: 0.45, green: 0.45, blue: 0.46, alpha: 1.0)
+    )
+}
+
+extension UIColor {
+    /// Adds support for dark and light interface style modes.
+    convenience init(light: UIColor, dark: UIColor) {
+        if #available(iOS 13.0, *) {
+            self.init(dynamicProvider: { trait in
+                trait.userInterfaceStyle == .dark ? dark : light
+            })
+        } else {
+            self.init(cgColor: light.cgColor)
+        }
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/Common/Extensions/View+Extension.swift
+++ b/deltachat-ios/MCEmojiPicker/Common/Extensions/View+Extension.swift
@@ -1,0 +1,62 @@
+// The MIT License (MIT)
+//
+// Copyright © 2023 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+@available(iOS 13, *)
+extension View {
+    /// The method adds a macOS style emoji picker.
+    ///
+    /// - Parameters:
+    ///     - isPresented: Observed value which is responsible for the state of the picker.
+    ///     - selectedEmoji: Observed value which is updated by the selected emoji.
+    ///     - arrowDirection: The direction of the arrow for EmojiPicker.
+    ///     - customHeight: Custom height for EmojiPicker.
+    ///     - horizontalInset: Inset from the sourceView border.
+    ///     - isDismissAfterChoosing: A boolean value that determines whether the screen will be hidden after the emoji is selected.
+    ///     - selectedEmojiCategoryTintColor: Color for the selected emoji category.
+    ///     - feedBackGeneratorStyle: Feedback generator style. To turn off, set `nil` to this parameter.
+    @ViewBuilder public func emojiPicker(
+        isPresented: Binding<Bool>,
+        selectedEmoji: Binding<String>,
+        arrowDirection: MCPickerArrowDirection? = nil,
+        customHeight: CGFloat? = nil,
+        horizontalInset: CGFloat? = nil,
+        isDismissAfterChoosing: Bool? = nil,
+        selectedEmojiCategoryTintColor: UIColor? = nil,
+        feedBackGeneratorStyle: UIImpactFeedbackGenerator.FeedbackStyle? = nil
+    ) -> some View {
+        self.overlay(
+            MCEmojiPickerRepresentableController(
+                isPresented: isPresented,
+                selectedEmoji: selectedEmoji,
+                arrowDirection: arrowDirection,
+                customHeight: customHeight,
+                horizontalInset: horizontalInset,
+                isDismissAfterChoosing: isDismissAfterChoosing,
+                selectedEmojiCategoryTintColor: selectedEmojiCategoryTintColor,
+                feedBackGeneratorStyle: feedBackGeneratorStyle
+            )
+                .allowsHitTesting(false)
+        )
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/Model/MCEmoji.swift
+++ b/deltachat-ios/MCEmojiPicker/Model/MCEmoji.swift
@@ -1,0 +1,161 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+/// The main model for interacting with emojis.
+struct MCEmoji {
+    
+    // MARK: - Types
+    
+    /// Keys for storage in UserDefaults.
+    private enum StorageKeys {
+        case skinTone(_ emoji: MCEmoji)
+        case usageTimestamps(_ emoji: MCEmoji)
+
+        var key: String {
+            switch self {
+            case .skinTone(let emoji):
+                return emoji.emojiKeys.emoji()
+            case .usageTimestamps(let emoji):
+                return StorageKeys.skinTone(emoji).key + "-usage-timestamps"
+            }
+        }
+    }
+    
+    // MARK: - Public Properties
+    
+    /// A boolean indicating whether the skin for this emoji has been selected before.
+    public var isSkinBeenSelectedBefore: Bool {
+        skinTone != nil
+    }
+    /// The current skin tone for this emoji, if one has been selected.
+    public var skinTone: MCEmojiSkinTone? {
+        let skinToneRawValue = UserDefaults.standard.integer(forKey: StorageKeys.skinTone(self).key)
+        return MCEmojiSkinTone(rawValue: skinToneRawValue)
+    }
+    /// All times when the emoji has been selected.
+    public var usage: [TimeInterval] {
+        (UserDefaults.standard.array(forKey: StorageKeys.usageTimestamps(self).key) as? [TimeInterval]) ?? []
+    }
+    /// The number of times this emoji has been selected.
+    public var usageCount: Int {
+        usage.count
+    }
+    /// The last time when this emoji has been selected.
+    public var lastUsage: TimeInterval {
+        usage.first ?? .zero
+    }
+    
+    /// The string representation of the emoji.
+    private(set) public var string: String = ""
+    /// The keys used to represent the emoji.
+    private(set) public var emojiKeys: [Int]
+    /// A boolean indicating whether this emoji has different skin tones available.
+    private(set) public var isSkinToneSupport: Bool
+    /// The search key for the emoji.
+    private(set) public var searchKey: String
+    /// The emoji version.
+    private(set) public var version: Double
+    
+    // MARK: - Initializers
+    
+    /// Initializes a new instance of the `MCEmoji` struct.
+    
+    /// - Parameters:
+    ///   - emojiKeys: The keys used to represent the emoji.
+    ///   - isSkinToneSupport: A boolean indicating whether this emoji has different skin tones available.
+    ///   - searchKey: The search key for the emoji.
+    ///   - version: The emoji version.
+    public init(
+        emojiKeys: [Int],
+        isSkinToneSupport: Bool,
+        searchKey: String,
+        version: Double
+    ) {
+        self.emojiKeys = emojiKeys
+        self.isSkinToneSupport = isSkinToneSupport
+        self.searchKey = searchKey
+        self.version = version
+        
+        string = getEmoji()
+    }
+    
+    // MARK: - Public Methods
+
+    /// Sets the skin tone of the emoji.
+    
+    /// - Parameters:
+    ///   - skinToneRawValue: The raw value of the `MCEmojiSkinTone`.
+    public mutating func set(skinToneRawValue: Int) {
+        UserDefaults.standard.set(skinToneRawValue, forKey: StorageKeys.skinTone(self).key)
+        string = getEmoji()
+    }
+    
+    /// Increments the usage count for this emoji.
+    public func incrementUsageCount() {
+        let nowTimestamp = Date().timeIntervalSince1970
+        UserDefaults.standard.set([nowTimestamp] + usage, forKey: StorageKeys.usageTimestamps(self).key)
+    }
+    
+    // MARK: - Private Methods
+    
+    /// Returns the string representation of this smiley. Considering the skin tone, if it has been selected.
+    private func getEmoji() -> String {
+        guard isSkinToneSupport,
+              let skinTone = skinTone,
+              let skinToneKey = skinTone.skinKey else {
+            return emojiKeys.emoji()
+        }
+        var bufferEmojiKeys = emojiKeys
+        bufferEmojiKeys.insert(skinToneKey, at: 1)
+        return bufferEmojiKeys.emoji()
+    }
+}
+
+/// This enumeration allows you to determine which skin tones can be set for `MCEmoji`.
+enum MCEmojiSkinTone: Int, CaseIterable {
+    case none = 1
+    case light = 2
+    case mediumLight = 3
+    case medium = 4
+    case mediumDark = 5
+    case dark = 6
+    
+    /// Hex value for the skin tone.
+    var skinKey: Int? {
+        switch self {
+        case .none:
+            return nil
+        case .light:
+            return 0x1F3FB
+        case .mediumLight:
+            return 0x1F3FC
+        case .medium:
+            return 0x1F3FD
+        case .mediumDark:
+            return 0x1F3FE
+        case .dark:
+            return 0x1F3FF
+        }
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/Model/MCEmojiCategory.swift
+++ b/deltachat-ios/MCEmojiPicker/Model/MCEmojiCategory.swift
@@ -1,0 +1,67 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+/// The main model that is used to configure the main collection.
+struct MCEmojiCategory {
+    var type: MCEmojiCategoryType
+    var categoryName: String
+    var emojis: [MCEmoji]
+}
+
+/// This enumeration shows a list of categories that are contained in the main collection.
+enum MCEmojiCategoryType: Int, CaseIterable {
+    case frequentlyUsed
+    case people
+    case nature
+    case foodAndDrink
+    case activity
+    case travelAndPlaces
+    case objects
+    case symbols
+    case flags
+    
+    /// A constant key for accessing name localization resources for each category.
+    var localizeKey: String {
+        switch self {
+        case .frequentlyUsed:
+            return "frequentlyUsed"
+        case .people:
+            return "emotionsAndPeople"
+        case .nature:
+            return "animalsAndNature"
+        case .foodAndDrink:
+            return "foodAndDrinks"
+        case .activity:
+            return "activities"
+        case .travelAndPlaces:
+            return "travellingAndPlaces"
+        case .objects:
+            return "items"
+        case .symbols:
+            return "symbols"
+        case .flags:
+            return "flags"
+        }
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/Model/MCPickerArrowDirection.swift
+++ b/deltachat-ios/MCEmojiPicker/Model/MCPickerArrowDirection.swift
@@ -1,0 +1,29 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+/// This is a temporary enumeration that duplicates two cases from `UIPopoverArrowDirection'.
+public enum MCPickerArrowDirection: UInt {
+    case up = 1
+    case down = 2
+}

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/ar.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/ar.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,32 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "الأكثر استخداما";
+"emotionsAndPeople" = "ابتسامات وأشخاص";
+"animalsAndNature" = "حيوانات وطبيعة";
+"foodAndDrinks" = "طعام وشراب";
+"activities" = "نشاط";
+"travellingAndPlaces" = "سفر وأماكن";
+"items" = "عناصر";
+"symbols" = "رموز";
+"flags" = "أعلام";
+

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/ca.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/ca.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "ÜS FREQUENT";
+"emotionsAndPeople" = "EMOTICONES I PERSONES";
+"animalsAndNature" = "ANIMALS I NATURA";
+"foodAndDrinks" = "MENJAR I BEGUDA";
+"activities" = "ACTIVITATS";
+"travellingAndPlaces" = "VIATGES I LLOCS";
+"items" = "OBJECTES";
+"symbols" = "SÍMBOLS";
+"flags" = "BANDERES";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/cs.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/cs.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "ČASTO POUŽÍVANÉ";
+"emotionsAndPeople" = "SMAJLÍCI A LIDÉ";
+"animalsAndNature" = "ZVÍŘATA A PŘRODA";
+"foodAndDrinks" = "JÍDLO A PITÍ";
+"activities" = "AKTIVITA";
+"travellingAndPlaces" = "CESTOVÁNÍ A MÍSTA";
+"items" = "OBJEKTY";
+"symbols" = "SYMBOLY";
+"flags" = "VLAJKY";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/da.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/da.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "HYPPIGT BRUGTE";
+"emotionsAndPeople" = "SMILEYS OG PERSONER";
+"animalsAndNature" = "DYR OG NATUR";
+"foodAndDrinks" = "MAD OG DRIKKEVARER";
+"activities" = "AKTIVITET";
+"travellingAndPlaces" = "REJSER OG STEDER";
+"items" = "OBJEKTER";
+"symbols" = "SYMBOLER";
+"flags" = "FLAG";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/de.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/de.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "OFT BENUTZT";
+"emotionsAndPeople" = "SMILEYS & PERSONEN";
+"animalsAndNature" = "TIERE & NATUR";
+"foodAndDrinks" = "ESSEN & TRINKEN";
+"activities" = "AKTIVITÄT";
+"travellingAndPlaces" = "REISEN & ORTE";
+"items" = "OBJEKTE";
+"symbols" = "SYMBOLE";
+"flags" = "FLAGGEN";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/el.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/el.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "ΣΥΧΝΗ ΧΡΗΣΗ";
+"emotionsAndPeople" = "ΦΑΤΣΟΥΛΕΣ ΚΑΙ ΑΤΟΜΑ";
+"animalsAndNature" = "ΖΩΑ ΚΑΙ ΦΥΣΗ";
+"foodAndDrinks" = "ΦΑΓΗΤΟ ΚΑΙ ΠΟΤΟ";
+"activities" = "ΔΡΑΣΤΗΡΙΟΤΗΤΑ";
+"travellingAndPlaces" = "ΤΑΞΙΔΙΑ ΚΑΙ ΜΕΡΗ";
+"items" = "ANTIKEIMENA";
+"symbols" = "ΣΥΜΒΟΛΑ";
+"flags" = "ΣΗΜΑΙΕΣ";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/en-AU.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/en-AU.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "FREQUENTLY USED";
+"emotionsAndPeople" = "SMILEYS & PEOPLE";
+"animalsAndNature" = "ANIMALS & NATURE";
+"foodAndDrinks" = "FOOD & DRINK";
+"activities" = "ACTIVITY";
+"travellingAndPlaces" = "TRAVEL & PLACES";
+"items" = "OBJECTS";
+"symbols" = "SYMBOLS";
+"flags" = "FLAGS";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/en-GB.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/en-GB.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "FREQUENTLY USED";
+"emotionsAndPeople" = "SMILEYS & PEOPLE";
+"animalsAndNature" = "ANIMALS & NATURE";
+"foodAndDrinks" = "FOOD & DRINK";
+"activities" = "ACTIVITY";
+"travellingAndPlaces" = "TRAVEL & PLACES";
+"items" = "OBJECTS";
+"symbols" = "SYMBOLS";
+"flags" = "FLAGS";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/en-IN.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/en-IN.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "FREQUENTLY USED";
+"emotionsAndPeople" = "SMILEYS & PEOPLE";
+"animalsAndNature" = "ANIMALS & NATURE";
+"foodAndDrinks" = "FOOD & DRINK";
+"activities" = "ACTIVITY";
+"travellingAndPlaces" = "TRAVEL & PLACES";
+"items" = "OBJECTS";
+"symbols" = "SYMBOLS";
+"flags" = "FLAGS";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/en.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/en.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "FREQUENTLY USED";
+"emotionsAndPeople" = "SMILEYS & PEOPLE";
+"animalsAndNature" = "ANIMALS & NATURE";
+"foodAndDrinks" = "FOOD & DRINK";
+"activities" = "ACTIVITY";
+"travellingAndPlaces" = "TRAVEL & PLACES";
+"items" = "OBJECTS";
+"symbols" = "SYMBOLS";
+"flags" = "FLAGS";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/es-419.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/es-419.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "MÁS FRECUENTES";
+"emotionsAndPeople" = "CARAS Y PERSONAS";
+"animalsAndNature" = "ANIMALES Y NATURALEZA";
+"foodAndDrinks" = "ALIMENTOS Y BEBIDAS";
+"activities" = "ACTIVIDAD";
+"travellingAndPlaces" = "VIAJES Y LUGARES";
+"items" = "OBJETOS";
+"symbols" = "SÍMBOLOS";
+"flags" = "BANDERAS";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/es.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/es.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "USADOS CON FRECUENCIA";
+"emotionsAndPeople" = "EMOTICONOS Y PERSONAS";
+"animalsAndNature" = "ANIMALES Y NATURALEZA";
+"foodAndDrinks" = "COMIDA Y BEBIDA";
+"activities" = "ACTIVIDADES";
+"travellingAndPlaces" = "VIAJES Y DESTINOS";
+"items" = "OBJETOS";
+"symbols" = "SÍMBOLOS";
+"flags" = "BANDERAS";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/fi.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/fi.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "USEIN KÄYTETYT";
+"emotionsAndPeople" = "HYMIÖT JA IHMISET";
+"animalsAndNature" = "ELÄIMET JA LUONTO";
+"foodAndDrinks" = "RUOKA JA JUOMA";
+"activities" = "TOIMINTA";
+"travellingAndPlaces" = "MATKAILU JA PAIKAT";
+"items" = "ESINEET";
+"symbols" = "SYMBOLIT";
+"flags" = "LIPUT";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/fr-CA.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/fr-CA.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "UTILISÉS FRÉQUEMMENT";
+"emotionsAndPeople" = "ÉMOTICÔNES ET PERSONNES";
+"animalsAndNature" = "ANIMAUX ET NATURE";
+"foodAndDrinks" = "ALIMENT ET BOISSON";
+"activities" = "ACTIVITÉ";
+"travellingAndPlaces" = "VOYAGES ET LIEUX";
+"items" = "OBJETS";
+"symbols" = "SYMBOLES";
+"flags" = "DRAPEAUX";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/fr.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/fr.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "SOUVENT UTILISÉS";
+"emotionsAndPeople" = "ÉMOTICÔNES ET PERSONNAGES";
+"animalsAndNature" = "ANIMAUX ET NATURE";
+"foodAndDrinks" = "NOURRITURE ET BOISSONS";
+"activities" = "ACTIVITÉS";
+"travellingAndPlaces" = "VOYAGES ET LIEUX";
+"items" = "OBJETS";
+"symbols" = "SYMBOLES";
+"flags" = "DRAPEAUX";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/he.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/he.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "בשימוש תדיר";
+"emotionsAndPeople" = "סמיילי ואנשים";
+"animalsAndNature" = "בעלי חיים וטבע";
+"foodAndDrinks" = "מזון ומשקאות";
+"activities" = "פעילות";
+"travellingAndPlaces" = "נסיעות ומקומות";
+"items" = "חפצים";
+"symbols" = "סימנים";
+"flags" = "דגלים";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/hi.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/hi.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "अक्सर उपयोग होने वाले";
+"emotionsAndPeople" = "स्माइली और लोग";
+"animalsAndNature" = "पशु और प्रकृति";
+"foodAndDrinks" = "खाद्य और पेय";
+"activities" = "ऐक्टिविटी";
+"travellingAndPlaces" = "यात्रा और स्थान";
+"items" = "चीजें";
+"symbols" = "चिह्न";
+"flags" = "फ़्लैग";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/hr.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/hr.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "ČESTO KORIŠTENO";
+"emotionsAndPeople" = "SMAJLIĆI I OSOBE";
+"animalsAndNature" = "ŽIVOTINJE I NATURE";
+"foodAndDrinks" = "HRANA I PIĆE";
+"activities" = "AKTIVNOST";
+"travellingAndPlaces" = "PUTOVANJA I MJESTA";
+"items" = "PREDMETI";
+"symbols" = "SIMBOLI";
+"flags" = "ZASTAVE";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/hu.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/hu.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "GYAKRAN HASZNÁLTAK";
+"emotionsAndPeople" = "HANGULATJELEK ÉS EMBEREK";
+"animalsAndNature" = "ÁLLATOK ÉS TERMÉSZET";
+"foodAndDrinks" = "ÉTELEK ÉS ITALOK";
+"activities" = "TEVÉKENYSÉG";
+"travellingAndPlaces" = "UTAZÁS ÉS HELYEK";
+"items" = "TÁRGYAK";
+"symbols" = "SZIMBÓLUMOK";
+"flags" = "ZÁSZLÓK";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/id.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/id.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "SERING DIGUNAKAN";
+"emotionsAndPeople" = "SMILEY & ORANG";
+"animalsAndNature" = "HEWAN & ALAM";
+"foodAndDrinks" = "MAKANAN & MINUMAN";
+"activities" = "AKTIVITAS";
+"travellingAndPlaces" = "PERJALANAN & TEMPAT";
+"items" = "OBJEK";
+"symbols" = "SIMBOL";
+"flags" = "BENDERA";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/it.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/it.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "USATE DI FREQUENTE";
+"emotionsAndPeople" = "EMOTICON E PERSONE";
+"animalsAndNature" = "ANIMALI E NATURA";
+"foodAndDrinks" = "CIBO E BEVANDE";
+"activities" = "ATTIVITÀ";
+"travellingAndPlaces" = "VIAGGI E LUOGHI";
+"items" = "OGGETTI";
+"symbols" = "SIMBOLI";
+"flags" = "BANDIERE";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/ja.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/ja.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "よく使う項目";
+"emotionsAndPeople" = "スマイリーと人々";
+"animalsAndNature" = "動物と自然";
+"foodAndDrinks" = "食べ物と飲み物";
+"activities" = "活動";
+"travellingAndPlaces" = "旅行と場所";
+"items" = "物";
+"symbols" = "記号";
+"flags" = "旗";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/ko.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/ko.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "자주 사용하는 항목";
+"emotionsAndPeople" = "스마일리 및 사람";
+"animalsAndNature" = "동물 및 자연";
+"foodAndDrinks" = "음식 및 음료";
+"activities" = "활동";
+"travellingAndPlaces" = "여행 및 장소";
+"items" = "사물";
+"symbols" = "기호";
+"flags" = "깃발";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/ms.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/ms.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "KERAP DIGUNAKAN";
+"emotionsAndPeople" = "MUKA SENYUM & ORANG";
+"animalsAndNature" = "HAIWAN & ALAM";
+"foodAndDrinks" = "MAKANAN & MINUMAN";
+"activities" = "AKTIVITI";
+"travellingAndPlaces" = "PERJALANAN & TEMPAT";
+"items" = "OBJEK";
+"symbols" = "SIMBOL";
+"flags" = "BENDERA";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/nb.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/nb.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "OFTE BRUKT";
+"emotionsAndPeople" = "SMILEFJES OG PERSONER";
+"animalsAndNature" = "DYR OG NATUR";
+"foodAndDrinks" = "MAT OG DRIKKE";
+"activities" = "AKTIVITET";
+"travellingAndPlaces" = "REISE OG STEDER";
+"items" = "OBJEKTER";
+"symbols" = "SYMBOLER";
+"flags" = "FLAGG";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/nl.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/nl.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "VAAK GEBRUIKT";
+"emotionsAndPeople" = "SMILEYS EN MENSEN";
+"animalsAndNature" = "DIEREN EN NATUUR";
+"foodAndDrinks" = "ETEN EN DRINKEN";
+"activities" = "ACTIVITEIT";
+"travellingAndPlaces" = "REIZEN EN PLAATSEN";
+"items" = "OBJECTEN";
+"symbols" = "SYMBOLEN";
+"flags" = "VLAGGEN";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/pl.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/pl.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "CZĘSTO UŻYWANE";
+"emotionsAndPeople" = "BUŻKI I OSOBY";
+"animalsAndNature" = "ZWIERZĘTA I NATURA";
+"foodAndDrinks" = "ŻYWNOŚĆ I NAPOJE";
+"activities" = "AKTYWNOŚĆ";
+"travellingAndPlaces" = "PODRÓŻE I MIEJSCA";
+"items" = "OBIEKTY";
+"symbols" = "SYMBOLE";
+"flags" = "FLAGI";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/pt-BR.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/pt-BR.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "MAIS USADOS";
+"emotionsAndPeople" = "SORRISOS E PESSOAS";
+"animalsAndNature" = "ANIMAIS E NATUREZA";
+"foodAndDrinks" = "COMIDA E BEBIDA";
+"activities" = "ATIVIDADES";
+"travellingAndPlaces" = "VIAGEM E LUGARES";
+"items" = "OBJETOS";
+"symbols" = "SÍMBOLOS";
+"flags" = "BANDEIRAS";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/pt-PT.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/pt-PT.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "USADOS COM FREQUÊNCIA";
+"emotionsAndPeople" = "SMILEYS E PESSOAS";
+"animalsAndNature" = "ANIMAIS E NATUREZA";
+"foodAndDrinks" = "ALIMENTAÇÃO E BEBIDAS";
+"activities" = "ATIVIDADE";
+"travellingAndPlaces" = "VIAGENS E LUGARES";
+"items" = "OBJETOS";
+"symbols" = "SÍMBOLOS";
+"flags" = "BANDEIRAS";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/ro.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/ro.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "UTILIZATE FRECVENT";
+"emotionsAndPeople" = "EMOTICOANE ȘI PERSOANE";
+"animalsAndNature" = "ANIMALE ȘI NATURĂ";
+"foodAndDrinks" = "MÂNCĂRURI ȘI BĂUTURI";
+"activities" = "ACTIVITĂȚI";
+"travellingAndPlaces" = "CĂLĂTORII ȘI LOCURI";
+"items" = "OBIECTE";
+"symbols" = "SIMBOLURI";
+"flags" = "STEAGURI";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/ru.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/ru.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "ЧАСТО ИСПОЛЬЗУЕМЫЕ";
+"emotionsAndPeople" = "СМАЙЛИКИ И ЛЮДИ";
+"animalsAndNature" = "ЖИВОТНЫЕ И ПРИРОДА";
+"foodAndDrinks" = "ЕДА И НАПИТКИ";
+"activities" = "АКТИВНОСТЬ";
+"travellingAndPlaces" = "ПУТЕШЕСТВИЯ И МЕСТНОСТИ";
+"items" = "ПРЕДМЕТЫ";
+"symbols" = "СИМВОЛЫ";
+"flags" = "ФЛАГИ";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/sk.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/sk.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "ČASTO POUŽÍVANÉ";
+"emotionsAndPeople" = "SMAJLÍKY A ĽUDIA";
+"animalsAndNature" = "ZVIERATÁ A PRÍRODA";
+"foodAndDrinks" = "JEDLO A NÁPOJE";
+"activities" = "AKTIVITA";
+"travellingAndPlaces" = "CESTOVANIE A MIESTA";
+"items" = "OBJEKTY";
+"symbols" = "SYMBOLY";
+"flags" = "VLAJKY";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/sv.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/sv.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "OFTA ANVÄNDA";
+"emotionsAndPeople" = "SMILEYS OCH MÄNNISKOR";
+"animalsAndNature" = "DJUR OCH NATUR";
+"foodAndDrinks" = "MAT OCH DRYCK";
+"activities" = "AKTIVITET";
+"travellingAndPlaces" = "RESOR OCH PLATSER";
+"items" = "OBJEKT";
+"symbols" = "SYMBOLER";
+"flags" = "FLAGGOR";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/th.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/th.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "ที่ใช้ประจำ";
+"emotionsAndPeople" = "ใบหน้ายิ้มและผู้คน";
+"animalsAndNature" = "สัตว์และธรรมชาติ";
+"foodAndDrinks" = "อาหารและเครื่องดื่ม";
+"activities" = "กิจกรรม";
+"travellingAndPlaces" = "การท่องเที่ยวและสถานที่";
+"items" = "วัตถุ";
+"symbols" = "สัญลักษณ์";
+"flags" = "ธง";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/tr.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/tr.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "SIK KULLANILANLAR";
+"emotionsAndPeople" = "YÜZ İFADELERİ VE İNSANLAR";
+"animalsAndNature" = "HAYVANLAR VE DOĞA";
+"foodAndDrinks" = "YİYECEK VE İÇECEK";
+"activities" = "ETKİNLİK";
+"travellingAndPlaces" = "SEYAHAT VE YERLER";
+"items" = "NESNELER";
+"symbols" = "SEMBOLLER";
+"flags" = "BAYRAKLAR";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/uk.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/uk.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "ЧАСТО ВЖИВАНІ";
+"emotionsAndPeople" = "СМАЙЛИКИ Й ЛЮДИ";
+"animalsAndNature" = "ФЛОРА І ФАУНА";
+"foodAndDrinks" = "ЇЖА І НАПОЇ";
+"activities" = "АКТИВНІСТЬ";
+"travellingAndPlaces" = "ПОДОРОЖІ Й МІСЦЯ";
+"objects" = "ОБʼЄКТИ";
+"symbols" = "СИМВОЛИ";
+"flags" = "ПРАПОРИ";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/vi.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/vi.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "THƯỜNG DÙNG";
+"emotionsAndPeople" = "MẶT CƯỜI & NGƯỜI";
+"animalsAndNature" = "ĐỘNG VẬT & TỰ NHIÊN";
+"foodAndDrinks" = "ĐỒ ĂN & ĐỒ UỐNG";
+"activities" = "HOẠT ĐỘNG";
+"travellingAndPlaces" = "DU LỊCH & ĐỊA ĐIỂM";
+"items" = "ĐỒ VẬT";
+"symbols" = "KÝ HIỆU";
+"flags" = "CỜ";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/zh-HK.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/zh-HK.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "常用";
+"emotionsAndPeople" = "表情與人物";
+"animalsAndNature" = "動物與自然";
+"foodAndDrinks" = "飲食";
+"activities" = "活動";
+"travellingAndPlaces" = "旅行與地點";
+"items" = "物件";
+"symbols" = "符號";
+"flags" = "旗幟";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/zh-Hans.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/zh-Hans.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "常用";
+"emotionsAndPeople" = "表情符号与人物";
+"animalsAndNature" = "动物与自然";
+"foodAndDrinks" = "食物与饮料";
+"activities" = "活动";
+"travellingAndPlaces" = "旅行与地点";
+"items" = "物体";
+"symbols" = "符号";
+"flags" = "旗帜";

--- a/deltachat-ios/MCEmojiPicker/Resources/Localization/zh-Hant.lproj/MCEmojiPickerLocalizable.strings
+++ b/deltachat-ios/MCEmojiPicker/Resources/Localization/zh-Hant.lproj/MCEmojiPickerLocalizable.strings
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+"frequentlyUsed" = "常用項目";
+"emotionsAndPeople" = "表情符號與人物";
+"animalsAndNature" = "動物與自然";
+"foodAndDrinks" = "美食佳飲";
+"activities" = "活動";
+"travellingAndPlaces" = "旅遊與地點";
+"items" = "物品";
+"symbols" = "符號";
+"flags" = "旗幟";

--- a/deltachat-ios/MCEmojiPicker/Services/MCUnicodeManager.swift
+++ b/deltachat-ios/MCEmojiPicker/Services/MCUnicodeManager.swift
@@ -1,0 +1,11399 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import UIKit.UIDevice
+
+/// Protocol for the `MCUnicodeManager`.
+protocol MCUnicodeManagerProtocol {
+    /// Returns categories with filtered emoji arrays that are available in the current version of iOS.
+    func getEmojisForCurrentIOSVersion() -> [MCEmojiCategory]
+}
+
+fileprivate extension MCEmojiCategoryType {
+    var emojiCategoryTitle: String {
+        NSLocalizedString(
+            self.localizeKey,
+            tableName: "MCEmojiPickerLocalizable",
+            bundle: .module,
+            comment: ""
+        )
+    }
+}
+
+/// The class is responsible for getting a relevant set of emojis for iOS version.
+final class MCUnicodeManager: MCUnicodeManagerProtocol {
+    
+    /// The maximum number of frequently used emojis to include in the `frequentlyUsed` category.
+    public let maxFrequentlyUsedEmojisCount: Int
+    
+    // MARK: - Initializers
+    
+    public init(maxFrequentlyUsedEmojis: Int = 30) {
+        self.maxFrequentlyUsedEmojisCount = maxFrequentlyUsedEmojis
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Returns all emojis available for the current device's iOS version.
+    func getEmojisForCurrentIOSVersion() -> [MCEmojiCategory] {
+        let frequentlyUsedEmojis: MCEmojiCategory = .init(
+            type: .frequentlyUsed,
+            categoryName: MCEmojiCategoryType.frequentlyUsed.emojiCategoryTitle,
+            emojis: getFrequentlyUsedEmojis()
+        )
+        return [frequentlyUsedEmojis] + defaultEmojis
+    }
+    
+    // MARK: - Private Methods
+
+    /// Returns the top n (`maxFrequentlyUsedEmojis`) emojis by usage, for emojis with a `usageCount` > 0.
+    private func getFrequentlyUsedEmojis() -> [MCEmoji] {
+        Array(
+            defaultEmojis
+                .flatMap({ $0.emojis })
+                .filter({ $0.usageCount > 0 })
+                .sorted(by: { lhs, rhs in
+                    let (aUsage, bUsage) = (lhs.usage, rhs.usage)
+                    guard aUsage.count != bUsage.count else {
+                        // Break ties with most recent usage
+                        return lhs.lastUsage > rhs.lastUsage
+                    }
+                    return aUsage.count > bUsage.count
+                })
+                .prefix(maxFrequentlyUsedEmojisCount)
+        )
+    }
+
+    // MARK: - Private Properties
+    
+    /// The maximum available emoji version for the current iOS version.
+    private static let maxCurrentAvailableEmojiVersion: Double = {
+        let currentIOSVersion = (UIDevice.current.systemVersion as NSString).floatValue
+        switch currentIOSVersion {
+        case 12.1...13.1:
+            return 11.0
+        case 13.2...14.1:
+            return 12.0
+        case 14.2...14.4:
+            return 13.0
+        case 14.5...15.3:
+            return 13.1
+        case 15.4...16.3:
+            return 14.0
+        case 16.4...:
+            return 15.0
+        default:
+            return 5.0
+        }
+    }()
+    
+    private var defaultEmojis: [MCEmojiCategory] {
+        [
+            peopleEmojis,
+            natureEmojis,
+            foodAndDrinkEmojis,
+            activityEmojis,
+            travelAndPlacesEmojis,
+            objectEmojis,
+            symbolEmojis,
+            flagEmojis
+        ]
+    }
+    
+    private let peopleEmojis: MCEmojiCategory = .init(
+        type: .people,
+        categoryName: MCEmojiCategoryType.people.emojiCategoryTitle,
+        emojis: [
+            MCEmoji(
+                emojiKeys: [0x1F600],
+                isSkinToneSupport: false,
+                searchKey: "grinningFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F603],
+                isSkinToneSupport: false,
+                searchKey: "grinningFaceWithBigEyes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F604],
+                isSkinToneSupport: false,
+                searchKey: "grinningFaceWithSmilingEyes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F601],
+                isSkinToneSupport: false,
+                searchKey: "beamingFaceWithSmilingEyes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F606],
+                isSkinToneSupport: false,
+                searchKey: "grinningSquintingFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F605],
+                isSkinToneSupport: false,
+                searchKey: "grinningFaceWithSweat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F923],
+                isSkinToneSupport: false,
+                searchKey: "rollingOnTheFloorLaughing",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F602],
+                isSkinToneSupport: false,
+                searchKey: "faceWithTearsOfJoy",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F642],
+                isSkinToneSupport: false,
+                searchKey: "slightlySmilingFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F643],
+                isSkinToneSupport: false,
+                searchKey: "upsideDownFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAE0],
+                isSkinToneSupport: false,
+                searchKey: "meltingFace",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F609],
+                isSkinToneSupport: false,
+                searchKey: "winkingFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F60A],
+                isSkinToneSupport: false,
+                searchKey: "smilingFaceWithSmilingEyes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F607],
+                isSkinToneSupport: false,
+                searchKey: "smilingFaceWithHalo",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F970],
+                isSkinToneSupport: false,
+                searchKey: "smilingFaceWithHearts",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F60D],
+                isSkinToneSupport: false,
+                searchKey: "smilingFaceWithHeartEyes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F929],
+                isSkinToneSupport: false,
+                searchKey: "starStruck",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F618],
+                isSkinToneSupport: false,
+                searchKey: "faceBlowingAKiss",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F617],
+                isSkinToneSupport: false,
+                searchKey: "kissingFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x263A, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "smilingFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F61A],
+                isSkinToneSupport: false,
+                searchKey: "kissingFaceWithClosedEyes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F619],
+                isSkinToneSupport: false,
+                searchKey: "kissingFaceWithSmilingEyes",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F972],
+                isSkinToneSupport: false,
+                searchKey: "smilingFaceWithTear",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F60B],
+                isSkinToneSupport: false,
+                searchKey: "faceSavoringFood",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F61B],
+                isSkinToneSupport: false,
+                searchKey: "faceWithTongue",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F61C],
+                isSkinToneSupport: false,
+                searchKey: "winkingFaceWithTongue",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F92A],
+                isSkinToneSupport: false,
+                searchKey: "zanyFace",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F61D],
+                isSkinToneSupport: false,
+                searchKey: "squintingFaceWithTongue",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F911],
+                isSkinToneSupport: false,
+                searchKey: "moneyMouthFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F917],
+                isSkinToneSupport: false,
+                searchKey: "smilingFaceWithOpenHands",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F92D],
+                isSkinToneSupport: false,
+                searchKey: "faceWithHandOverMouth",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAE2],
+                isSkinToneSupport: false,
+                searchKey: "faceWithOpenEyesAndHandOverMouth",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAE3],
+                isSkinToneSupport: false,
+                searchKey: "faceWithPeekingEye",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F92B],
+                isSkinToneSupport: false,
+                searchKey: "shushingFace",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F914],
+                isSkinToneSupport: false,
+                searchKey: "thinkingFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAE1],
+                isSkinToneSupport: false,
+                searchKey: "salutingFace",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F910],
+                isSkinToneSupport: false,
+                searchKey: "zipperMouthFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F928],
+                isSkinToneSupport: false,
+                searchKey: "faceWithRaisedEyebrow",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F610],
+                isSkinToneSupport: false,
+                searchKey: "neutralFace",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F611],
+                isSkinToneSupport: false,
+                searchKey: "expressionlessFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F636],
+                isSkinToneSupport: false,
+                searchKey: "faceWithoutMouth",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAE5],
+                isSkinToneSupport: false,
+                searchKey: "dottedLineFace",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F636, 0x200D, 0x1F32B, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "faceInClouds",
+                version: 13.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F60F],
+                isSkinToneSupport: false,
+                searchKey: "smirkingFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F612],
+                isSkinToneSupport: false,
+                searchKey: "unamusedFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F644],
+                isSkinToneSupport: false,
+                searchKey: "faceWithRollingEyes",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F62C],
+                isSkinToneSupport: false,
+                searchKey: "grimacingFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F62E, 0x200D, 0x1F4A8],
+                isSkinToneSupport: false,
+                searchKey: "faceExhaling",
+                version: 13.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F925],
+                isSkinToneSupport: false,
+                searchKey: "lyingFace",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAE8],
+                isSkinToneSupport: false,
+                searchKey: "shakingFace",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F60C],
+                isSkinToneSupport: false,
+                searchKey: "relievedFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F614],
+                isSkinToneSupport: false,
+                searchKey: "pensiveFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F62A],
+                isSkinToneSupport: false,
+                searchKey: "sleepyFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F924],
+                isSkinToneSupport: false,
+                searchKey: "droolingFace",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F634],
+                isSkinToneSupport: false,
+                searchKey: "sleepingFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F637],
+                isSkinToneSupport: false,
+                searchKey: "faceWithMedicalMask",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F912],
+                isSkinToneSupport: false,
+                searchKey: "faceWithThermometer",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F915],
+                isSkinToneSupport: false,
+                searchKey: "faceWithHeadBandage",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F922],
+                isSkinToneSupport: false,
+                searchKey: "nauseatedFace",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F92E],
+                isSkinToneSupport: false,
+                searchKey: "faceVomiting",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F927],
+                isSkinToneSupport: false,
+                searchKey: "sneezingFace",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F975],
+                isSkinToneSupport: false,
+                searchKey: "hotFace",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F976],
+                isSkinToneSupport: false,
+                searchKey: "coldFace",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F974],
+                isSkinToneSupport: false,
+                searchKey: "woozyFace",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F635],
+                isSkinToneSupport: false,
+                searchKey: "faceWithCrossedOutEyes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F635, 0x200D, 0x1F4AB],
+                isSkinToneSupport: false,
+                searchKey: "faceWithSpiralEyes",
+                version: 13.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F92F],
+                isSkinToneSupport: false,
+                searchKey: "explodingHead",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F920],
+                isSkinToneSupport: false,
+                searchKey: "cowboyHatFace",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F973],
+                isSkinToneSupport: false,
+                searchKey: "partyingFace",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F978],
+                isSkinToneSupport: false,
+                searchKey: "disguisedFace",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F60E],
+                isSkinToneSupport: false,
+                searchKey: "smilingFaceWithSunglasses",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F913],
+                isSkinToneSupport: false,
+                searchKey: "nerdFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D0],
+                isSkinToneSupport: false,
+                searchKey: "faceWithMonocle",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F615],
+                isSkinToneSupport: false,
+                searchKey: "confusedFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAE4],
+                isSkinToneSupport: false,
+                searchKey: "faceWithDiagonalMouth",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F61F],
+                isSkinToneSupport: false,
+                searchKey: "worriedFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F641],
+                isSkinToneSupport: false,
+                searchKey: "slightlyFrowningFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2639, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "frowningFace",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F62E],
+                isSkinToneSupport: false,
+                searchKey: "faceWithOpenMouth",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F62F],
+                isSkinToneSupport: false,
+                searchKey: "hushedFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F632],
+                isSkinToneSupport: false,
+                searchKey: "astonishedFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F633],
+                isSkinToneSupport: false,
+                searchKey: "flushedFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F97A],
+                isSkinToneSupport: false,
+                searchKey: "pleadingFace",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F979],
+                isSkinToneSupport: false,
+                searchKey: "faceHoldingBackTears",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F626],
+                isSkinToneSupport: false,
+                searchKey: "frowningFaceWithOpenMouth",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F627],
+                isSkinToneSupport: false,
+                searchKey: "anguishedFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F628],
+                isSkinToneSupport: false,
+                searchKey: "fearfulFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F630],
+                isSkinToneSupport: false,
+                searchKey: "anxiousFaceWithSweat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F625],
+                isSkinToneSupport: false,
+                searchKey: "sadButRelievedFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F622],
+                isSkinToneSupport: false,
+                searchKey: "cryingFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F62D],
+                isSkinToneSupport: false,
+                searchKey: "loudlyCryingFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F631],
+                isSkinToneSupport: false,
+                searchKey: "faceScreamingInFear",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F616],
+                isSkinToneSupport: false,
+                searchKey: "confoundedFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F623],
+                isSkinToneSupport: false,
+                searchKey: "perseveringFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F61E],
+                isSkinToneSupport: false,
+                searchKey: "disappointedFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F613],
+                isSkinToneSupport: false,
+                searchKey: "downcastFaceWithSweat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F629],
+                isSkinToneSupport: false,
+                searchKey: "wearyFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F62B],
+                isSkinToneSupport: false,
+                searchKey: "tiredFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F971],
+                isSkinToneSupport: false,
+                searchKey: "yawningFace",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F624],
+                isSkinToneSupport: false,
+                searchKey: "faceWithSteamFromNose",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F621],
+                isSkinToneSupport: false,
+                searchKey: "enragedFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F620],
+                isSkinToneSupport: false,
+                searchKey: "angryFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F92C],
+                isSkinToneSupport: false,
+                searchKey: "faceWithSymbolsOnMouth",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F608],
+                isSkinToneSupport: false,
+                searchKey: "smilingFaceWithHorns",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F47F],
+                isSkinToneSupport: false,
+                searchKey: "angryFaceWithHorns",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F480],
+                isSkinToneSupport: false,
+                searchKey: "skull",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2620, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "skullAndCrossbones",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4A9],
+                isSkinToneSupport: false,
+                searchKey: "pileOfPoo",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F921],
+                isSkinToneSupport: false,
+                searchKey: "clownFace",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F479],
+                isSkinToneSupport: false,
+                searchKey: "ogre",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F47A],
+                isSkinToneSupport: false,
+                searchKey: "goblin",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F47B],
+                isSkinToneSupport: false,
+                searchKey: "ghost",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F47D],
+                isSkinToneSupport: false,
+                searchKey: "alien",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F47E],
+                isSkinToneSupport: false,
+                searchKey: "alienMonster",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F916],
+                isSkinToneSupport: false,
+                searchKey: "robot",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F63A],
+                isSkinToneSupport: false,
+                searchKey: "grinningCat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F638],
+                isSkinToneSupport: false,
+                searchKey: "grinningCatWithSmilingEyes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F639],
+                isSkinToneSupport: false,
+                searchKey: "catWithTearsOfJoy",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F63B],
+                isSkinToneSupport: false,
+                searchKey: "smilingCatWithHeartEyes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F63C],
+                isSkinToneSupport: false,
+                searchKey: "catWithWrySmile",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F63D],
+                isSkinToneSupport: false,
+                searchKey: "kissingCat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F640],
+                isSkinToneSupport: false,
+                searchKey: "wearyCat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F63F],
+                isSkinToneSupport: false,
+                searchKey: "cryingCat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F63E],
+                isSkinToneSupport: false,
+                searchKey: "poutingCat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F648],
+                isSkinToneSupport: false,
+                searchKey: "seeNoEvilMonkey",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F649],
+                isSkinToneSupport: false,
+                searchKey: "hearNoEvilMonkey",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64A],
+                isSkinToneSupport: false,
+                searchKey: "speakNoEvilMonkey",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F48C],
+                isSkinToneSupport: false,
+                searchKey: "loveLetter",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F498],
+                isSkinToneSupport: false,
+                searchKey: "heartWithArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F49D],
+                isSkinToneSupport: false,
+                searchKey: "heartWithRibbon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F496],
+                isSkinToneSupport: false,
+                searchKey: "sparklingHeart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F497],
+                isSkinToneSupport: false,
+                searchKey: "growingHeart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F493],
+                isSkinToneSupport: false,
+                searchKey: "beatingHeart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F49E],
+                isSkinToneSupport: false,
+                searchKey: "revolvingHearts",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F495],
+                isSkinToneSupport: false,
+                searchKey: "twoHearts",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F49F],
+                isSkinToneSupport: false,
+                searchKey: "heartDecoration",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2763, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "heartExclamation",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F494],
+                isSkinToneSupport: false,
+                searchKey: "brokenHeart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2764, 0xFE0F, 0x200D, 0x1F525],
+                isSkinToneSupport: false,
+                searchKey: "heartOnFire",
+                version: 13.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x2764, 0xFE0F, 0x200D, 0x1FA79],
+                isSkinToneSupport: false,
+                searchKey: "mendingHeart",
+                version: 13.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x2764, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "redHeart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA77],
+                isSkinToneSupport: false,
+                searchKey: "pinkHeart",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9E1],
+                isSkinToneSupport: false,
+                searchKey: "orangeHeart",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F49B],
+                isSkinToneSupport: false,
+                searchKey: "yellowHeart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F49A],
+                isSkinToneSupport: false,
+                searchKey: "greenHeart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F499],
+                isSkinToneSupport: false,
+                searchKey: "blueHeart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA75],
+                isSkinToneSupport: false,
+                searchKey: "lightBlueHeart",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F49C],
+                isSkinToneSupport: false,
+                searchKey: "purpleHeart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F90E],
+                isSkinToneSupport: false,
+                searchKey: "brownHeart",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5A4],
+                isSkinToneSupport: false,
+                searchKey: "blackHeart",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA76],
+                isSkinToneSupport: false,
+                searchKey: "greyHeart",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F90D],
+                isSkinToneSupport: false,
+                searchKey: "whiteHeart",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F48B],
+                isSkinToneSupport: false,
+                searchKey: "kissMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4AF],
+                isSkinToneSupport: false,
+                searchKey: "hundredPoints",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4A2],
+                isSkinToneSupport: false,
+                searchKey: "angerSymbol",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4A5],
+                isSkinToneSupport: false,
+                searchKey: "collision",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4AB],
+                isSkinToneSupport: false,
+                searchKey: "dizzy",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4A6],
+                isSkinToneSupport: false,
+                searchKey: "sweatDroplets",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4A8],
+                isSkinToneSupport: false,
+                searchKey: "dashingAway",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F573, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "hole",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4AC],
+                isSkinToneSupport: false,
+                searchKey: "speechBalloon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F441, 0xFE0F, 0x200D, 0x1F5E8, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "eyeInSpeechBubble",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5E8, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "leftSpeechBubble",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5EF, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "rightAngerBubble",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4AD],
+                isSkinToneSupport: false,
+                searchKey: "thoughtBalloon",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4A4],
+                isSkinToneSupport: false,
+                searchKey: "zZZ",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F44B],
+                isSkinToneSupport: true,
+                searchKey: "wavingHand",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F91A],
+                isSkinToneSupport: true,
+                searchKey: "raisedBackOfHand",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F590, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "handWithFingersSplayed",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x270B],
+                isSkinToneSupport: true,
+                searchKey: "raisedHand",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F596],
+                isSkinToneSupport: true,
+                searchKey: "vulcanSalute",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAF1],
+                isSkinToneSupport: true,
+                searchKey: "rightwardsHand",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAF2],
+                isSkinToneSupport: true,
+                searchKey: "leftwardsHand",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAF3],
+                isSkinToneSupport: true,
+                searchKey: "palmDownHand",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAF4],
+                isSkinToneSupport: true,
+                searchKey: "palmUpHand",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAF7],
+                isSkinToneSupport: true,
+                searchKey: "leftwardsPushingHand",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAF8],
+                isSkinToneSupport: true,
+                searchKey: "rightwardsPushingHand",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F44C],
+                isSkinToneSupport: true,
+                searchKey: "oKHand",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F90C],
+                isSkinToneSupport: true,
+                searchKey: "pinchedFingers",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F90F],
+                isSkinToneSupport: true,
+                searchKey: "pinchingHand",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x270C, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "victoryHand",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F91E],
+                isSkinToneSupport: true,
+                searchKey: "crossedFingers",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAF0],
+                isSkinToneSupport: true,
+                searchKey: "handWithIndexFingerAndThumbCrossed",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F91F],
+                isSkinToneSupport: true,
+                searchKey: "loveYouGesture",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F918],
+                isSkinToneSupport: true,
+                searchKey: "signOfTheHorns",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F919],
+                isSkinToneSupport: true,
+                searchKey: "callMeHand",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F448],
+                isSkinToneSupport: true,
+                searchKey: "backhandIndexPointingLeft",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F449],
+                isSkinToneSupport: true,
+                searchKey: "backhandIndexPointingRight",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F446],
+                isSkinToneSupport: true,
+                searchKey: "backhandIndexPointingUp",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F595],
+                isSkinToneSupport: true,
+                searchKey: "middleFinger",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F447],
+                isSkinToneSupport: true,
+                searchKey: "backhandIndexPointingDown",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x261D, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "indexPointingUp",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAF5],
+                isSkinToneSupport: true,
+                searchKey: "indexPointingAtTheViewer",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F44D],
+                isSkinToneSupport: true,
+                searchKey: "thumbsUp",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F44E],
+                isSkinToneSupport: true,
+                searchKey: "thumbsDown",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x270A],
+                isSkinToneSupport: true,
+                searchKey: "raisedFist",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F44A],
+                isSkinToneSupport: true,
+                searchKey: "oncomingFist",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F91B],
+                isSkinToneSupport: true,
+                searchKey: "leftFacingFist",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F91C],
+                isSkinToneSupport: true,
+                searchKey: "rightFacingFist",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F44F],
+                isSkinToneSupport: true,
+                searchKey: "clappingHands",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64C],
+                isSkinToneSupport: true,
+                searchKey: "raisingHands",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAF6],
+                isSkinToneSupport: true,
+                searchKey: "heartHands",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F450],
+                isSkinToneSupport: true,
+                searchKey: "openHands",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F932],
+                isSkinToneSupport: true,
+                searchKey: "palmsUpTogether",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F91D],
+                isSkinToneSupport: false,
+                searchKey: "handshake",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64F],
+                isSkinToneSupport: true,
+                searchKey: "foldedHands",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x270D, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "writingHand",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F485],
+                isSkinToneSupport: true,
+                searchKey: "nailPolish",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F933],
+                isSkinToneSupport: true,
+                searchKey: "selfie",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4AA],
+                isSkinToneSupport: true,
+                searchKey: "flexedBiceps",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9BE],
+                isSkinToneSupport: false,
+                searchKey: "mechanicalArm",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9BF],
+                isSkinToneSupport: false,
+                searchKey: "mechanicalLeg",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9B5],
+                isSkinToneSupport: true,
+                searchKey: "leg",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9B6],
+                isSkinToneSupport: true,
+                searchKey: "foot",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F442],
+                isSkinToneSupport: true,
+                searchKey: "ear",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9BB],
+                isSkinToneSupport: true,
+                searchKey: "earWithHearingAid",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F443],
+                isSkinToneSupport: true,
+                searchKey: "nose",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9E0],
+                isSkinToneSupport: false,
+                searchKey: "brain",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAC0],
+                isSkinToneSupport: false,
+                searchKey: "anatomicalHeart",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAC1],
+                isSkinToneSupport: false,
+                searchKey: "lungs",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9B7],
+                isSkinToneSupport: false,
+                searchKey: "tooth",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9B4],
+                isSkinToneSupport: false,
+                searchKey: "bone",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F440],
+                isSkinToneSupport: false,
+                searchKey: "eyes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F441, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "eye",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F445],
+                isSkinToneSupport: false,
+                searchKey: "tongue",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F444],
+                isSkinToneSupport: false,
+                searchKey: "mouth",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAE6],
+                isSkinToneSupport: false,
+                searchKey: "bitingLip",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F476],
+                isSkinToneSupport: true,
+                searchKey: "baby",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D2],
+                isSkinToneSupport: true,
+                searchKey: "child",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F466],
+                isSkinToneSupport: true,
+                searchKey: "boy",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F467],
+                isSkinToneSupport: true,
+                searchKey: "girl",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1],
+                isSkinToneSupport: true,
+                searchKey: "person",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F471],
+                isSkinToneSupport: true,
+                searchKey: "personBlondHair",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468],
+                isSkinToneSupport: true,
+                searchKey: "man",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D4],
+                isSkinToneSupport: true,
+                searchKey: "personBeard",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D4, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manBeard",
+                version: 13.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D4, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanBeard",
+                version: 13.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F9B0],
+                isSkinToneSupport: true,
+                searchKey: "manRedHair",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F9B1],
+                isSkinToneSupport: true,
+                searchKey: "manCurlyHair",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F9B3],
+                isSkinToneSupport: true,
+                searchKey: "manWhiteHair",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F9B2],
+                isSkinToneSupport: true,
+                searchKey: "manBald",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469],
+                isSkinToneSupport: true,
+                searchKey: "woman",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F9B0],
+                isSkinToneSupport: true,
+                searchKey: "womanRedHair",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F9B0],
+                isSkinToneSupport: true,
+                searchKey: "personRedHair",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F9B1],
+                isSkinToneSupport: true,
+                searchKey: "womanCurlyHair",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F9B1],
+                isSkinToneSupport: true,
+                searchKey: "personCurlyHair",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F9B3],
+                isSkinToneSupport: true,
+                searchKey: "womanWhiteHair",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F9B3],
+                isSkinToneSupport: true,
+                searchKey: "personWhiteHair",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F9B2],
+                isSkinToneSupport: true,
+                searchKey: "womanBald",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F9B2],
+                isSkinToneSupport: true,
+                searchKey: "personBald",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F471, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanBlondHair",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F471, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manBlondHair",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D3],
+                isSkinToneSupport: true,
+                searchKey: "olderPerson",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F474],
+                isSkinToneSupport: true,
+                searchKey: "oldMan",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F475],
+                isSkinToneSupport: true,
+                searchKey: "oldWoman",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64D],
+                isSkinToneSupport: true,
+                searchKey: "personFrowning",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64D, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manFrowning",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64D, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanFrowning",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64E],
+                isSkinToneSupport: true,
+                searchKey: "personPouting",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64E, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manPouting",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64E, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanPouting",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F645],
+                isSkinToneSupport: true,
+                searchKey: "personGesturingNO",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F645, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manGesturingNO",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F645, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanGesturingNO",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F646],
+                isSkinToneSupport: true,
+                searchKey: "personGesturingOK",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F646, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manGesturingOK",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F646, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanGesturingOK",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F481],
+                isSkinToneSupport: true,
+                searchKey: "personTippingHand",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F481, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manTippingHand",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F481, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanTippingHand",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64B],
+                isSkinToneSupport: true,
+                searchKey: "personRaisingHand",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64B, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manRaisingHand",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F64B, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanRaisingHand",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CF],
+                isSkinToneSupport: true,
+                searchKey: "deafPerson",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CF, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "deafMan",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CF, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "deafWoman",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F647],
+                isSkinToneSupport: true,
+                searchKey: "personBowing",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F647, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manBowing",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F647, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanBowing",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F926],
+                isSkinToneSupport: true,
+                searchKey: "personFacepalming",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F926, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manFacepalming",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F926, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanFacepalming",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F937],
+                isSkinToneSupport: true,
+                searchKey: "personShrugging",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F937, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manShrugging",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F937, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanShrugging",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x2695, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "healthWorker",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x2695, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manHealthWorker",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x2695, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanHealthWorker",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F393],
+                isSkinToneSupport: true,
+                searchKey: "student",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F393],
+                isSkinToneSupport: true,
+                searchKey: "manStudent",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F393],
+                isSkinToneSupport: true,
+                searchKey: "womanStudent",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F3EB],
+                isSkinToneSupport: true,
+                searchKey: "teacher",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F3EB],
+                isSkinToneSupport: true,
+                searchKey: "manTeacher",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F3EB],
+                isSkinToneSupport: true,
+                searchKey: "womanTeacher",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x2696, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "judge",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x2696, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manJudge",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x2696, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanJudge",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F33E],
+                isSkinToneSupport: true,
+                searchKey: "farmer",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F33E],
+                isSkinToneSupport: true,
+                searchKey: "manFarmer",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F33E],
+                isSkinToneSupport: true,
+                searchKey: "womanFarmer",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F373],
+                isSkinToneSupport: true,
+                searchKey: "cook",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F373],
+                isSkinToneSupport: true,
+                searchKey: "manCook",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F373],
+                isSkinToneSupport: true,
+                searchKey: "womanCook",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F527],
+                isSkinToneSupport: true,
+                searchKey: "mechanic",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F527],
+                isSkinToneSupport: true,
+                searchKey: "manMechanic",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F527],
+                isSkinToneSupport: true,
+                searchKey: "womanMechanic",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F3ED],
+                isSkinToneSupport: true,
+                searchKey: "factoryWorker",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F3ED],
+                isSkinToneSupport: true,
+                searchKey: "manFactoryWorker",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F3ED],
+                isSkinToneSupport: true,
+                searchKey: "womanFactoryWorker",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F4BC],
+                isSkinToneSupport: true,
+                searchKey: "officeWorker",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F4BC],
+                isSkinToneSupport: true,
+                searchKey: "manOfficeWorker",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F4BC],
+                isSkinToneSupport: true,
+                searchKey: "womanOfficeWorker",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F52C],
+                isSkinToneSupport: true,
+                searchKey: "scientist",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F52C],
+                isSkinToneSupport: true,
+                searchKey: "manScientist",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F52C],
+                isSkinToneSupport: true,
+                searchKey: "womanScientist",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F4BB],
+                isSkinToneSupport: true,
+                searchKey: "technologist",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F4BB],
+                isSkinToneSupport: true,
+                searchKey: "manTechnologist",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F4BB],
+                isSkinToneSupport: true,
+                searchKey: "womanTechnologist",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F3A4],
+                isSkinToneSupport: true,
+                searchKey: "singer",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F3A4],
+                isSkinToneSupport: true,
+                searchKey: "manSinger",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F3A4],
+                isSkinToneSupport: true,
+                searchKey: "womanSinger",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F3A8],
+                isSkinToneSupport: true,
+                searchKey: "artist",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F3A8],
+                isSkinToneSupport: true,
+                searchKey: "manArtist",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F3A8],
+                isSkinToneSupport: true,
+                searchKey: "womanArtist",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x2708, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "pilot",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x2708, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manPilot",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x2708, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanPilot",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F680],
+                isSkinToneSupport: true,
+                searchKey: "astronaut",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F680],
+                isSkinToneSupport: true,
+                searchKey: "manAstronaut",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F680],
+                isSkinToneSupport: true,
+                searchKey: "womanAstronaut",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F692],
+                isSkinToneSupport: true,
+                searchKey: "firefighter",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F692],
+                isSkinToneSupport: true,
+                searchKey: "manFirefighter",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F692],
+                isSkinToneSupport: true,
+                searchKey: "womanFirefighter",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F46E],
+                isSkinToneSupport: true,
+                searchKey: "policeOfficer",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F46E, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manPoliceOfficer",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F46E, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanPoliceOfficer",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F575, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "detective",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F575, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manDetective",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F575, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanDetective",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F482],
+                isSkinToneSupport: true,
+                searchKey: "guard",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F482, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manGuard",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F482, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanGuard",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F977],
+                isSkinToneSupport: true,
+                searchKey: "ninja",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F477],
+                isSkinToneSupport: true,
+                searchKey: "constructionWorker",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F477, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manConstructionWorker",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F477, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanConstructionWorker",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAC5],
+                isSkinToneSupport: true,
+                searchKey: "personWithCrown",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F934],
+                isSkinToneSupport: true,
+                searchKey: "prince",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F478],
+                isSkinToneSupport: true,
+                searchKey: "princess",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F473],
+                isSkinToneSupport: true,
+                searchKey: "personWearingTurban",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F473, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manWearingTurban",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F473, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanWearingTurban",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F472],
+                isSkinToneSupport: true,
+                searchKey: "personWithSkullcap",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D5],
+                isSkinToneSupport: true,
+                searchKey: "womanWithHeadscarf",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F935],
+                isSkinToneSupport: true,
+                searchKey: "personInTuxedo",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F935, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manInTuxedo",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F935, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanInTuxedo",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F470],
+                isSkinToneSupport: true,
+                searchKey: "personWithVeil",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F470, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manWithVeil",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F470, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanWithVeil",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F930],
+                isSkinToneSupport: true,
+                searchKey: "pregnantWoman",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAC3],
+                isSkinToneSupport: true,
+                searchKey: "pregnantMan",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAC4],
+                isSkinToneSupport: true,
+                searchKey: "pregnantPerson",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F931],
+                isSkinToneSupport: true,
+                searchKey: "breastFeeding",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F37C],
+                isSkinToneSupport: true,
+                searchKey: "womanFeedingBaby",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F37C],
+                isSkinToneSupport: true,
+                searchKey: "manFeedingBaby",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F37C],
+                isSkinToneSupport: true,
+                searchKey: "personFeedingBaby",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F47C],
+                isSkinToneSupport: true,
+                searchKey: "babyAngel",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F385],
+                isSkinToneSupport: true,
+                searchKey: "santaClaus",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F936],
+                isSkinToneSupport: true,
+                searchKey: "mrsClaus",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F384],
+                isSkinToneSupport: true,
+                searchKey: "mxClaus",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9B8],
+                isSkinToneSupport: true,
+                searchKey: "superhero",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9B8, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manSuperhero",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9B8, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanSuperhero",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9B9],
+                isSkinToneSupport: true,
+                searchKey: "supervillain",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9B9, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manSupervillain",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9B9, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanSupervillain",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D9],
+                isSkinToneSupport: true,
+                searchKey: "mage",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D9, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manMage",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D9, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanMage",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DA],
+                isSkinToneSupport: true,
+                searchKey: "fairy",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DA, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manFairy",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DA, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanFairy",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DB],
+                isSkinToneSupport: true,
+                searchKey: "vampire",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DB, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manVampire",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DB, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanVampire",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DC],
+                isSkinToneSupport: true,
+                searchKey: "merperson",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DC, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "merman",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DC, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "mermaid",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DD],
+                isSkinToneSupport: true,
+                searchKey: "elf",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DD, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manElf",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DD, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanElf",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DE],
+                isSkinToneSupport: false,
+                searchKey: "genie",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DE, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "manGenie",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DE, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "womanGenie",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DF],
+                isSkinToneSupport: false,
+                searchKey: "zombie",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DF, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "manZombie",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9DF, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "womanZombie",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CC],
+                isSkinToneSupport: false,
+                searchKey: "troll",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F486],
+                isSkinToneSupport: true,
+                searchKey: "personGettingMassage",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F486, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manGettingMassage",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F486, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanGettingMassage",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F487],
+                isSkinToneSupport: true,
+                searchKey: "personGettingHaircut",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F487, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manGettingHaircut",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F487, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanGettingHaircut",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B6],
+                isSkinToneSupport: true,
+                searchKey: "personWalking",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B6, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manWalking",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B6, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanWalking",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CD],
+                isSkinToneSupport: true,
+                searchKey: "personStanding",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CD, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manStanding",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CD, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanStanding",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CE],
+                isSkinToneSupport: true,
+                searchKey: "personKneeling",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CE, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manKneeling",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CE, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanKneeling",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F9AF],
+                isSkinToneSupport: true,
+                searchKey: "personWithWhiteCane",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F9AF],
+                isSkinToneSupport: true,
+                searchKey: "manWithWhiteCane",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F9AF],
+                isSkinToneSupport: true,
+                searchKey: "womanWithWhiteCane",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F9BC],
+                isSkinToneSupport: true,
+                searchKey: "personInMotorizedWheelchair",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F9BC],
+                isSkinToneSupport: true,
+                searchKey: "manInMotorizedWheelchair",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F9BC],
+                isSkinToneSupport: true,
+                searchKey: "womanInMotorizedWheelchair",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F9BD],
+                isSkinToneSupport: true,
+                searchKey: "personInManualWheelchair",
+                version: 12.1
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F9BD],
+                isSkinToneSupport: true,
+                searchKey: "manInManualWheelchair",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F9BD],
+                isSkinToneSupport: true,
+                searchKey: "womanInManualWheelchair",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C3],
+                isSkinToneSupport: true,
+                searchKey: "personRunning",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C3, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manRunning",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C3, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanRunning",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F483],
+                isSkinToneSupport: true,
+                searchKey: "womanDancing",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F57A],
+                isSkinToneSupport: true,
+                searchKey: "manDancing",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F574, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "personInSuitLevitating",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F46F],
+                isSkinToneSupport: false,
+                searchKey: "peopleWithBunnyEars",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F46F, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "menWithBunnyEars",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F46F, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "womenWithBunnyEars",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D6],
+                isSkinToneSupport: true,
+                searchKey: "personInSteamyRoom",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D6, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manInSteamyRoom",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D6, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanInSteamyRoom",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D7],
+                isSkinToneSupport: true,
+                searchKey: "personClimbing",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D7, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manClimbing",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D7, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanClimbing",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93A],
+                isSkinToneSupport: false,
+                searchKey: "personFencing",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C7],
+                isSkinToneSupport: true,
+                searchKey: "horseRacing",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F7, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "skier",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C2],
+                isSkinToneSupport: false,
+                searchKey: "snowboarder",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CC, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "personGolfing",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CC, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manGolfing",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CC, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanGolfing",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C4],
+                isSkinToneSupport: true,
+                searchKey: "personSurfing",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C4, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manSurfing",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C4, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanSurfing",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A3],
+                isSkinToneSupport: true,
+                searchKey: "personRowingBoat",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A3, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manRowingBoat",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A3, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanRowingBoat",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CA],
+                isSkinToneSupport: true,
+                searchKey: "personSwimming",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CA, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manSwimming",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CA, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanSwimming",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F9, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "personBouncingBall",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F9, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manBouncingBall",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F9, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanBouncingBall",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CB, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "personLiftingWeights",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CB, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manLiftingWeights",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CB, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanLiftingWeights",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B4],
+                isSkinToneSupport: true,
+                searchKey: "personBiking",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B4, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manBiking",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B4, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanBiking",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B5],
+                isSkinToneSupport: true,
+                searchKey: "personMountainBiking",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B5, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manMountainBiking",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B5, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanMountainBiking",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F938],
+                isSkinToneSupport: true,
+                searchKey: "personCartwheeling",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F938, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manCartwheeling",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F938, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanCartwheeling",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93C],
+                isSkinToneSupport: false,
+                searchKey: "peopleWrestling",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93C, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "menWrestling",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93C, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "womenWrestling",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93D],
+                isSkinToneSupport: true,
+                searchKey: "personPlayingWaterPolo",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93D, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manPlayingWaterPolo",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93D, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanPlayingWaterPolo",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93E],
+                isSkinToneSupport: true,
+                searchKey: "personPlayingHandball",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93E, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manPlayingHandball",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93E, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanPlayingHandball",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F939],
+                isSkinToneSupport: true,
+                searchKey: "personJuggling",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F939, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manJuggling",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F939, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanJuggling",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D8],
+                isSkinToneSupport: true,
+                searchKey: "personInLotusPosition",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D8, 0x200D, 0x2642, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "manInLotusPosition",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D8, 0x200D, 0x2640, 0xFE0F],
+                isSkinToneSupport: true,
+                searchKey: "womanInLotusPosition",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6C0],
+                isSkinToneSupport: true,
+                searchKey: "personTakingBath",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6CC],
+                isSkinToneSupport: false,
+                searchKey: "personInBed",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9D1, 0x200D, 0x1F91D, 0x200D, 0x1F9D1],
+                isSkinToneSupport: false,
+                searchKey: "peopleHoldingHands",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F46D],
+                isSkinToneSupport: false,
+                searchKey: "womenHoldingHands",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F46B],
+                isSkinToneSupport: false,
+                searchKey: "womanAndManHoldingHands",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F46C],
+                isSkinToneSupport: false,
+                searchKey: "menHoldingHands",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F48F],
+                isSkinToneSupport: false,
+                searchKey: "kiss",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x2764, 0xFE0F, 0x200D, 0x1F48B, 0x200D, 0x1F468],
+                isSkinToneSupport: false,
+                searchKey: "kissWomanMan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x2764, 0xFE0F, 0x200D, 0x1F48B, 0x200D, 0x1F468],
+                isSkinToneSupport: false,
+                searchKey: "kissManMan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x2764, 0xFE0F, 0x200D, 0x1F48B, 0x200D, 0x1F469],
+                isSkinToneSupport: false,
+                searchKey: "kissWomanWoman",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F491],
+                isSkinToneSupport: false,
+                searchKey: "coupleWithHeart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x2764, 0xFE0F, 0x200D, 0x1F468],
+                isSkinToneSupport: false,
+                searchKey: "coupleWithHeartWomanMan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x2764, 0xFE0F, 0x200D, 0x1F468],
+                isSkinToneSupport: false,
+                searchKey: "coupleWithHeartManMan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x2764, 0xFE0F, 0x200D, 0x1F469],
+                isSkinToneSupport: false,
+                searchKey: "coupleWithHeartWomanWoman",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F46A],
+                isSkinToneSupport: false,
+                searchKey: "family",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F469, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyManWomanBoy",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F469, 0x200D, 0x1F467],
+                isSkinToneSupport: false,
+                searchKey: "familyManWomanGirl",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F469, 0x200D, 0x1F467, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyManWomanGirlBoy",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F469, 0x200D, 0x1F466, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyManWomanBoyBoy",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F469, 0x200D, 0x1F467, 0x200D, 0x1F467],
+                isSkinToneSupport: false,
+                searchKey: "familyManWomanGirlGirl",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F468, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyManManBoy",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F468, 0x200D, 0x1F467],
+                isSkinToneSupport: false,
+                searchKey: "familyManManGirl",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F468, 0x200D, 0x1F467, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyManManGirlBoy",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F468, 0x200D, 0x1F466, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyManManBoyBoy",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F468, 0x200D, 0x1F467, 0x200D, 0x1F467],
+                isSkinToneSupport: false,
+                searchKey: "familyManManGirlGirl",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F469, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyWomanWomanBoy",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F469, 0x200D, 0x1F467],
+                isSkinToneSupport: false,
+                searchKey: "familyWomanWomanGirl",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F469, 0x200D, 0x1F467, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyWomanWomanGirlBoy",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F469, 0x200D, 0x1F466, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyWomanWomanBoyBoy",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F469, 0x200D, 0x1F467, 0x200D, 0x1F467],
+                isSkinToneSupport: false,
+                searchKey: "familyWomanWomanGirlGirl",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyManBoy",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F466, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyManBoyBoy",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F467],
+                isSkinToneSupport: false,
+                searchKey: "familyManGirl",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F467, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyManGirlBoy",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F468, 0x200D, 0x1F467, 0x200D, 0x1F467],
+                isSkinToneSupport: false,
+                searchKey: "familyManGirlGirl",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyWomanBoy",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F466, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyWomanBoyBoy",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F467],
+                isSkinToneSupport: false,
+                searchKey: "familyWomanGirl",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F467, 0x200D, 0x1F466],
+                isSkinToneSupport: false,
+                searchKey: "familyWomanGirlBoy",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F469, 0x200D, 0x1F467, 0x200D, 0x1F467],
+                isSkinToneSupport: false,
+                searchKey: "familyWomanGirlGirl",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5E3, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "speakingHead",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F464],
+                isSkinToneSupport: false,
+                searchKey: "bustInSilhouette",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F465],
+                isSkinToneSupport: false,
+                searchKey: "bustsInSilhouette",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAC2],
+                isSkinToneSupport: false,
+                searchKey: "peopleHugging",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F463],
+                isSkinToneSupport: false,
+                searchKey: "footprints",
+                version: 0.6
+            )
+        ].filter({ $0.version <= maxCurrentAvailableEmojiVersion })
+    )
+            
+    private let natureEmojis: MCEmojiCategory = .init(
+        type: .nature,
+        categoryName: MCEmojiCategoryType.nature.emojiCategoryTitle,
+        emojis: [
+            MCEmoji(
+                emojiKeys: [0x1F435],
+                isSkinToneSupport: false,
+                searchKey: "monkeyFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F412],
+                isSkinToneSupport: false,
+                searchKey: "monkey",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F98D],
+                isSkinToneSupport: false,
+                searchKey: "gorilla",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9A7],
+                isSkinToneSupport: false,
+                searchKey: "orangutan",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F436],
+                isSkinToneSupport: false,
+                searchKey: "dogFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F415],
+                isSkinToneSupport: false,
+                searchKey: "dog",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9AE],
+                isSkinToneSupport: false,
+                searchKey: "guideDog",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F415, 0x200D, 0x1F9BA],
+                isSkinToneSupport: false,
+                searchKey: "serviceDog",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F429],
+                isSkinToneSupport: false,
+                searchKey: "poodle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F43A],
+                isSkinToneSupport: false,
+                searchKey: "wolf",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F98A],
+                isSkinToneSupport: false,
+                searchKey: "fox",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F99D],
+                isSkinToneSupport: false,
+                searchKey: "raccoon",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F431],
+                isSkinToneSupport: false,
+                searchKey: "catFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F408],
+                isSkinToneSupport: false,
+                searchKey: "cat",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F408, 0x200D, 0x2B1B],
+                isSkinToneSupport: false,
+                searchKey: "blackCat",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F981],
+                isSkinToneSupport: false,
+                searchKey: "lion",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F42F],
+                isSkinToneSupport: false,
+                searchKey: "tigerFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F405],
+                isSkinToneSupport: false,
+                searchKey: "tiger",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F406],
+                isSkinToneSupport: false,
+                searchKey: "leopard",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F434],
+                isSkinToneSupport: false,
+                searchKey: "horseFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FACE],
+                isSkinToneSupport: false,
+                searchKey: "moose",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FACF],
+                isSkinToneSupport: false,
+                searchKey: "donkey",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F40E],
+                isSkinToneSupport: false,
+                searchKey: "horse",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F984],
+                isSkinToneSupport: false,
+                searchKey: "unicorn",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F993],
+                isSkinToneSupport: false,
+                searchKey: "zebra",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F98C],
+                isSkinToneSupport: false,
+                searchKey: "deer",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9AC],
+                isSkinToneSupport: false,
+                searchKey: "bison",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F42E],
+                isSkinToneSupport: false,
+                searchKey: "cowFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F402],
+                isSkinToneSupport: false,
+                searchKey: "ox",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F403],
+                isSkinToneSupport: false,
+                searchKey: "waterBuffalo",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F404],
+                isSkinToneSupport: false,
+                searchKey: "cow",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F437],
+                isSkinToneSupport: false,
+                searchKey: "pigFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F416],
+                isSkinToneSupport: false,
+                searchKey: "pig",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F417],
+                isSkinToneSupport: false,
+                searchKey: "boar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F43D],
+                isSkinToneSupport: false,
+                searchKey: "pigNose",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F40F],
+                isSkinToneSupport: false,
+                searchKey: "ram",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F411],
+                isSkinToneSupport: false,
+                searchKey: "ewe",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F410],
+                isSkinToneSupport: false,
+                searchKey: "goat",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F42A],
+                isSkinToneSupport: false,
+                searchKey: "camel",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F42B],
+                isSkinToneSupport: false,
+                searchKey: "twoHumpCamel",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F999],
+                isSkinToneSupport: false,
+                searchKey: "llama",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F992],
+                isSkinToneSupport: false,
+                searchKey: "giraffe",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F418],
+                isSkinToneSupport: false,
+                searchKey: "elephant",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9A3],
+                isSkinToneSupport: false,
+                searchKey: "mammoth",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F98F],
+                isSkinToneSupport: false,
+                searchKey: "rhinoceros",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F99B],
+                isSkinToneSupport: false,
+                searchKey: "hippopotamus",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F42D],
+                isSkinToneSupport: false,
+                searchKey: "mouseFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F401],
+                isSkinToneSupport: false,
+                searchKey: "mouse",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F400],
+                isSkinToneSupport: false,
+                searchKey: "rat",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F439],
+                isSkinToneSupport: false,
+                searchKey: "hamster",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F430],
+                isSkinToneSupport: false,
+                searchKey: "rabbitFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F407],
+                isSkinToneSupport: false,
+                searchKey: "rabbit",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F43F, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "chipmunk",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9AB],
+                isSkinToneSupport: false,
+                searchKey: "beaver",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F994],
+                isSkinToneSupport: false,
+                searchKey: "hedgehog",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F987],
+                isSkinToneSupport: false,
+                searchKey: "bat",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F43B],
+                isSkinToneSupport: false,
+                searchKey: "bear",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F43B, 0x200D, 0x2744, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "polarBear",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F428],
+                isSkinToneSupport: false,
+                searchKey: "koala",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F43C],
+                isSkinToneSupport: false,
+                searchKey: "panda",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9A5],
+                isSkinToneSupport: false,
+                searchKey: "sloth",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9A6],
+                isSkinToneSupport: false,
+                searchKey: "otter",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9A8],
+                isSkinToneSupport: false,
+                searchKey: "skunk",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F998],
+                isSkinToneSupport: false,
+                searchKey: "kangaroo",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9A1],
+                isSkinToneSupport: false,
+                searchKey: "badger",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F43E],
+                isSkinToneSupport: false,
+                searchKey: "pawPrints",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F983],
+                isSkinToneSupport: false,
+                searchKey: "turkey",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F414],
+                isSkinToneSupport: false,
+                searchKey: "chicken",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F413],
+                isSkinToneSupport: false,
+                searchKey: "rooster",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F423],
+                isSkinToneSupport: false,
+                searchKey: "hatchingChick",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F424],
+                isSkinToneSupport: false,
+                searchKey: "babyChick",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F425],
+                isSkinToneSupport: false,
+                searchKey: "frontFacingBabyChick",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F426],
+                isSkinToneSupport: false,
+                searchKey: "bird",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F427],
+                isSkinToneSupport: false,
+                searchKey: "penguin",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F54A, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "dove",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F985],
+                isSkinToneSupport: false,
+                searchKey: "eagle",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F986],
+                isSkinToneSupport: false,
+                searchKey: "duck",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9A2],
+                isSkinToneSupport: false,
+                searchKey: "swan",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F989],
+                isSkinToneSupport: false,
+                searchKey: "owl",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9A4],
+                isSkinToneSupport: false,
+                searchKey: "dodo",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAB6],
+                isSkinToneSupport: false,
+                searchKey: "feather",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9A9],
+                isSkinToneSupport: false,
+                searchKey: "flamingo",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F99A],
+                isSkinToneSupport: false,
+                searchKey: "peacock",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F99C],
+                isSkinToneSupport: false,
+                searchKey: "parrot",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FABD],
+                isSkinToneSupport: false,
+                searchKey: "wing",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F426, 0x200D, 0x2B1B],
+                isSkinToneSupport: false,
+                searchKey: "blackBird",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FABF],
+                isSkinToneSupport: false,
+                searchKey: "goose",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F438],
+                isSkinToneSupport: false,
+                searchKey: "frog",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F40A],
+                isSkinToneSupport: false,
+                searchKey: "crocodile",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F422],
+                isSkinToneSupport: false,
+                searchKey: "turtle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F98E],
+                isSkinToneSupport: false,
+                searchKey: "lizard",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F40D],
+                isSkinToneSupport: false,
+                searchKey: "snake",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F432],
+                isSkinToneSupport: false,
+                searchKey: "dragonFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F409],
+                isSkinToneSupport: false,
+                searchKey: "dragon",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F995],
+                isSkinToneSupport: false,
+                searchKey: "sauropod",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F996],
+                isSkinToneSupport: false,
+                searchKey: "tRex",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F433],
+                isSkinToneSupport: false,
+                searchKey: "spoutingWhale",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F40B],
+                isSkinToneSupport: false,
+                searchKey: "whale",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F42C],
+                isSkinToneSupport: false,
+                searchKey: "dolphin",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9AD],
+                isSkinToneSupport: false,
+                searchKey: "seal",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F41F],
+                isSkinToneSupport: false,
+                searchKey: "fish",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F420],
+                isSkinToneSupport: false,
+                searchKey: "tropicalFish",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F421],
+                isSkinToneSupport: false,
+                searchKey: "blowfish",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F988],
+                isSkinToneSupport: false,
+                searchKey: "shark",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F419],
+                isSkinToneSupport: false,
+                searchKey: "octopus",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F41A],
+                isSkinToneSupport: false,
+                searchKey: "spiralShell",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAB8],
+                isSkinToneSupport: false,
+                searchKey: "coral",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FABC],
+                isSkinToneSupport: false,
+                searchKey: "jellyfish",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F40C],
+                isSkinToneSupport: false,
+                searchKey: "snail",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F98B],
+                isSkinToneSupport: false,
+                searchKey: "butterfly",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F41B],
+                isSkinToneSupport: false,
+                searchKey: "bug",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F41C],
+                isSkinToneSupport: false,
+                searchKey: "ant",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F41D],
+                isSkinToneSupport: false,
+                searchKey: "honeybee",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAB2],
+                isSkinToneSupport: false,
+                searchKey: "beetle",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F41E],
+                isSkinToneSupport: false,
+                searchKey: "ladyBeetle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F997],
+                isSkinToneSupport: false,
+                searchKey: "cricket",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAB3],
+                isSkinToneSupport: false,
+                searchKey: "cockroach",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F577, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "spider",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F578, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "spiderWeb",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F982],
+                isSkinToneSupport: false,
+                searchKey: "scorpion",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F99F],
+                isSkinToneSupport: false,
+                searchKey: "mosquito",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAB0],
+                isSkinToneSupport: false,
+                searchKey: "fly",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAB1],
+                isSkinToneSupport: false,
+                searchKey: "worm",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9A0],
+                isSkinToneSupport: false,
+                searchKey: "microbe",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F490],
+                isSkinToneSupport: false,
+                searchKey: "bouquet",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F338],
+                isSkinToneSupport: false,
+                searchKey: "cherryBlossom",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4AE],
+                isSkinToneSupport: false,
+                searchKey: "whiteFlower",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAB7],
+                isSkinToneSupport: false,
+                searchKey: "lotus",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F5, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "rosette",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F339],
+                isSkinToneSupport: false,
+                searchKey: "rose",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F940],
+                isSkinToneSupport: false,
+                searchKey: "wiltedFlower",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F33A],
+                isSkinToneSupport: false,
+                searchKey: "hibiscus",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F33B],
+                isSkinToneSupport: false,
+                searchKey: "sunflower",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F33C],
+                isSkinToneSupport: false,
+                searchKey: "blossom",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F337],
+                isSkinToneSupport: false,
+                searchKey: "tulip",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FABB],
+                isSkinToneSupport: false,
+                searchKey: "hyacinth",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F331],
+                isSkinToneSupport: false,
+                searchKey: "seedling",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAB4],
+                isSkinToneSupport: false,
+                searchKey: "pottedPlant",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F332],
+                isSkinToneSupport: false,
+                searchKey: "evergreenTree",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F333],
+                isSkinToneSupport: false,
+                searchKey: "deciduousTree",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F334],
+                isSkinToneSupport: false,
+                searchKey: "palmTree",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F335],
+                isSkinToneSupport: false,
+                searchKey: "cactus",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F33E],
+                isSkinToneSupport: false,
+                searchKey: "sheafOfRice",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F33F],
+                isSkinToneSupport: false,
+                searchKey: "herb",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2618, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "shamrock",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F340],
+                isSkinToneSupport: false,
+                searchKey: "fourLeafClover",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F341],
+                isSkinToneSupport: false,
+                searchKey: "mapleLeaf",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F342],
+                isSkinToneSupport: false,
+                searchKey: "fallenLeaf",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F343],
+                isSkinToneSupport: false,
+                searchKey: "leafFlutteringInWind",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAB9],
+                isSkinToneSupport: false,
+                searchKey: "emptyNest",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FABA],
+                isSkinToneSupport: false,
+                searchKey: "nestWithEggs",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F344],
+                isSkinToneSupport: false,
+                searchKey: "mushroom",
+                version: 0.6
+            )
+        ].filter({ $0.version <= maxCurrentAvailableEmojiVersion })
+    )
+    
+    private let foodAndDrinkEmojis: MCEmojiCategory = .init(
+        type: .foodAndDrink,
+        categoryName: MCEmojiCategoryType.foodAndDrink.emojiCategoryTitle,
+        emojis: [
+            MCEmoji(
+                emojiKeys: [0x1F347],
+                isSkinToneSupport: false,
+                searchKey: "grapes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F348],
+                isSkinToneSupport: false,
+                searchKey: "melon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F349],
+                isSkinToneSupport: false,
+                searchKey: "watermelon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F34A],
+                isSkinToneSupport: false,
+                searchKey: "tangerine",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F34B],
+                isSkinToneSupport: false,
+                searchKey: "lemon",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F34C],
+                isSkinToneSupport: false,
+                searchKey: "banana",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F34D],
+                isSkinToneSupport: false,
+                searchKey: "pineapple",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F96D],
+                isSkinToneSupport: false,
+                searchKey: "mango",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F34E],
+                isSkinToneSupport: false,
+                searchKey: "redApple",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F34F],
+                isSkinToneSupport: false,
+                searchKey: "greenApple",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F350],
+                isSkinToneSupport: false,
+                searchKey: "pear",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F351],
+                isSkinToneSupport: false,
+                searchKey: "peach",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F352],
+                isSkinToneSupport: false,
+                searchKey: "cherries",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F353],
+                isSkinToneSupport: false,
+                searchKey: "strawberry",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAD0],
+                isSkinToneSupport: false,
+                searchKey: "blueberries",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F95D],
+                isSkinToneSupport: false,
+                searchKey: "kiwiFruit",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F345],
+                isSkinToneSupport: false,
+                searchKey: "tomato",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAD2],
+                isSkinToneSupport: false,
+                searchKey: "olive",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F965],
+                isSkinToneSupport: false,
+                searchKey: "coconut",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F951],
+                isSkinToneSupport: false,
+                searchKey: "avocado",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F346],
+                isSkinToneSupport: false,
+                searchKey: "eggplant",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F954],
+                isSkinToneSupport: false,
+                searchKey: "potato",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F955],
+                isSkinToneSupport: false,
+                searchKey: "carrot",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F33D],
+                isSkinToneSupport: false,
+                searchKey: "earOfCorn",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F336, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "hotPepper",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAD1],
+                isSkinToneSupport: false,
+                searchKey: "bellPepper",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F952],
+                isSkinToneSupport: false,
+                searchKey: "cucumber",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F96C],
+                isSkinToneSupport: false,
+                searchKey: "leafyGreen",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F966],
+                isSkinToneSupport: false,
+                searchKey: "broccoli",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9C4],
+                isSkinToneSupport: false,
+                searchKey: "garlic",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9C5],
+                isSkinToneSupport: false,
+                searchKey: "onion",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F95C],
+                isSkinToneSupport: false,
+                searchKey: "peanuts",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAD8],
+                isSkinToneSupport: false,
+                searchKey: "beans",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F330],
+                isSkinToneSupport: false,
+                searchKey: "chestnut",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FADA],
+                isSkinToneSupport: false,
+                searchKey: "gingerRoot",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FADB],
+                isSkinToneSupport: false,
+                searchKey: "peaPod",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F35E],
+                isSkinToneSupport: false,
+                searchKey: "bread",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F950],
+                isSkinToneSupport: false,
+                searchKey: "croissant",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F956],
+                isSkinToneSupport: false,
+                searchKey: "baguetteBread",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAD3],
+                isSkinToneSupport: false,
+                searchKey: "flatbread",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F968],
+                isSkinToneSupport: false,
+                searchKey: "pretzel",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F96F],
+                isSkinToneSupport: false,
+                searchKey: "bagel",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F95E],
+                isSkinToneSupport: false,
+                searchKey: "pancakes",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9C7],
+                isSkinToneSupport: false,
+                searchKey: "waffle",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9C0],
+                isSkinToneSupport: false,
+                searchKey: "cheeseWedge",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F356],
+                isSkinToneSupport: false,
+                searchKey: "meatOnBone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F357],
+                isSkinToneSupport: false,
+                searchKey: "poultryLeg",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F969],
+                isSkinToneSupport: false,
+                searchKey: "cutOfMeat",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F953],
+                isSkinToneSupport: false,
+                searchKey: "bacon",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F354],
+                isSkinToneSupport: false,
+                searchKey: "hamburger",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F35F],
+                isSkinToneSupport: false,
+                searchKey: "frenchFries",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F355],
+                isSkinToneSupport: false,
+                searchKey: "pizza",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F32D],
+                isSkinToneSupport: false,
+                searchKey: "hotDog",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F96A],
+                isSkinToneSupport: false,
+                searchKey: "sandwich",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F32E],
+                isSkinToneSupport: false,
+                searchKey: "taco",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F32F],
+                isSkinToneSupport: false,
+                searchKey: "burrito",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAD4],
+                isSkinToneSupport: false,
+                searchKey: "tamale",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F959],
+                isSkinToneSupport: false,
+                searchKey: "stuffedFlatbread",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9C6],
+                isSkinToneSupport: false,
+                searchKey: "falafel",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F95A],
+                isSkinToneSupport: false,
+                searchKey: "egg",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F373],
+                isSkinToneSupport: false,
+                searchKey: "cooking",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F958],
+                isSkinToneSupport: false,
+                searchKey: "shallowPanOfFood",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F372],
+                isSkinToneSupport: false,
+                searchKey: "potOfFood",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAD5],
+                isSkinToneSupport: false,
+                searchKey: "fondue",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F963],
+                isSkinToneSupport: false,
+                searchKey: "bowlWithSpoon",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F957],
+                isSkinToneSupport: false,
+                searchKey: "greenSalad",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F37F],
+                isSkinToneSupport: false,
+                searchKey: "popcorn",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9C8],
+                isSkinToneSupport: false,
+                searchKey: "butter",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9C2],
+                isSkinToneSupport: false,
+                searchKey: "salt",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F96B],
+                isSkinToneSupport: false,
+                searchKey: "cannedFood",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F371],
+                isSkinToneSupport: false,
+                searchKey: "bentoBox",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F358],
+                isSkinToneSupport: false,
+                searchKey: "riceCracker",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F359],
+                isSkinToneSupport: false,
+                searchKey: "riceBall",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F35A],
+                isSkinToneSupport: false,
+                searchKey: "cookedRice",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F35B],
+                isSkinToneSupport: false,
+                searchKey: "curryRice",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F35C],
+                isSkinToneSupport: false,
+                searchKey: "steamingBowl",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F35D],
+                isSkinToneSupport: false,
+                searchKey: "spaghetti",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F360],
+                isSkinToneSupport: false,
+                searchKey: "roastedSweetPotato",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F362],
+                isSkinToneSupport: false,
+                searchKey: "oden",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F363],
+                isSkinToneSupport: false,
+                searchKey: "sushi",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F364],
+                isSkinToneSupport: false,
+                searchKey: "friedShrimp",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F365],
+                isSkinToneSupport: false,
+                searchKey: "fishCakeWithSwirl",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F96E],
+                isSkinToneSupport: false,
+                searchKey: "moonCake",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F361],
+                isSkinToneSupport: false,
+                searchKey: "dango",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F95F],
+                isSkinToneSupport: false,
+                searchKey: "dumpling",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F960],
+                isSkinToneSupport: false,
+                searchKey: "fortuneCookie",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F961],
+                isSkinToneSupport: false,
+                searchKey: "takeoutBox",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F980],
+                isSkinToneSupport: false,
+                searchKey: "crab",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F99E],
+                isSkinToneSupport: false,
+                searchKey: "lobster",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F990],
+                isSkinToneSupport: false,
+                searchKey: "shrimp",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F991],
+                isSkinToneSupport: false,
+                searchKey: "squid",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9AA],
+                isSkinToneSupport: false,
+                searchKey: "oyster",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F366],
+                isSkinToneSupport: false,
+                searchKey: "softIceCream",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F367],
+                isSkinToneSupport: false,
+                searchKey: "shavedIce",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F368],
+                isSkinToneSupport: false,
+                searchKey: "iceCream",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F369],
+                isSkinToneSupport: false,
+                searchKey: "doughnut",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F36A],
+                isSkinToneSupport: false,
+                searchKey: "cookie",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F382],
+                isSkinToneSupport: false,
+                searchKey: "birthdayCake",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F370],
+                isSkinToneSupport: false,
+                searchKey: "shortcake",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9C1],
+                isSkinToneSupport: false,
+                searchKey: "cupcake",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F967],
+                isSkinToneSupport: false,
+                searchKey: "pie",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F36B],
+                isSkinToneSupport: false,
+                searchKey: "chocolateBar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F36C],
+                isSkinToneSupport: false,
+                searchKey: "candy",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F36D],
+                isSkinToneSupport: false,
+                searchKey: "lollipop",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F36E],
+                isSkinToneSupport: false,
+                searchKey: "custard",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F36F],
+                isSkinToneSupport: false,
+                searchKey: "honeyPot",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F37C],
+                isSkinToneSupport: false,
+                searchKey: "babyBottle",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F95B],
+                isSkinToneSupport: false,
+                searchKey: "glassOfMilk",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2615],
+                isSkinToneSupport: false,
+                searchKey: "hotBeverage",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAD6],
+                isSkinToneSupport: false,
+                searchKey: "teapot",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F375],
+                isSkinToneSupport: false,
+                searchKey: "teacupWithoutHandle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F376],
+                isSkinToneSupport: false,
+                searchKey: "sake",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F37E],
+                isSkinToneSupport: false,
+                searchKey: "bottleWithPoppingCork",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F377],
+                isSkinToneSupport: false,
+                searchKey: "wineGlass",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F378],
+                isSkinToneSupport: false,
+                searchKey: "cocktailGlass",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F379],
+                isSkinToneSupport: false,
+                searchKey: "tropicalDrink",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F37A],
+                isSkinToneSupport: false,
+                searchKey: "beerMug",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F37B],
+                isSkinToneSupport: false,
+                searchKey: "clinkingBeerMugs",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F942],
+                isSkinToneSupport: false,
+                searchKey: "clinkingGlasses",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F943],
+                isSkinToneSupport: false,
+                searchKey: "tumblerGlass",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAD7],
+                isSkinToneSupport: false,
+                searchKey: "pouringLiquid",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F964],
+                isSkinToneSupport: false,
+                searchKey: "cupWithStraw",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CB],
+                isSkinToneSupport: false,
+                searchKey: "bubbleTea",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9C3],
+                isSkinToneSupport: false,
+                searchKey: "beverageBox",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9C9],
+                isSkinToneSupport: false,
+                searchKey: "mate",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9CA],
+                isSkinToneSupport: false,
+                searchKey: "ice",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F962],
+                isSkinToneSupport: false,
+                searchKey: "chopsticks",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F37D, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "forkAndKnifeWithPlate",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F374],
+                isSkinToneSupport: false,
+                searchKey: "forkAndKnife",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F944],
+                isSkinToneSupport: false,
+                searchKey: "spoon",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F52A],
+                isSkinToneSupport: false,
+                searchKey: "kitchenKnife",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAD9],
+                isSkinToneSupport: false,
+                searchKey: "jar",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3FA],
+                isSkinToneSupport: false,
+                searchKey: "amphora",
+                version: 1.0
+            )
+        ].filter({ $0.version <= maxCurrentAvailableEmojiVersion })
+    )
+            
+    private let activityEmojis: MCEmojiCategory = .init(
+        type: .activity,
+        categoryName: MCEmojiCategoryType.activity.emojiCategoryTitle,
+        emojis: [
+            MCEmoji(
+                emojiKeys: [0x1F383],
+                isSkinToneSupport: false,
+                searchKey: "jackOLantern",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F384],
+                isSkinToneSupport: false,
+                searchKey: "christmasTree",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F386],
+                isSkinToneSupport: false,
+                searchKey: "fireworks",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F387],
+                isSkinToneSupport: false,
+                searchKey: "sparkler",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9E8],
+                isSkinToneSupport: false,
+                searchKey: "firecracker",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2728],
+                isSkinToneSupport: false,
+                searchKey: "sparkles",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F388],
+                isSkinToneSupport: false,
+                searchKey: "balloon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F389],
+                isSkinToneSupport: false,
+                searchKey: "partyPopper",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F38A],
+                isSkinToneSupport: false,
+                searchKey: "confettiBall",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F38B],
+                isSkinToneSupport: false,
+                searchKey: "tanabataTree",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F38D],
+                isSkinToneSupport: false,
+                searchKey: "pineDecoration",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F38E],
+                isSkinToneSupport: false,
+                searchKey: "japaneseDolls",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F38F],
+                isSkinToneSupport: false,
+                searchKey: "carpStreamer",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F390],
+                isSkinToneSupport: false,
+                searchKey: "windChime",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F391],
+                isSkinToneSupport: false,
+                searchKey: "moonViewingCeremony",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9E7],
+                isSkinToneSupport: false,
+                searchKey: "redEnvelope",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F380],
+                isSkinToneSupport: false,
+                searchKey: "ribbon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F381],
+                isSkinToneSupport: false,
+                searchKey: "wrappedGift",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F397, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "reminderRibbon",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F39F, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "admissionTickets",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3AB],
+                isSkinToneSupport: false,
+                searchKey: "ticket",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F396, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "militaryMedal",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C6],
+                isSkinToneSupport: false,
+                searchKey: "trophy",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C5],
+                isSkinToneSupport: false,
+                searchKey: "sportsMedal",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F947],
+                isSkinToneSupport: false,
+                searchKey: "1stPlaceMedal",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F948],
+                isSkinToneSupport: false,
+                searchKey: "2ndPlaceMedal",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F949],
+                isSkinToneSupport: false,
+                searchKey: "3rdPlaceMedal",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26BD],
+                isSkinToneSupport: false,
+                searchKey: "soccerBall",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26BE],
+                isSkinToneSupport: false,
+                searchKey: "baseball",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F94E],
+                isSkinToneSupport: false,
+                searchKey: "softball",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C0],
+                isSkinToneSupport: false,
+                searchKey: "basketball",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3D0],
+                isSkinToneSupport: false,
+                searchKey: "volleyball",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C8],
+                isSkinToneSupport: false,
+                searchKey: "americanFootball",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3C9],
+                isSkinToneSupport: false,
+                searchKey: "rugbyFootball",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3BE],
+                isSkinToneSupport: false,
+                searchKey: "tennis",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F94F],
+                isSkinToneSupport: false,
+                searchKey: "flyingDisc",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3B3],
+                isSkinToneSupport: false,
+                searchKey: "bowling",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CF],
+                isSkinToneSupport: false,
+                searchKey: "cricketGame",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3D1],
+                isSkinToneSupport: false,
+                searchKey: "fieldHockey",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3D2],
+                isSkinToneSupport: false,
+                searchKey: "iceHockey",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F94D],
+                isSkinToneSupport: false,
+                searchKey: "lacrosse",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3D3],
+                isSkinToneSupport: false,
+                searchKey: "pingPong",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F8],
+                isSkinToneSupport: false,
+                searchKey: "badminton",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F94A],
+                isSkinToneSupport: false,
+                searchKey: "boxingGlove",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F94B],
+                isSkinToneSupport: false,
+                searchKey: "martialArtsUniform",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F945],
+                isSkinToneSupport: false,
+                searchKey: "goalNet",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F3],
+                isSkinToneSupport: false,
+                searchKey: "flagInHole",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F8, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "iceSkate",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3A3],
+                isSkinToneSupport: false,
+                searchKey: "fishingPole",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F93F],
+                isSkinToneSupport: false,
+                searchKey: "divingMask",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3BD],
+                isSkinToneSupport: false,
+                searchKey: "runningShirt",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3BF],
+                isSkinToneSupport: false,
+                searchKey: "skis",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6F7],
+                isSkinToneSupport: false,
+                searchKey: "sled",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F94C],
+                isSkinToneSupport: false,
+                searchKey: "curlingStone",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3AF],
+                isSkinToneSupport: false,
+                searchKey: "bullseye",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA80],
+                isSkinToneSupport: false,
+                searchKey: "yoYo",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA81],
+                isSkinToneSupport: false,
+                searchKey: "kite",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F52B],
+                isSkinToneSupport: false,
+                searchKey: "waterPistol",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3B1],
+                isSkinToneSupport: false,
+                searchKey: "pool8Ball",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F52E],
+                isSkinToneSupport: false,
+                searchKey: "crystalBall",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA84],
+                isSkinToneSupport: false,
+                searchKey: "magicWand",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3AE],
+                isSkinToneSupport: false,
+                searchKey: "videoGame",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F579, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "joystick",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3B0],
+                isSkinToneSupport: false,
+                searchKey: "slotMachine",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3B2],
+                isSkinToneSupport: false,
+                searchKey: "gameDie",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9E9],
+                isSkinToneSupport: false,
+                searchKey: "puzzlePiece",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9F8],
+                isSkinToneSupport: false,
+                searchKey: "teddyBear",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA85],
+                isSkinToneSupport: false,
+                searchKey: "piñata",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAA9],
+                isSkinToneSupport: false,
+                searchKey: "mirrorBall",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA86],
+                isSkinToneSupport: false,
+                searchKey: "nestingDolls",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2660, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "spadeSuit",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2665, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "heartSuit",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2666, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "diamondSuit",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2663, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "clubSuit",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x265F, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "chessPawn",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F0CF],
+                isSkinToneSupport: false,
+                searchKey: "joker",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F004],
+                isSkinToneSupport: false,
+                searchKey: "mahjongRedDragon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3B4],
+                isSkinToneSupport: false,
+                searchKey: "flowerPlayingCards",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3AD],
+                isSkinToneSupport: false,
+                searchKey: "performingArts",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5BC, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "framedPicture",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3A8],
+                isSkinToneSupport: false,
+                searchKey: "artistPalette",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9F5],
+                isSkinToneSupport: false,
+                searchKey: "thread",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAA1],
+                isSkinToneSupport: false,
+                searchKey: "sewingNeedle",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9F6],
+                isSkinToneSupport: false,
+                searchKey: "yarn",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAA2],
+                isSkinToneSupport: false,
+                searchKey: "knot",
+                version: 13.0
+            )
+        ].filter({ $0.version <= maxCurrentAvailableEmojiVersion })
+    )
+    
+    private let travelAndPlacesEmojis: MCEmojiCategory = .init(
+        type: .travelAndPlaces,
+        categoryName: MCEmojiCategoryType.travelAndPlaces.emojiCategoryTitle,
+        emojis: [
+            MCEmoji(
+                emojiKeys: [0x1F30D],
+                isSkinToneSupport: false,
+                searchKey: "globeShowingEuropeAfrica",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F30E],
+                isSkinToneSupport: false,
+                searchKey: "globeShowingAmericas",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F30F],
+                isSkinToneSupport: false,
+                searchKey: "globeShowingAsiaAustralia",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F310],
+                isSkinToneSupport: false,
+                searchKey: "globeWithMeridians",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5FA, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "worldMap",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5FE],
+                isSkinToneSupport: false,
+                searchKey: "mapOfJapan",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9ED],
+                isSkinToneSupport: false,
+                searchKey: "compass",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3D4, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "snowCappedMountain",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F0, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "mountain",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F30B],
+                isSkinToneSupport: false,
+                searchKey: "volcano",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5FB],
+                isSkinToneSupport: false,
+                searchKey: "mountFuji",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3D5, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "camping",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3D6, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "beachWithUmbrella",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3DC, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "desert",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3DD, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "desertIsland",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3DE, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "nationalPark",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3DF, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "stadium",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3DB, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "classicalBuilding",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3D7, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "buildingConstruction",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9F1],
+                isSkinToneSupport: false,
+                searchKey: "brick",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAA8],
+                isSkinToneSupport: false,
+                searchKey: "rock",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAB5],
+                isSkinToneSupport: false,
+                searchKey: "wood",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6D6],
+                isSkinToneSupport: false,
+                searchKey: "hut",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3D8, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "houses",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3DA, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "derelictHouse",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3E0],
+                isSkinToneSupport: false,
+                searchKey: "house",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3E1],
+                isSkinToneSupport: false,
+                searchKey: "houseWithGarden",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3E2],
+                isSkinToneSupport: false,
+                searchKey: "officeBuilding",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3E3],
+                isSkinToneSupport: false,
+                searchKey: "japanesePostOffice",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3E4],
+                isSkinToneSupport: false,
+                searchKey: "postOffice",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3E5],
+                isSkinToneSupport: false,
+                searchKey: "hospital",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3E6],
+                isSkinToneSupport: false,
+                searchKey: "bank",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3E8],
+                isSkinToneSupport: false,
+                searchKey: "hotel",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3E9],
+                isSkinToneSupport: false,
+                searchKey: "loveHotel",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3EA],
+                isSkinToneSupport: false,
+                searchKey: "convenienceStore",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3EB],
+                isSkinToneSupport: false,
+                searchKey: "school",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3EC],
+                isSkinToneSupport: false,
+                searchKey: "departmentStore",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3ED],
+                isSkinToneSupport: false,
+                searchKey: "factory",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3EF],
+                isSkinToneSupport: false,
+                searchKey: "japaneseCastle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F0],
+                isSkinToneSupport: false,
+                searchKey: "castle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F492],
+                isSkinToneSupport: false,
+                searchKey: "wedding",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5FC],
+                isSkinToneSupport: false,
+                searchKey: "tokyoTower",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5FD],
+                isSkinToneSupport: false,
+                searchKey: "statueOfLiberty",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26EA],
+                isSkinToneSupport: false,
+                searchKey: "church",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F54C],
+                isSkinToneSupport: false,
+                searchKey: "mosque",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6D5],
+                isSkinToneSupport: false,
+                searchKey: "hinduTemple",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F54D],
+                isSkinToneSupport: false,
+                searchKey: "synagogue",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26E9, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "shintoShrine",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F54B],
+                isSkinToneSupport: false,
+                searchKey: "kaaba",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F2],
+                isSkinToneSupport: false,
+                searchKey: "fountain",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26FA],
+                isSkinToneSupport: false,
+                searchKey: "tent",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F301],
+                isSkinToneSupport: false,
+                searchKey: "foggy",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F303],
+                isSkinToneSupport: false,
+                searchKey: "nightWithStars",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3D9, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "cityscape",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F304],
+                isSkinToneSupport: false,
+                searchKey: "sunriseOverMountains",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F305],
+                isSkinToneSupport: false,
+                searchKey: "sunrise",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F306],
+                isSkinToneSupport: false,
+                searchKey: "cityscapeAtDusk",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F307],
+                isSkinToneSupport: false,
+                searchKey: "sunset",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F309],
+                isSkinToneSupport: false,
+                searchKey: "bridgeAtNight",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2668, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "hotSprings",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3A0],
+                isSkinToneSupport: false,
+                searchKey: "carouselHorse",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6DD],
+                isSkinToneSupport: false,
+                searchKey: "playgroundSlide",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3A1],
+                isSkinToneSupport: false,
+                searchKey: "ferrisWheel",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3A2],
+                isSkinToneSupport: false,
+                searchKey: "rollerCoaster",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F488],
+                isSkinToneSupport: false,
+                searchKey: "barberPole",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3AA],
+                isSkinToneSupport: false,
+                searchKey: "circusTent",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F682],
+                isSkinToneSupport: false,
+                searchKey: "locomotive",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F683],
+                isSkinToneSupport: false,
+                searchKey: "railwayCar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F684],
+                isSkinToneSupport: false,
+                searchKey: "highSpeedTrain",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F685],
+                isSkinToneSupport: false,
+                searchKey: "bulletTrain",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F686],
+                isSkinToneSupport: false,
+                searchKey: "train",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F687],
+                isSkinToneSupport: false,
+                searchKey: "metro",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F688],
+                isSkinToneSupport: false,
+                searchKey: "lightRail",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F689],
+                isSkinToneSupport: false,
+                searchKey: "station",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F68A],
+                isSkinToneSupport: false,
+                searchKey: "tram",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F69D],
+                isSkinToneSupport: false,
+                searchKey: "monorail",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F69E],
+                isSkinToneSupport: false,
+                searchKey: "mountainRailway",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F68B],
+                isSkinToneSupport: false,
+                searchKey: "tramCar",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F68C],
+                isSkinToneSupport: false,
+                searchKey: "bus",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F68D],
+                isSkinToneSupport: false,
+                searchKey: "oncomingBus",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F68E],
+                isSkinToneSupport: false,
+                searchKey: "trolleybus",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F690],
+                isSkinToneSupport: false,
+                searchKey: "minibus",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F691],
+                isSkinToneSupport: false,
+                searchKey: "ambulance",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F692],
+                isSkinToneSupport: false,
+                searchKey: "fireEngine",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F693],
+                isSkinToneSupport: false,
+                searchKey: "policeCar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F694],
+                isSkinToneSupport: false,
+                searchKey: "oncomingPoliceCar",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F695],
+                isSkinToneSupport: false,
+                searchKey: "taxi",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F696],
+                isSkinToneSupport: false,
+                searchKey: "oncomingTaxi",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F697],
+                isSkinToneSupport: false,
+                searchKey: "automobile",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F698],
+                isSkinToneSupport: false,
+                searchKey: "oncomingAutomobile",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F699],
+                isSkinToneSupport: false,
+                searchKey: "sportUtilityVehicle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6FB],
+                isSkinToneSupport: false,
+                searchKey: "pickupTruck",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F69A],
+                isSkinToneSupport: false,
+                searchKey: "deliveryTruck",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F69B],
+                isSkinToneSupport: false,
+                searchKey: "articulatedLorry",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F69C],
+                isSkinToneSupport: false,
+                searchKey: "tractor",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CE, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "racingCar",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3CD, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "motorcycle",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6F5],
+                isSkinToneSupport: false,
+                searchKey: "motorScooter",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9BD],
+                isSkinToneSupport: false,
+                searchKey: "manualWheelchair",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9BC],
+                isSkinToneSupport: false,
+                searchKey: "motorizedWheelchair",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6FA],
+                isSkinToneSupport: false,
+                searchKey: "autoRickshaw",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B2],
+                isSkinToneSupport: false,
+                searchKey: "bicycle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6F4],
+                isSkinToneSupport: false,
+                searchKey: "kickScooter",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6F9],
+                isSkinToneSupport: false,
+                searchKey: "skateboard",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6FC],
+                isSkinToneSupport: false,
+                searchKey: "rollerSkate",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F68F],
+                isSkinToneSupport: false,
+                searchKey: "busStop",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6E3, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "motorway",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6E4, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "railwayTrack",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6E2, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "oilDrum",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x26FD],
+                isSkinToneSupport: false,
+                searchKey: "fuelPump",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6DE],
+                isSkinToneSupport: false,
+                searchKey: "wheel",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A8],
+                isSkinToneSupport: false,
+                searchKey: "policeCarLight",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A5],
+                isSkinToneSupport: false,
+                searchKey: "horizontalTrafficLight",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A6],
+                isSkinToneSupport: false,
+                searchKey: "verticalTrafficLight",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6D1],
+                isSkinToneSupport: false,
+                searchKey: "stopSign",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A7],
+                isSkinToneSupport: false,
+                searchKey: "construction",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2693],
+                isSkinToneSupport: false,
+                searchKey: "anchor",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6DF],
+                isSkinToneSupport: false,
+                searchKey: "ringBuoy",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F5],
+                isSkinToneSupport: false,
+                searchKey: "sailboat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6F6],
+                isSkinToneSupport: false,
+                searchKey: "canoe",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A4],
+                isSkinToneSupport: false,
+                searchKey: "speedboat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6F3, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "passengerShip",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F4, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "ferry",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6E5, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "motorBoat",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A2],
+                isSkinToneSupport: false,
+                searchKey: "ship",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2708, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "airplane",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6E9, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "smallAirplane",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6EB],
+                isSkinToneSupport: false,
+                searchKey: "airplaneDeparture",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6EC],
+                isSkinToneSupport: false,
+                searchKey: "airplaneArrival",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA82],
+                isSkinToneSupport: false,
+                searchKey: "parachute",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4BA],
+                isSkinToneSupport: false,
+                searchKey: "seat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F681],
+                isSkinToneSupport: false,
+                searchKey: "helicopter",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F69F],
+                isSkinToneSupport: false,
+                searchKey: "suspensionRailway",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A0],
+                isSkinToneSupport: false,
+                searchKey: "mountainCableway",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A1],
+                isSkinToneSupport: false,
+                searchKey: "aerialTramway",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6F0, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "satellite",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F680],
+                isSkinToneSupport: false,
+                searchKey: "rocket",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6F8],
+                isSkinToneSupport: false,
+                searchKey: "flyingSaucer",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6CE, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "bellhopBell",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9F3],
+                isSkinToneSupport: false,
+                searchKey: "luggage",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x231B],
+                isSkinToneSupport: false,
+                searchKey: "hourglassDone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x23F3],
+                isSkinToneSupport: false,
+                searchKey: "hourglassNotDone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x231A],
+                isSkinToneSupport: false,
+                searchKey: "watch",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x23F0],
+                isSkinToneSupport: false,
+                searchKey: "alarmClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x23F1, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "stopwatch",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x23F2, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "timerClock",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F570, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "mantelpieceClock",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F55B],
+                isSkinToneSupport: false,
+                searchKey: "twelveOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F567],
+                isSkinToneSupport: false,
+                searchKey: "twelveThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F550],
+                isSkinToneSupport: false,
+                searchKey: "oneOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F55C],
+                isSkinToneSupport: false,
+                searchKey: "oneThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F551],
+                isSkinToneSupport: false,
+                searchKey: "twoOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F55D],
+                isSkinToneSupport: false,
+                searchKey: "twoThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F552],
+                isSkinToneSupport: false,
+                searchKey: "threeOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F55E],
+                isSkinToneSupport: false,
+                searchKey: "threeThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F553],
+                isSkinToneSupport: false,
+                searchKey: "fourOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F55F],
+                isSkinToneSupport: false,
+                searchKey: "fourThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F554],
+                isSkinToneSupport: false,
+                searchKey: "fiveOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F560],
+                isSkinToneSupport: false,
+                searchKey: "fiveThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F555],
+                isSkinToneSupport: false,
+                searchKey: "sixOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F561],
+                isSkinToneSupport: false,
+                searchKey: "sixThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F556],
+                isSkinToneSupport: false,
+                searchKey: "sevenOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F562],
+                isSkinToneSupport: false,
+                searchKey: "sevenThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F557],
+                isSkinToneSupport: false,
+                searchKey: "eightOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F563],
+                isSkinToneSupport: false,
+                searchKey: "eightThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F558],
+                isSkinToneSupport: false,
+                searchKey: "nineOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F564],
+                isSkinToneSupport: false,
+                searchKey: "nineThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F559],
+                isSkinToneSupport: false,
+                searchKey: "tenOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F565],
+                isSkinToneSupport: false,
+                searchKey: "tenThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F55A],
+                isSkinToneSupport: false,
+                searchKey: "elevenOClock",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F566],
+                isSkinToneSupport: false,
+                searchKey: "elevenThirty",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F311],
+                isSkinToneSupport: false,
+                searchKey: "newMoon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F312],
+                isSkinToneSupport: false,
+                searchKey: "waxingCrescentMoon",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F313],
+                isSkinToneSupport: false,
+                searchKey: "firstQuarterMoon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F314],
+                isSkinToneSupport: false,
+                searchKey: "waxingGibbousMoon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F315],
+                isSkinToneSupport: false,
+                searchKey: "fullMoon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F316],
+                isSkinToneSupport: false,
+                searchKey: "waningGibbousMoon",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F317],
+                isSkinToneSupport: false,
+                searchKey: "lastQuarterMoon",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F318],
+                isSkinToneSupport: false,
+                searchKey: "waningCrescentMoon",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F319],
+                isSkinToneSupport: false,
+                searchKey: "crescentMoon",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F31A],
+                isSkinToneSupport: false,
+                searchKey: "newMoonFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F31B],
+                isSkinToneSupport: false,
+                searchKey: "firstQuarterMoonFace",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F31C],
+                isSkinToneSupport: false,
+                searchKey: "lastQuarterMoonFace",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F321, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "thermometer",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x2600, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "sun",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F31D],
+                isSkinToneSupport: false,
+                searchKey: "fullMoonFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F31E],
+                isSkinToneSupport: false,
+                searchKey: "sunWithFace",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA90],
+                isSkinToneSupport: false,
+                searchKey: "ringedPlanet",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2B50],
+                isSkinToneSupport: false,
+                searchKey: "star",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F31F],
+                isSkinToneSupport: false,
+                searchKey: "glowingStar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F320],
+                isSkinToneSupport: false,
+                searchKey: "shootingStar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F30C],
+                isSkinToneSupport: false,
+                searchKey: "milkyWay",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2601, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "cloud",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26C5],
+                isSkinToneSupport: false,
+                searchKey: "sunBehindCloud",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26C8, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "cloudWithLightningAndRain",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F324, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "sunBehindSmallCloud",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F325, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "sunBehindLargeCloud",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F326, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "sunBehindRainCloud",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F327, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "cloudWithRain",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F328, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "cloudWithSnow",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F329, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "cloudWithLightning",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F32A, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "tornado",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F32B, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "fog",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F32C, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "windFace",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F300],
+                isSkinToneSupport: false,
+                searchKey: "cyclone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F308],
+                isSkinToneSupport: false,
+                searchKey: "rainbow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F302],
+                isSkinToneSupport: false,
+                searchKey: "closedUmbrella",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2602, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "umbrella",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x2614],
+                isSkinToneSupport: false,
+                searchKey: "umbrellaWithRainDrops",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26F1, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "umbrellaOnGround",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x26A1],
+                isSkinToneSupport: false,
+                searchKey: "highVoltage",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2744, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "snowflake",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2603, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "snowman",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x26C4],
+                isSkinToneSupport: false,
+                searchKey: "snowmanWithoutSnow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2604, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "comet",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F525],
+                isSkinToneSupport: false,
+                searchKey: "fire",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4A7],
+                isSkinToneSupport: false,
+                searchKey: "droplet",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F30A],
+                isSkinToneSupport: false,
+                searchKey: "waterWave",
+                version: 0.6
+            )
+        ].filter({ $0.version <= maxCurrentAvailableEmojiVersion })
+    )
+    
+    private let objectEmojis: MCEmojiCategory = .init(
+        type: .objects,
+        categoryName: MCEmojiCategoryType.objects.emojiCategoryTitle,
+        emojis: [
+            MCEmoji(
+                emojiKeys: [0x1F453],
+                isSkinToneSupport: false,
+                searchKey: "glasses",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F576, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "sunglasses",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F97D],
+                isSkinToneSupport: false,
+                searchKey: "goggles",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F97C],
+                isSkinToneSupport: false,
+                searchKey: "labCoat",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9BA],
+                isSkinToneSupport: false,
+                searchKey: "safetyVest",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F454],
+                isSkinToneSupport: false,
+                searchKey: "necktie",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F455],
+                isSkinToneSupport: false,
+                searchKey: "tShirt",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F456],
+                isSkinToneSupport: false,
+                searchKey: "jeans",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9E3],
+                isSkinToneSupport: false,
+                searchKey: "scarf",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9E4],
+                isSkinToneSupport: false,
+                searchKey: "gloves",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9E5],
+                isSkinToneSupport: false,
+                searchKey: "coat",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9E6],
+                isSkinToneSupport: false,
+                searchKey: "socks",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F457],
+                isSkinToneSupport: false,
+                searchKey: "dress",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F458],
+                isSkinToneSupport: false,
+                searchKey: "kimono",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F97B],
+                isSkinToneSupport: false,
+                searchKey: "sari",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA71],
+                isSkinToneSupport: false,
+                searchKey: "onePieceSwimsuit",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA72],
+                isSkinToneSupport: false,
+                searchKey: "briefs",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA73],
+                isSkinToneSupport: false,
+                searchKey: "shorts",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F459],
+                isSkinToneSupport: false,
+                searchKey: "bikini",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F45A],
+                isSkinToneSupport: false,
+                searchKey: "womanSClothes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAAD],
+                isSkinToneSupport: false,
+                searchKey: "foldingHandFan",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F45B],
+                isSkinToneSupport: false,
+                searchKey: "purse",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F45C],
+                isSkinToneSupport: false,
+                searchKey: "handbag",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F45D],
+                isSkinToneSupport: false,
+                searchKey: "clutchBag",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6CD, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "shoppingBags",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F392],
+                isSkinToneSupport: false,
+                searchKey: "backpack",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA74],
+                isSkinToneSupport: false,
+                searchKey: "thongSandal",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F45E],
+                isSkinToneSupport: false,
+                searchKey: "manSShoe",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F45F],
+                isSkinToneSupport: false,
+                searchKey: "runningShoe",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F97E],
+                isSkinToneSupport: false,
+                searchKey: "hikingBoot",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F97F],
+                isSkinToneSupport: false,
+                searchKey: "flatShoe",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F460],
+                isSkinToneSupport: false,
+                searchKey: "highHeeledShoe",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F461],
+                isSkinToneSupport: false,
+                searchKey: "womanSSandal",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA70],
+                isSkinToneSupport: false,
+                searchKey: "balletShoes",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F462],
+                isSkinToneSupport: false,
+                searchKey: "womanSBoot",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAAE],
+                isSkinToneSupport: false,
+                searchKey: "hairPick",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F451],
+                isSkinToneSupport: false,
+                searchKey: "crown",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F452],
+                isSkinToneSupport: false,
+                searchKey: "womanSHat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3A9],
+                isSkinToneSupport: false,
+                searchKey: "topHat",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F393],
+                isSkinToneSupport: false,
+                searchKey: "graduationCap",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9E2],
+                isSkinToneSupport: false,
+                searchKey: "billedCap",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA96],
+                isSkinToneSupport: false,
+                searchKey: "militaryHelmet",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26D1, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "rescueWorkerSHelmet",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4FF],
+                isSkinToneSupport: false,
+                searchKey: "prayerBeads",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F484],
+                isSkinToneSupport: false,
+                searchKey: "lipstick",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F48D],
+                isSkinToneSupport: false,
+                searchKey: "ring",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F48E],
+                isSkinToneSupport: false,
+                searchKey: "gemStone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F507],
+                isSkinToneSupport: false,
+                searchKey: "mutedSpeaker",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F508],
+                isSkinToneSupport: false,
+                searchKey: "speakerLowVolume",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F509],
+                isSkinToneSupport: false,
+                searchKey: "speakerMediumVolume",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F50A],
+                isSkinToneSupport: false,
+                searchKey: "speakerHighVolume",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4E2],
+                isSkinToneSupport: false,
+                searchKey: "loudspeaker",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4E3],
+                isSkinToneSupport: false,
+                searchKey: "megaphone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4EF],
+                isSkinToneSupport: false,
+                searchKey: "postalHorn",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F514],
+                isSkinToneSupport: false,
+                searchKey: "bell",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F515],
+                isSkinToneSupport: false,
+                searchKey: "bellWithSlash",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3BC],
+                isSkinToneSupport: false,
+                searchKey: "musicalScore",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3B5],
+                isSkinToneSupport: false,
+                searchKey: "musicalNote",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3B6],
+                isSkinToneSupport: false,
+                searchKey: "musicalNotes",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F399, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "studioMicrophone",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F39A, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "levelSlider",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F39B, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "controlKnobs",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3A4],
+                isSkinToneSupport: false,
+                searchKey: "microphone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3A7],
+                isSkinToneSupport: false,
+                searchKey: "headphone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4FB],
+                isSkinToneSupport: false,
+                searchKey: "radio",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3B7],
+                isSkinToneSupport: false,
+                searchKey: "saxophone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA97],
+                isSkinToneSupport: false,
+                searchKey: "accordion",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3B8],
+                isSkinToneSupport: false,
+                searchKey: "guitar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3B9],
+                isSkinToneSupport: false,
+                searchKey: "musicalKeyboard",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3BA],
+                isSkinToneSupport: false,
+                searchKey: "trumpet",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3BB],
+                isSkinToneSupport: false,
+                searchKey: "violin",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA95],
+                isSkinToneSupport: false,
+                searchKey: "banjo",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F941],
+                isSkinToneSupport: false,
+                searchKey: "drum",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA98],
+                isSkinToneSupport: false,
+                searchKey: "longDrum",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA87],
+                isSkinToneSupport: false,
+                searchKey: "maracas",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA88],
+                isSkinToneSupport: false,
+                searchKey: "flute",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4F1],
+                isSkinToneSupport: false,
+                searchKey: "mobilePhone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4F2],
+                isSkinToneSupport: false,
+                searchKey: "mobilePhoneWithArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x260E, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "telephone",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4DE],
+                isSkinToneSupport: false,
+                searchKey: "telephoneReceiver",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4DF],
+                isSkinToneSupport: false,
+                searchKey: "pager",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4E0],
+                isSkinToneSupport: false,
+                searchKey: "faxMachine",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F50B],
+                isSkinToneSupport: false,
+                searchKey: "battery",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAAB],
+                isSkinToneSupport: false,
+                searchKey: "lowBattery",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F50C],
+                isSkinToneSupport: false,
+                searchKey: "electricPlug",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4BB],
+                isSkinToneSupport: false,
+                searchKey: "laptop",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5A5, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "desktopComputer",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5A8, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "printer",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x2328, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "keyboard",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5B1, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "computerMouse",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5B2, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "trackball",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4BD],
+                isSkinToneSupport: false,
+                searchKey: "computerDisk",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4BE],
+                isSkinToneSupport: false,
+                searchKey: "floppyDisk",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4BF],
+                isSkinToneSupport: false,
+                searchKey: "opticalDisk",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4C0],
+                isSkinToneSupport: false,
+                searchKey: "dvd",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9EE],
+                isSkinToneSupport: false,
+                searchKey: "abacus",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3A5],
+                isSkinToneSupport: false,
+                searchKey: "movieCamera",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F39E, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "filmFrames",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4FD, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "filmProjector",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3AC],
+                isSkinToneSupport: false,
+                searchKey: "clapperBoard",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4FA],
+                isSkinToneSupport: false,
+                searchKey: "television",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4F7],
+                isSkinToneSupport: false,
+                searchKey: "camera",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4F8],
+                isSkinToneSupport: false,
+                searchKey: "cameraWithFlash",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4F9],
+                isSkinToneSupport: false,
+                searchKey: "videoCamera",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4FC],
+                isSkinToneSupport: false,
+                searchKey: "videocassette",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F50D],
+                isSkinToneSupport: false,
+                searchKey: "magnifyingGlassTiltedLeft",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F50E],
+                isSkinToneSupport: false,
+                searchKey: "magnifyingGlassTiltedRight",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F56F, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "candle",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4A1],
+                isSkinToneSupport: false,
+                searchKey: "lightBulb",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F526],
+                isSkinToneSupport: false,
+                searchKey: "flashlight",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3EE],
+                isSkinToneSupport: false,
+                searchKey: "redPaperLantern",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA94],
+                isSkinToneSupport: false,
+                searchKey: "diyaLamp",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4D4],
+                isSkinToneSupport: false,
+                searchKey: "notebookWithDecorativeCover",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4D5],
+                isSkinToneSupport: false,
+                searchKey: "closedBook",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4D6],
+                isSkinToneSupport: false,
+                searchKey: "openBook",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4D7],
+                isSkinToneSupport: false,
+                searchKey: "greenBook",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4D8],
+                isSkinToneSupport: false,
+                searchKey: "blueBook",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4D9],
+                isSkinToneSupport: false,
+                searchKey: "orangeBook",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4DA],
+                isSkinToneSupport: false,
+                searchKey: "books",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4D3],
+                isSkinToneSupport: false,
+                searchKey: "notebook",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4D2],
+                isSkinToneSupport: false,
+                searchKey: "ledger",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4C3],
+                isSkinToneSupport: false,
+                searchKey: "pageWithCurl",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4DC],
+                isSkinToneSupport: false,
+                searchKey: "scroll",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4C4],
+                isSkinToneSupport: false,
+                searchKey: "pageFacingUp",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4F0],
+                isSkinToneSupport: false,
+                searchKey: "newspaper",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5DE, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "rolledUpNewspaper",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4D1],
+                isSkinToneSupport: false,
+                searchKey: "bookmarkTabs",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F516],
+                isSkinToneSupport: false,
+                searchKey: "bookmark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F7, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "label",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4B0],
+                isSkinToneSupport: false,
+                searchKey: "moneyBag",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA99],
+                isSkinToneSupport: false,
+                searchKey: "coin",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4B4],
+                isSkinToneSupport: false,
+                searchKey: "yenBanknote",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4B5],
+                isSkinToneSupport: false,
+                searchKey: "dollarBanknote",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4B6],
+                isSkinToneSupport: false,
+                searchKey: "euroBanknote",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4B7],
+                isSkinToneSupport: false,
+                searchKey: "poundBanknote",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4B8],
+                isSkinToneSupport: false,
+                searchKey: "moneyWithWings",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4B3],
+                isSkinToneSupport: false,
+                searchKey: "creditCard",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9FE],
+                isSkinToneSupport: false,
+                searchKey: "receipt",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4B9],
+                isSkinToneSupport: false,
+                searchKey: "chartIncreasingWithYen",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2709, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "envelope",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4E7],
+                isSkinToneSupport: false,
+                searchKey: "eMail",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4E8],
+                isSkinToneSupport: false,
+                searchKey: "incomingEnvelope",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4E9],
+                isSkinToneSupport: false,
+                searchKey: "envelopeWithArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4E4],
+                isSkinToneSupport: false,
+                searchKey: "outboxTray",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4E5],
+                isSkinToneSupport: false,
+                searchKey: "inboxTray",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4E6],
+                isSkinToneSupport: false,
+                searchKey: "package",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4EB],
+                isSkinToneSupport: false,
+                searchKey: "closedMailboxWithRaisedFlag",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4EA],
+                isSkinToneSupport: false,
+                searchKey: "closedMailboxWithLoweredFlag",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4EC],
+                isSkinToneSupport: false,
+                searchKey: "openMailboxWithRaisedFlag",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4ED],
+                isSkinToneSupport: false,
+                searchKey: "openMailboxWithLoweredFlag",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4EE],
+                isSkinToneSupport: false,
+                searchKey: "postbox",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5F3, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "ballotBoxWithBallot",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x270F, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "pencil",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2712, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "blackNib",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F58B, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "fountainPen",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F58A, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "pen",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F58C, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "paintbrush",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F58D, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "crayon",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4DD],
+                isSkinToneSupport: false,
+                searchKey: "memo",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4BC],
+                isSkinToneSupport: false,
+                searchKey: "briefcase",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4C1],
+                isSkinToneSupport: false,
+                searchKey: "fileFolder",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4C2],
+                isSkinToneSupport: false,
+                searchKey: "openFileFolder",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5C2, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "cardIndexDividers",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4C5],
+                isSkinToneSupport: false,
+                searchKey: "calendar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4C6],
+                isSkinToneSupport: false,
+                searchKey: "tearOffCalendar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5D2, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "spiralNotepad",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5D3, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "spiralCalendar",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4C7],
+                isSkinToneSupport: false,
+                searchKey: "cardIndex",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4C8],
+                isSkinToneSupport: false,
+                searchKey: "chartIncreasing",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4C9],
+                isSkinToneSupport: false,
+                searchKey: "chartDecreasing",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4CA],
+                isSkinToneSupport: false,
+                searchKey: "barChart",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4CB],
+                isSkinToneSupport: false,
+                searchKey: "clipboard",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4CC],
+                isSkinToneSupport: false,
+                searchKey: "pushpin",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4CD],
+                isSkinToneSupport: false,
+                searchKey: "roundPushpin",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4CE],
+                isSkinToneSupport: false,
+                searchKey: "paperclip",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F587, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "linkedPaperclips",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4CF],
+                isSkinToneSupport: false,
+                searchKey: "straightRuler",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4D0],
+                isSkinToneSupport: false,
+                searchKey: "triangularRuler",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2702, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "scissors",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5C3, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "cardFileBox",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5C4, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "fileCabinet",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5D1, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "wastebasket",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F512],
+                isSkinToneSupport: false,
+                searchKey: "locked",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F513],
+                isSkinToneSupport: false,
+                searchKey: "unlocked",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F50F],
+                isSkinToneSupport: false,
+                searchKey: "lockedWithPen",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F510],
+                isSkinToneSupport: false,
+                searchKey: "lockedWithKey",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F511],
+                isSkinToneSupport: false,
+                searchKey: "key",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5DD, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "oldKey",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F528],
+                isSkinToneSupport: false,
+                searchKey: "hammer",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA93],
+                isSkinToneSupport: false,
+                searchKey: "axe",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26CF, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "pick",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x2692, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "hammerAndPick",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6E0, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "hammerAndWrench",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5E1, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "dagger",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x2694, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "crossedSwords",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4A3],
+                isSkinToneSupport: false,
+                searchKey: "bomb",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA83],
+                isSkinToneSupport: false,
+                searchKey: "boomerang",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F9],
+                isSkinToneSupport: false,
+                searchKey: "bowAndArrow",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6E1, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "shield",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA9A],
+                isSkinToneSupport: false,
+                searchKey: "carpentrySaw",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F527],
+                isSkinToneSupport: false,
+                searchKey: "wrench",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA9B],
+                isSkinToneSupport: false,
+                searchKey: "screwdriver",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F529],
+                isSkinToneSupport: false,
+                searchKey: "nutAndBolt",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2699, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "gear",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5DC, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "clamp",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x2696, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "balanceScale",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9AF],
+                isSkinToneSupport: false,
+                searchKey: "whiteCane",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F517],
+                isSkinToneSupport: false,
+                searchKey: "link",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26D3, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "chains",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA9D],
+                isSkinToneSupport: false,
+                searchKey: "hook",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9F0],
+                isSkinToneSupport: false,
+                searchKey: "toolbox",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9F2],
+                isSkinToneSupport: false,
+                searchKey: "magnet",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA9C],
+                isSkinToneSupport: false,
+                searchKey: "ladder",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2697, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "alembic",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9EA],
+                isSkinToneSupport: false,
+                searchKey: "testTube",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9EB],
+                isSkinToneSupport: false,
+                searchKey: "petriDish",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9EC],
+                isSkinToneSupport: false,
+                searchKey: "dna",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F52C],
+                isSkinToneSupport: false,
+                searchKey: "microscope",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F52D],
+                isSkinToneSupport: false,
+                searchKey: "telescope",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4E1],
+                isSkinToneSupport: false,
+                searchKey: "satelliteAntenna",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F489],
+                isSkinToneSupport: false,
+                searchKey: "syringe",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA78],
+                isSkinToneSupport: false,
+                searchKey: "dropOfBlood",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F48A],
+                isSkinToneSupport: false,
+                searchKey: "pill",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA79],
+                isSkinToneSupport: false,
+                searchKey: "adhesiveBandage",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA7C],
+                isSkinToneSupport: false,
+                searchKey: "crutch",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA7A],
+                isSkinToneSupport: false,
+                searchKey: "stethoscope",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA7B],
+                isSkinToneSupport: false,
+                searchKey: "xRay",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6AA],
+                isSkinToneSupport: false,
+                searchKey: "door",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6D7],
+                isSkinToneSupport: false,
+                searchKey: "elevator",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA9E],
+                isSkinToneSupport: false,
+                searchKey: "mirror",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA9F],
+                isSkinToneSupport: false,
+                searchKey: "window",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6CF, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "bed",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6CB, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "couchAndLamp",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA91],
+                isSkinToneSupport: false,
+                searchKey: "chair",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6BD],
+                isSkinToneSupport: false,
+                searchKey: "toilet",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAA0],
+                isSkinToneSupport: false,
+                searchKey: "plunger",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6BF],
+                isSkinToneSupport: false,
+                searchKey: "shower",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6C1],
+                isSkinToneSupport: false,
+                searchKey: "bathtub",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAA4],
+                isSkinToneSupport: false,
+                searchKey: "mouseTrap",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FA92],
+                isSkinToneSupport: false,
+                searchKey: "razor",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9F4],
+                isSkinToneSupport: false,
+                searchKey: "lotionBottle",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9F7],
+                isSkinToneSupport: false,
+                searchKey: "safetyPin",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9F9],
+                isSkinToneSupport: false,
+                searchKey: "broom",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9FA],
+                isSkinToneSupport: false,
+                searchKey: "basket",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9FB],
+                isSkinToneSupport: false,
+                searchKey: "rollOfPaper",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAA3],
+                isSkinToneSupport: false,
+                searchKey: "bucket",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9FC],
+                isSkinToneSupport: false,
+                searchKey: "soap",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAE7],
+                isSkinToneSupport: false,
+                searchKey: "bubbles",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAA5],
+                isSkinToneSupport: false,
+                searchKey: "toothbrush",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9FD],
+                isSkinToneSupport: false,
+                searchKey: "sponge",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9EF],
+                isSkinToneSupport: false,
+                searchKey: "fireExtinguisher",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6D2],
+                isSkinToneSupport: false,
+                searchKey: "shoppingCart",
+                version: 3.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6AC],
+                isSkinToneSupport: false,
+                searchKey: "cigarette",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26B0, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "coffin",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAA6],
+                isSkinToneSupport: false,
+                searchKey: "headstone",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26B1, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "funeralUrn",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F9FF],
+                isSkinToneSupport: false,
+                searchKey: "nazarAmulet",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAAC],
+                isSkinToneSupport: false,
+                searchKey: "hamsa",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F5FF],
+                isSkinToneSupport: false,
+                searchKey: "moai",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAA7],
+                isSkinToneSupport: false,
+                searchKey: "placard",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAAA],
+                isSkinToneSupport: false,
+                searchKey: "identificationCard",
+                version: 14.0
+            )
+        ].filter({ $0.version <= maxCurrentAvailableEmojiVersion })
+    )
+    
+    private let symbolEmojis: MCEmojiCategory = .init(
+        type: .symbols,
+        categoryName: MCEmojiCategoryType.symbols.emojiCategoryTitle,
+        emojis: [
+            MCEmoji(
+                emojiKeys: [0x1F3E7],
+                isSkinToneSupport: false,
+                searchKey: "aTMSign",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6AE],
+                isSkinToneSupport: false,
+                searchKey: "litterInBinSign",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B0],
+                isSkinToneSupport: false,
+                searchKey: "potableWater",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x267F],
+                isSkinToneSupport: false,
+                searchKey: "wheelchairSymbol",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B9],
+                isSkinToneSupport: false,
+                searchKey: "menSRoom",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6BA],
+                isSkinToneSupport: false,
+                searchKey: "womenSRoom",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6BB],
+                isSkinToneSupport: false,
+                searchKey: "restroom",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6BC],
+                isSkinToneSupport: false,
+                searchKey: "babySymbol",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6BE],
+                isSkinToneSupport: false,
+                searchKey: "waterCloset",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6C2],
+                isSkinToneSupport: false,
+                searchKey: "passportControl",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6C3],
+                isSkinToneSupport: false,
+                searchKey: "customs",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6C4],
+                isSkinToneSupport: false,
+                searchKey: "baggageClaim",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6C5],
+                isSkinToneSupport: false,
+                searchKey: "leftLuggage",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26A0, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "warning",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B8],
+                isSkinToneSupport: false,
+                searchKey: "childrenCrossing",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26D4],
+                isSkinToneSupport: false,
+                searchKey: "noEntry",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6AB],
+                isSkinToneSupport: false,
+                searchKey: "prohibited",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B3],
+                isSkinToneSupport: false,
+                searchKey: "noBicycles",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6AD],
+                isSkinToneSupport: false,
+                searchKey: "noSmoking",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6AF],
+                isSkinToneSupport: false,
+                searchKey: "noLittering",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B1],
+                isSkinToneSupport: false,
+                searchKey: "nonPotableWater",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6B7],
+                isSkinToneSupport: false,
+                searchKey: "noPedestrians",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4F5],
+                isSkinToneSupport: false,
+                searchKey: "noMobilePhones",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F51E],
+                isSkinToneSupport: false,
+                searchKey: "noOneUnderEighteen",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2622, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "radioactive",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2623, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "biohazard",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2B06, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "upArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2197, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "upRightArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x27A1, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "rightArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2198, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "downRightArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2B07, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "downArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2199, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "downLeftArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2B05, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "leftArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2196, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "upLeftArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2195, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "upDownArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2194, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "leftRightArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x21A9, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "rightArrowCurvingLeft",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x21AA, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "leftArrowCurvingRight",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2934, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "rightArrowCurvingUp",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2935, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "rightArrowCurvingDown",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F503],
+                isSkinToneSupport: false,
+                searchKey: "clockwiseVerticalArrows",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F504],
+                isSkinToneSupport: false,
+                searchKey: "counterclockwiseArrowsButton",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F519],
+                isSkinToneSupport: false,
+                searchKey: "bACKArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F51A],
+                isSkinToneSupport: false,
+                searchKey: "eNDArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F51B],
+                isSkinToneSupport: false,
+                searchKey: "oNArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F51C],
+                isSkinToneSupport: false,
+                searchKey: "sOONArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F51D],
+                isSkinToneSupport: false,
+                searchKey: "tOPArrow",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6D0],
+                isSkinToneSupport: false,
+                searchKey: "placeOfWorship",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x269B, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "atomSymbol",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F549, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "om",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x2721, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "starOfDavid",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x2638, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "wheelOfDharma",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x262F, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "yinYang",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x271D, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "latinCross",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x2626, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "orthodoxCross",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x262A, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "starAndCrescent",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x262E, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "peaceSymbol",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F54E],
+                isSkinToneSupport: false,
+                searchKey: "menorah",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F52F],
+                isSkinToneSupport: false,
+                searchKey: "dottedSixPointedStar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1FAAF],
+                isSkinToneSupport: false,
+                searchKey: "khanda",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2648],
+                isSkinToneSupport: false,
+                searchKey: "aries",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2649],
+                isSkinToneSupport: false,
+                searchKey: "taurus",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x264A],
+                isSkinToneSupport: false,
+                searchKey: "gemini",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x264B],
+                isSkinToneSupport: false,
+                searchKey: "cancer",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x264C],
+                isSkinToneSupport: false,
+                searchKey: "leo",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x264D],
+                isSkinToneSupport: false,
+                searchKey: "virgo",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x264E],
+                isSkinToneSupport: false,
+                searchKey: "libra",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x264F],
+                isSkinToneSupport: false,
+                searchKey: "scorpio",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2650],
+                isSkinToneSupport: false,
+                searchKey: "sagittarius",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2651],
+                isSkinToneSupport: false,
+                searchKey: "capricorn",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2652],
+                isSkinToneSupport: false,
+                searchKey: "aquarius",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2653],
+                isSkinToneSupport: false,
+                searchKey: "pisces",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26CE],
+                isSkinToneSupport: false,
+                searchKey: "ophiuchus",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F500],
+                isSkinToneSupport: false,
+                searchKey: "shuffleTracksButton",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F501],
+                isSkinToneSupport: false,
+                searchKey: "repeatButton",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F502],
+                isSkinToneSupport: false,
+                searchKey: "repeatSingleButton",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x25B6, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "playButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x23E9],
+                isSkinToneSupport: false,
+                searchKey: "fastForwardButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x23ED, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "nextTrackButton",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x23EF, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "playOrPauseButton",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x25C0, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "reverseButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x23EA],
+                isSkinToneSupport: false,
+                searchKey: "fastReverseButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x23EE, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "lastTrackButton",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F53C],
+                isSkinToneSupport: false,
+                searchKey: "upwardsButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x23EB],
+                isSkinToneSupport: false,
+                searchKey: "fastUpButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F53D],
+                isSkinToneSupport: false,
+                searchKey: "downwardsButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x23EC],
+                isSkinToneSupport: false,
+                searchKey: "fastDownButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x23F8, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "pauseButton",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x23F9, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "stopButton",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x23FA, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "recordButton",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x23CF, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "ejectButton",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3A6],
+                isSkinToneSupport: false,
+                searchKey: "cinema",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F505],
+                isSkinToneSupport: false,
+                searchKey: "dimButton",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F506],
+                isSkinToneSupport: false,
+                searchKey: "brightButton",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4F6],
+                isSkinToneSupport: false,
+                searchKey: "antennaBars",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6DC],
+                isSkinToneSupport: false,
+                searchKey: "wireless",
+                version: 15.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4F3],
+                isSkinToneSupport: false,
+                searchKey: "vibrationMode",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4F4],
+                isSkinToneSupport: false,
+                searchKey: "mobilePhoneOff",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2640, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "femaleSign",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2642, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "maleSign",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26A7, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "transgenderSymbol",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2716, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "multiply",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2795],
+                isSkinToneSupport: false,
+                searchKey: "plus",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2796],
+                isSkinToneSupport: false,
+                searchKey: "minus",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2797],
+                isSkinToneSupport: false,
+                searchKey: "divide",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7F0],
+                isSkinToneSupport: false,
+                searchKey: "heavyEqualsSign",
+                version: 14.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x267E, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "infinity",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x203C, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "doubleExclamationMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2049, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "exclamationQuestionMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2753],
+                isSkinToneSupport: false,
+                searchKey: "redQuestionMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2754],
+                isSkinToneSupport: false,
+                searchKey: "whiteQuestionMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2755],
+                isSkinToneSupport: false,
+                searchKey: "whiteExclamationMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2757],
+                isSkinToneSupport: false,
+                searchKey: "redExclamationMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x3030, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "wavyDash",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4B1],
+                isSkinToneSupport: false,
+                searchKey: "currencyExchange",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4B2],
+                isSkinToneSupport: false,
+                searchKey: "heavyDollarSign",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2695, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "medicalSymbol",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x267B, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "recyclingSymbol",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x269C, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "fleurDeLis",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F531],
+                isSkinToneSupport: false,
+                searchKey: "tridentEmblem",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4DB],
+                isSkinToneSupport: false,
+                searchKey: "nameBadge",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F530],
+                isSkinToneSupport: false,
+                searchKey: "japaneseSymbolForBeginner",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2B55],
+                isSkinToneSupport: false,
+                searchKey: "hollowRedCircle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2705],
+                isSkinToneSupport: false,
+                searchKey: "checkMarkButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2611, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "checkBoxWithCheck",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2714, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "checkMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x274C],
+                isSkinToneSupport: false,
+                searchKey: "crossMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x274E],
+                isSkinToneSupport: false,
+                searchKey: "crossMarkButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x27B0],
+                isSkinToneSupport: false,
+                searchKey: "curlyLoop",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x27BF],
+                isSkinToneSupport: false,
+                searchKey: "doubleCurlyLoop",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x303D, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "partAlternationMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2733, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "eightSpokedAsterisk",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2734, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "eightPointedStar",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2747, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "sparkle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x00A9, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "copyright",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x00AE, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "registered",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2122, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "tradeMark",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x0023, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x002A, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x0030, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap0",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x0031, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap1",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x0032, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap2",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x0033, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap3",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x0034, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap4",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x0035, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap5",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x0036, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap6",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x0037, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap7",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x0038, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap8",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x0039, 0xFE0F, 0x20E3],
+                isSkinToneSupport: false,
+                searchKey: "keycap9",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F51F],
+                isSkinToneSupport: false,
+                searchKey: "keycap10",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F520],
+                isSkinToneSupport: false,
+                searchKey: "inputLatinUppercase",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F521],
+                isSkinToneSupport: false,
+                searchKey: "inputLatinLowercase",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F522],
+                isSkinToneSupport: false,
+                searchKey: "inputNumbers",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F523],
+                isSkinToneSupport: false,
+                searchKey: "inputSymbols",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F524],
+                isSkinToneSupport: false,
+                searchKey: "inputLatinLetters",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F170, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "aButtonBloodType",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F18E],
+                isSkinToneSupport: false,
+                searchKey: "aBButtonBloodType",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F171, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "bButtonBloodType",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F191],
+                isSkinToneSupport: false,
+                searchKey: "cLButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F192],
+                isSkinToneSupport: false,
+                searchKey: "cOOLButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F193],
+                isSkinToneSupport: false,
+                searchKey: "fREEButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2139, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "information",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F194],
+                isSkinToneSupport: false,
+                searchKey: "iDButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x24C2, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "circledM",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F195],
+                isSkinToneSupport: false,
+                searchKey: "nEWButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F196],
+                isSkinToneSupport: false,
+                searchKey: "nGButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F17E, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "oButtonBloodType",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F197],
+                isSkinToneSupport: false,
+                searchKey: "oKButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F17F, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "pButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F198],
+                isSkinToneSupport: false,
+                searchKey: "sOSButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F199],
+                isSkinToneSupport: false,
+                searchKey: "uPButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F19A],
+                isSkinToneSupport: false,
+                searchKey: "vSButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F201],
+                isSkinToneSupport: false,
+                searchKey: "japaneseHereButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F202, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "japaneseServiceChargeButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F237, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "japaneseMonthlyAmountButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F236],
+                isSkinToneSupport: false,
+                searchKey: "japaneseNotFreeOfChargeButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F22F],
+                isSkinToneSupport: false,
+                searchKey: "japaneseReservedButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F250],
+                isSkinToneSupport: false,
+                searchKey: "japaneseBargainButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F239],
+                isSkinToneSupport: false,
+                searchKey: "japaneseDiscountButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F21A],
+                isSkinToneSupport: false,
+                searchKey: "japaneseFreeOfChargeButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F232],
+                isSkinToneSupport: false,
+                searchKey: "japaneseProhibitedButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F251],
+                isSkinToneSupport: false,
+                searchKey: "japaneseAcceptableButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F238],
+                isSkinToneSupport: false,
+                searchKey: "japaneseApplicationButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F234],
+                isSkinToneSupport: false,
+                searchKey: "japanesePassingGradeButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F233],
+                isSkinToneSupport: false,
+                searchKey: "japaneseVacancyButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x3297, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "japaneseCongratulationsButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x3299, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "japaneseSecretButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F23A],
+                isSkinToneSupport: false,
+                searchKey: "japaneseOpenForBusinessButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F235],
+                isSkinToneSupport: false,
+                searchKey: "japaneseNoVacancyButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F534],
+                isSkinToneSupport: false,
+                searchKey: "redCircle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7E0],
+                isSkinToneSupport: false,
+                searchKey: "orangeCircle",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7E1],
+                isSkinToneSupport: false,
+                searchKey: "yellowCircle",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7E2],
+                isSkinToneSupport: false,
+                searchKey: "greenCircle",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F535],
+                isSkinToneSupport: false,
+                searchKey: "blueCircle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7E3],
+                isSkinToneSupport: false,
+                searchKey: "purpleCircle",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7E4],
+                isSkinToneSupport: false,
+                searchKey: "brownCircle",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x26AB],
+                isSkinToneSupport: false,
+                searchKey: "blackCircle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x26AA],
+                isSkinToneSupport: false,
+                searchKey: "whiteCircle",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7E5],
+                isSkinToneSupport: false,
+                searchKey: "redSquare",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7E7],
+                isSkinToneSupport: false,
+                searchKey: "orangeSquare",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7E8],
+                isSkinToneSupport: false,
+                searchKey: "yellowSquare",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7E9],
+                isSkinToneSupport: false,
+                searchKey: "greenSquare",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7E6],
+                isSkinToneSupport: false,
+                searchKey: "blueSquare",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7EA],
+                isSkinToneSupport: false,
+                searchKey: "purpleSquare",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F7EB],
+                isSkinToneSupport: false,
+                searchKey: "brownSquare",
+                version: 12.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x2B1B],
+                isSkinToneSupport: false,
+                searchKey: "blackLargeSquare",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x2B1C],
+                isSkinToneSupport: false,
+                searchKey: "whiteLargeSquare",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x25FC, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "blackMediumSquare",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x25FB, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "whiteMediumSquare",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x25FE],
+                isSkinToneSupport: false,
+                searchKey: "blackMediumSmallSquare",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x25FD],
+                isSkinToneSupport: false,
+                searchKey: "whiteMediumSmallSquare",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x25AA, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "blackSmallSquare",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x25AB, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "whiteSmallSquare",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F536],
+                isSkinToneSupport: false,
+                searchKey: "largeOrangeDiamond",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F537],
+                isSkinToneSupport: false,
+                searchKey: "largeBlueDiamond",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F538],
+                isSkinToneSupport: false,
+                searchKey: "smallOrangeDiamond",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F539],
+                isSkinToneSupport: false,
+                searchKey: "smallBlueDiamond",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F53A],
+                isSkinToneSupport: false,
+                searchKey: "redTrianglePointedUp",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F53B],
+                isSkinToneSupport: false,
+                searchKey: "redTrianglePointedDown",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F4A0],
+                isSkinToneSupport: false,
+                searchKey: "diamondWithADot",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F518],
+                isSkinToneSupport: false,
+                searchKey: "radioButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F533],
+                isSkinToneSupport: false,
+                searchKey: "whiteSquareButton",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F532],
+                isSkinToneSupport: false,
+                searchKey: "blackSquareButton",
+                version: 0.6
+            )
+        ].filter({ $0.version <= maxCurrentAvailableEmojiVersion })
+    )
+    
+    private let flagEmojis: MCEmojiCategory = .init(
+        type: .flags,
+        categoryName: MCEmojiCategoryType.flags.emojiCategoryTitle,
+        emojis: [
+            MCEmoji(
+                emojiKeys: [0x1F3C1],
+                isSkinToneSupport: false,
+                searchKey: "chequeredFlag",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F6A9],
+                isSkinToneSupport: false,
+                searchKey: "triangularFlag",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F38C],
+                isSkinToneSupport: false,
+                searchKey: "crossedFlags",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F4],
+                isSkinToneSupport: false,
+                searchKey: "blackFlag",
+                version: 1.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F3, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "whiteFlag",
+                version: 0.7
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F3, 0xFE0F, 0x200D, 0x1F308],
+                isSkinToneSupport: false,
+                searchKey: "rainbowFlag",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F3, 0xFE0F, 0x200D, 0x26A7, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "transgenderFlag",
+                version: 13.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F4, 0x200D, 0x2620, 0xFE0F],
+                isSkinToneSupport: false,
+                searchKey: "pirateFlag",
+                version: 11.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1E8],
+                isSkinToneSupport: false,
+                searchKey: "flagAscensionIsland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1E9],
+                isSkinToneSupport: false,
+                searchKey: "flagAndorra",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagUnitedArabEmirates",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1EB],
+                isSkinToneSupport: false,
+                searchKey: "flagAfghanistan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagAntiguaBarbuda",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1EE],
+                isSkinToneSupport: false,
+                searchKey: "flagAnguilla",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1F1],
+                isSkinToneSupport: false,
+                searchKey: "flagAlbania",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagArmenia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagAngola",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1F6],
+                isSkinToneSupport: false,
+                searchKey: "flagAntarctica",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagArgentina",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagAmericanSamoa",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagAustria",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1FA],
+                isSkinToneSupport: false,
+                searchKey: "flagAustralia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1FC],
+                isSkinToneSupport: false,
+                searchKey: "flagAruba",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1FD],
+                isSkinToneSupport: false,
+                searchKey: "flagÅlandIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E6, 0x1F1FF],
+                isSkinToneSupport: false,
+                searchKey: "flagAzerbaijan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagBosniaHerzegovina",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1E7],
+                isSkinToneSupport: false,
+                searchKey: "flagBarbados",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1E9],
+                isSkinToneSupport: false,
+                searchKey: "flagBangladesh",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagBelgium",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1EB],
+                isSkinToneSupport: false,
+                searchKey: "flagBurkinaFaso",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagBulgaria",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1ED],
+                isSkinToneSupport: false,
+                searchKey: "flagBahrain",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1EE],
+                isSkinToneSupport: false,
+                searchKey: "flagBurundi",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1EF],
+                isSkinToneSupport: false,
+                searchKey: "flagBenin",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1F1],
+                isSkinToneSupport: false,
+                searchKey: "flagStBarthélemy",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagBermuda",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagBrunei",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagBolivia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1F6],
+                isSkinToneSupport: false,
+                searchKey: "flagCaribbeanNetherlands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagBrazil",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagBahamas",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagBhutan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1FB],
+                isSkinToneSupport: false,
+                searchKey: "flagBouvetIsland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1FC],
+                isSkinToneSupport: false,
+                searchKey: "flagBotswana",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1FE],
+                isSkinToneSupport: false,
+                searchKey: "flagBelarus",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E7, 0x1F1FF],
+                isSkinToneSupport: false,
+                searchKey: "flagBelize",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagCanada",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1E8],
+                isSkinToneSupport: false,
+                searchKey: "flagCocosKeelingIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1E9],
+                isSkinToneSupport: false,
+                searchKey: "flagCongoKinshasa",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1EB],
+                isSkinToneSupport: false,
+                searchKey: "flagCentralAfricanRepublic",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagCongoBrazzaville",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1ED],
+                isSkinToneSupport: false,
+                searchKey: "flagSwitzerland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1EE],
+                isSkinToneSupport: false,
+                searchKey: "flagCôteDIvoire",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1F0],
+                isSkinToneSupport: false,
+                searchKey: "flagCookIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1F1],
+                isSkinToneSupport: false,
+                searchKey: "flagChile",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagCameroon",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagChina",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagColombia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1F5],
+                isSkinToneSupport: false,
+                searchKey: "flagClippertonIsland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagCostaRica",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1FA],
+                isSkinToneSupport: false,
+                searchKey: "flagCuba",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1FB],
+                isSkinToneSupport: false,
+                searchKey: "flagCapeVerde",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1FC],
+                isSkinToneSupport: false,
+                searchKey: "flagCuraçao",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1FD],
+                isSkinToneSupport: false,
+                searchKey: "flagChristmasIsland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1FE],
+                isSkinToneSupport: false,
+                searchKey: "flagCyprus",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E8, 0x1F1FF],
+                isSkinToneSupport: false,
+                searchKey: "flagCzechia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E9, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagGermany",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E9, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagDiegoGarcia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E9, 0x1F1EF],
+                isSkinToneSupport: false,
+                searchKey: "flagDjibouti",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E9, 0x1F1F0],
+                isSkinToneSupport: false,
+                searchKey: "flagDenmark",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E9, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagDominica",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E9, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagDominicanRepublic",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1E9, 0x1F1FF],
+                isSkinToneSupport: false,
+                searchKey: "flagAlgeria",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EA, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagCeutaMelilla",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EA, 0x1F1E8],
+                isSkinToneSupport: false,
+                searchKey: "flagEcuador",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EA, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagEstonia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EA, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagEgypt",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EA, 0x1F1ED],
+                isSkinToneSupport: false,
+                searchKey: "flagWesternSahara",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EA, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagEritrea",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EA, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagSpain",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EA, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagEthiopia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EA, 0x1F1FA],
+                isSkinToneSupport: false,
+                searchKey: "flagEuropeanUnion",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EB, 0x1F1EE],
+                isSkinToneSupport: false,
+                searchKey: "flagFinland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EB, 0x1F1EF],
+                isSkinToneSupport: false,
+                searchKey: "flagFiji",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EB, 0x1F1F0],
+                isSkinToneSupport: false,
+                searchKey: "flagFalklandIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EB, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagMicronesia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EB, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagFaroeIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EB, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagFrance",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagGabon",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1E7],
+                isSkinToneSupport: false,
+                searchKey: "flagUnitedKingdom",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1E9],
+                isSkinToneSupport: false,
+                searchKey: "flagGrenada",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagGeorgia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1EB],
+                isSkinToneSupport: false,
+                searchKey: "flagFrenchGuiana",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagGuernsey",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1ED],
+                isSkinToneSupport: false,
+                searchKey: "flagGhana",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1EE],
+                isSkinToneSupport: false,
+                searchKey: "flagGibraltar",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1F1],
+                isSkinToneSupport: false,
+                searchKey: "flagGreenland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagGambia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagGuinea",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1F5],
+                isSkinToneSupport: false,
+                searchKey: "flagGuadeloupe",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1F6],
+                isSkinToneSupport: false,
+                searchKey: "flagEquatorialGuinea",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagGreece",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagSouthGeorgiaSouthSandwichIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagGuatemala",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1FA],
+                isSkinToneSupport: false,
+                searchKey: "flagGuam",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1FC],
+                isSkinToneSupport: false,
+                searchKey: "flagGuineaBissau",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EC, 0x1F1FE],
+                isSkinToneSupport: false,
+                searchKey: "flagGuyana",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1ED, 0x1F1F0],
+                isSkinToneSupport: false,
+                searchKey: "flagHongKongSARChina",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1ED, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagHeardMcDonaldIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1ED, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagHonduras",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1ED, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagCroatia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1ED, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagHaiti",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1ED, 0x1F1FA],
+                isSkinToneSupport: false,
+                searchKey: "flagHungary",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1E8],
+                isSkinToneSupport: false,
+                searchKey: "flagCanaryIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1E9],
+                isSkinToneSupport: false,
+                searchKey: "flagIndonesia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagIreland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1F1],
+                isSkinToneSupport: false,
+                searchKey: "flagIsrael",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagIsleOfMan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagIndia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagBritishIndianOceanTerritory",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1F6],
+                isSkinToneSupport: false,
+                searchKey: "flagIraq",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagIran",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagIceland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EE, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagItaly",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EF, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagJersey",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EF, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagJamaica",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EF, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagJordan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1EF, 0x1F1F5],
+                isSkinToneSupport: false,
+                searchKey: "flagJapan",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagKenya",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagKyrgyzstan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1ED],
+                isSkinToneSupport: false,
+                searchKey: "flagCambodia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1EE],
+                isSkinToneSupport: false,
+                searchKey: "flagKiribati",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagComoros",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagStKittsNevis",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1F5],
+                isSkinToneSupport: false,
+                searchKey: "flagNorthKorea",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagSouthKorea",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1FC],
+                isSkinToneSupport: false,
+                searchKey: "flagKuwait",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1FE],
+                isSkinToneSupport: false,
+                searchKey: "flagCaymanIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F0, 0x1F1FF],
+                isSkinToneSupport: false,
+                searchKey: "flagKazakhstan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagLaos",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1E7],
+                isSkinToneSupport: false,
+                searchKey: "flagLebanon",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1E8],
+                isSkinToneSupport: false,
+                searchKey: "flagStLucia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1EE],
+                isSkinToneSupport: false,
+                searchKey: "flagLiechtenstein",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1F0],
+                isSkinToneSupport: false,
+                searchKey: "flagSriLanka",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagLiberia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagLesotho",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagLithuania",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1FA],
+                isSkinToneSupport: false,
+                searchKey: "flagLuxembourg",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1FB],
+                isSkinToneSupport: false,
+                searchKey: "flagLatvia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F1, 0x1F1FE],
+                isSkinToneSupport: false,
+                searchKey: "flagLibya",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagMorocco",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1E8],
+                isSkinToneSupport: false,
+                searchKey: "flagMonaco",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1E9],
+                isSkinToneSupport: false,
+                searchKey: "flagMoldova",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagMontenegro",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1EB],
+                isSkinToneSupport: false,
+                searchKey: "flagStMartin",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagMadagascar",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1ED],
+                isSkinToneSupport: false,
+                searchKey: "flagMarshallIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1F0],
+                isSkinToneSupport: false,
+                searchKey: "flagNorthMacedonia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1F1],
+                isSkinToneSupport: false,
+                searchKey: "flagMali",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagMyanmarBurma",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagMongolia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagMacaoSARChina",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1F5],
+                isSkinToneSupport: false,
+                searchKey: "flagNorthernMarianaIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1F6],
+                isSkinToneSupport: false,
+                searchKey: "flagMartinique",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagMauritania",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagMontserrat",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagMalta",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1FA],
+                isSkinToneSupport: false,
+                searchKey: "flagMauritius",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1FB],
+                isSkinToneSupport: false,
+                searchKey: "flagMaldives",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1FC],
+                isSkinToneSupport: false,
+                searchKey: "flagMalawi",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1FD],
+                isSkinToneSupport: false,
+                searchKey: "flagMexico",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1FE],
+                isSkinToneSupport: false,
+                searchKey: "flagMalaysia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F2, 0x1F1FF],
+                isSkinToneSupport: false,
+                searchKey: "flagMozambique",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagNamibia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1E8],
+                isSkinToneSupport: false,
+                searchKey: "flagNewCaledonia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagNiger",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1EB],
+                isSkinToneSupport: false,
+                searchKey: "flagNorfolkIsland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagNigeria",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1EE],
+                isSkinToneSupport: false,
+                searchKey: "flagNicaragua",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1F1],
+                isSkinToneSupport: false,
+                searchKey: "flagNetherlands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagNorway",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1F5],
+                isSkinToneSupport: false,
+                searchKey: "flagNepal",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagNauru",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1FA],
+                isSkinToneSupport: false,
+                searchKey: "flagNiue",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F3, 0x1F1FF],
+                isSkinToneSupport: false,
+                searchKey: "flagNewZealand",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F4, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagOman",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagPanama",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagPeru",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1EB],
+                isSkinToneSupport: false,
+                searchKey: "flagFrenchPolynesia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagPapuaNewGuinea",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1ED],
+                isSkinToneSupport: false,
+                searchKey: "flagPhilippines",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1F0],
+                isSkinToneSupport: false,
+                searchKey: "flagPakistan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1F1],
+                isSkinToneSupport: false,
+                searchKey: "flagPoland",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagStPierreMiquelon",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagPitcairnIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagPuertoRico",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagPalestinianTerritories",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagPortugal",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1FC],
+                isSkinToneSupport: false,
+                searchKey: "flagPalau",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F5, 0x1F1FE],
+                isSkinToneSupport: false,
+                searchKey: "flagParaguay",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F6, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagQatar",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F7, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagRéunion",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F7, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagRomania",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F7, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagSerbia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F7, 0x1F1FA],
+                isSkinToneSupport: false,
+                searchKey: "flagRussia",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F7, 0x1F1FC],
+                isSkinToneSupport: false,
+                searchKey: "flagRwanda",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagSaudiArabia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1E7],
+                isSkinToneSupport: false,
+                searchKey: "flagSolomonIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1E8],
+                isSkinToneSupport: false,
+                searchKey: "flagSeychelles",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1E9],
+                isSkinToneSupport: false,
+                searchKey: "flagSudan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagSweden",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagSingapore",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1ED],
+                isSkinToneSupport: false,
+                searchKey: "flagStHelena",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1EE],
+                isSkinToneSupport: false,
+                searchKey: "flagSlovenia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1EF],
+                isSkinToneSupport: false,
+                searchKey: "flagSvalbardJanMayen",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1F0],
+                isSkinToneSupport: false,
+                searchKey: "flagSlovakia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1F1],
+                isSkinToneSupport: false,
+                searchKey: "flagSierraLeone",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagSanMarino",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagSenegal",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagSomalia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagSuriname",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagSouthSudan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagSãoToméPríncipe",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1FB],
+                isSkinToneSupport: false,
+                searchKey: "flagElSalvador",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1FD],
+                isSkinToneSupport: false,
+                searchKey: "flagSintMaarten",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1FE],
+                isSkinToneSupport: false,
+                searchKey: "flagSyria",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F8, 0x1F1FF],
+                isSkinToneSupport: false,
+                searchKey: "flagEswatini",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagTristanDaCunha",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1E8],
+                isSkinToneSupport: false,
+                searchKey: "flagTurksCaicosIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1E9],
+                isSkinToneSupport: false,
+                searchKey: "flagChad",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1EB],
+                isSkinToneSupport: false,
+                searchKey: "flagFrenchSouthernTerritories",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagTogo",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1ED],
+                isSkinToneSupport: false,
+                searchKey: "flagThailand",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1EF],
+                isSkinToneSupport: false,
+                searchKey: "flagTajikistan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1F0],
+                isSkinToneSupport: false,
+                searchKey: "flagTokelau",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1F1],
+                isSkinToneSupport: false,
+                searchKey: "flagTimorLeste",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagTurkmenistan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagTunisia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1F4],
+                isSkinToneSupport: false,
+                searchKey: "flagTonga",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1F7],
+                isSkinToneSupport: false,
+                searchKey: "flagTurkey",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagTrinidadTobago",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1FB],
+                isSkinToneSupport: false,
+                searchKey: "flagTuvalu",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1FC],
+                isSkinToneSupport: false,
+                searchKey: "flagTaiwan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1F9, 0x1F1FF],
+                isSkinToneSupport: false,
+                searchKey: "flagTanzania",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FA, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagUkraine",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FA, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagUganda",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FA, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagUSOutlyingIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FA, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagUnitedNations",
+                version: 4.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FA, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagUnitedStates",
+                version: 0.6
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FA, 0x1F1FE],
+                isSkinToneSupport: false,
+                searchKey: "flagUruguay",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FA, 0x1F1FF],
+                isSkinToneSupport: false,
+                searchKey: "flagUzbekistan",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FB, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagVaticanCity",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FB, 0x1F1E8],
+                isSkinToneSupport: false,
+                searchKey: "flagStVincentGrenadines",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FB, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagVenezuela",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FB, 0x1F1EC],
+                isSkinToneSupport: false,
+                searchKey: "flagBritishVirginIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FB, 0x1F1EE],
+                isSkinToneSupport: false,
+                searchKey: "flagUSVirginIslands",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FB, 0x1F1F3],
+                isSkinToneSupport: false,
+                searchKey: "flagVietnam",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FB, 0x1F1FA],
+                isSkinToneSupport: false,
+                searchKey: "flagVanuatu",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FC, 0x1F1EB],
+                isSkinToneSupport: false,
+                searchKey: "flagWallisFutuna",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FC, 0x1F1F8],
+                isSkinToneSupport: false,
+                searchKey: "flagSamoa",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FD, 0x1F1F0],
+                isSkinToneSupport: false,
+                searchKey: "flagKosovo",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FE, 0x1F1EA],
+                isSkinToneSupport: false,
+                searchKey: "flagYemen",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FE, 0x1F1F9],
+                isSkinToneSupport: false,
+                searchKey: "flagMayotte",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FF, 0x1F1E6],
+                isSkinToneSupport: false,
+                searchKey: "flagSouthAfrica",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FF, 0x1F1F2],
+                isSkinToneSupport: false,
+                searchKey: "flagZambia",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F1FF, 0x1F1FC],
+                isSkinToneSupport: false,
+                searchKey: "flagZimbabwe",
+                version: 2.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F4, 0xE0067, 0xE0062, 0xE0065, 0xE006E, 0xE0067, 0xE007F],
+                isSkinToneSupport: false,
+                searchKey: "flagEngland",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F4, 0xE0067, 0xE0062, 0xE0073, 0xE0063, 0xE0074, 0xE007F],
+                isSkinToneSupport: false,
+                searchKey: "flagScotland",
+                version: 5.0
+            ),
+            MCEmoji(
+                emojiKeys: [0x1F3F4, 0xE0067, 0xE0062, 0xE0077, 0xE006C, 0xE0073, 0xE007F],
+                isSkinToneSupport: false,
+                searchKey: "flagWales",
+                version: 5.0
+            )
+        ].filter({ $0.version <= maxCurrentAvailableEmojiVersion })
+    )
+    
+}

--- a/deltachat-ios/MCEmojiPicker/View/MCEmojiPickerRepresentableController.swift
+++ b/deltachat-ios/MCEmojiPicker/View/MCEmojiPickerRepresentableController.swift
@@ -1,0 +1,163 @@
+// The MIT License (MIT)
+//
+// Copyright © 2023 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+public struct MCEmojiPickerRepresentableController: UIViewControllerRepresentable {
+    
+    // MARK: - Public Properties
+    
+    /// Observed value which is responsible for the state of the picker.
+    ///
+    /// If the value of this property is `true`, the EmojiPicker will be presented.
+    /// If the value of this property is `false`, the EmojiPicker will be hidden.
+    @Binding var isPresented: Bool
+    
+    /// Observed value which is updated by the selected emoji.
+    @Binding var selectedEmoji: String
+    
+    /// The direction of the arrow for EmojiPicker.
+    ///
+    /// The default value of this property is `.up`.
+    public var arrowDirection: MCPickerArrowDirection?
+    
+    /// Custom height for EmojiPicker.
+    /// But it will be limited by the distance from sourceView.origin.y to the upper or lower bound(depends on permittedArrowDirections).
+    ///
+    /// The default value of this property is `nil`.
+    public var customHeight: CGFloat?
+    
+    /// Inset from the sourceView border.
+    ///
+    /// The default value of this property is `0`.
+    public var horizontalInset: CGFloat?
+    
+    /// A boolean value that determines whether the screen will be hidden after the emoji is selected.
+    ///
+    /// If this property’s value is `true`, the EmojiPicker will be dismissed after the emoji is selected.
+    /// If you want EmojiPicker not to dismissed after emoji selection, you must set this property to `false`.
+    /// The default value of this property is `true`.
+    public var isDismissAfterChoosing: Bool?
+    
+    /// Color for the selected emoji category.
+    ///
+    /// The default value of this property is `.systemBlue`.
+    public var selectedEmojiCategoryTintColor: UIColor?
+    
+    /// Feedback generator style. To turn off, set `nil` to this parameter.
+    ///
+    /// The default value of this property is `.light`.
+    public var feedBackGeneratorStyle: UIImpactFeedbackGenerator.FeedbackStyle?
+    
+    // MARK: - Initializers
+    
+    public init(
+        isPresented: Binding<Bool>,
+        selectedEmoji: Binding<String>,
+        arrowDirection: MCPickerArrowDirection? = nil,
+        customHeight: CGFloat? = nil,
+        horizontalInset: CGFloat? = nil,
+        isDismissAfterChoosing: Bool? = nil,
+        selectedEmojiCategoryTintColor: UIColor? = nil,
+        feedBackGeneratorStyle: UIImpactFeedbackGenerator.FeedbackStyle? = nil
+    ) {
+        self._isPresented = isPresented
+        self._selectedEmoji = selectedEmoji
+        self.arrowDirection = arrowDirection
+        self.customHeight = customHeight
+        self.horizontalInset = horizontalInset
+        self.isDismissAfterChoosing = isDismissAfterChoosing
+        self.selectedEmojiCategoryTintColor = selectedEmojiCategoryTintColor
+        self.feedBackGeneratorStyle = feedBackGeneratorStyle
+    }
+    
+    // MARK: - Public Methods
+    
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    public func makeUIViewController(context: Context) -> UIViewController {
+        UIViewController()
+    }
+    
+    public func updateUIViewController(_ representableController: UIViewController, context: Context) {
+        guard !context.coordinator.isNewEmojiSet else {
+            context.coordinator.isNewEmojiSet.toggle()
+            return
+        }
+        switch isPresented {
+        case true:
+            guard representableController.presentedViewController == nil else { return }
+            let emojiPicker = MCEmojiPickerViewController()
+            emojiPicker.delegate = context.coordinator
+            emojiPicker.sourceView = representableController.view
+            if let arrowDirection { emojiPicker.arrowDirection = arrowDirection }
+            if let customHeight { emojiPicker.customHeight = customHeight }
+            if let horizontalInset { emojiPicker.horizontalInset = horizontalInset }
+            if let isDismissAfterChoosing { emojiPicker.isDismissAfterChoosing = isDismissAfterChoosing }
+            if let selectedEmojiCategoryTintColor {
+                emojiPicker.selectedEmojiCategoryTintColor = selectedEmojiCategoryTintColor
+            }
+            if let feedBackGeneratorStyle { emojiPicker.feedBackGeneratorStyle = feedBackGeneratorStyle }
+            context.coordinator.addPickerDismissingObserver()
+            representableController.present(emojiPicker, animated: true)
+        case false:
+            if representableController.presentedViewController is MCEmojiPickerViewController && context.coordinator.isPresented {
+                representableController.presentedViewController?.dismiss(animated: true)
+            }
+        }
+        context.coordinator.isPresented = isPresented
+    }
+}
+
+// MARK: - Coordinator
+
+@available(iOS 13.0, *)
+extension MCEmojiPickerRepresentableController {
+    public class Coordinator: NSObject, MCEmojiPickerDelegate {
+        
+        public var isNewEmojiSet = false
+        public var isPresented = false
+        
+        private var representableController: MCEmojiPickerRepresentableController
+        
+        init(_ representableController: MCEmojiPickerRepresentableController) {
+            self.representableController = representableController
+        }
+        
+        public func addPickerDismissingObserver() {
+            NotificationCenter.default.addObserver(self, selector: #selector(pickerDismissingAction), name: .MCEmojiPickerDidDisappear, object: nil)
+        }
+        
+        public func didGetEmoji(emoji: String) {
+            isNewEmojiSet.toggle()
+            representableController.selectedEmoji = emoji
+        }
+        
+        @objc public func pickerDismissingAction() {
+            NotificationCenter.default.removeObserver(self, name: .MCEmojiPickerDidDisappear, object: nil)
+            representableController.isPresented = false
+        }
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/MCEmojiPickerViewController.swift
+++ b/deltachat-ios/MCEmojiPicker/View/MCEmojiPickerViewController.swift
@@ -1,0 +1,248 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+public protocol MCEmojiPickerDelegate: AnyObject {
+    func didGetEmoji(emoji: String)
+}
+
+public final class MCEmojiPickerViewController: UIViewController {
+    
+    // MARK: - Public Properties
+    
+    /// Delegate for selecting an emoji object.
+    public weak var delegate: MCEmojiPickerDelegate?
+    
+    /// The direction of the arrow for EmojiPicker.
+    ///
+    /// The default value of this property is `.up`.
+    public var arrowDirection: MCPickerArrowDirection = .up
+    
+    /// Custom height for EmojiPicker.
+    /// But it will be limited by the distance from sourceView.origin.y to the upper or lower bound(depends on permittedArrowDirections).
+    ///
+    /// The default value of this property is `nil`.
+    public var customHeight: CGFloat? = nil
+    
+    /// Inset from the sourceView border.
+    ///
+    /// The default value of this property is `0`.
+    public var horizontalInset: CGFloat = 0
+    
+    /// A boolean value that determines whether the screen will be hidden after the emoji is selected.
+    ///
+    /// If this property’s value is `true`, the EmojiPicker will be dismissed after the emoji is selected.
+    /// If you want EmojiPicker not to dismissed after emoji selection, you must set this property to `false`.
+    /// The default value of this property is `true`.
+    public var isDismissAfterChoosing: Bool = true
+    
+    /// Color for the selected emoji category.
+    ///
+    /// The default value of this property is `.systemBlue`.
+    public var selectedEmojiCategoryTintColor: UIColor? {
+        didSet {
+            guard let selectedEmojiCategoryTintColor = selectedEmojiCategoryTintColor else { return }
+            emojiPickerView.selectedEmojiCategoryTintColor = selectedEmojiCategoryTintColor
+        }
+    }
+    
+    /// The view containing the anchor rectangle for the popover.
+    public var sourceView: UIView? {
+        didSet {
+            popoverPresentationController?.sourceView = sourceView
+        }
+    }
+    
+    /// Feedback generator style. To turn off, set `nil` to this parameter.
+    ///
+    /// The default value of this property is `.light`.
+    public var feedBackGeneratorStyle: UIImpactFeedbackGenerator.FeedbackStyle? = .light {
+        didSet {
+            guard let feedBackGeneratorStyle = feedBackGeneratorStyle else {
+                generator = nil
+                return
+            }
+            generator = UIImpactFeedbackGenerator(style: feedBackGeneratorStyle)
+        }
+    }
+    
+    // MARK: - Private Properties
+    
+    private var generator: UIImpactFeedbackGenerator? = UIImpactFeedbackGenerator(style: .light)
+    private var viewModel: MCEmojiPickerViewModelProtocol = MCEmojiPickerViewModel()
+    private lazy var emojiPickerView: MCEmojiPickerView = {
+        let categories = viewModel.emojiCategories.map { $0.type }
+        return MCEmojiPickerView(categoryTypes: categories, delegate: self)
+    }()
+    
+    // MARK: - Initializers
+    
+    public init() {
+        super.init(nibName: nil, bundle: nil)
+        setupPopoverPresentationStyle()
+        setupDelegates()
+        bindViewModel()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life Cycle
+    
+    public override func loadView() {
+        view = emojiPickerView
+    }
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        setupPreferredContentSize()
+        setupArrowDirections()
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupHorizontalInset()
+    }
+    
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        NotificationCenter.default.post(name: .MCEmojiPickerDidDisappear, object: nil)
+    }
+    
+    // MARK: - Private Methods
+    
+    private func bindViewModel() {
+        viewModel.selectedEmoji.bind { [unowned self] emoji in
+            guard let emoji = emoji else { return }
+            feedbackImpactOccurred()
+            delegate?.didGetEmoji(emoji: emoji.string)
+            if isDismissAfterChoosing {
+                dismiss(animated: true, completion: nil)
+            }
+        }
+        viewModel.selectedEmojiCategoryIndex.bind { [unowned self] categoryIndex in
+            self.emojiPickerView.updateSelectedCategoryIcon(with: categoryIndex)
+        }
+    }
+    
+    private func setupDelegates() {
+        presentationController?.delegate = self
+    }
+    
+    private func setupPopoverPresentationStyle() {
+        modalPresentationStyle = .popover
+    }
+    
+    private func setupPreferredContentSize() {
+        preferredContentSize = {
+            switch UIDevice.current.userInterfaceIdiom {
+            case .phone:
+                let sideInset: CGFloat = 19
+                let screenWidth: CGFloat = UIScreen.main.nativeBounds.width / UIScreen.main.nativeScale
+                let popoverWidth: CGFloat = screenWidth - (sideInset * 2)
+                // The number 0.16 was taken based on the proportion of height to the width of the EmojiPicker on MacOS.
+                let heightProportionToWidth: CGFloat = 1.16
+                return CGSize(
+                    width: popoverWidth,
+                    height: customHeight ?? popoverWidth * heightProportionToWidth
+                )
+            default:
+                return CGSize(width: 340, height: 380)
+            }
+        }()
+    }
+    
+    private func setupArrowDirections() {
+        popoverPresentationController?.permittedArrowDirections = []
+    }
+    
+    private func setupHorizontalInset() {
+        guard let sourceView = sourceView else { return }
+        popoverPresentationController?.sourceRect = CGRect(
+            x: 0,
+            y: popoverPresentationController?.arrowDirection == .up ? horizontalInset : -horizontalInset,
+            width: sourceView.frame.width,
+            height: sourceView.frame.height
+        )
+    }
+}
+
+// MARK: - EmojiPickerViewDelegate
+
+extension MCEmojiPickerViewController: MCEmojiPickerViewDelegate {
+    func didChoiceEmojiCategory(at index: Int) {
+        updateCurrentSelectedEmojiCategoryIndex(with: index)
+    }
+    
+    func numberOfSections() -> Int {
+        viewModel.numberOfSections()
+    }
+    
+    func numberOfItems(in section: Int) -> Int {
+        viewModel.numberOfItems(in: section)
+    }
+    
+    func emoji(at indexPath: IndexPath) -> MCEmoji {
+        viewModel.emoji(at: indexPath)
+    }
+    
+    func sectionHeaderName(for section: Int) -> String {
+        viewModel.sectionHeaderName(for: section)
+    }
+    
+    func getCurrentSelectedEmojiCategoryIndex() -> Int {
+        viewModel.selectedEmojiCategoryIndex.value
+    }
+    
+    func updateCurrentSelectedEmojiCategoryIndex(with index: Int) {
+        viewModel.selectedEmojiCategoryIndex.value = index
+    }
+    
+    func getEmojiPickerFrame() -> CGRect {
+        presentationController?.presentedView?.frame ?? view.frame
+    }
+    
+    func updateEmojiSkinTone(_ skinToneRawValue: Int, in indexPath: IndexPath) {
+        viewModel.selectedEmoji.value = viewModel.updateEmojiSkinTone(
+            skinToneRawValue,
+            in: indexPath
+        )
+    }
+    
+    func feedbackImpactOccurred() {
+        generator?.impactOccurred()
+    }
+    
+    func didChoiceEmoji(_ emoji: MCEmoji?) {
+        viewModel.selectedEmoji.value = emoji
+    }
+}
+
+// MARK: - UIAdaptivePresentationControllerDelegate
+
+extension MCEmojiPickerViewController: UIAdaptivePresentationControllerDelegate {
+    public func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+        return .none
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/MCEmojiPickerViewController.swift
+++ b/deltachat-ios/MCEmojiPicker/View/MCEmojiPickerViewController.swift
@@ -56,6 +56,10 @@ public final class MCEmojiPickerViewController: UIViewController {
     /// The default value of this property is `true`.
     public var isDismissAfterChoosing: Bool = true
     
+    private lazy var cancelButton: UIBarButtonItem = {
+        return UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel, target: self, action: #selector(cancelAction))
+    }()
+
     /// Color for the selected emoji category.
     ///
     /// The default value of this property is `.systemBlue`.
@@ -151,7 +155,11 @@ public final class MCEmojiPickerViewController: UIViewController {
     }
     
     private func setupPopoverPresentationStyle() {
-        modalPresentationStyle = .popover
+        if sourceView != nil {
+            modalPresentationStyle = .popover
+        } else {
+            navigationItem.setRightBarButton(cancelButton, animated: false)
+        }
     }
     
     private func setupPreferredContentSize() {
@@ -174,7 +182,10 @@ public final class MCEmojiPickerViewController: UIViewController {
     }
     
     private func setupArrowDirections() {
-        popoverPresentationController?.permittedArrowDirections = []
+        guard let sourceView = sourceView else { return }
+        popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection(
+            rawValue: arrowDirection.rawValue
+        )
     }
     
     private func setupHorizontalInset() {
@@ -236,6 +247,10 @@ extension MCEmojiPickerViewController: MCEmojiPickerViewDelegate {
     
     func didChoiceEmoji(_ emoji: MCEmoji?) {
         viewModel.selectedEmoji.value = emoji
+    }
+
+    @objc func cancelAction() {
+        dismiss(animated: true, completion: nil)
     }
 }
 

--- a/deltachat-ios/MCEmojiPicker/View/Views/EmojiCategoryView/MCEmojiCategoryIconView.swift
+++ b/deltachat-ios/MCEmojiPicker/View/Views/EmojiCategoryView/MCEmojiCategoryIconView.swift
@@ -1,0 +1,1165 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+/// States for `MCEmojiCategoryIconView`.
+enum MCEmojiCategoryIconViewState {
+    case standard
+    case highlighted
+    case selected
+}
+
+/// Responsible for rendering the icon for the target emoji category in the desired color.
+final class MCEmojiCategoryIconView: UIView {
+    
+    // MARK: - Private Properties
+    
+    /// Target icon type.
+    private var type: MCEmojiCategoryType
+    /// Current tint color for the icon.
+    private var currentIconTintColor: UIColor = .systemGray
+    /// Selected tint color for the icon.
+    private var selectedIconTintColor: UIColor
+    /// Current icon state.
+    private var state: MCEmojiCategoryIconViewState = .standard
+    
+    // MARK: - Initializers
+    
+    init(
+        type: MCEmojiCategoryType,
+        selectedIconTintColor: UIColor
+    ) {
+        self.type = type
+        self.selectedIconTintColor = selectedIconTintColor
+        super.init(frame: .zero)
+        setupBackground()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Public Methods
+    
+    /// New centered rect based on bounds width to prevent stretching of the icon.
+    ///
+    /// - Parameter state: Target icon state. Based on this state, the target color will be selected.
+    public func updateIconTintColor(for state: MCEmojiCategoryIconViewState) {
+        guard self.state != state else { return }
+        self.state = state
+        switch state {
+        case .standard:
+            currentIconTintColor = .systemGray
+        case .highlighted:
+            currentIconTintColor = adjust(color: currentIconTintColor)
+        case .selected:
+            currentIconTintColor = selectedIconTintColor
+        }
+        setNeedsDisplay()
+    }
+    
+    // MARK: - Private Methods
+    
+    /// Increases brightness or decreases saturation.
+    private func adjust(color: UIColor, by percentage: CGFloat = 40.0) -> UIColor {
+        var hue: CGFloat = 0, saturation: CGFloat = 0, brightness: CGFloat = 0, alpha: CGFloat = 0
+        if color.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha) {
+            switch brightness < 1.0 {
+            case true:
+                let newB: CGFloat = max(min(brightness + (percentage / 100.0) * brightness, 1.0), 0.0)
+                return UIColor(hue: hue, saturation: saturation, brightness: newB, alpha: alpha)
+            case false:
+                let newS: CGFloat = min(max(saturation - (percentage / 100.0) * saturation, 0.0), 1.0)
+                return UIColor(hue: hue, saturation: newS, brightness: brightness, alpha: alpha)
+            }
+        }
+        return color
+    }
+    
+    private func setupBackground() {
+        translatesAutoresizingMaskIntoConstraints = false
+        backgroundColor = .clear
+    }
+}
+
+// MARK: - Drawing
+
+extension MCEmojiCategoryIconView {
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        // New centered rect based on bounds width to prevent stretching of the icon.
+        let rect = CGRect(
+            origin: CGPoint(
+                x: 0,
+                y: (rect.height - rect.width) / 2
+            ),
+            size: CGSize(
+                width: rect.width,
+                height: rect.width
+            )
+        )
+        switch type {
+        case .frequentlyUsed:
+            CategoryIconsDrawKit.drawFrequentlyUsedCategory(frame: rect, tintColor: currentIconTintColor)
+        case .people:
+            CategoryIconsDrawKit.drawPeopleCategory(frame: rect, tintColor: currentIconTintColor)
+        case .nature:
+            CategoryIconsDrawKit.drawNatureCategory(frame: rect, tintColor: currentIconTintColor)
+        case .foodAndDrink:
+            CategoryIconsDrawKit.drawFoodAndDrinkCategory(frame: rect, tintColor: currentIconTintColor)
+        case .activity:
+            CategoryIconsDrawKit.drawActivityCategory(frame: rect, tintColor: currentIconTintColor)
+        case .travelAndPlaces:
+            CategoryIconsDrawKit.drawTravelAndPlacesCategory(frame: rect, tintColor: currentIconTintColor)
+        case .objects:
+            CategoryIconsDrawKit.drawObjectsCategory(frame: rect, tintColor: currentIconTintColor)
+        case .symbols:
+            CategoryIconsDrawKit.drawSymbolsCategory(frame: rect, tintColor: currentIconTintColor)
+        case .flags:
+            CategoryIconsDrawKit.drawFlagsCategory(frame: rect, tintColor: currentIconTintColor)
+        }
+    }
+    
+    /// Responsible for rendering icons for emoji categories.
+    private class CategoryIconsDrawKit: NSObject {
+
+        public enum ResizingBehavior: Int {
+            /// The content is proportionally resized to fit into the target rectangle.
+            case aspectFit
+            /// The content is proportionally resized to completely fill the target rectangle.
+            case aspectFill
+            /// The content is stretched to match the entire target rectangle.
+            case stretch
+            /// The content is centered in the target rectangle, but it is NOT resized.
+            case center
+
+            public func apply(rect: CGRect, target: CGRect) -> CGRect {
+                if rect == target || target == CGRect.zero {
+                    return rect
+                }
+
+                var scales = CGSize.zero
+                scales.width = abs(target.width / rect.width)
+                scales.height = abs(target.height / rect.height)
+
+                switch self {
+                    case .aspectFit:
+                        scales.width = min(scales.width, scales.height)
+                        scales.height = scales.width
+                    case .aspectFill:
+                        scales.width = max(scales.width, scales.height)
+                        scales.height = scales.width
+                    case .stretch:
+                        break
+                    case .center:
+                        scales.width = 1
+                        scales.height = 1
+                }
+
+                var result = rect.standardized
+                result.size.width *= scales.width
+                result.size.height *= scales.height
+                result.origin.x = target.minX + (target.width - result.width) / 2
+                result.origin.y = target.minY + (target.height - result.height) / 2
+                return result
+            }
+        }
+
+        // MARK: - People Category
+        
+        public class func drawFrequentlyUsedCategory(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 400, height: 400), resizing: ResizingBehavior = .aspectFit, tintColor: UIColor) {
+            guard let context = UIGraphicsGetCurrentContext() else { return }
+            
+            context.saveGState()
+            let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 400, height: 400), target: targetFrame)
+            context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
+            context.scaleBy(x: resizedFrame.width / 400, y: resizedFrame.height / 400)
+            
+            let shape = UIBezierPath()
+            shape.move(to: CGPoint(x: 89.74, y: 215.05))
+            shape.addLine(to: CGPoint(x: 195.75, y: 215.05))
+            shape.addCurve(to: CGPoint(x: 206.58, y: 204.28), controlPoint1: CGPoint(x: 201.8, y: 215.05), controlPoint2: CGPoint(x: 206.58, y: 210.46))
+            shape.addLine(to: CGPoint(x: 206.58, y: 67.37))
+            shape.addCurve(to: CGPoint(x: 195.75, y: 56.86), controlPoint1: CGPoint(x: 206.58, y: 61.39), controlPoint2: CGPoint(x: 201.8, y: 56.86))
+            shape.addCurve(to: CGPoint(x: 185.24, y: 67.37), controlPoint1: CGPoint(x: 189.89, y: 56.86), controlPoint2: CGPoint(x: 185.24, y: 61.39))
+            shape.addLine(to: CGPoint(x: 185.24, y: 193.77))
+            shape.addLine(to: CGPoint(x: 89.74, y: 193.77))
+            shape.addCurve(to: CGPoint(x: 79.04, y: 204.28), controlPoint1: CGPoint(x: 83.57, y: 193.77), controlPoint2: CGPoint(x: 79.04, y: 198.36))
+            shape.addCurve(to: CGPoint(x: 89.74, y: 215.05), controlPoint1: CGPoint(x: 79.04, y: 210.46), controlPoint2: CGPoint(x: 83.57, y: 215.05))
+            shape.close()
+            shape.move(to: CGPoint(x: 195.89, y: 391.78))
+            shape.addCurve(to: CGPoint(x: 391.84, y: 195.89), controlPoint1: CGPoint(x: 303.3, y: 391.78), controlPoint2: CGPoint(x: 391.84, y: 303.1))
+            shape.addCurve(to: CGPoint(x: 195.75, y: 0), controlPoint1: CGPoint(x: 391.84, y: 88.54), controlPoint2: CGPoint(x: 303.16, y: 0))
+            shape.addCurve(to: CGPoint(x: 0, y: 195.89), controlPoint1: CGPoint(x: 88.54, y: 0), controlPoint2: CGPoint(x: 0, y: 88.54))
+            shape.addCurve(to: CGPoint(x: 195.89, y: 391.78), controlPoint1: CGPoint(x: 0, y: 303.1), controlPoint2: CGPoint(x: 88.67, y: 391.78))
+            shape.close()
+            shape.move(to: CGPoint(x: 195.89, y: 366.45))
+            shape.addCurve(to: CGPoint(x: 25.47, y: 195.89), controlPoint1: CGPoint(x: 101.4, y: 366.45), controlPoint2: CGPoint(x: 25.47, y: 290.38))
+            shape.addCurve(to: CGPoint(x: 195.75, y: 25.27), controlPoint1: CGPoint(x: 25.47, y: 101.4), controlPoint2: CGPoint(x: 101.27, y: 25.27))
+            shape.addCurve(to: CGPoint(x: 366.51, y: 195.89), controlPoint1: CGPoint(x: 290.24, y: 25.27), controlPoint2: CGPoint(x: 366.51, y: 101.4))
+            shape.addCurve(to: CGPoint(x: 195.89, y: 366.45), controlPoint1: CGPoint(x: 366.51, y: 290.38), controlPoint2: CGPoint(x: 290.38, y: 366.45))
+            shape.close()
+            tintColor.setFill()
+            shape.fill()
+            
+            context.restoreGState()
+        }
+
+        public class func drawPeopleCategory(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 400, height: 400), resizing: ResizingBehavior = .aspectFit, tintColor: UIColor) {
+            guard let context = UIGraphicsGetCurrentContext() else { return }
+            
+            context.saveGState()
+            let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 400, height: 400), target: targetFrame)
+            context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
+            context.scaleBy(x: resizedFrame.width / 400, y: resizedFrame.height / 400)
+            
+            let ovalPath = UIBezierPath(ovalIn: CGRect(x: 14, y: 14, width: 372, height: 372))
+            tintColor.setStroke()
+            ovalPath.lineWidth = 20
+            ovalPath.stroke()
+            
+            let oval2Path = UIBezierPath(ovalIn: CGRect(x: 235, y: 123, width: 46, height: 57))
+            tintColor.setFill()
+            oval2Path.fill()
+            
+            let oval3Path = UIBezierPath(ovalIn: CGRect(x: 120, y: 123, width: 46, height: 57))
+            tintColor.setFill()
+            oval3Path.fill()
+            
+            let bezierPath = UIBezierPath()
+            bezierPath.move(to: CGPoint(x: 199.5, y: 235.47))
+            bezierPath.addCurve(to: CGPoint(x: 334, y: 235.47), controlPoint1: CGPoint(x: 273.79, y: 235.47), controlPoint2: CGPoint(x: 334, y: 198.42))
+            bezierPath.addCurve(to: CGPoint(x: 199.5, y: 349), controlPoint1: CGPoint(x: 334, y: 272.52), controlPoint2: CGPoint(x: 282.27, y: 349))
+            bezierPath.addCurve(to: CGPoint(x: 65, y: 235.47), controlPoint1: CGPoint(x: 116.41, y: 349), controlPoint2: CGPoint(x: 65, y: 272.52))
+            bezierPath.addCurve(to: CGPoint(x: 199.5, y: 235.47), controlPoint1: CGPoint(x: 65, y: 198.42), controlPoint2: CGPoint(x: 125.21, y: 235.47))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 96.13, y: 239.21))
+            bezierPath.addCurve(to: CGPoint(x: 96, y: 239.93), controlPoint1: CGPoint(x: 96.05, y: 239.44), controlPoint2: CGPoint(x: 96, y: 239.68))
+            bezierPath.addLine(to: CGPoint(x: 96, y: 256.39))
+            bezierPath.addCurve(to: CGPoint(x: 96.82, y: 258), controlPoint1: CGPoint(x: 96, y: 257.03), controlPoint2: CGPoint(x: 96.3, y: 257.63))
+            bezierPath.addCurve(to: CGPoint(x: 199, y: 288), controlPoint1: CGPoint(x: 124.15, y: 278), controlPoint2: CGPoint(x: 158.21, y: 288))
+            bezierPath.addCurve(to: CGPoint(x: 301.18, y: 258), controlPoint1: CGPoint(x: 239.79, y: 288), controlPoint2: CGPoint(x: 273.85, y: 278))
+            bezierPath.addCurve(to: CGPoint(x: 302, y: 256.39), controlPoint1: CGPoint(x: 301.7, y: 257.63), controlPoint2: CGPoint(x: 302, y: 257.03))
+            bezierPath.addLine(to: CGPoint(x: 302, y: 239.93))
+            bezierPath.addCurve(to: CGPoint(x: 300, y: 237.93), controlPoint1: CGPoint(x: 302, y: 238.82), controlPoint2: CGPoint(x: 301.1, y: 237.93))
+            bezierPath.addCurve(to: CGPoint(x: 299.28, y: 238.06), controlPoint1: CGPoint(x: 299.75, y: 237.93), controlPoint2: CGPoint(x: 299.51, y: 237.97))
+            bezierPath.addCurve(to: CGPoint(x: 199, y: 257.4), controlPoint1: CGPoint(x: 265.85, y: 250.95), controlPoint2: CGPoint(x: 232.43, y: 257.4))
+            bezierPath.addCurve(to: CGPoint(x: 98.72, y: 238.06), controlPoint1: CGPoint(x: 165.57, y: 257.4), controlPoint2: CGPoint(x: 132.15, y: 250.95))
+            bezierPath.addCurve(to: CGPoint(x: 96.13, y: 239.21), controlPoint1: CGPoint(x: 97.69, y: 237.67), controlPoint2: CGPoint(x: 96.53, y: 238.18))
+            bezierPath.close()
+            bezierPath.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezierPath.fill()
+            
+            context.restoreGState()
+        }
+        
+        // MARK: - Nature Category
+
+         public class func drawNatureCategory(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 400, height: 400), resizing: ResizingBehavior = .aspectFit, tintColor: UIColor) {
+             guard let context = UIGraphicsGetCurrentContext() else { return }
+            
+            context.saveGState()
+            let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 400, height: 400), target: targetFrame)
+            context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
+            context.scaleBy(x: resizedFrame.width / 400, y: resizedFrame.height / 400)
+            
+            let bezierPath = UIBezierPath()
+            bezierPath.move(to: CGPoint(x: 252.54, y: 57.99))
+            bezierPath.addCurve(to: CGPoint(x: 337.17, y: 51.32), controlPoint1: CGPoint(x: 252.54, y: 57.99), controlPoint2: CGPoint(x: 298.47, y: 9.87))
+            bezierPath.addCurve(to: CGPoint(x: 327.12, y: 145.87), controlPoint1: CGPoint(x: 374.14, y: 90.93), controlPoint2: CGPoint(x: 327.12, y: 145.87))
+            tintColor.setStroke()
+            bezierPath.lineWidth = 20
+            bezierPath.miterLimit = 20
+            bezierPath.stroke()
+            
+            let bezier2Path = UIBezierPath()
+            bezier2Path.move(to: CGPoint(x: 153, y: 60.12))
+            bezier2Path.addCurve(to: CGPoint(x: 64.31, y: 51.11), controlPoint1: CGPoint(x: 153, y: 60.12), controlPoint2: CGPoint(x: 102.8, y: 10.2))
+            bezier2Path.addCurve(to: CGPoint(x: 73.25, y: 141), controlPoint1: CGPoint(x: 27.53, y: 90.2), controlPoint2: CGPoint(x: 73.25, y: 141))
+            tintColor.setStroke()
+            bezier2Path.lineWidth = 20
+            bezier2Path.miterLimit = 20
+            bezier2Path.stroke()
+            
+            let ovalPath = UIBezierPath(ovalIn: CGRect(x: 251, y: 172, width: 42, height: 57))
+            tintColor.setFill()
+            ovalPath.fill()
+            
+            let bezier3Path = UIBezierPath()
+            bezier3Path.move(to: CGPoint(x: 210.56, y: 292.46))
+            bezier3Path.addCurve(to: CGPoint(x: 201, y: 295), controlPoint1: CGPoint(x: 207.17, y: 294.04), controlPoint2: CGPoint(x: 203.88, y: 295))
+            bezier3Path.addCurve(to: CGPoint(x: 191.57, y: 292.53), controlPoint1: CGPoint(x: 198.15, y: 295), controlPoint2: CGPoint(x: 194.91, y: 294.07))
+            bezier3Path.addLine(to: CGPoint(x: 181.18, y: 286))
+            bezier3Path.addCurve(to: CGPoint(x: 164, y: 260.82), controlPoint1: CGPoint(x: 171.87, y: 278.65), controlPoint2: CGPoint(x: 164, y: 268.29))
+            bezier3Path.addCurve(to: CGPoint(x: 177.88, y: 248), controlPoint1: CGPoint(x: 164, y: 248), controlPoint2: CGPoint(x: 177.88, y: 248))
+            bezier3Path.addLine(to: CGPoint(x: 201, y: 248))
+            bezier3Path.addLine(to: CGPoint(x: 224.12, y: 248))
+            bezier3Path.addCurve(to: CGPoint(x: 238, y: 260.82), controlPoint1: CGPoint(x: 224.12, y: 248), controlPoint2: CGPoint(x: 238, y: 248))
+            bezier3Path.addCurve(to: CGPoint(x: 220.95, y: 285.9), controlPoint1: CGPoint(x: 238, y: 268.26), controlPoint2: CGPoint(x: 230.2, y: 278.54))
+            bezier3Path.addLine(to: CGPoint(x: 210.56, y: 292.46))
+            bezier3Path.close()
+            bezier3Path.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezier3Path.fill()
+            
+            let bezier4Path = UIBezierPath()
+            bezier4Path.move(to: CGPoint(x: 209.15, y: 319.52))
+            bezier4Path.addCurve(to: CGPoint(x: 212.7, y: 316.69), controlPoint1: CGPoint(x: 210.04, y: 319.52), controlPoint2: CGPoint(x: 212.44, y: 319.52))
+            bezier4Path.addLine(to: CGPoint(x: 223, y: 317.3))
+            bezier4Path.addCurve(to: CGPoint(x: 209.15, y: 330), controlPoint1: CGPoint(x: 222.75, y: 322.4), controlPoint2: CGPoint(x: 218.87, y: 330))
+            bezier4Path.addCurve(to: CGPoint(x: 199.58, y: 326.25), controlPoint1: CGPoint(x: 204.21, y: 330), controlPoint2: CGPoint(x: 201.22, y: 327.95))
+            bezier4Path.addCurve(to: CGPoint(x: 196, y: 317.05), controlPoint1: CGPoint(x: 195.97, y: 322.49), controlPoint2: CGPoint(x: 195.99, y: 317.48))
+            bezier4Path.addLine(to: CGPoint(x: 196, y: 288.66))
+            bezier4Path.addCurve(to: CGPoint(x: 206.32, y: 282), controlPoint1: CGPoint(x: 204.58, y: 283.07), controlPoint2: CGPoint(x: 204.58, y: 283.07))
+            bezier4Path.addLine(to: CGPoint(x: 206.32, y: 317.18))
+            bezier4Path.addCurve(to: CGPoint(x: 206.97, y: 318.93), controlPoint1: CGPoint(x: 206.32, y: 317.2), controlPoint2: CGPoint(x: 206.41, y: 318.36))
+            bezier4Path.addCurve(to: CGPoint(x: 209.15, y: 319.52), controlPoint1: CGPoint(x: 207.43, y: 319.42), controlPoint2: CGPoint(x: 208.41, y: 319.52))
+            bezier4Path.close()
+            bezier4Path.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezier4Path.fill()
+            
+            let bezier5Path = UIBezierPath()
+            bezier5Path.move(to: CGPoint(x: 209.15, y: 319.52))
+            bezier5Path.addCurve(to: CGPoint(x: 212.7, y: 316.69), controlPoint1: CGPoint(x: 210.04, y: 319.52), controlPoint2: CGPoint(x: 212.44, y: 319.52))
+            bezier5Path.addLine(to: CGPoint(x: 223, y: 317.3))
+            bezier5Path.addCurve(to: CGPoint(x: 209.15, y: 330), controlPoint1: CGPoint(x: 222.75, y: 322.4), controlPoint2: CGPoint(x: 218.87, y: 330))
+            bezier5Path.addCurve(to: CGPoint(x: 199.58, y: 326.25), controlPoint1: CGPoint(x: 204.21, y: 330), controlPoint2: CGPoint(x: 201.22, y: 327.95))
+            bezier5Path.addCurve(to: CGPoint(x: 196, y: 317.05), controlPoint1: CGPoint(x: 195.97, y: 322.49), controlPoint2: CGPoint(x: 195.99, y: 317.48))
+            bezier5Path.addLine(to: CGPoint(x: 196, y: 288.66))
+            bezier5Path.addCurve(to: CGPoint(x: 206.32, y: 282), controlPoint1: CGPoint(x: 204.58, y: 283.07), controlPoint2: CGPoint(x: 204.58, y: 283.07))
+            bezier5Path.addLine(to: CGPoint(x: 206.32, y: 317.18))
+            bezier5Path.addCurve(to: CGPoint(x: 206.97, y: 318.93), controlPoint1: CGPoint(x: 206.32, y: 317.2), controlPoint2: CGPoint(x: 206.41, y: 318.36))
+            bezier5Path.addCurve(to: CGPoint(x: 209.15, y: 319.52), controlPoint1: CGPoint(x: 207.43, y: 319.42), controlPoint2: CGPoint(x: 208.41, y: 319.52))
+            bezier5Path.close()
+            tintColor.setStroke()
+            bezier5Path.lineWidth = 1
+            bezier5Path.miterLimit = 1
+            bezier5Path.stroke()
+            
+            let bezier6Path = UIBezierPath()
+            bezier6Path.move(to: CGPoint(x: 192.85, y: 319.52))
+            bezier6Path.addCurve(to: CGPoint(x: 189.3, y: 316.69), controlPoint1: CGPoint(x: 191.96, y: 319.52), controlPoint2: CGPoint(x: 189.56, y: 319.52))
+            bezier6Path.addLine(to: CGPoint(x: 179, y: 317.3))
+            bezier6Path.addCurve(to: CGPoint(x: 192.85, y: 330), controlPoint1: CGPoint(x: 179.25, y: 322.4), controlPoint2: CGPoint(x: 183.13, y: 330))
+            bezier6Path.addCurve(to: CGPoint(x: 202.42, y: 326.25), controlPoint1: CGPoint(x: 197.79, y: 330), controlPoint2: CGPoint(x: 200.78, y: 327.95))
+            bezier6Path.addCurve(to: CGPoint(x: 206, y: 317.05), controlPoint1: CGPoint(x: 206.03, y: 322.49), controlPoint2: CGPoint(x: 206.01, y: 317.48))
+            bezier6Path.addLine(to: CGPoint(x: 206, y: 288.66))
+            bezier6Path.addCurve(to: CGPoint(x: 195.68, y: 282), controlPoint1: CGPoint(x: 197.42, y: 283.07), controlPoint2: CGPoint(x: 197.42, y: 283.07))
+            bezier6Path.addLine(to: CGPoint(x: 195.68, y: 317.18))
+            bezier6Path.addCurve(to: CGPoint(x: 195.03, y: 318.93), controlPoint1: CGPoint(x: 195.68, y: 317.2), controlPoint2: CGPoint(x: 195.59, y: 318.36))
+            bezier6Path.addCurve(to: CGPoint(x: 192.85, y: 319.52), controlPoint1: CGPoint(x: 194.57, y: 319.42), controlPoint2: CGPoint(x: 193.59, y: 319.52))
+            bezier6Path.close()
+            bezier6Path.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezier6Path.fill()
+            
+            let bezier7Path = UIBezierPath()
+            bezier7Path.move(to: CGPoint(x: 192.85, y: 319.52))
+            bezier7Path.addCurve(to: CGPoint(x: 189.3, y: 316.69), controlPoint1: CGPoint(x: 191.96, y: 319.52), controlPoint2: CGPoint(x: 189.56, y: 319.52))
+            bezier7Path.addLine(to: CGPoint(x: 179, y: 317.3))
+            bezier7Path.addCurve(to: CGPoint(x: 192.85, y: 330), controlPoint1: CGPoint(x: 179.25, y: 322.4), controlPoint2: CGPoint(x: 183.13, y: 330))
+            bezier7Path.addCurve(to: CGPoint(x: 202.42, y: 326.25), controlPoint1: CGPoint(x: 197.79, y: 330), controlPoint2: CGPoint(x: 200.78, y: 327.95))
+            bezier7Path.addCurve(to: CGPoint(x: 206, y: 317.05), controlPoint1: CGPoint(x: 206.03, y: 322.49), controlPoint2: CGPoint(x: 206.01, y: 317.48))
+            bezier7Path.addLine(to: CGPoint(x: 206, y: 288.66))
+            bezier7Path.addCurve(to: CGPoint(x: 195.68, y: 282), controlPoint1: CGPoint(x: 197.42, y: 283.07), controlPoint2: CGPoint(x: 197.42, y: 283.07))
+            bezier7Path.addLine(to: CGPoint(x: 195.68, y: 317.18))
+            bezier7Path.addCurve(to: CGPoint(x: 195.03, y: 318.93), controlPoint1: CGPoint(x: 195.68, y: 317.2), controlPoint2: CGPoint(x: 195.59, y: 318.36))
+            bezier7Path.addCurve(to: CGPoint(x: 192.85, y: 319.52), controlPoint1: CGPoint(x: 194.57, y: 319.42), controlPoint2: CGPoint(x: 193.59, y: 319.52))
+            bezier7Path.close()
+            tintColor.setStroke()
+            bezier7Path.lineWidth = 1
+            bezier7Path.miterLimit = 1
+            bezier7Path.stroke()
+            
+            let oval2Path = UIBezierPath(ovalIn: CGRect(x: 108, y: 172, width: 42, height: 57))
+            tintColor.setFill()
+            oval2Path.fill()
+            
+            let bezier8Path = UIBezierPath()
+            bezier8Path.move(to: CGPoint(x: 204.73, y: 43))
+            bezier8Path.addCurve(to: CGPoint(x: 65.18, y: 154.91), controlPoint1: CGPoint(x: 99.8, y: 43), controlPoint2: CGPoint(x: 65.18, y: 154.91))
+            bezier8Path.addCurve(to: CGPoint(x: 23.2, y: 262.68), controlPoint1: CGPoint(x: 65.18, y: 154.91), controlPoint2: CGPoint(x: 5.77, y: 200.68))
+            bezier8Path.addCurve(to: CGPoint(x: 111.35, y: 337.27), controlPoint1: CGPoint(x: 44.19, y: 337.27), controlPoint2: CGPoint(x: 111.35, y: 337.27))
+            bezier8Path.addLine(to: CGPoint(x: 131.72, y: 337.27))
+            bezier8Path.addLine(to: CGPoint(x: 139.92, y: 337.27))
+            bezier8Path.addCurve(to: CGPoint(x: 200.13, y: 366), controlPoint1: CGPoint(x: 155.98, y: 358.82), controlPoint2: CGPoint(x: 184.07, y: 366))
+            bezier8Path.addCurve(to: CGPoint(x: 259.85, y: 337.27), controlPoint1: CGPoint(x: 216.19, y: 366), controlPoint2: CGPoint(x: 243.8, y: 358.82))
+            bezier8Path.addLine(to: CGPoint(x: 269.08, y: 337.27))
+            bezier8Path.addLine(to: CGPoint(x: 288.65, y: 337.27))
+            bezier8Path.addCurve(to: CGPoint(x: 376.8, y: 262.68), controlPoint1: CGPoint(x: 288.65, y: 337.27), controlPoint2: CGPoint(x: 355.81, y: 337.27))
+            bezier8Path.addCurve(to: CGPoint(x: 334.82, y: 154.91), controlPoint1: CGPoint(x: 394.23, y: 200.68), controlPoint2: CGPoint(x: 334.82, y: 154.91))
+            bezier8Path.addCurve(to: CGPoint(x: 204.73, y: 43), controlPoint1: CGPoint(x: 334.82, y: 154.91), controlPoint2: CGPoint(x: 309.65, y: 43))
+            bezier8Path.close()
+            tintColor.setStroke()
+            bezier8Path.lineWidth = 20
+            bezier8Path.miterLimit = 20
+            bezier8Path.stroke()
+            
+            context.restoreGState()
+        }
+        
+        // MARK: - Food And Drink Category
+
+         public class func drawFoodAndDrinkCategory(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 400, height: 400), resizing: ResizingBehavior = .aspectFit, tintColor: UIColor) {
+             guard let context = UIGraphicsGetCurrentContext() else { return }
+            
+            context.saveGState()
+            let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 400, height: 400), target: targetFrame)
+            context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
+            context.scaleBy(x: resizedFrame.width / 400, y: resizedFrame.height / 400)
+            
+            let bezierPath = UIBezierPath()
+            bezierPath.move(to: CGPoint(x: 162.72, y: 99.23))
+            bezierPath.addLine(to: CGPoint(x: 171.73, y: 49.8))
+            bezierPath.addLine(to: CGPoint(x: 232.3, y: 70.5))
+            bezierPath.addLine(to: CGPoint(x: 239, y: 50.92))
+            bezierPath.addLine(to: CGPoint(x: 168.47, y: 26.82))
+            bezierPath.addCurve(to: CGPoint(x: 168.41, y: 26.8), controlPoint1: CGPoint(x: 168.45, y: 26.81), controlPoint2: CGPoint(x: 168.43, y: 26.81))
+            bezierPath.addLine(to: CGPoint(x: 167.12, y: 26.36))
+            bezierPath.addLine(to: CGPoint(x: 167.11, y: 26.39))
+            bezierPath.addCurve(to: CGPoint(x: 164.42, y: 26), controlPoint1: CGPoint(x: 166.25, y: 26.16), controlPoint2: CGPoint(x: 165.36, y: 26))
+            bezierPath.addCurve(to: CGPoint(x: 154.42, y: 33.82), controlPoint1: CGPoint(x: 159.59, y: 26), controlPoint2: CGPoint(x: 155.55, y: 29.32))
+            bezierPath.addLine(to: CGPoint(x: 154.38, y: 33.8))
+            bezierPath.addLine(to: CGPoint(x: 141.82, y: 99.23))
+            bezierPath.addLine(to: CGPoint(x: 162.72, y: 99.23))
+            bezierPath.close()
+            bezierPath.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezierPath.fill()
+            
+            let bezier2Path = UIBezierPath()
+            bezier2Path.move(to: CGPoint(x: 7, y: 99))
+            bezier2Path.addLine(to: CGPoint(x: 190, y: 99))
+            bezier2Path.addLine(to: CGPoint(x: 188.05, y: 119))
+            bezier2Path.addLine(to: CGPoint(x: 9.03, y: 119))
+            bezier2Path.addLine(to: CGPoint(x: 7, y: 99))
+            bezier2Path.close()
+            bezier2Path.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezier2Path.fill()
+            
+            let bezier3Path = UIBezierPath()
+            bezier3Path.move(to: CGPoint(x: 7, y: 99))
+            bezier3Path.addLine(to: CGPoint(x: 27, y: 99))
+            bezier3Path.addLine(to: CGPoint(x: 54.48, y: 374))
+            bezier3Path.addLine(to: CGPoint(x: 34.48, y: 374))
+            bezier3Path.addLine(to: CGPoint(x: 7, y: 99))
+            bezier3Path.close()
+            bezier3Path.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezier3Path.fill()
+            
+            let bezier4Path = UIBezierPath()
+            bezier4Path.move(to: CGPoint(x: 81.84, y: 304))
+            bezier4Path.addCurve(to: CGPoint(x: 73.04, y: 341.05), controlPoint1: CGPoint(x: 77.06, y: 316.6), controlPoint2: CGPoint(x: 72.91, y: 334.07))
+            bezier4Path.addCurve(to: CGPoint(x: 223.55, y: 373.92), controlPoint1: CGPoint(x: 73.75, y: 377.24), controlPoint2: CGPoint(x: 140.42, y: 373.92))
+            bezier4Path.addCurve(to: CGPoint(x: 376.96, y: 341.05), controlPoint1: CGPoint(x: 306.68, y: 373.92), controlPoint2: CGPoint(x: 376.96, y: 375))
+            bezier4Path.addCurve(to: CGPoint(x: 369.55, y: 304), controlPoint1: CGPoint(x: 376.96, y: 334.21), controlPoint2: CGPoint(x: 373.74, y: 316.84))
+            bezier4Path.addLine(to: CGPoint(x: 81.84, y: 304))
+            bezier4Path.close()
+            tintColor.setStroke()
+            bezier4Path.lineWidth = 20
+            bezier4Path.miterLimit = 20
+            bezier4Path.stroke()
+            
+            let bezier5Path = UIBezierPath()
+            bezier5Path.move(to: CGPoint(x: 371.87, y: 256))
+            bezier5Path.addLine(to: CGPoint(x: 354.12, y: 259.94))
+            bezier5Path.addLine(to: CGPoint(x: 220.85, y: 294.71))
+            bezier5Path.addLine(to: CGPoint(x: 217.15, y: 295.53))
+            bezier5Path.addLine(to: CGPoint(x: 213.46, y: 294.66))
+            bezier5Path.addLine(to: CGPoint(x: 76.01, y: 259.88))
+            bezier5Path.addLine(to: CGPoint(x: 67.14, y: 257.79))
+            bezier5Path.addCurve(to: CGPoint(x: 58, y: 282.87), controlPoint1: CGPoint(x: 59.99, y: 265.29), controlPoint2: CGPoint(x: 58, y: 275.21))
+            bezier5Path.addCurve(to: CGPoint(x: 76.47, y: 308), controlPoint1: CGPoint(x: 58, y: 292.74), controlPoint2: CGPoint(x: 63.95, y: 300.09))
+            bezier5Path.addLine(to: CGPoint(x: 375.41, y: 308))
+            bezier5Path.addCurve(to: CGPoint(x: 392, y: 280.66), controlPoint1: CGPoint(x: 388.58, y: 299.7), controlPoint2: CGPoint(x: 392, y: 290.83))
+            bezier5Path.addCurve(to: CGPoint(x: 381.54, y: 256.02), controlPoint1: CGPoint(x: 392, y: 272.11), controlPoint2: CGPoint(x: 391.21, y: 263.33))
+            bezier5Path.addCurve(to: CGPoint(x: 371.87, y: 256), controlPoint1: CGPoint(x: 381.2, y: 256.01), controlPoint2: CGPoint(x: 377.7, y: 256.01))
+            bezier5Path.close()
+            bezier5Path.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezier5Path.fill()
+            
+            context.saveGState()
+            context.beginTransparencyLayer(auxiliaryInfo: nil)
+            
+            let clipPath = UIBezierPath()
+            clipPath.move(to: CGPoint(x: 373.74, y: 246))
+            clipPath.addLine(to: CGPoint(x: 76.26, y: 246))
+            clipPath.addLine(to: CGPoint(x: 216.78, y: 293))
+            clipPath.addLine(to: CGPoint(x: 373.74, y: 246))
+            clipPath.close()
+            clipPath.move(to: CGPoint(x: 60.24, y: 230))
+            clipPath.addLine(to: CGPoint(x: 389.76, y: 230))
+            clipPath.addLine(to: CGPoint(x: 389.76, y: 309))
+            clipPath.addLine(to: CGPoint(x: 60.24, y: 309))
+            clipPath.addLine(to: CGPoint(x: 60.24, y: 230))
+            clipPath.close()
+            clipPath.usesEvenOddFillRule = true
+            clipPath.addClip()
+            
+            let bezier6Path = UIBezierPath()
+            bezier6Path.move(to: CGPoint(x: 373.74, y: 246))
+            bezier6Path.addLine(to: CGPoint(x: 76.26, y: 246))
+            bezier6Path.addLine(to: CGPoint(x: 216.78, y: 293))
+            bezier6Path.addLine(to: CGPoint(x: 373.74, y: 246))
+            bezier6Path.close()
+            tintColor.setStroke()
+            bezier6Path.lineWidth = 30
+            bezier6Path.miterLimit = 30
+            bezier6Path.lineJoinStyle = .round
+            bezier6Path.stroke()
+
+            context.endTransparencyLayer()
+            context.restoreGState()
+            
+            let bezier8Path = UIBezierPath()
+            bezier8Path.move(to: CGPoint(x: 69.25, y: 237))
+            bezier8Path.addLine(to: CGPoint(x: 378.66, y: 237))
+            bezier8Path.addCurve(to: CGPoint(x: 382.33, y: 226.8), controlPoint1: CGPoint(x: 380.81, y: 234.35), controlPoint2: CGPoint(x: 382.33, y: 232.07))
+            bezier8Path.addCurve(to: CGPoint(x: 225.61, y: 154), controlPoint1: CGPoint(x: 382.33, y: 178.81), controlPoint2: CGPoint(x: 311.99, y: 154))
+            bezier8Path.addCurve(to: CGPoint(x: 67.67, y: 226.8), controlPoint1: CGPoint(x: 139.24, y: 154), controlPoint2: CGPoint(x: 67.67, y: 178.81))
+            bezier8Path.addCurve(to: CGPoint(x: 69.25, y: 237), controlPoint1: CGPoint(x: 67.67, y: 230.85), controlPoint2: CGPoint(x: 68.27, y: 234.07))
+            bezier8Path.close()
+            tintColor.setStroke()
+            bezier8Path.lineWidth = 20
+            bezier8Path.miterLimit = 20
+            bezier8Path.stroke()
+            
+            let rectanglePath = UIBezierPath(rect: CGRect(x: 49, y: 354, width: 41, height: 20))
+            tintColor.setFill()
+            rectanglePath.fill()
+            
+            let bezier9Path = UIBezierPath()
+            bezier9Path.move(to: CGPoint(x: 170, y: 99))
+            bezier9Path.addLine(to: CGPoint(x: 190, y: 99))
+            bezier9Path.addLine(to: CGPoint(x: 184.4, y: 156))
+            bezier9Path.addLine(to: CGPoint(x: 164.4, y: 156))
+            bezier9Path.addLine(to: CGPoint(x: 170, y: 99))
+            bezier9Path.close()
+            bezier9Path.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezier9Path.fill()
+            
+            context.restoreGState()
+        }
+            
+        // MARK: - Activity Category
+
+         public class func drawActivityCategory(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 400, height: 400), resizing: ResizingBehavior = .aspectFit, tintColor: UIColor) {
+             guard let context = UIGraphicsGetCurrentContext() else { return }
+            
+            context.saveGState()
+            let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 400, height: 400), target: targetFrame)
+            context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
+            context.scaleBy(x: resizedFrame.width / 400, y: resizedFrame.height / 400)
+             
+             let ovalPath = UIBezierPath(ovalIn: CGRect(x: 12, y: 12, width: 376, height: 376))
+             tintColor.setStroke()
+             ovalPath.lineWidth = 20
+             ovalPath.stroke()
+             
+             let bezierPath = UIBezierPath()
+             bezierPath.move(to: CGPoint(x: 271.2, y: 292.04))
+             bezierPath.addLine(to: CGPoint(x: 223.21, y: 278.64))
+             bezierPath.addLine(to: CGPoint(x: 176.15, y: 303.11))
+             bezierPath.addLine(to: CGPoint(x: 160.88, y: 292.96))
+             bezierPath.addLine(to: CGPoint(x: 218.46, y: 262.95))
+             bezierPath.addLine(to: CGPoint(x: 218.46, y: 206.41))
+             bezierPath.addLine(to: CGPoint(x: 228.52, y: 186.19))
+             bezierPath.addLine(to: CGPoint(x: 271.36, y: 160.45))
+             bezierPath.addCurve(to: CGPoint(x: 271.36, y: 96.97), controlPoint1: CGPoint(x: 270.38, y: 112.38), controlPoint2: CGPoint(x: 270.38, y: 91.22))
+             bezierPath.addLine(to: CGPoint(x: 290.26, y: 103.94))
+             bezierPath.addCurve(to: CGPoint(x: 290.2, y: 154.07), controlPoint1: CGPoint(x: 290.01, y: 127.78), controlPoint2: CGPoint(x: 289.98, y: 144.49))
+             bezierPath.addLine(to: CGPoint(x: 291.03, y: 153.66))
+             bezierPath.addLine(to: CGPoint(x: 324.56, y: 206.82))
+             bezierPath.addLine(to: CGPoint(x: 366.84, y: 197.49))
+             bezierPath.addLine(to: CGPoint(x: 371.7, y: 172.12))
+             bezierPath.addLine(to: CGPoint(x: 377.33, y: 172.12))
+             bezierPath.addCurve(to: CGPoint(x: 377.25, y: 231.7), controlPoint1: CGPoint(x: 380.66, y: 192.11), controlPoint2: CGPoint(x: 380.63, y: 211.97))
+             bezierPath.addLine(to: CGPoint(x: 366.55, y: 211.7))
+             bezierPath.addLine(to: CGPoint(x: 332.9, y: 220.04))
+             bezierPath.addLine(to: CGPoint(x: 288.61, y: 292.39))
+             bezierPath.addLine(to: CGPoint(x: 287.01, y: 336.04))
+             bezierPath.addLine(to: CGPoint(x: 313.26, y: 339.26))
+             bezierPath.addCurve(to: CGPoint(x: 271.2, y: 366.02), controlPoint1: CGPoint(x: 299.74, y: 350.26), controlPoint2: CGPoint(x: 285.72, y: 359.18))
+             bezierPath.addCurve(to: CGPoint(x: 229.32, y: 378.29), controlPoint1: CGPoint(x: 256.68, y: 372.86), controlPoint2: CGPoint(x: 242.72, y: 376.95))
+             bezierPath.addLine(to: CGPoint(x: 229.34, y: 372.51))
+             bezierPath.addLine(to: CGPoint(x: 176.28, y: 353.04))
+             bezierPath.addLine(to: CGPoint(x: 176.15, y: 341.41))
+             bezierPath.addLine(to: CGPoint(x: 237.51, y: 363.66))
+             bezierPath.addLine(to: CGPoint(x: 270.66, y: 341.32))
+             bezierPath.addCurve(to: CGPoint(x: 271.2, y: 292.04), controlPoint1: CGPoint(x: 271.02, y: 308.46), controlPoint2: CGPoint(x: 271.2, y: 292.04))
+             bezierPath.close()
+             bezierPath.usesEvenOddFillRule = true
+             tintColor.setFill()
+             bezierPath.fill()
+             
+             let bezier2Path = UIBezierPath()
+             bezier2Path.move(to: CGPoint(x: 218.46, y: 206.41))
+             bezier2Path.addLine(to: CGPoint(x: 155.31, y: 171.03))
+             bezier2Path.addLine(to: CGPoint(x: 166.06, y: 153.14))
+             bezier2Path.addLine(to: CGPoint(x: 228.52, y: 186.19))
+             bezier2Path.addLine(to: CGPoint(x: 218.46, y: 206.41))
+             bezier2Path.close()
+             bezier2Path.usesEvenOddFillRule = true
+             tintColor.setFill()
+             bezier2Path.fill()
+             
+             let bezier3Path = UIBezierPath()
+             bezier3Path.move(to: CGPoint(x: 219.36, y: 52.44))
+             bezier3Path.addLine(to: CGPoint(x: 219.36, y: 22.29))
+             bezier3Path.addLine(to: CGPoint(x: 222.91, y: 20))
+             bezier3Path.addCurve(to: CGPoint(x: 282.56, y: 37.15), controlPoint1: CGPoint(x: 243.58, y: 22.84), controlPoint2: CGPoint(x: 264.27, y: 27.8))
+             bezier3Path.addCurve(to: CGPoint(x: 334.14, y: 77.17), controlPoint1: CGPoint(x: 301.64, y: 46.91), controlPoint2: CGPoint(x: 320.37, y: 62.64))
+             bezier3Path.addLine(to: CGPoint(x: 334.14, y: 83.09))
+             bezier3Path.addLine(to: CGPoint(x: 290.07, y: 104.06))
+             bezier3Path.addLine(to: CGPoint(x: 271.11, y: 96.99))
+             bezier3Path.addLine(to: CGPoint(x: 221.32, y: 65.69))
+             bezier3Path.addLine(to: CGPoint(x: 219.36, y: 52.44))
+             bezier3Path.close()
+             bezier3Path.usesEvenOddFillRule = true
+             tintColor.setFill()
+             bezier3Path.fill()
+             
+             let bezier4Path = UIBezierPath()
+             bezier4Path.move(to: CGPoint(x: 161.74, y: 81.17))
+             bezier4Path.addLine(to: CGPoint(x: 219.36, y: 51.18))
+             bezier4Path.addLine(to: CGPoint(x: 221.76, y: 65.9))
+             bezier4Path.addLine(to: CGPoint(x: 165.57, y: 96.97))
+             bezier4Path.addLine(to: CGPoint(x: 161.74, y: 81.17))
+             bezier4Path.close()
+             bezier4Path.usesEvenOddFillRule = true
+             tintColor.setFill()
+             bezier4Path.fill()
+             
+             let bezier5Path = UIBezierPath()
+             bezier5Path.move(to: CGPoint(x: 92.54, y: 201.76))
+             bezier5Path.addLine(to: CGPoint(x: 61.64, y: 153.48))
+             bezier5Path.addLine(to: CGPoint(x: 20.79, y: 171.7))
+             bezier5Path.addLine(to: CGPoint(x: 21.59, y: 167.08))
+             bezier5Path.addCurve(to: CGPoint(x: 23.57, y: 157.03), controlPoint1: CGPoint(x: 22.16, y: 163.7), controlPoint2: CGPoint(x: 22.8, y: 160.34))
+             bezier5Path.addLine(to: CGPoint(x: 23.85, y: 155.81))
+             bezier5Path.addLine(to: CGPoint(x: 58.31, y: 140.41))
+             bezier5Path.addLine(to: CGPoint(x: 92.49, y: 85.71))
+             bezier5Path.addLine(to: CGPoint(x: 85.08, y: 63.23))
+             bezier5Path.addCurve(to: CGPoint(x: 90.63, y: 58.42), controlPoint1: CGPoint(x: 85.08, y: 63.23), controlPoint2: CGPoint(x: 89.12, y: 59.56))
+             bezier5Path.addCurve(to: CGPoint(x: 96.83, y: 54.32), controlPoint1: CGPoint(x: 92.14, y: 57.27), controlPoint2: CGPoint(x: 96.83, y: 54.32))
+             bezier5Path.addLine(to: CGPoint(x: 107.11, y: 80.23))
+             bezier5Path.addLine(to: CGPoint(x: 161.74, y: 81.17))
+             bezier5Path.addLine(to: CGPoint(x: 165.57, y: 96.97))
+             bezier5Path.addLine(to: CGPoint(x: 166.06, y: 153.14))
+             bezier5Path.addLine(to: CGPoint(x: 155.31, y: 171.03))
+             bezier5Path.addLine(to: CGPoint(x: 108.93, y: 201.29))
+             bezier5Path.addLine(to: CGPoint(x: 92.54, y: 201.76))
+             bezier5Path.close()
+             bezier5Path.usesEvenOddFillRule = true
+             tintColor.setFill()
+             bezier5Path.fill()
+             
+             let bezier6Path = UIBezierPath()
+             bezier6Path.move(to: CGPoint(x: 92.54, y: 258.03))
+             bezier6Path.addLine(to: CGPoint(x: 109.23, y: 264.27))
+             bezier6Path.addLine(to: CGPoint(x: 108.93, y: 201.08))
+             bezier6Path.addLine(to: CGPoint(x: 92.54, y: 201.76))
+             bezier6Path.addLine(to: CGPoint(x: 92.54, y: 258.03))
+             bezier6Path.close()
+             bezier6Path.usesEvenOddFillRule = true
+             tintColor.setFill()
+             bezier6Path.fill()
+             
+             let bezier7Path = UIBezierPath()
+             bezier7Path.move(to: CGPoint(x: 176.28, y: 353.04))
+             bezier7Path.addLine(to: CGPoint(x: 128.8, y: 355.44))
+             bezier7Path.addLine(to: CGPoint(x: 128.45, y: 367.25))
+             bezier7Path.addCurve(to: CGPoint(x: 122.34, y: 365.38), controlPoint1: CGPoint(x: 128.45, y: 367.25), controlPoint2: CGPoint(x: 125.65, y: 367.03))
+             bezier7Path.addCurve(to: CGPoint(x: 116.74, y: 360.91), controlPoint1: CGPoint(x: 119.05, y: 363.74), controlPoint2: CGPoint(x: 116.74, y: 360.91))
+             bezier7Path.addLine(to: CGPoint(x: 117.04, y: 348.63))
+             bezier7Path.addLine(to: CGPoint(x: 74.53, y: 300.03))
+             bezier7Path.addLine(to: CGPoint(x: 50.83, y: 303.81))
+             bezier7Path.addLine(to: CGPoint(x: 43.07, y: 292))
+             bezier7Path.addLine(to: CGPoint(x: 64.18, y: 288.34))
+             bezier7Path.addLine(to: CGPoint(x: 92.54, y: 258.03))
+             bezier7Path.addLine(to: CGPoint(x: 109.23, y: 264.27))
+             bezier7Path.addLine(to: CGPoint(x: 160.88, y: 292.96))
+             bezier7Path.addLine(to: CGPoint(x: 176.15, y: 303.11))
+             bezier7Path.addCurve(to: CGPoint(x: 176.15, y: 341.41), controlPoint1: CGPoint(x: 176.12, y: 320.26), controlPoint2: CGPoint(x: 176.12, y: 333.02))
+             bezier7Path.addLine(to: CGPoint(x: 176.28, y: 353.04))
+             bezier7Path.close()
+             bezier7Path.usesEvenOddFillRule = true
+             tintColor.setFill()
+             bezier7Path.fill()
+        }
+        
+        // MARK: - Travel And Places Category
+
+         public class func drawTravelAndPlacesCategory(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 400, height: 400), resizing: ResizingBehavior = .aspectFit, tintColor: UIColor) {
+             guard let context = UIGraphicsGetCurrentContext() else { return }
+            
+            context.saveGState()
+            let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 400, height: 400), target: targetFrame)
+            context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
+            context.scaleBy(x: resizedFrame.width / 400, y: resizedFrame.height / 400)
+            
+            let bezierPath = UIBezierPath()
+            bezierPath.move(to: CGPoint(x: 221, y: 51))
+            bezierPath.addLine(to: CGPoint(x: 189, y: 51))
+            bezierPath.addLine(to: CGPoint(x: 189, y: 83))
+            bezierPath.addLine(to: CGPoint(x: 221, y: 83))
+            bezierPath.addLine(to: CGPoint(x: 221, y: 51))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 189, y: 136))
+            bezierPath.addLine(to: CGPoint(x: 221, y: 136))
+            bezierPath.addLine(to: CGPoint(x: 221, y: 104))
+            bezierPath.addLine(to: CGPoint(x: 189, y: 104))
+            bezierPath.addLine(to: CGPoint(x: 189, y: 136))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 263.67, y: 115.06))
+            bezierPath.addLine(to: CGPoint(x: 263.67, y: 8))
+            bezierPath.addLine(to: CGPoint(x: 92.56, y: 8))
+            bezierPath.addLine(to: CGPoint(x: 92.56, y: 147.18))
+            bezierPath.addLine(to: CGPoint(x: 7, y: 147.18))
+            bezierPath.addLine(to: CGPoint(x: 7, y: 372))
+            bezierPath.addLine(to: CGPoint(x: 28.39, y: 372))
+            bezierPath.addLine(to: CGPoint(x: 28.39, y: 168.59))
+            bezierPath.addLine(to: CGPoint(x: 113.94, y: 168.59))
+            bezierPath.addLine(to: CGPoint(x: 113.94, y: 29.41))
+            bezierPath.addLine(to: CGPoint(x: 242.28, y: 29.41))
+            bezierPath.addLine(to: CGPoint(x: 242.28, y: 136.47))
+            bezierPath.addLine(to: CGPoint(x: 263.67, y: 136.47))
+            bezierPath.addLine(to: CGPoint(x: 370.61, y: 136.47))
+            bezierPath.addLine(to: CGPoint(x: 370.61, y: 372))
+            bezierPath.addLine(to: CGPoint(x: 392, y: 372))
+            bezierPath.addLine(to: CGPoint(x: 392, y: 115.06))
+            bezierPath.addLine(to: CGPoint(x: 263.67, y: 115.06))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 135, y: 136))
+            bezierPath.addLine(to: CGPoint(x: 167, y: 136))
+            bezierPath.addLine(to: CGPoint(x: 167, y: 104))
+            bezierPath.addLine(to: CGPoint(x: 135, y: 104))
+            bezierPath.addLine(to: CGPoint(x: 135, y: 136))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 317, y: 243))
+            bezierPath.addLine(to: CGPoint(x: 349, y: 243))
+            bezierPath.addLine(to: CGPoint(x: 349, y: 211))
+            bezierPath.addLine(to: CGPoint(x: 317, y: 211))
+            bezierPath.addLine(to: CGPoint(x: 317, y: 243))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 317, y: 190))
+            bezierPath.addLine(to: CGPoint(x: 349, y: 190))
+            bezierPath.addLine(to: CGPoint(x: 349, y: 158))
+            bezierPath.addLine(to: CGPoint(x: 317, y: 158))
+            bezierPath.addLine(to: CGPoint(x: 317, y: 190))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 167, y: 51))
+            bezierPath.addLine(to: CGPoint(x: 135, y: 51))
+            bezierPath.addLine(to: CGPoint(x: 135, y: 83))
+            bezierPath.addLine(to: CGPoint(x: 167, y: 83))
+            bezierPath.addLine(to: CGPoint(x: 167, y: 51))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 82, y: 190))
+            bezierPath.addLine(to: CGPoint(x: 50, y: 190))
+            bezierPath.addLine(to: CGPoint(x: 50, y: 222))
+            bezierPath.addLine(to: CGPoint(x: 82, y: 222))
+            bezierPath.addLine(to: CGPoint(x: 82, y: 190))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 290.5, y: 321))
+            bezierPath.addCurve(to: CGPoint(x: 272, y: 302.5), controlPoint1: CGPoint(x: 280.28, y: 321), controlPoint2: CGPoint(x: 272, y: 312.72))
+            bezierPath.addCurve(to: CGPoint(x: 290.5, y: 284), controlPoint1: CGPoint(x: 272, y: 292.29), controlPoint2: CGPoint(x: 280.28, y: 284))
+            bezierPath.addCurve(to: CGPoint(x: 309, y: 302.5), controlPoint1: CGPoint(x: 300.72, y: 284), controlPoint2: CGPoint(x: 309, y: 292.29))
+            bezierPath.addCurve(to: CGPoint(x: 290.5, y: 321), controlPoint1: CGPoint(x: 309, y: 312.72), controlPoint2: CGPoint(x: 300.72, y: 321))
+            bezierPath.addLine(to: CGPoint(x: 290.5, y: 321))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 199.5, y: 265))
+            bezierPath.addLine(to: CGPoint(x: 127, y: 265))
+            bezierPath.addCurve(to: CGPoint(x: 199.5, y: 189), controlPoint1: CGPoint(x: 127, y: 226.35), controlPoint2: CGPoint(x: 127, y: 189))
+            bezierPath.addCurve(to: CGPoint(x: 272, y: 265), controlPoint1: CGPoint(x: 272, y: 189), controlPoint2: CGPoint(x: 272, y: 226.35))
+            bezierPath.addLine(to: CGPoint(x: 199.5, y: 265))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 253.6, y: 339))
+            bezierPath.addLine(to: CGPoint(x: 146.4, y: 339))
+            bezierPath.addCurve(to: CGPoint(x: 133, y: 328.5), controlPoint1: CGPoint(x: 139, y: 339), controlPoint2: CGPoint(x: 133, y: 334.3))
+            bezierPath.addCurve(to: CGPoint(x: 146.4, y: 318), controlPoint1: CGPoint(x: 133, y: 322.7), controlPoint2: CGPoint(x: 139, y: 318))
+            bezierPath.addLine(to: CGPoint(x: 253.6, y: 318))
+            bezierPath.addCurve(to: CGPoint(x: 267, y: 328.5), controlPoint1: CGPoint(x: 261, y: 318), controlPoint2: CGPoint(x: 267, y: 322.7))
+            bezierPath.addCurve(to: CGPoint(x: 253.6, y: 339), controlPoint1: CGPoint(x: 267, y: 334.3), controlPoint2: CGPoint(x: 261, y: 339))
+            bezierPath.addLine(to: CGPoint(x: 253.6, y: 339))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 108.5, y: 321))
+            bezierPath.addCurve(to: CGPoint(x: 90, y: 302.5), controlPoint1: CGPoint(x: 98.28, y: 321), controlPoint2: CGPoint(x: 90, y: 312.72))
+            bezierPath.addCurve(to: CGPoint(x: 108.5, y: 284), controlPoint1: CGPoint(x: 90, y: 292.29), controlPoint2: CGPoint(x: 98.28, y: 284))
+            bezierPath.addCurve(to: CGPoint(x: 127, y: 302.5), controlPoint1: CGPoint(x: 118.72, y: 284), controlPoint2: CGPoint(x: 127, y: 292.29))
+            bezierPath.addCurve(to: CGPoint(x: 108.5, y: 321), controlPoint1: CGPoint(x: 127, y: 312.72), controlPoint2: CGPoint(x: 118.72, y: 321))
+            bezierPath.addLine(to: CGPoint(x: 108.5, y: 321))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 304.63, y: 258.98))
+            bezierPath.addLine(to: CGPoint(x: 296.07, y: 258.98))
+            bezierPath.addLine(to: CGPoint(x: 296.07, y: 240.46))
+            bezierPath.addCurve(to: CGPoint(x: 223.64, y: 168), controlPoint1: CGPoint(x: 296.07, y: 200.44), controlPoint2: CGPoint(x: 263.63, y: 168))
+            bezierPath.addLine(to: CGPoint(x: 175.36, y: 168))
+            bezierPath.addCurve(to: CGPoint(x: 102.93, y: 240.46), controlPoint1: CGPoint(x: 135.36, y: 168), controlPoint2: CGPoint(x: 102.93, y: 200.44))
+            bezierPath.addLine(to: CGPoint(x: 102.93, y: 258.98))
+            bezierPath.addLine(to: CGPoint(x: 94.37, y: 258.98))
+            bezierPath.addCurve(to: CGPoint(x: 71, y: 284.44), controlPoint1: CGPoint(x: 81.46, y: 258.98), controlPoint2: CGPoint(x: 71, y: 270.39))
+            bezierPath.addLine(to: CGPoint(x: 71, y: 335.39))
+            bezierPath.addCurve(to: CGPoint(x: 81.71, y: 356.75), controlPoint1: CGPoint(x: 71, y: 344.36), controlPoint2: CGPoint(x: 75.27, y: 352.21))
+            bezierPath.addLine(to: CGPoint(x: 81.71, y: 379.27))
+            bezierPath.addCurve(to: CGPoint(x: 93.78, y: 391.36), controlPoint1: CGPoint(x: 81.71, y: 385.95), controlPoint2: CGPoint(x: 87.12, y: 391.36))
+            bezierPath.addLine(to: CGPoint(x: 117.91, y: 391.36))
+            bezierPath.addCurve(to: CGPoint(x: 129.99, y: 379.27), controlPoint1: CGPoint(x: 124.58, y: 391.36), controlPoint2: CGPoint(x: 129.99, y: 385.95))
+            bezierPath.addLine(to: CGPoint(x: 129.99, y: 360.86))
+            bezierPath.addLine(to: CGPoint(x: 269.01, y: 360.86))
+            bezierPath.addLine(to: CGPoint(x: 269.01, y: 380.93))
+            bezierPath.addCurve(to: CGPoint(x: 281.09, y: 393), controlPoint1: CGPoint(x: 269.01, y: 387.59), controlPoint2: CGPoint(x: 274.42, y: 393))
+            bezierPath.addLine(to: CGPoint(x: 305.22, y: 393))
+            bezierPath.addCurve(to: CGPoint(x: 317.29, y: 380.93), controlPoint1: CGPoint(x: 311.88, y: 393), controlPoint2: CGPoint(x: 317.29, y: 387.59))
+            bezierPath.addLine(to: CGPoint(x: 317.29, y: 357.14))
+            bezierPath.addLine(to: CGPoint(x: 316.63, y: 357.14))
+            bezierPath.addCurve(to: CGPoint(x: 328, y: 335.39), controlPoint1: CGPoint(x: 323.42, y: 352.68), controlPoint2: CGPoint(x: 328, y: 344.66))
+            bezierPath.addLine(to: CGPoint(x: 328, y: 284.44))
+            bezierPath.addCurve(to: CGPoint(x: 304.63, y: 258.98), controlPoint1: CGPoint(x: 328, y: 270.39), controlPoint2: CGPoint(x: 317.54, y: 258.98))
+            bezierPath.addLine(to: CGPoint(x: 304.63, y: 258.98))
+            bezierPath.close()
+            bezierPath.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezierPath.fill()
+            
+            context.endTransparencyLayer()
+            context.restoreGState()
+        }
+        
+        // MARK: - Objects Category
+
+         public class func drawObjectsCategory(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 400, height: 400), resizing: ResizingBehavior = .aspectFit, tintColor: UIColor) {
+             guard let context = UIGraphicsGetCurrentContext() else { return }
+            
+            context.saveGState()
+            let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 400, height: 400), target: targetFrame)
+            context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
+            context.scaleBy(x: resizedFrame.width / 400, y: resizedFrame.height / 400)
+             
+             let bezierPath = UIBezierPath()
+             bezierPath.move(to: CGPoint(x: 234.36, y: 197.39))
+             bezierPath.addCurve(to: CGPoint(x: 229.92, y: 196.76), controlPoint1: CGPoint(x: 232.82, y: 197.39), controlPoint2: CGPoint(x: 231.34, y: 197.14))
+             bezierPath.addLine(to: CGPoint(x: 208.94, y: 216.11))
+             bezierPath.addLine(to: CGPoint(x: 208.94, y: 281.31))
+             bezierPath.addLine(to: CGPoint(x: 188.6, y: 281.31))
+             bezierPath.addLine(to: CGPoint(x: 188.6, y: 216.46))
+             bezierPath.addLine(to: CGPoint(x: 167.34, y: 196.86))
+             bezierPath.addCurve(to: CGPoint(x: 163.17, y: 197.39), controlPoint1: CGPoint(x: 166, y: 197.18), controlPoint2: CGPoint(x: 164.62, y: 197.39))
+             bezierPath.addCurve(to: CGPoint(x: 145.38, y: 179.59), controlPoint1: CGPoint(x: 153.34, y: 197.39), controlPoint2: CGPoint(x: 145.38, y: 189.43))
+             bezierPath.addCurve(to: CGPoint(x: 163.17, y: 161.79), controlPoint1: CGPoint(x: 145.38, y: 169.76), controlPoint2: CGPoint(x: 153.34, y: 161.79))
+             bezierPath.addCurve(to: CGPoint(x: 180.97, y: 179.59), controlPoint1: CGPoint(x: 173.01, y: 161.79), controlPoint2: CGPoint(x: 180.97, y: 169.76))
+             bezierPath.addCurve(to: CGPoint(x: 179.85, y: 185.63), controlPoint1: CGPoint(x: 180.97, y: 181.72), controlPoint2: CGPoint(x: 180.53, y: 183.73))
+             bezierPath.addLine(to: CGPoint(x: 198.58, y: 202.9))
+             bezierPath.addLine(to: CGPoint(x: 217.6, y: 185.35))
+             bezierPath.addCurve(to: CGPoint(x: 216.57, y: 179.59), controlPoint1: CGPoint(x: 216.98, y: 183.54), controlPoint2: CGPoint(x: 216.57, y: 181.62))
+             bezierPath.addCurve(to: CGPoint(x: 234.36, y: 161.79), controlPoint1: CGPoint(x: 216.57, y: 169.76), controlPoint2: CGPoint(x: 224.53, y: 161.79))
+             bezierPath.addCurve(to: CGPoint(x: 252.16, y: 179.59), controlPoint1: CGPoint(x: 244.2, y: 161.79), controlPoint2: CGPoint(x: 252.16, y: 169.76))
+             bezierPath.addCurve(to: CGPoint(x: 234.36, y: 197.39), controlPoint1: CGPoint(x: 252.16, y: 189.43), controlPoint2: CGPoint(x: 244.2, y: 197.39))
+             bezierPath.addLine(to: CGPoint(x: 234.36, y: 197.39))
+             bezierPath.close()
+             bezierPath.usesEvenOddFillRule = true
+             tintColor.setFill()
+             bezierPath.fill()
+             
+             let rectanglePath = UIBezierPath(rect: CGRect(x: 156.15, y: 300.7, width: 86, height: 21))
+             tintColor.setFill()
+             rectanglePath.fill()
+             
+             let bezier2Path = UIBezierPath()
+             bezier2Path.move(to: CGPoint(x: 158.11, y: 335.47))
+             bezier2Path.addLine(to: CGPoint(x: 207.02, y: 335.47))
+             bezier2Path.addCurve(to: CGPoint(x: 211.02, y: 339.47), controlPoint1: CGPoint(x: 209.22, y: 335.47), controlPoint2: CGPoint(x: 211.02, y: 337.27))
+             bezier2Path.addLine(to: CGPoint(x: 211.02, y: 352.05))
+             bezier2Path.addCurve(to: CGPoint(x: 207.02, y: 356.05), controlPoint1: CGPoint(x: 211.02, y: 354.26), controlPoint2: CGPoint(x: 209.22, y: 356.05))
+             bezier2Path.addLine(to: CGPoint(x: 158.11, y: 356.05))
+             bezier2Path.addLine(to: CGPoint(x: 158.11, y: 356.05))
+             bezier2Path.addLine(to: CGPoint(x: 158.11, y: 335.47))
+             bezier2Path.close()
+             bezier2Path.usesEvenOddFillRule = true
+             tintColor.setFill()
+             bezier2Path.fill()
+             
+             context.saveGState()
+             context.beginTransparencyLayer(auxiliaryInfo: nil)
+             
+             let clipPath = UIBezierPath()
+             clipPath.move(to: CGPoint(x: 199.07, y: 7))
+             clipPath.addCurve(to: CGPoint(x: 67, y: 135.67), controlPoint1: CGPoint(x: 123.58, y: 7), controlPoint2: CGPoint(x: 67, y: 64.73))
+             clipPath.addCurve(to: CGPoint(x: 98.16, y: 229.46), controlPoint1: CGPoint(x: 67, y: 171.81), controlPoint2: CGPoint(x: 76.75, y: 210.58))
+             clipPath.addCurve(to: CGPoint(x: 136.21, y: 300.54), controlPoint1: CGPoint(x: 118.3, y: 250.79), controlPoint2: CGPoint(x: 132.99, y: 273.33))
+             clipPath.addLine(to: CGPoint(x: 138.69, y: 321.52))
+             clipPath.addLine(to: CGPoint(x: 138.69, y: 368.62))
+             clipPath.addCurve(to: CGPoint(x: 157.44, y: 389.73), controlPoint1: CGPoint(x: 138.69, y: 379), controlPoint2: CGPoint(x: 146.57, y: 387.88))
+             clipPath.addCurve(to: CGPoint(x: 199.07, y: 393), controlPoint1: CGPoint(x: 167.3, y: 391.42), controlPoint2: CGPoint(x: 186.97, y: 393))
+             clipPath.addCurve(to: CGPoint(x: 240.7, y: 389.73), controlPoint1: CGPoint(x: 211.17, y: 393), controlPoint2: CGPoint(x: 230.84, y: 391.42))
+             clipPath.addCurve(to: CGPoint(x: 259.45, y: 368.62), controlPoint1: CGPoint(x: 251.57, y: 387.88), controlPoint2: CGPoint(x: 259.45, y: 379))
+             clipPath.addLine(to: CGPoint(x: 259.45, y: 321.52))
+             clipPath.addLine(to: CGPoint(x: 261.93, y: 300.54))
+             clipPath.addCurve(to: CGPoint(x: 299.98, y: 229.46), controlPoint1: CGPoint(x: 265.15, y: 273.33), controlPoint2: CGPoint(x: 280.22, y: 249.95))
+             clipPath.addCurve(to: CGPoint(x: 331.52, y: 135.67), controlPoint1: CGPoint(x: 321.34, y: 210.16), controlPoint2: CGPoint(x: 331.52, y: 171.81))
+             clipPath.addCurve(to: CGPoint(x: 199.07, y: 7), controlPoint1: CGPoint(x: 331.52, y: 64.73), controlPoint2: CGPoint(x: 274.57, y: 7))
+             clipPath.addLine(to: CGPoint(x: 199.07, y: 7))
+             clipPath.close()
+             clipPath.usesEvenOddFillRule = true
+             clipPath.addClip()
+             
+             let bezier3Path = UIBezierPath()
+             bezier3Path.move(to: CGPoint(x: 199.07, y: 7))
+             bezier3Path.addCurve(to: CGPoint(x: 67, y: 135.67), controlPoint1: CGPoint(x: 123.58, y: 7), controlPoint2: CGPoint(x: 67, y: 64.73))
+             bezier3Path.addCurve(to: CGPoint(x: 98.16, y: 229.46), controlPoint1: CGPoint(x: 67, y: 171.81), controlPoint2: CGPoint(x: 76.75, y: 210.58))
+             bezier3Path.addCurve(to: CGPoint(x: 136.21, y: 300.54), controlPoint1: CGPoint(x: 118.3, y: 250.79), controlPoint2: CGPoint(x: 132.99, y: 273.33))
+             bezier3Path.addLine(to: CGPoint(x: 138.69, y: 321.52))
+             bezier3Path.addLine(to: CGPoint(x: 138.69, y: 368.62))
+             bezier3Path.addCurve(to: CGPoint(x: 157.44, y: 389.73), controlPoint1: CGPoint(x: 138.69, y: 379), controlPoint2: CGPoint(x: 146.57, y: 387.88))
+             bezier3Path.addCurve(to: CGPoint(x: 199.07, y: 393), controlPoint1: CGPoint(x: 167.3, y: 391.42), controlPoint2: CGPoint(x: 186.97, y: 393))
+             bezier3Path.addCurve(to: CGPoint(x: 240.7, y: 389.73), controlPoint1: CGPoint(x: 211.17, y: 393), controlPoint2: CGPoint(x: 230.84, y: 391.42))
+             bezier3Path.addCurve(to: CGPoint(x: 259.45, y: 368.62), controlPoint1: CGPoint(x: 251.57, y: 387.88), controlPoint2: CGPoint(x: 259.45, y: 379))
+             bezier3Path.addLine(to: CGPoint(x: 259.45, y: 321.52))
+             bezier3Path.addLine(to: CGPoint(x: 261.93, y: 300.54))
+             bezier3Path.addCurve(to: CGPoint(x: 299.98, y: 229.46), controlPoint1: CGPoint(x: 265.15, y: 273.33), controlPoint2: CGPoint(x: 280.22, y: 249.95))
+             bezier3Path.addCurve(to: CGPoint(x: 331.52, y: 135.67), controlPoint1: CGPoint(x: 321.34, y: 210.16), controlPoint2: CGPoint(x: 331.52, y: 171.81))
+             bezier3Path.addCurve(to: CGPoint(x: 199.07, y: 7), controlPoint1: CGPoint(x: 331.52, y: 64.73), controlPoint2: CGPoint(x: 274.57, y: 7))
+             bezier3Path.addLine(to: CGPoint(x: 199.07, y: 7))
+             bezier3Path.close()
+             tintColor.setStroke()
+             bezier3Path.lineWidth = 40
+             bezier3Path.miterLimit = 40
+             bezier3Path.stroke()
+
+             context.endTransparencyLayer()
+             context.restoreGState()
+        }
+        
+        // MARK: - Symbols Category
+
+         public class func drawSymbolsCategory(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 400, height: 400), resizing: ResizingBehavior = .aspectFit, tintColor: UIColor) {
+             guard let context = UIGraphicsGetCurrentContext() else { return }
+            
+            context.saveGState()
+            let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 400, height: 400), target: targetFrame)
+            context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
+            context.scaleBy(x: resizedFrame.width / 400, y: resizedFrame.height / 400)
+            
+            context.saveGState()
+            context.beginTransparencyLayer(auxiliaryInfo: nil)
+            
+            let clipPath = UIBezierPath()
+            clipPath.move(to: CGPoint(x: 98, y: 10))
+            clipPath.addLine(to: CGPoint(x: 301, y: 10))
+            clipPath.addCurve(to: CGPoint(x: 390, y: 99), controlPoint1: CGPoint(x: 350.15, y: 10), controlPoint2: CGPoint(x: 390, y: 49.85))
+            clipPath.addLine(to: CGPoint(x: 390, y: 302))
+            clipPath.addCurve(to: CGPoint(x: 301, y: 391), controlPoint1: CGPoint(x: 390, y: 351.15), controlPoint2: CGPoint(x: 350.15, y: 391))
+            clipPath.addLine(to: CGPoint(x: 98, y: 391))
+            clipPath.addCurve(to: CGPoint(x: 9, y: 302), controlPoint1: CGPoint(x: 48.85, y: 391), controlPoint2: CGPoint(x: 9, y: 351.15))
+            clipPath.addLine(to: CGPoint(x: 9, y: 99))
+            clipPath.addCurve(to: CGPoint(x: 98, y: 10), controlPoint1: CGPoint(x: 9, y: 49.85), controlPoint2: CGPoint(x: 48.85, y: 10))
+            clipPath.close()
+            clipPath.usesEvenOddFillRule = true
+            clipPath.addClip()
+            
+            let bezier2Path = UIBezierPath()
+            bezier2Path.move(to: CGPoint(x: 98, y: 10))
+            bezier2Path.addLine(to: CGPoint(x: 301, y: 10))
+            bezier2Path.addCurve(to: CGPoint(x: 390, y: 99), controlPoint1: CGPoint(x: 350.15, y: 10), controlPoint2: CGPoint(x: 390, y: 49.85))
+            bezier2Path.addLine(to: CGPoint(x: 390, y: 302))
+            bezier2Path.addCurve(to: CGPoint(x: 301, y: 391), controlPoint1: CGPoint(x: 390, y: 351.15), controlPoint2: CGPoint(x: 350.15, y: 391))
+            bezier2Path.addLine(to: CGPoint(x: 98, y: 391))
+            bezier2Path.addCurve(to: CGPoint(x: 9, y: 302), controlPoint1: CGPoint(x: 48.85, y: 391), controlPoint2: CGPoint(x: 9, y: 351.15))
+            bezier2Path.addLine(to: CGPoint(x: 9, y: 99))
+            bezier2Path.addCurve(to: CGPoint(x: 98, y: 10), controlPoint1: CGPoint(x: 9, y: 49.85), controlPoint2: CGPoint(x: 48.85, y: 10))
+            bezier2Path.close()
+            tintColor.setStroke()
+            bezier2Path.lineWidth = 40
+            bezier2Path.miterLimit = 40
+            bezier2Path.stroke()
+            
+            context.endTransparencyLayer()
+            context.restoreGState()
+            
+            let bezierPath = UIBezierPath()
+            bezierPath.move(to: CGPoint(x: 229.85, y: 247.93))
+            bezierPath.addCurve(to: CGPoint(x: 240.53, y: 231.67), controlPoint1: CGPoint(x: 229.85, y: 238.58), controlPoint2: CGPoint(x: 233.37, y: 231.67))
+            bezierPath.addCurve(to: CGPoint(x: 251.05, y: 248.09), controlPoint1: CGPoint(x: 247.4, y: 231.67), controlPoint2: CGPoint(x: 251.05, y: 238.19))
+            bezierPath.addLine(to: CGPoint(x: 251.05, y: 248.78))
+            bezierPath.addCurve(to: CGPoint(x: 240.45, y: 265.26), controlPoint1: CGPoint(x: 251.05, y: 258.75), controlPoint2: CGPoint(x: 247.1, y: 265.26))
+            bezierPath.addCurve(to: CGPoint(x: 229.85, y: 248.62), controlPoint1: CGPoint(x: 233.67, y: 265.26), controlPoint2: CGPoint(x: 229.85, y: 258.59))
+            bezierPath.addLine(to: CGPoint(x: 229.85, y: 247.93))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 239.8, y: 279.66))
+            bezierPath.addCurve(to: CGPoint(x: 264.55, y: 249.68), controlPoint1: CGPoint(x: 255.6, y: 279.66), controlPoint2: CGPoint(x: 264.55, y: 265.87))
+            bezierPath.addLine(to: CGPoint(x: 264.55, y: 247.17))
+            bezierPath.addCurve(to: CGPoint(x: 239.97, y: 217.28), controlPoint1: CGPoint(x: 264.55, y: 230.44), controlPoint2: CGPoint(x: 255.43, y: 217.28))
+            bezierPath.addCurve(to: CGPoint(x: 215.4, y: 246.99), controlPoint1: CGPoint(x: 224.52, y: 217.28), controlPoint2: CGPoint(x: 215.4, y: 230.61))
+            bezierPath.addLine(to: CGPoint(x: 215.4, y: 249.5))
+            bezierPath.addCurve(to: CGPoint(x: 239.8, y: 279.66), controlPoint1: CGPoint(x: 215.4, y: 266.32), controlPoint2: CGPoint(x: 224.25, y: 279.66))
+            bezierPath.addLine(to: CGPoint(x: 239.8, y: 279.66))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 313.69, y: 311.16))
+            bezierPath.addCurve(to: CGPoint(x: 303.08, y: 327.64), controlPoint1: CGPoint(x: 313.69, y: 321.13), controlPoint2: CGPoint(x: 309.74, y: 327.64))
+            bezierPath.addCurve(to: CGPoint(x: 292.49, y: 311), controlPoint1: CGPoint(x: 296.29, y: 327.64), controlPoint2: CGPoint(x: 292.49, y: 320.97))
+            bezierPath.addLine(to: CGPoint(x: 292.49, y: 310.31))
+            bezierPath.addCurve(to: CGPoint(x: 303.16, y: 294.05), controlPoint1: CGPoint(x: 292.49, y: 300.95), controlPoint2: CGPoint(x: 295.99, y: 294.05))
+            bezierPath.addCurve(to: CGPoint(x: 313.69, y: 310.46), controlPoint1: CGPoint(x: 310.03, y: 294.05), controlPoint2: CGPoint(x: 313.69, y: 300.57))
+            bezierPath.addLine(to: CGPoint(x: 313.69, y: 311.16))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 303.57, y: 280.62))
+            bezierPath.addCurve(to: CGPoint(x: 279, y: 310.33), controlPoint1: CGPoint(x: 288.12, y: 280.62), controlPoint2: CGPoint(x: 279, y: 293.95))
+            bezierPath.addLine(to: CGPoint(x: 279, y: 312.83))
+            bezierPath.addCurve(to: CGPoint(x: 303.4, y: 343), controlPoint1: CGPoint(x: 279, y: 329.67), controlPoint2: CGPoint(x: 287.85, y: 343))
+            bezierPath.addCurve(to: CGPoint(x: 328.15, y: 313.02), controlPoint1: CGPoint(x: 319.2, y: 343), controlPoint2: CGPoint(x: 328.15, y: 329.21))
+            bezierPath.addLine(to: CGPoint(x: 328.15, y: 310.51))
+            bezierPath.addCurve(to: CGPoint(x: 303.57, y: 280.62), controlPoint1: CGPoint(x: 328.15, y: 293.77), controlPoint2: CGPoint(x: 319.03, y: 280.62))
+            bezierPath.addLine(to: CGPoint(x: 303.57, y: 280.62))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 67, y: 80.99))
+            bezierPath.addLine(to: CGPoint(x: 203.84, y: 80.99))
+            bezierPath.addLine(to: CGPoint(x: 203.84, y: 57))
+            bezierPath.addLine(to: CGPoint(x: 67, y: 57))
+            bezierPath.addLine(to: CGPoint(x: 67, y: 80.99))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 67, y: 120.12))
+            bezierPath.addLine(to: CGPoint(x: 123.34, y: 120.31))
+            bezierPath.addLine(to: CGPoint(x: 123.34, y: 193.28))
+            bezierPath.addLine(to: CGPoint(x: 147.49, y: 193.28))
+            bezierPath.addLine(to: CGPoint(x: 147.49, y: 120.39))
+            bezierPath.addLine(to: CGPoint(x: 203.84, y: 120.58))
+            bezierPath.addLine(to: CGPoint(x: 203.84, y: 96.35))
+            bezierPath.addLine(to: CGPoint(x: 67, y: 96.35))
+            bezierPath.addLine(to: CGPoint(x: 67, y: 120.12))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 291.4, y: 158.49))
+            bezierPath.addLine(to: CGPoint(x: 291.4, y: 80.89))
+            bezierPath.addCurve(to: CGPoint(x: 319.21, y: 119), controlPoint1: CGPoint(x: 291.4, y: 80.89), controlPoint2: CGPoint(x: 317.43, y: 94.16))
+            bezierPath.addCurve(to: CGPoint(x: 309.69, y: 157.8), controlPoint1: CGPoint(x: 320.59, y: 138.35), controlPoint2: CGPoint(x: 302.01, y: 150.34))
+            bezierPath.addCurve(to: CGPoint(x: 331.98, y: 118.13), controlPoint1: CGPoint(x: 309.69, y: 157.8), controlPoint2: CGPoint(x: 331.58, y: 137.52))
+            bezierPath.addCurve(to: CGPoint(x: 276.03, y: 57), controlPoint1: CGPoint(x: 332.87, y: 74.79), controlPoint2: CGPoint(x: 304.58, y: 57))
+            bezierPath.addLine(to: CGPoint(x: 276.03, y: 145.37))
+            bezierPath.addCurve(to: CGPoint(x: 248.17, y: 151.27), controlPoint1: CGPoint(x: 276.03, y: 145.37), controlPoint2: CGPoint(x: 267.19, y: 141.57))
+            bezierPath.addCurve(to: CGPoint(x: 230.02, y: 186.89), controlPoint1: CGPoint(x: 229.13, y: 160.97), controlPoint2: CGPoint(x: 224.69, y: 175.91))
+            bezierPath.addCurve(to: CGPoint(x: 291.4, y: 158.49), controlPoint1: CGPoint(x: 236.66, y: 200.59), controlPoint2: CGPoint(x: 291.4, y: 197.28))
+            bezierPath.addLine(to: CGPoint(x: 291.4, y: 158.49))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 328.15, y: 218.23))
+            bezierPath.addLine(to: CGPoint(x: 309.95, y: 218.23))
+            bezierPath.addLine(to: CGPoint(x: 264.88, y: 278.15))
+            bezierPath.addLine(to: CGPoint(x: 217.33, y: 343))
+            bezierPath.addLine(to: CGPoint(x: 236.17, y: 343))
+            bezierPath.addLine(to: CGPoint(x: 281.41, y: 280.27))
+            bezierPath.addLine(to: CGPoint(x: 328.15, y: 218.23))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 126.62, y: 328.6))
+            bezierPath.addCurve(to: CGPoint(x: 101.69, y: 307.39), controlPoint1: CGPoint(x: 113.72, y: 328.6), controlPoint2: CGPoint(x: 101.69, y: 321.62))
+            bezierPath.addCurve(to: CGPoint(x: 117.55, y: 285.46), controlPoint1: CGPoint(x: 101.69, y: 297), controlPoint2: CGPoint(x: 108.14, y: 290.66))
+            bezierPath.addCurve(to: CGPoint(x: 121.3, y: 283.5), controlPoint1: CGPoint(x: 118.78, y: 284.74), controlPoint2: CGPoint(x: 120, y: 284.12))
+            bezierPath.addLine(to: CGPoint(x: 152.76, y: 318.31))
+            bezierPath.addCurve(to: CGPoint(x: 126.62, y: 328.6), controlPoint1: CGPoint(x: 145.97, y: 325.55), controlPoint2: CGPoint(x: 135.16, y: 328.6))
+            bezierPath.addLine(to: CGPoint(x: 126.62, y: 328.6))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 129.59, y: 231.67))
+            bezierPath.addCurve(to: CGPoint(x: 145.05, y: 246.52), controlPoint1: CGPoint(x: 138.48, y: 231.67), controlPoint2: CGPoint(x: 145.05, y: 237.57))
+            bezierPath.addCurve(to: CGPoint(x: 126.57, y: 267.18), controlPoint1: CGPoint(x: 145.05, y: 256.35), controlPoint2: CGPoint(x: 137.33, y: 261.72))
+            bezierPath.addCurve(to: CGPoint(x: 114.22, y: 246.61), controlPoint1: CGPoint(x: 117.24, y: 257.96), controlPoint2: CGPoint(x: 114.22, y: 252.78))
+            bezierPath.addCurve(to: CGPoint(x: 129.59, y: 231.67), controlPoint1: CGPoint(x: 114.22, y: 238.02), controlPoint2: CGPoint(x: 120.44, y: 231.67))
+            bezierPath.addLine(to: CGPoint(x: 129.59, y: 231.67))
+            bezierPath.close()
+            bezierPath.move(to: CGPoint(x: 182.85, y: 276.98))
+            bezierPath.addLine(to: CGPoint(x: 182.85, y: 272.39))
+            bezierPath.addLine(to: CGPoint(x: 167.19, y: 272.39))
+            bezierPath.addLine(to: CGPoint(x: 167.19, y: 276.44))
+            bezierPath.addCurve(to: CGPoint(x: 162.01, y: 306.03), controlPoint1: CGPoint(x: 167.19, y: 289.15), controlPoint2: CGPoint(x: 165.79, y: 299.19))
+            bezierPath.addLine(to: CGPoint(x: 134.66, y: 276.53))
+            bezierPath.addCurve(to: CGPoint(x: 159.81, y: 245.6), controlPoint1: CGPoint(x: 148.11, y: 269.33), controlPoint2: CGPoint(x: 159.81, y: 260.71))
+            bezierPath.addCurve(to: CGPoint(x: 128.58, y: 218.23), controlPoint1: CGPoint(x: 159.81, y: 228.81), controlPoint2: CGPoint(x: 145.74, y: 218.23))
+            bezierPath.addCurve(to: CGPoint(x: 97.36, y: 245.51), controlPoint1: CGPoint(x: 110.38, y: 218.23), controlPoint2: CGPoint(x: 97.36, y: 230.14))
+            bezierPath.addCurve(to: CGPoint(x: 112.14, y: 273.33), controlPoint1: CGPoint(x: 97.36, y: 256.53), controlPoint2: CGPoint(x: 104.23, y: 264.89))
+            bezierPath.addCurve(to: CGPoint(x: 107.39, y: 275.82), controlPoint1: CGPoint(x: 110.47, y: 274.13), controlPoint2: CGPoint(x: 108.88, y: 274.94))
+            bezierPath.addCurve(to: CGPoint(x: 84.35, y: 308.79), controlPoint1: CGPoint(x: 94.02, y: 283.28), controlPoint2: CGPoint(x: 84.35, y: 292.97))
+            bezierPath.addCurve(to: CGPoint(x: 124.89, y: 343), controlPoint1: CGPoint(x: 84.35, y: 330.03), controlPoint2: CGPoint(x: 101.85, y: 343))
+            bezierPath.addCurve(to: CGPoint(x: 162.62, y: 329.49), controlPoint1: CGPoint(x: 137.12, y: 343), controlPoint2: CGPoint(x: 151.36, y: 339.27))
+            bezierPath.addLine(to: CGPoint(x: 173.09, y: 340.6))
+            bezierPath.addLine(to: CGPoint(x: 194.2, y: 340.6))
+            bezierPath.addLine(to: CGPoint(x: 173.09, y: 317.94))
+            bezierPath.addCurve(to: CGPoint(x: 182.85, y: 276.98), controlPoint1: CGPoint(x: 179.86, y: 307.72), controlPoint2: CGPoint(x: 182.85, y: 293.68))
+            bezierPath.addLine(to: CGPoint(x: 182.85, y: 276.98))
+            bezierPath.close()
+            bezierPath.usesEvenOddFillRule = true
+            tintColor.setFill()
+            bezierPath.fill()
+
+            context.endTransparencyLayer()
+            context.restoreGState()
+        }
+        
+        // MARK: - Flags Category
+
+         public class func drawFlagsCategory(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 400, height: 400), resizing: ResizingBehavior = .aspectFit, tintColor: UIColor) {
+             guard let context = UIGraphicsGetCurrentContext() else { return }
+            
+            context.saveGState()
+            let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 400, height: 400), target: targetFrame)
+            context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
+            context.scaleBy(x: resizedFrame.width / 400, y: resizedFrame.height / 400)
+            
+             context.saveGState()
+             context.beginTransparencyLayer(auxiliaryInfo: nil)
+             
+             let clipPath = UIBezierPath()
+             clipPath.move(to: CGPoint(x: 45.99, y: 241.38))
+             clipPath.addLine(to: CGPoint(x: 45.99, y: 20.39))
+             clipPath.addCurve(to: CGPoint(x: 353.99, y: 30.91), controlPoint1: CGPoint(x: 169.21, y: 95.34), controlPoint2: CGPoint(x: 230.81, y: -44.01))
+             clipPath.addLine(to: CGPoint(x: 353.99, y: 230.88))
+             clipPath.addCurve(to: CGPoint(x: 68.03, y: 251.38), controlPoint1: CGPoint(x: 238.37, y: 168.45), controlPoint2: CGPoint(x: 177.01, y: 291.08))
+             clipPath.addLine(to: CGPoint(x: 67.99, y: 394))
+             clipPath.addLine(to: CGPoint(x: 45.99, y: 394))
+             clipPath.addLine(to: CGPoint(x: 45.99, y: 241.4))
+             clipPath.addLine(to: CGPoint(x: 45.99, y: 241.38))
+             clipPath.close()
+             clipPath.usesEvenOddFillRule = true
+             clipPath.addClip()
+             
+             let bezierPath = UIBezierPath()
+             bezierPath.move(to: CGPoint(x: 45.99, y: 241.38))
+             bezierPath.addLine(to: CGPoint(x: 45.99, y: 20.39))
+             bezierPath.addCurve(to: CGPoint(x: 353.99, y: 30.91), controlPoint1: CGPoint(x: 169.21, y: 95.34), controlPoint2: CGPoint(x: 230.81, y: -44.01))
+             bezierPath.addLine(to: CGPoint(x: 353.99, y: 230.88))
+             bezierPath.addCurve(to: CGPoint(x: 68.03, y: 251.38), controlPoint1: CGPoint(x: 238.37, y: 168.45), controlPoint2: CGPoint(x: 177.01, y: 291.08))
+             bezierPath.addLine(to: CGPoint(x: 67.99, y: 394))
+             bezierPath.addLine(to: CGPoint(x: 45.99, y: 394))
+             bezierPath.addLine(to: CGPoint(x: 45.99, y: 241.4))
+             bezierPath.addLine(to: CGPoint(x: 45.99, y: 241.38))
+             bezierPath.close()
+             tintColor.setStroke()
+             bezierPath.lineWidth = 44
+             bezierPath.miterLimit = 44
+             bezierPath.stroke()
+             
+             context.endTransparencyLayer()
+             context.restoreGState()
+        }
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/Views/EmojiCategoryView/MCTouchableEmojiCategoryView.swift
+++ b/deltachat-ios/MCEmojiPicker/View/Views/EmojiCategoryView/MCTouchableEmojiCategoryView.swift
@@ -1,0 +1,116 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+/// Delegate for handling touch gesture.
+protocol MCEmojiCategoryViewDelegate: AnyObject {
+    /**
+     Processes an event by category selection.
+     
+     - Parameter index: index of the selected category.
+     */
+    func didChoiceCategory(at index: Int)
+}
+
+/// The class store the category icon and processes handling touches.
+final class MCTouchableEmojiCategoryView: UIView {
+    
+    // MARK: - Private Properties
+    
+    private var categoryIconView: MCEmojiCategoryIconView
+    /// Insets for categoryIconView.
+    private lazy var categoryIconViewInsets: UIEdgeInsets = {
+        // The number 0.23 was taken based on the proportion of this element to the width of the EmojiPicker on MacOS.
+        let inset = bounds.width * 0.23
+        return UIEdgeInsets(top: inset, left: inset, bottom: inset, right: inset)
+    }()
+    /// Target category index.
+    private var categoryIndex: Int
+    
+    private weak var delegate: MCEmojiCategoryViewDelegate?
+    
+    // MARK: - Initializers
+    
+    init(
+        delegate: MCEmojiCategoryViewDelegate,
+        categoryIndex: Int,
+        categoryType: MCEmojiCategoryType,
+        selectedEmojiCategoryTintColor: UIColor
+    ) {
+        self.delegate = delegate
+        self.categoryIndex = categoryIndex
+        self.categoryIconView = MCEmojiCategoryIconView(
+            type: categoryType,
+            selectedIconTintColor: selectedEmojiCategoryTintColor
+        )
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setupCategoryIconViewLayout()
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        categoryIconView.updateIconTintColor(for: .highlighted)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        categoryIconView.updateIconTintColor(for: .selected)
+        delegate?.didChoiceCategory(at: categoryIndex)
+    }
+    
+    // MARK: - Public Methods
+    
+    /**
+     Updates the icon state to the selected one if the indexes match and the standard one if not.
+     
+     - Parameter selectedCategoryIndex: Selected category index.
+     */
+    public func updateCategoryViewState(selectedCategoryIndex: Int) {
+        categoryIconView.updateIconTintColor(
+            for: categoryIndex == selectedCategoryIndex ? .selected : .standard
+        )
+    }
+    
+    // MARK: - Private Methods
+    
+    private func setupCategoryIconViewLayout() {
+        guard !categoryIconView.isDescendant(of: self) else { return }
+        addSubview(categoryIconView)
+        NSLayoutConstraint.activate([
+            categoryIconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: categoryIconViewInsets.left),
+            categoryIconView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -categoryIconViewInsets.right),
+            categoryIconView.topAnchor.constraint(equalTo: topAnchor, constant: categoryIconViewInsets.top),
+            categoryIconView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -categoryIconViewInsets.bottom)
+        ])
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/Views/EmojiPreviewView/MCEmojiPreviewBackgroundView.swift
+++ b/deltachat-ios/MCEmojiPicker/View/Views/EmojiPreviewView/MCEmojiPreviewBackgroundView.swift
@@ -1,0 +1,218 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+/// The class where the background is drawn for `MCEmojiPreviewView`.
+final class MCEmojiPreviewBackgroundView: UIView {
+    
+    // MARK: - Public Properties
+    
+    public var contentFrame: CGRect {
+        return .init(
+            origin: .init(
+                x: 0,
+                y: Constants.mainCornerRadius / 2
+            ),
+            size: topRectangleFrame.size
+        )
+    }
+    
+    // MARK: - Constants
+    
+    private enum Constants {
+        static let mainCornerRadius = 10.0
+        static let bottomCornerRadius = 6.0
+        
+        static let shadowRadius: Double = 2.5
+        static let shadowOpacity: Float = 0.05
+        static let shadowOffset: CGSize = .init(width: 0, height: 5)
+        
+        static let borderWidth = 0.1
+    }
+    
+    // MARK: - Private Properties
+    
+    private var backgroundPath: CGPath? {
+        didSet {
+            setupShadow()
+            setupBorders()
+        }
+    }
+    
+    private var senderFrame: CGRect
+    private var topRectangleFrame: CGRect = .zero
+    private var bottomRectangleFrame: CGRect = .zero
+    
+    // MARK: - Initializers
+    
+    init(
+        frame: CGRect,
+        senderFrame: CGRect
+    ) {
+        self.senderFrame = senderFrame
+        super.init(frame: frame)
+        backgroundColor = .clear
+        initFramesForRectangles()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Private Methods
+    
+    private func initFramesForRectangles() {
+        bottomRectangleFrame = .init(
+            x: senderFrame.origin.x,
+            y: senderFrame.origin.y - (senderFrame.height * 1.25 - senderFrame.height),
+            width: senderFrame.width,
+            height: senderFrame.height * 1.25
+        )
+        topRectangleFrame = .init(
+            origin: .zero,
+            size: .init(
+                width: frame.width,
+                height: frame.height - (
+                    bottomRectangleFrame.height
+                )
+            )
+        )
+    }
+    
+    private func setupShadow() {
+        layer.shadowPath = backgroundPath
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowRadius = Constants.shadowRadius
+        layer.shadowOpacity = Constants.shadowOpacity
+        layer.shadowOffset = Constants.shadowOffset
+    }
+    
+    private func setupBorders() {
+        let borderLayer = CAShapeLayer()
+        borderLayer.path = backgroundPath
+        borderLayer.fillColor = UIColor.clear.cgColor
+        borderLayer.strokeColor = UIColor.gray.cgColor
+        borderLayer.lineWidth = Constants.borderWidth
+        borderLayer.frame = bounds
+        layer.addSublayer(borderLayer)
+    }
+}
+
+// MARK: - Drawing
+
+extension MCEmojiPreviewBackgroundView {
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        drawBackground()
+    }
+    
+    private func drawBackground() {
+        UIColor.previewAndSkinToneBackgroundViewColor.setFill()
+        
+        let path = UIBezierPath()
+        path.addArc(
+            withCenter: .init(
+                x: bottomRectangleFrame.minX + Constants.bottomCornerRadius,
+                y: bottomRectangleFrame.maxY - Constants.bottomCornerRadius
+            ),
+            radius: Constants.bottomCornerRadius,
+            startAngle: Double.upAngle,
+            endAngle: Double.leftAngle,
+            clockwise: true
+        )
+        path.addLine(
+            to: .init(
+                x: bottomRectangleFrame.minX,
+                y: bottomRectangleFrame.minY + Constants.mainCornerRadius * 2
+            )
+        )
+        path.addCurve(
+            to: .init(
+                x: topRectangleFrame.minX,
+                y: topRectangleFrame.maxY - Constants.mainCornerRadius
+            ),
+            controlPoint1: .init(
+                x: bottomRectangleFrame.minX,
+                y: bottomRectangleFrame.minY - Constants.mainCornerRadius / 2
+            ),
+            controlPoint2: .init(
+                x: topRectangleFrame.minX,
+                y: topRectangleFrame.maxY + Constants.mainCornerRadius / 2
+            )
+        )
+        path.addArc(
+            withCenter: .init(
+                x: topRectangleFrame.minX + Constants.mainCornerRadius,
+                y: topRectangleFrame.minY + Constants.mainCornerRadius
+            ),
+            radius: Constants.mainCornerRadius,
+            startAngle: Double.leftAngle,
+            endAngle: Double.downAngle,
+            clockwise: true
+        )
+        path.addArc(
+            withCenter: .init(
+                x: topRectangleFrame.maxX - Constants.mainCornerRadius,
+                y: topRectangleFrame.minY + Constants.mainCornerRadius
+            ),
+            radius: Constants.mainCornerRadius,
+            startAngle: Double.downAngle,
+            endAngle: Double.rightAngle,
+            clockwise: true
+        )
+        path.addLine(
+            to: .init(
+                x: topRectangleFrame.maxX,
+                y: topRectangleFrame.maxY - Constants.mainCornerRadius
+            )
+        )
+        path.addCurve(
+            to: .init(
+                x: bottomRectangleFrame.maxX,
+                y: bottomRectangleFrame.minY + Constants.mainCornerRadius * 2
+            ),
+            controlPoint1: .init(
+                x: topRectangleFrame.maxX,
+                y: topRectangleFrame.maxY + Constants.mainCornerRadius / 2
+            ),
+            controlPoint2: .init(
+                x: bottomRectangleFrame.maxX,
+                y: bottomRectangleFrame.minY - Constants.mainCornerRadius / 2
+            )
+        )
+        path.addArc(
+            withCenter: .init(
+                x: bottomRectangleFrame.maxX - Constants.bottomCornerRadius,
+                y: bottomRectangleFrame.maxY - Constants.bottomCornerRadius
+            ),
+            radius: Constants.bottomCornerRadius,
+            startAngle: Double.rightAngle,
+            endAngle: Double.upAngle,
+            clockwise: true
+        )
+        path.close()
+        path.fill()
+        
+        backgroundPath = path.cgPath
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/Views/EmojiPreviewView/MCEmojiPreviewView.swift
+++ b/deltachat-ios/MCEmojiPicker/View/Views/EmojiPreviewView/MCEmojiPreviewView.swift
@@ -1,0 +1,89 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+final class MCEmojiPreviewView: UIView {
+    
+    // MARK: - Private Properties
+    
+    private let emojiLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 30.fit())
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private lazy var backgroundView = MCEmojiPreviewBackgroundView(
+        frame: bounds,
+        senderFrame: sender.convert(sender.bounds, to: self)
+    )
+    
+    private var sender: UIView
+    private var sourceView: UIView
+    
+    // MARK: - Initializers
+    
+    init(
+        emoji: MCEmoji?,
+        sender: UIView,
+        sourceView: UIView
+    ) {
+        self.emojiLabel.text = emoji?.string
+        self.sender = sender
+        self.sourceView = sourceView
+        super.init(frame: .zero)
+        setupLayout()
+        setupBackground()
+        setupEmojiLabelLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Private Methods
+    
+    private func setupLayout() {
+        let sourceRect = sender.convert(sender.bounds, to: sourceView)
+        let targetViewSize = CGSize(
+            width: sourceRect.height * 1.5,
+            height: sourceRect.height * 2.65
+        )
+        
+        frame = .init(
+            x: sourceRect.midX - targetViewSize.width / 2,
+            y: sourceRect.maxY - targetViewSize.height,
+            width: targetViewSize.width,
+            height: targetViewSize.height
+        )
+    }
+    
+    private func setupBackground() {
+        addSubview(backgroundView)
+    }
+    
+    private func setupEmojiLabelLayout() {
+        emojiLabel.frame = backgroundView.contentFrame
+        addSubview(emojiLabel)
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/Views/EmojiSkinTonePickerView/MCEmojiSkinTonePickerBackgroundView.swift
+++ b/deltachat-ios/MCEmojiPicker/View/Views/EmojiSkinTonePickerView/MCEmojiSkinTonePickerBackgroundView.swift
@@ -1,0 +1,220 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+/// The class where the background is drawn for `MCEmojiSkinTonePickerView`.
+final class MCEmojiSkinTonePickerBackgroundView: UIView {
+    
+    // MARK: - Public Properties
+    
+    public var contentFrame: CGRect {
+        return topRectangleFrame
+    }
+    
+    // MARK: - Constants
+    
+    private enum Constants {
+        static let mainCornerRadius = 10.0
+        static let bottomCornerRadius = 6.0
+        
+        static let shadowRadius: Double = 2.5
+        static let shadowOpacity: Float = 0.05
+        static let shadowOffset: CGSize = .init(width: 0, height: 5)
+        
+        static let borderWidth = 0.1
+    }
+    
+    // MARK: - Private Properties
+    
+    private var senderFrame: CGRect
+    private var topRectangleFrame: CGRect = .zero
+    private var bottomRectangleFrame: CGRect = .zero
+    
+    private var backgroundPath: CGPath? {
+        didSet {
+            setupShadow()
+            setupBorders()
+        }
+    }
+    
+    // MARK: - Initializers
+    
+    init(
+        frame: CGRect,
+        senderFrame: CGRect
+    ) {
+        self.senderFrame = senderFrame
+        super.init(frame: frame)
+        backgroundColor = .clear
+        initFramesForRectangles()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        if let backgroundPath = backgroundPath, backgroundPath.contains(point) {
+            return super.hitTest(point, with: event)
+        }
+        return nil
+    }
+    
+    // MARK: - Private Methods
+    
+    private func initFramesForRectangles() {
+        bottomRectangleFrame = .init(
+            x: senderFrame.origin.x,
+            y: senderFrame.origin.y - (senderFrame.height * 1.25 - senderFrame.height),
+            width: senderFrame.width,
+            height: senderFrame.height * 1.25
+        )
+        topRectangleFrame = .init(
+            x: 0,
+            y: 0,
+            width: frame.width,
+            height: frame.height - (
+                bottomRectangleFrame.height
+            )
+        )
+    }
+    
+    private func setupShadow() {
+        layer.shadowPath = backgroundPath
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowRadius = Constants.shadowRadius
+        layer.shadowOpacity = Constants.shadowOpacity
+        layer.shadowOffset = Constants.shadowOffset
+    }
+    
+    private func setupBorders() {
+        let borderLayer = CAShapeLayer()
+        borderLayer.path = backgroundPath
+        borderLayer.fillColor = UIColor.clear.cgColor
+        borderLayer.strokeColor = UIColor.gray.cgColor
+        borderLayer.lineWidth = Constants.borderWidth
+        borderLayer.frame = bounds
+        layer.addSublayer(borderLayer)
+    }
+}
+
+// MARK: - Drawing
+
+extension MCEmojiSkinTonePickerBackgroundView {
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        drawBackground()
+    }
+    
+    private func drawBackground() {
+        UIColor.previewAndSkinToneBackgroundViewColor.setFill()
+        
+        let path = UIBezierPath()
+        path.addArc(
+            withCenter: .init(
+                x: topRectangleFrame.minX + Constants.mainCornerRadius,
+                y: topRectangleFrame.minY + Constants.mainCornerRadius
+            ),
+            radius: Constants.mainCornerRadius,
+            startAngle: Double.leftAngle,
+            endAngle: Double.downAngle,
+            clockwise: true
+        )
+        path.addArc(
+            withCenter: .init(
+                x: topRectangleFrame.maxX - Constants.mainCornerRadius,
+                y: topRectangleFrame.minY + Constants.mainCornerRadius
+            ),
+            radius: Constants.mainCornerRadius,
+            startAngle: Double.downAngle,
+            endAngle: Double.rightAngle,
+            clockwise: true
+        )
+        path.addArc(
+            withCenter: .init(
+                x: topRectangleFrame.maxX - Constants.mainCornerRadius,
+                y: topRectangleFrame.maxY - Constants.mainCornerRadius
+            ),
+            radius: Constants.mainCornerRadius,
+            startAngle: Double.rightAngle,
+            endAngle: Double.upAngle,
+            clockwise: true
+        )
+        path.addArc(
+            withCenter: .init(
+                x: bottomRectangleFrame.maxX + Constants.mainCornerRadius,
+                y: bottomRectangleFrame.minY + Constants.mainCornerRadius
+            ),
+            radius: Constants.mainCornerRadius,
+            startAngle: Double.downAngle,
+            endAngle: Double.leftAngle,
+            clockwise: false
+        )
+        path.addArc(
+            withCenter: .init(
+                x: bottomRectangleFrame.maxX - Constants.bottomCornerRadius,
+                y: bottomRectangleFrame.maxY - Constants.bottomCornerRadius
+            ),
+            radius: Constants.bottomCornerRadius,
+            startAngle: Double.rightAngle,
+            endAngle: Double.upAngle,
+            clockwise: true
+        )
+        path.addArc(
+            withCenter: .init(
+                x: bottomRectangleFrame.minX + Constants.bottomCornerRadius,
+                y: bottomRectangleFrame.maxY - Constants.bottomCornerRadius
+            ),
+            radius: Constants.bottomCornerRadius,
+            startAngle: Double.upAngle,
+            endAngle: Double.leftAngle,
+            clockwise: true
+        )
+        path.addArc(
+            withCenter: .init(
+                x: bottomRectangleFrame.minX - Constants.mainCornerRadius,
+                y: bottomRectangleFrame.minY + Constants.mainCornerRadius
+            ),
+            radius: Constants.mainCornerRadius,
+            startAngle: Double.rightAngle,
+            endAngle: Double.downAngle,
+            clockwise: false
+        )
+        path.addArc(
+            withCenter: .init(
+                x: topRectangleFrame.minX + Constants.mainCornerRadius,
+                y: topRectangleFrame.maxY - Constants.mainCornerRadius
+            ),
+            radius: Constants.mainCornerRadius,
+            startAngle: Double.upAngle,
+            endAngle: Double.leftAngle,
+            clockwise: true
+        )
+        path.close()
+        path.fill()
+        
+        backgroundPath = path.cgPath
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/Views/EmojiSkinTonePickerView/MCEmojiSkinTonePickerContainerView.swift
+++ b/deltachat-ios/MCEmojiPicker/View/Views/EmojiSkinTonePickerView/MCEmojiSkinTonePickerContainerView.swift
@@ -1,0 +1,138 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+protocol MCEmojiSkinTonePickerDelegate: AnyObject {
+    func updateSkinTone(
+        _ skinToneRawValue: Int,
+        in cell: MCEmojiCollectionViewCell
+    )
+    func feedbackImpactOccurred()
+    func didEmojiSkinTonePickerDismissed()
+}
+
+final class MCEmojiSkinTonePickerContainerView: UIView {
+    
+    // MARK: - Private Properties
+    
+    private var sender: UIView
+    private var sourceView: UIView
+    private var emojiPickerFrame: CGRect
+    private var cell: MCEmojiCollectionViewCell
+    private var emoji: MCEmoji?
+    
+    private weak var delegate: MCEmojiSkinTonePickerDelegate?
+    
+    private lazy var skinTonePicker = MCEmojiSkinTonePickerView(
+        delegate: self,
+        emoji: emoji,
+        sender: sender,
+        sourceView: sourceView,
+        emojiPickerFrame: emojiPickerFrame
+    )
+    
+    // MARK: - Initializers
+    
+    init(
+        delegate: MCEmojiSkinTonePickerDelegate,
+        cell: MCEmojiCollectionViewCell,
+        emoji: MCEmoji?,
+        frame: CGRect,
+        sourceView: UIView,
+        emojiPickerFrame: CGRect
+    ) {
+        self.delegate = delegate
+        self.cell = cell
+        self.emoji = emoji
+        self.sender = cell.emojiLabel
+        self.sourceView = sourceView
+        self.emojiPickerFrame = emojiPickerFrame
+        super.init(frame: frame)
+        setupSkinTonePicker()
+        setupNotifications()
+        setupGestureRecognizers()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func orientationChanged() {
+        removeFromSuperview()
+        delegate?.didEmojiSkinTonePickerDismissed()
+    }
+    
+    @objc private func backgroundTapAction() {
+        removeFromSuperview()
+        delegate?.didEmojiSkinTonePickerDismissed()
+    }
+    
+    // MARK: - Private Methods
+    
+    private func setupSkinTonePicker() {
+        addSubview(skinTonePicker)
+    }
+    
+    private func setupNotifications() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(orientationChanged),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
+    }
+    
+    private func setupGestureRecognizers() {
+        addGestureRecognizer(
+            UITapGestureRecognizer(
+                target: self,
+                action: #selector(backgroundTapAction)
+            )
+        )
+    }
+}
+
+// MARK: - MCEmojiSkinTonePickerViewDelegate
+
+extension MCEmojiSkinTonePickerContainerView: MCEmojiSkinTonePickerViewDelegate {
+    func didSelectEmojiTone(_ emojiToneIndex: Int?) {
+        removeFromSuperview()
+        delegate?.didEmojiSkinTonePickerDismissed()
+        guard let emojiToneIndex = emojiToneIndex else { return }
+        delegate?.updateSkinTone(emojiToneIndex + 1, in: cell)
+    }
+    
+    func feedbackImpactOccurred() {
+        delegate?.feedbackImpactOccurred()
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/Views/EmojiSkinTonePickerView/MCEmojiSkinTonePickerView.swift
+++ b/deltachat-ios/MCEmojiPicker/View/Views/EmojiSkinTonePickerView/MCEmojiSkinTonePickerView.swift
@@ -1,0 +1,221 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+protocol MCEmojiSkinTonePickerViewDelegate: AnyObject {
+    func didSelectEmojiTone(_ emojiToneIndex: Int?)
+    func feedbackImpactOccurred()
+}
+
+final class MCEmojiSkinTonePickerView: UIView {
+    
+    // MARK: - Constants
+    
+    private enum Constants {
+        static let topInset = 8.0
+        static let horizontalAmountInset = 24.0
+        static let stackViewSpacing = 4.0
+        static let separatorInset = 12.0
+        static let separatorWidth = 0.3
+        static let separatorColor: UIColor = UIColor(
+            light: UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.2),
+            dark: UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.2)
+        )
+    }
+    
+    // MARK: - Private Properties
+    
+    private lazy var backgroundView = MCEmojiSkinTonePickerBackgroundView(
+        frame: bounds,
+        senderFrame: sender.convert(sender.bounds, to: self)
+    )
+    private lazy var emojiLabels: [UIView] = {
+        var arrangedSubviews = contentStackView.arrangedSubviews
+        arrangedSubviews.remove(at: 1)
+        return arrangedSubviews
+    }()
+    
+    private var emoji: MCEmoji?
+    private var selectedSkinTone: Int?
+    
+    private var contentStackView = UIStackView()
+    
+    private var sender: UIView
+    private var sourceView: UIView
+    private var emojiPickerFrame: CGRect
+    
+    private weak var delegate: MCEmojiSkinTonePickerViewDelegate?
+    
+    // MARK: - Initializers
+    
+    init(
+        delegate: MCEmojiSkinTonePickerViewDelegate,
+        emoji: MCEmoji?,
+        sender: UIView,
+        sourceView: UIView,
+        emojiPickerFrame: CGRect
+    ) {
+        self.delegate = delegate
+        self.emoji = emoji
+        self.sender = sender
+        self.sourceView = sourceView
+        self.emojiPickerFrame = emojiPickerFrame
+        super.init(frame: .zero)
+        setupLayout()
+        setupBackground()
+        setupContent()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        updateCurrentSelectedSkinToneIndex(with: touches, state: .began)
+    }
+    
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesMoved(touches, with: event)
+        updateCurrentSelectedSkinToneIndex(with: touches, state: .changed)
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        delegate?.didSelectEmojiTone(selectedSkinTone)
+    }
+    
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesCancelled(touches, with: event)
+        delegate?.didSelectEmojiTone(selectedSkinTone)
+    }
+    
+    // MARK: - Private Methods
+    
+    private func updateCurrentSelectedSkinToneIndex(
+        with touches: Set<UITouch>,
+        state: UIGestureRecognizer.State
+    ) {
+        guard
+            let location = touches.first?.location(in: contentStackView),
+            let newSelectedIndex = emojiLabels.firstIndex(where: {
+                return $0.frame.contains(
+                    .init(
+                        x: location.x,
+                        y: $0.frame.midY
+                    )
+                )
+            }),
+            !(state == .began && !contentStackView.frame.contains(location)),
+            selectedSkinTone != newSelectedIndex
+        else { return }
+        selectedSkinTone = newSelectedIndex
+        if state != .began {
+            delegate?.feedbackImpactOccurred()
+        }
+        for (index, emojiLabel) in emojiLabels.enumerated() {
+            let isCurrentLabel = index == newSelectedIndex
+            emojiLabel.backgroundColor = isCurrentLabel ? .systemBlue : .clear
+        }
+    }
+    
+    private func setupLayout() {
+        let sourceRect = sender.convert(sender.bounds, to: sourceView)
+        let targetViewSize = CGSize(
+            width: sourceRect.width * 7.25,
+            height: sourceRect.height * 2.65
+        )
+        
+        frame = .init(
+            x: sourceRect.midX - targetViewSize.width / 2,
+            y: sourceRect.maxY - targetViewSize.height,
+            width: targetViewSize.width,
+            height: targetViewSize.height
+        )
+
+        if frame.minX < emojiPickerFrame.minX {
+            frame.origin.x = emojiPickerFrame.minX
+        }
+
+        if frame.maxX > emojiPickerFrame.maxX {
+            frame.origin.x = emojiPickerFrame.maxX - targetViewSize.width
+        }
+    }
+    
+    private func setupBackground() {
+        addSubview(backgroundView)
+    }
+    
+    private func setupContent() {
+        let itemHeight = sender.convert(sender.bounds, to: sourceView).size.height
+        let separatorSpacing = Constants.separatorInset * 2 + Constants.separatorWidth
+        let itemsSpacing = Constants.stackViewSpacing * Double(MCEmojiSkinTone.allCases.count - 2)
+        let allSpacings = separatorSpacing + itemsSpacing + Constants.horizontalAmountInset
+        let itemWidth = round((backgroundView.contentFrame.width - allSpacings) / Double(MCEmojiSkinTone.allCases.count))
+        let stackViewWidth = (Constants.stackViewSpacing * 4) + (itemWidth * Double(MCEmojiSkinTone.allCases.count)) + separatorSpacing
+        
+        var arrangedSubviews: [UIView] = MCEmojiSkinTone.allCases.map({
+            let label = UILabel()
+            label.translatesAutoresizingMaskIntoConstraints = false
+            label.widthAnchor.constraint(equalToConstant: itemWidth).isActive = true
+            label.heightAnchor.constraint(equalToConstant: itemHeight).isActive = true
+            label.clipsToBounds = true
+            label.layer.cornerRadius = itemHeight * 0.12
+            label.font = UIFont.systemFont(ofSize: 29.fit(isOnlyToIncrease: false))
+            var emojiKey = emoji?.emojiKeys ?? []
+            if let skinToneKey = $0.skinKey {
+                emojiKey.insert(skinToneKey, at: 1)
+            }
+            if emoji?.skinTone == $0 {
+                label.backgroundColor = .systemBlue
+            }
+            label.text = emojiKey.emoji()
+            label.textAlignment = .center
+            return label
+        })
+        let separatorView: UIView = {
+            let view = UIView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            view.widthAnchor.constraint(equalToConstant: Constants.separatorWidth).isActive = true
+            view.heightAnchor.constraint(equalToConstant: itemHeight - Constants.topInset).isActive = true
+            view.backgroundColor = Constants.separatorColor
+            return view
+        }()
+        arrangedSubviews.insert(separatorView, at: 1)
+        
+        contentStackView = UIStackView(arrangedSubviews: arrangedSubviews)
+        contentStackView.alignment = .center
+        contentStackView.spacing = Constants.stackViewSpacing
+        contentStackView.frame = .init(
+            x: (backgroundView.bounds.size.width - stackViewWidth) / 2,
+            y: Constants.topInset,
+            width: stackViewWidth,
+            height: itemHeight
+        )
+        contentStackView.setCustomSpacing(Constants.separatorInset, after: separatorView)
+        contentStackView.setCustomSpacing(Constants.separatorInset, after: arrangedSubviews[0])
+        addSubview(contentStackView)
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/Views/MCEmojiCollectionViewCell.swift
+++ b/deltachat-ios/MCEmojiPicker/View/Views/MCEmojiCollectionViewCell.swift
@@ -1,0 +1,219 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+protocol MCEmojiCollectionViewCellDelegate: AnyObject {
+    func preview(_ emoji: MCEmoji?, in cell: MCEmojiCollectionViewCell)
+    func choiceSkinTone(_ emoji: MCEmoji?, in cell: MCEmojiCollectionViewCell)
+    func didSelect(_ emoji: MCEmoji?, in cell: MCEmojiCollectionViewCell)
+}
+
+final class MCEmojiCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: - Public Properties
+    
+    public let emojiLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: Constants.emojiLabelFontSize)
+        label.textAlignment = .center
+        return label
+    }()
+    
+    // MARK: - Constants
+    
+    private enum Constants {
+        static let emojiLabelFontSize = 29.0.fit()
+        static let emojiLabelInsets = UIEdgeInsets(top: 0, left: 2, bottom: 0, right: -2)
+        
+        static let containerCornerRadius = 8.0
+        
+        static let selectCellBackgroundAnimationDuration = 0.3
+        static let selectedCellBackgroundViewColor = UIColor(
+            light: UIColor(red: 0.78, green: 0.78, blue: 0.8, alpha: 1.0),
+            dark: UIColor(red: 0.28, green: 0.28, blue: 0.29, alpha: 1.0)
+        )
+    }
+    
+    // MARK: - Private Properties
+    
+    private let containerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.clipsToBounds = true
+        if #available(iOS 13.0, *) {
+            view.layer.cornerCurve = .continuous
+        }
+        view.layer.cornerRadius = Constants.containerCornerRadius
+        return view
+    }()
+    
+    private var emoji: MCEmoji?
+    private var isSkinTonePickerShown = false
+    
+    private weak var delegate: MCEmojiCollectionViewCellDelegate?
+    
+    // MARK: - Initializers
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+        setupGestureRecognizers()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        guard !isFirstChoiceSkinTone() else { return }
+        containerView.backgroundColor = Constants.selectedCellBackgroundViewColor
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        guard let emoji = emoji,
+              !(emoji.isSkinToneSupport && !emoji.isSkinBeenSelectedBefore) else { return }
+        delegate?.didSelect(emoji, in: self)
+        UIView.animate(withDuration: Constants.selectCellBackgroundAnimationDuration, delay: 0) {
+            self.containerView.backgroundColor = .clear
+        }
+    }
+    
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesCancelled(touches, with: event)
+        containerView.backgroundColor = .clear
+    }
+    
+    // MARK: - Public Methods
+    
+    public func configure(
+        emoji: MCEmoji?,
+        delegate: MCEmojiCollectionViewCellDelegate?
+    ) {
+        self.emoji = emoji
+        self.emojiLabel.text = emoji?.string
+        self.delegate = delegate
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func previewLongPressGestureAction(
+        _ gestureRecognizer: UILongPressGestureRecognizer
+    ) {
+        guard let emoji = emoji else { return }
+        switch gestureRecognizer.state {
+        case .began:
+            guard !isFirstChoiceSkinTone() else { return }
+            delegate?.preview(emoji, in: self)
+        case .ended where !isSkinTonePickerShown:
+            delegate?.didSelect(emoji, in: self)
+        default:
+            break
+        }
+    }
+    
+    @objc private func choiceSkinToneLongPressGestureAction(
+        _ gestureRecognizer: UILongPressGestureRecognizer
+    ) {
+        guard let emoji = emoji else { return }
+        switch gestureRecognizer.state {
+        case .began where emoji.isSkinToneSupport && emoji.isSkinBeenSelectedBefore:
+            isSkinTonePickerShown = true
+            delegate?.choiceSkinTone(emoji, in: self)
+        case .ended where !emoji.isSkinToneSupport:
+            delegate?.didSelect(emoji, in: self)
+        default:
+            break
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    private func isFirstChoiceSkinTone() -> Bool {
+        guard let emoji = emoji else { return true }
+        isSkinTonePickerShown = false
+        switch emoji.isSkinToneSupport && !emoji.isSkinBeenSelectedBefore && !isSkinTonePickerShown {
+        case true:
+            isSkinTonePickerShown = true
+            delegate?.choiceSkinTone(emoji, in: self)
+            return true
+        case false:
+            return false
+        }
+    }
+    
+    private func setupLayout() {
+        contentView.addSubview(containerView)
+        contentView.addSubview(emojiLabel)
+        
+        NSLayoutConstraint.activate([
+            containerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            containerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            containerView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            containerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            
+            emojiLabel.leadingAnchor.constraint(
+                equalTo: contentView.leadingAnchor,
+                constant: Constants.emojiLabelInsets.left
+            ),
+            emojiLabel.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: Constants.emojiLabelInsets.right
+            ),
+            emojiLabel.topAnchor.constraint(equalTo: contentView.topAnchor),
+            emojiLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+    
+    private func setupGestureRecognizers() {
+        let previewLongPressGesture = UILongPressGestureRecognizer(
+            target: self,
+            action: #selector(previewLongPressGestureAction)
+        )
+        let choiceSkinToneLongPressGesture = UILongPressGestureRecognizer(
+            target: self,
+            action: #selector(choiceSkinToneLongPressGestureAction)
+        )
+        choiceSkinToneLongPressGesture.delegate = self
+        previewLongPressGesture.delegate = self
+        previewLongPressGesture.minimumPressDuration = 0.15
+        containerView.addGestureRecognizer(previewLongPressGesture)
+        containerView.addGestureRecognizer(choiceSkinToneLongPressGesture)
+    }
+    
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension MCEmojiCollectionViewCell: UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        return true
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/Views/MCEmojiPickerView.swift
+++ b/deltachat-ios/MCEmojiPicker/View/Views/MCEmojiPickerView.swift
@@ -1,0 +1,429 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+protocol MCEmojiPickerViewDelegate: AnyObject {
+    /// Processes an event by category selection.
+    ///
+    /// - Parameter index: index of the selected category.
+    func didChoiceEmojiCategory(at index: Int)
+    func didChoiceEmoji(_ emoji: MCEmoji?)
+    func numberOfSections() -> Int
+    func numberOfItems(in section: Int) -> Int
+    func emoji(at indexPath: IndexPath) -> MCEmoji
+    func sectionHeaderName(for section: Int) -> String
+    func getCurrentSelectedEmojiCategoryIndex() -> Int
+    func updateCurrentSelectedEmojiCategoryIndex(with index: Int)
+    func getEmojiPickerFrame() -> CGRect
+    func updateEmojiSkinTone(_ skinToneRawValue: Int, in indexPath: IndexPath)
+    func feedbackImpactOccurred()
+}
+
+final class MCEmojiPickerView: UIView {
+    
+    // MARK: - Public Properties
+    
+    public var selectedEmojiCategoryTintColor = Constants.defaultSelectedEmojiCategoryTintColor
+    
+    // MARK: - Constants
+    
+    private enum Constants {
+        static let defaultSelectedEmojiCategoryTintColor = UIColor.systemBlue
+        
+        static let verticalScrollIndicatorTopInset = 8.0
+        static let collectionViewContentInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        
+        static let countOfEmojisInRow = 8.0
+        static let collectionViewHeaderHeight = 40.0
+        
+        static let categoriesStackViewInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: -16)
+        
+        static let separatorHeight = 0.8
+        static let separatorColor = UIColor(
+            light: UIColor(red: 0.78, green: 0.78, blue: 0.78, alpha: 1.0),
+            dark: UIColor(red: 0.22, green: 0.22, blue: 0.23, alpha: 1.0)
+        )
+    }
+    
+    // MARK: - Private Properties
+    
+    private let emojiCategoryTypes: [MCEmojiCategoryType]
+    
+    private let collectionView: UICollectionView = {
+        let layout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
+        layout.sectionHeadersPinToVisibleBounds = true
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.verticalScrollIndicatorInsets.top = Constants.verticalScrollIndicatorTopInset
+        collectionView.contentInset = Constants.collectionViewContentInsets
+        collectionView.backgroundColor = .clear
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.register(
+            MCEmojiCollectionViewCell.self,
+            forCellWithReuseIdentifier: MCEmojiCollectionViewCell.reuseIdentifier
+        )
+        collectionView.register(
+            MCEmojiSectionHeader.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: MCEmojiSectionHeader.reuseIdentifier
+        )
+        return collectionView
+    }()
+    
+    private let categoriesStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.backgroundColor = .popoverBackgroundColor
+        stackView.distribution = .fillEqually
+        return stackView
+    }()
+    
+    private var previewContainerView = UIView()
+    private var categoryViews = [MCTouchableEmojiCategoryView]()
+    
+    /// Height for categoriesStackView.
+    private lazy var categoriesStackViewHeight: CGFloat = {
+        // The number 0.13 was taken based on the proportion of this element to the width of the EmojiPicker on MacOS.
+        return bounds.width * 0.13
+    }()
+    
+    private weak var delegate: MCEmojiPickerViewDelegate?
+    
+    // MARK: - Initializers
+    
+    init(categoryTypes: [MCEmojiCategoryType] = MCEmojiCategoryType.allCases, delegate: MCEmojiPickerViewDelegate) {
+        self.delegate = delegate
+        self.emojiCategoryTypes = categoryTypes
+        super.init(frame: .zero)
+        setupBackgroundColor()
+        setupDelegates()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        setupCategoryViews()
+        setupCollectionViewLayout()
+        setupCollectionViewBottomInsets()
+        setupCategoriesControlLayout()
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Passes the index of the selected category to all categoryViews to update the state.
+    ///
+    /// - Parameter categoryIndex: Selected category index.
+    public func updateSelectedCategoryIcon(with categoryIndex: Int) {
+        categoryViews.forEach({
+            $0.updateCategoryViewState(selectedCategoryIndex: categoryIndex)
+        })
+    }
+    
+    // MARK: - Private Methods
+    
+    private func setupBackgroundColor() {
+        backgroundColor = .popoverBackgroundColor
+    }
+    
+    private func setupDelegates() {
+        collectionView.delegate = self
+        collectionView.dataSource = self
+    }
+    
+    private func setupCollectionViewBottomInsets() {
+        collectionView.contentInset.bottom = categoriesStackViewHeight
+        collectionView.verticalScrollIndicatorInsets.bottom = categoriesStackViewHeight
+    }
+    
+    private func setupCollectionViewLayout() {
+        addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            collectionView.topAnchor.constraint(equalTo: topAnchor, constant: safeAreaInsets.top),
+            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -safeAreaInsets.bottom)
+        ])
+    }
+    
+    private func setupCategoriesControlLayout() {
+        let separatorView = UIView()
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        separatorView.backgroundColor = Constants.separatorColor
+        
+        addSubview(categoriesStackView)
+        addSubview(separatorView)
+        
+        NSLayoutConstraint.activate([
+            categoriesStackView.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: Constants.categoriesStackViewInsets.left
+            ),
+            categoriesStackView.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: Constants.categoriesStackViewInsets.right
+            ),
+            categoriesStackView.bottomAnchor.constraint(
+                equalTo: bottomAnchor,
+                constant: -safeAreaInsets.bottom
+            ),
+            categoriesStackView.heightAnchor.constraint(
+                equalToConstant: categoriesStackViewHeight
+            ),
+            
+            separatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            separatorView.topAnchor.constraint(equalTo: categoriesStackView.topAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: Constants.separatorHeight)
+        ])
+    }
+    
+    private func setupCategoryViews() {
+        for categoryIndex in 0...emojiCategoryTypes.count - 1 {
+            let categoryView = MCTouchableEmojiCategoryView(
+                delegate: self,
+                categoryIndex: categoryIndex,
+                categoryType: emojiCategoryTypes[categoryIndex],
+                selectedEmojiCategoryTintColor: selectedEmojiCategoryTintColor
+            )
+            // Installing selected state for first category.
+            categoryView.updateCategoryViewState(selectedCategoryIndex: .zero)
+            categoryViews.append(categoryView)
+            categoriesStackView.addArrangedSubview(categoryView)
+        }
+    }
+    
+    private func toggleCollectionScrollAbility(isEnabled: Bool) {
+        collectionView.isScrollEnabled = isEnabled
+    }
+    
+    /// Scroll collectionView to header for selected category.
+    ///
+    /// - Parameter section: Selected category index.
+    private func scrollToHeader(for section: Int) {
+        guard let cellFrame = collectionView.collectionViewLayout.layoutAttributesForItem(at: IndexPath(item: 0, section: section))?.frame,
+              let headerFrame = collectionView.collectionViewLayout.layoutAttributesForSupplementaryView(
+                ofKind: UICollectionView.elementKindSectionHeader,
+                at: IndexPath(item: .zero, section: section)
+              )?.frame
+        else { return }
+        collectionView.setContentOffset(
+            CGPoint(
+                x:  -collectionView.contentInset.left,
+                y: cellFrame.minY - headerFrame.height
+            ),
+            animated: false
+        )
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension MCEmojiPickerView: UICollectionViewDataSource {
+    public func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return delegate?.numberOfSections() ?? .zero
+    }
+    
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
+        return delegate?.numberOfItems(in: section) ?? .zero
+    }
+    
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: MCEmojiCollectionViewCell.reuseIdentifier,
+                for: indexPath
+              ) as? MCEmojiCollectionViewCell
+        else { return UICollectionViewCell() }
+        cell.configure(
+            emoji: delegate?.emoji(at: indexPath),
+            delegate: self
+        )
+        return cell
+    }
+    
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath
+    ) -> UICollectionReusableView {
+        guard kind == UICollectionView.elementKindSectionHeader,
+              let sectionHeader = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: MCEmojiSectionHeader.reuseIdentifier,
+                for: indexPath
+              ) as? MCEmojiSectionHeader
+        else { return UICollectionReusableView() }
+        sectionHeader.configure(
+            with: delegate?.sectionHeaderName(
+                for: indexPath.section
+            ) ?? ""
+        )
+        return sectionHeader
+    }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension MCEmojiPickerView: UICollectionViewDelegateFlowLayout {
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        referenceSizeForHeaderInSection section: Int
+    ) -> CGSize {
+        return CGSize(
+            width: collectionView.frame.width,
+            height: Constants.collectionViewHeaderHeight
+        )
+    }
+
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        let sideInsets = collectionView.contentInset.right + collectionView.contentInset.left
+        let contentSize = collectionView.bounds.width - sideInsets
+        return CGSize(
+            width: contentSize / Constants.countOfEmojisInRow,
+            height: contentSize / Constants.countOfEmojisInRow
+        )
+    }
+    
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        minimumLineSpacingForSectionAt section: Int
+    ) -> CGFloat {
+        return .zero
+    }
+    
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        minimumInteritemSpacingForSectionAt section: Int
+    ) -> CGFloat {
+        return .zero
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+
+extension MCEmojiPickerView: UIScrollViewDelegate {
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        // Updating the selected category during scrolling
+        let indexPathsForVisibleHeaders = collectionView.indexPathsForVisibleSupplementaryElements(
+            ofKind: UICollectionView.elementKindSectionHeader
+        ).sorted(by: { $0.section < $1.section })
+        if let selectedEmojiCategoryIndex = indexPathsForVisibleHeaders.first?.section,
+           delegate?.getCurrentSelectedEmojiCategoryIndex() != selectedEmojiCategoryIndex {
+            delegate?.updateCurrentSelectedEmojiCategoryIndex(with: selectedEmojiCategoryIndex)
+        }
+    }
+}
+
+// MARK: - MCEmojiCollectionViewCellDelegate
+
+extension MCEmojiPickerView: MCEmojiCollectionViewCellDelegate {
+    func preview(_ emoji: MCEmoji?, in cell: MCEmojiCollectionViewCell) {
+        guard let sourceView = window else { return }
+        toggleCollectionScrollAbility(isEnabled: false)
+        
+        previewContainerView.removeFromSuperview()
+        previewContainerView = MCEmojiPreviewView(
+            emoji: emoji,
+            sender: cell.emojiLabel,
+            sourceView: sourceView
+        )
+        
+        sourceView.addSubview(previewContainerView)
+    }
+    
+    func choiceSkinTone(_ emoji: MCEmoji?, in cell: MCEmojiCollectionViewCell) {
+        guard let sourceView = window else { return }
+        toggleCollectionScrollAbility(isEnabled: false)
+        delegate?.feedbackImpactOccurred()
+        
+        previewContainerView.removeFromSuperview()
+        previewContainerView = MCEmojiSkinTonePickerContainerView(
+            delegate: self,
+            cell: cell,
+            emoji: emoji,
+            frame: sourceView.frame,
+            sourceView: sourceView,
+            emojiPickerFrame: delegate?.getEmojiPickerFrame() ?? .zero
+        )
+        
+        sourceView.addSubview(previewContainerView)
+    }
+    
+    func didSelect(_ emoji: MCEmoji?, in cell: MCEmojiCollectionViewCell) {
+        if previewContainerView is MCEmojiPreviewView {
+            toggleCollectionScrollAbility(isEnabled: true)
+            previewContainerView.removeFromSuperview()
+        }
+        delegate?.didChoiceEmoji(emoji)
+    }
+}
+
+
+// MARK: - EmojiCategoryViewDelegate
+
+extension MCEmojiPickerView: MCEmojiCategoryViewDelegate {
+    func didChoiceCategory(at index: Int) {
+        scrollToHeader(for: index)
+        delegate?.feedbackImpactOccurred()
+        delegate?.didChoiceEmojiCategory(at: index)
+    }
+}
+
+// MARK: - MCEmojiSkinTonePickerDelegate
+
+extension MCEmojiPickerView: MCEmojiSkinTonePickerDelegate {
+    func updateSkinTone(
+        _ skinToneRawValue: Int,
+        in cell: MCEmojiCollectionViewCell
+    ) {
+        guard let indexPath = collectionView.indexPath(for: cell) else { return }
+        delegate?.updateEmojiSkinTone(skinToneRawValue, in: indexPath)
+        UIView.performWithoutAnimation {
+            collectionView.reloadData()
+        }
+    }
+    
+    func feedbackImpactOccurred() {
+        delegate?.feedbackImpactOccurred()
+    }
+    
+    func didEmojiSkinTonePickerDismissed() {
+        toggleCollectionScrollAbility(isEnabled: true)
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/View/Views/MCEmojiSectionHeader.swift
+++ b/deltachat-ios/MCEmojiPicker/View/Views/MCEmojiSectionHeader.swift
@@ -1,0 +1,89 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+final class MCEmojiSectionHeader: UICollectionReusableView {
+    
+    // MARK: - Constants
+    
+    private enum Constants {
+        static let backgroundColor = UIColor.popoverBackgroundColor
+        
+        static let headerLabelColor = UIColor.systemGray
+        static let headerLabelFont = UIFont.systemFont(ofSize: 14.fit(), weight: .regular)
+        static let headerLabelInsets = UIEdgeInsets(top: 0, left: 7, bottom: -4, right: -16)
+    }
+    
+    // MARK: - Private Properties
+    
+    private let headerLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.textColor = Constants.headerLabelColor
+        label.font = Constants.headerLabelFont
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    // MARK: - Initializers
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupBackgroundColor()
+        setupHeaderLabelLayout()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Public Methods
+    
+    public func configure(with categoryName: String) {
+        headerLabel.text = categoryName
+    }
+    
+    // MARK: - Private Methods
+    
+    private func setupBackgroundColor() {
+        backgroundColor = Constants.backgroundColor
+    }
+    
+    private func setupHeaderLabelLayout() {
+        addSubview(headerLabel)
+        
+        NSLayoutConstraint.activate([
+            headerLabel.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: Constants.headerLabelInsets.left
+            ),
+            headerLabel.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: Constants.headerLabelInsets.right
+            ),
+            headerLabel.bottomAnchor.constraint(
+                equalTo: bottomAnchor,
+                constant: Constants.headerLabelInsets.bottom
+            )
+        ])
+    }
+}

--- a/deltachat-ios/MCEmojiPicker/ViewModel/MCEmojiPickerViewModel.swift
+++ b/deltachat-ios/MCEmojiPicker/ViewModel/MCEmojiPickerViewModel.swift
@@ -1,0 +1,104 @@
+// The MIT License (MIT)
+//
+// Copyright © 2022 Ivan Izyumkin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+/// Protocol for the `MCEmojiPickerViewModel`.
+protocol MCEmojiPickerViewModelProtocol {
+    /// Whether the picker shows empty categories. Default false.
+    var showEmptyEmojiCategories: Bool { get set }
+    /// The emoji categories being used
+    var emojiCategories: [MCEmojiCategory] { get }
+    /// The observed variable that is responsible for the choice of emoji.
+    var selectedEmoji: Observable<MCEmoji?> { get set }
+    /// The observed variable that is responsible for the choice of emoji category.
+    var selectedEmojiCategoryIndex: Observable<Int> { get set }
+    /// Clears the selected emoji, setting to `nil`.
+    func clearSelectedEmoji()
+    /// Returns the number of categories with emojis.
+    func numberOfSections() -> Int
+    /// Returns the number of emojis in the target section.
+    func numberOfItems(in section: Int) -> Int
+    /// Returns the `MCEmoji` for the target `IndexPath`.
+    func emoji(at indexPath: IndexPath) -> MCEmoji
+    /// Returns the localized section name for the target section.
+    func sectionHeaderName(for section: Int) -> String
+    /// Updates the emoji skin tone and returns the updated `MCEmoji`.
+    func updateEmojiSkinTone(_ skinToneRawValue: Int, in indexPath: IndexPath) -> MCEmoji
+}
+
+/// View model which using in `MCEmojiPickerViewController`.
+final class MCEmojiPickerViewModel: MCEmojiPickerViewModelProtocol {
+    
+    // MARK: - Public Properties
+    
+    public var selectedEmoji = Observable<MCEmoji?>(value: nil)
+    public var selectedEmojiCategoryIndex = Observable<Int>(value: 0)
+    public var showEmptyEmojiCategories = false
+    public var emojiCategories: [MCEmojiCategory] {
+        allEmojiCategories.filter({ showEmptyEmojiCategories || !$0.emojis.isEmpty })
+    }
+    
+    // MARK: - Private Properties
+    
+    /// All emoji categories.
+    private var allEmojiCategories = [MCEmojiCategory]()
+    
+    // MARK: - Initializers
+    
+    init(unicodeManager: MCUnicodeManagerProtocol = MCUnicodeManager()) {
+        allEmojiCategories = unicodeManager.getEmojisForCurrentIOSVersion()
+        // Increment usage of each emoji upon selection
+        selectedEmoji.bind { emoji in
+            emoji?.incrementUsageCount()
+        }
+    }
+    
+    // MARK: - Public Methods
+    
+    public func clearSelectedEmoji() {
+        selectedEmoji.value = nil
+    }
+    
+    public func numberOfSections() -> Int {
+        return emojiCategories.count
+    }
+    
+    public func numberOfItems(in section: Int) -> Int {
+        return emojiCategories[section].emojis.count
+    }
+    
+    public func emoji(at indexPath: IndexPath) -> MCEmoji {
+        return emojiCategories[indexPath.section].emojis[indexPath.row]
+    }
+    
+    public func sectionHeaderName(for section: Int) -> String {
+        return emojiCategories[section].categoryName
+    }
+    
+    public func updateEmojiSkinTone(_ skinToneRawValue: Int, in indexPath: IndexPath) -> MCEmoji {
+        let categoryType: MCEmojiCategoryType = emojiCategories[indexPath.section].type
+        let allCategoriesIndex: Int = allEmojiCategories.firstIndex { $0.type == categoryType } ?? 0
+        allEmojiCategories[allCategoriesIndex].emojis[indexPath.row].set(skinToneRawValue: skinToneRawValue)
+        return allEmojiCategories[allCategoriesIndex].emojis[indexPath.row]
+    }
+}

--- a/deltachat-ios/View/Cell/GalleryCell.swift
+++ b/deltachat-ios/View/Cell/GalleryCell.swift
@@ -3,7 +3,6 @@ import DcCore
 import SDWebImage
 
 class GalleryCell: UICollectionViewCell {
-    static let reuseIdentifier = "gallery_cell"
 
     weak var item: GalleryItem?
 

--- a/deltachat-ios/View/Cell/WebxdcGridCell.swift
+++ b/deltachat-ios/View/Cell/WebxdcGridCell.swift
@@ -3,7 +3,6 @@ import DcCore
 import SDWebImage
 
 class WebxdcGridCell: UICollectionViewCell {
-    static let reuseIdentifier = "webxdc_cell"
 
     weak var item: GalleryItem?
 


### PR DESCRIPTION
this PR fixes both issues of https://github.com/deltachat/deltachat-ios/pull/2087 (emulator, misleading arrow) by just pulling in source code and finally change ~~one line~~ EDIT: it has become a handful lines, but now it is a nice pageSheet

<img width="320" alt="Screenshot 2024-02-27 at 23 51 17" src="https://github.com/deltachat/deltachat-ios/assets/9800740/1df31eaf-ad24-49dd-8c5d-164ac0f9a621">


but yeah, i agree with https://github.com/deltachat/deltachat-ios/pull/2087#issuecomment-1966058886 that there may be more ios-pm-style ways to do that, but i am not used to them :) at least, this PR shows what we actually want as a minimum