### PR TITLE
allow enlarging the account switcher

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -639,7 +639,7 @@ class ChatListViewController: UITableViewController {
         let accountSwitchNavigationController = UINavigationController(rootViewController: viewController)
         if #available(iOS 15.0, *) {
             if let sheet = accountSwitchNavigationController.sheetPresentationController {
-                sheet.detents = [.medium()]
+                sheet.detents = [.medium(), .large()]
                 sheet.preferredCornerRadius = 20
             }
         } else {


### PR DESCRIPTION
no super-important, but seems to be super-simple - i came over that at https://github.com/deltachat/deltachat-ios/pull/2087 and remembered the request from
https://support.delta.chat/t/enlarge-the-account-switcher-in-dc-ios-by-swiping-it-up/2941 :)

https://github.com/deltachat/deltachat-ios/assets/9800740/5de11759-66d5-4f3d-9a2c-6c0e8abaf606

