### PR TITLE
show reactions on 'Video', hide reactions on 'Video Chat Invitations', cleanup types

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -232,7 +232,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             if dcChat.canSend {
                 let messageId = messageIds[indexPath.row]
                 let message = dcContext.getMessage(id: messageId)
-                let showReaction = message.isInfo == false && message.isSetupMessage == false && message.viewtype != .videoChatInvitation
+                let showReaction = message.isInfo == false && message.isSetupMessage == false && message.type != DC_MSG_VIDEOCHAT_INVITATION
 
                 if showReaction {
                     menuItems = [reactionsMenu(indexPath: indexPath), replyItem, replyPrivatelyItem, forwardItem, infoItem, copyItem, deleteItem, selectMoreItem]
@@ -810,7 +810,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         }
 
         let cell: BaseMessageCell
-        switch Int32(message.type) {
+        switch message.type {
         case DC_MSG_VIDEOCHAT_INVITATION:
             let videoInviteCell = tableView.dequeueReusableCell(withIdentifier: "video_invite", for: indexPath) as? VideoInviteCell ?? VideoInviteCell()
             videoInviteCell.showSelectionBackground(tableView.isEditing)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -232,7 +232,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             if dcChat.canSend {
                 let messageId = messageIds[indexPath.row]
                 let message = dcContext.getMessage(id: messageId)
-                let showReaction = message.isInfo == false && message.isSetupMessage == false && message.viewtype != nil && message.viewtype != .video
+                let showReaction = message.isInfo == false && message.isSetupMessage == false && message.viewtype != .videoChatInvitation
 
                 if showReaction {
                     menuItems = [reactionsMenu(indexPath: indexPath), replyItem, replyPrivatelyItem, forwardItem, infoItem, copyItem, deleteItem, selectMoreItem]

--- a/deltachat-ios/Chat/DraftModel.swift
+++ b/deltachat-ios/Chat/DraftModel.swift
@@ -22,7 +22,7 @@ public class DraftModel {
     }
     var viewType: Int32? {
         if let viewType = draftMsg?.type {
-            return Int32(viewType)
+            return viewType
         }
         return nil
     }

--- a/deltachat-ios/Chat/DraftModel.swift
+++ b/deltachat-ios/Chat/DraftModel.swift
@@ -21,10 +21,7 @@ public class DraftModel {
         return draftMsg?.filemime
     }
     var viewType: Int32? {
-        if let viewType = draftMsg?.type {
-            return viewType
-        }
-        return nil
+        return draftMsg?.type
     }
 
     public init(dcContext: DcContext, chatId: Int) {

--- a/deltachat-ios/Controller/ContextMenuController.swift
+++ b/deltachat-ios/Controller/ContextMenuController.swift
@@ -23,14 +23,14 @@ class ContextMenuController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let viewType = msg.viewtype
+        let viewType = msg.type
         var thumbnailView: UIView?
         switch viewType {
-        case .image:
+        case DC_MSG_IMAGE, DC_MSG_STICKER:
             thumbnailView = makeImageView()
-        case .video:
+        case DC_MSG_VIDEO:
             thumbnailView = makeVideoView()
-        case .gif:
+        case DC_MSG_GIF:
             thumbnailView = makeGifView()
         default:
             return

--- a/deltachat-ios/DC/DcMsg.swift
+++ b/deltachat-ios/DC/DcMsg.swift
@@ -5,33 +5,6 @@ import UIKit
 /// See [dc_msg_t Class Reference](https://c.delta.chat/classdc__msg__t.html)
 public class DcMsg {
 
-    public enum MessageViewType: CustomStringConvertible {
-        case audio
-        case file
-        case gif
-        case image
-        case text
-        case video
-        case voice
-        case webxdc
-        case videoChatInvitation
-
-        public var description: String {
-            switch self {
-            // Use Internationalization, as appropriate.
-            case .audio: return "Audio"
-            case .file: return "File"
-            case .gif: return "GIF"
-            case .image: return "Image"
-            case .text: return "Text"
-            case .video: return "Video"
-            case .voice: return "Voice"
-            case .webxdc: return "Webxdc"
-            case .videoChatInvitation: return "VideoChatInvitation"
-            }
-        }
-    }
-
     var messagePointer: OpaquePointer?
 
     init(pointer: OpaquePointer?) {
@@ -141,35 +114,6 @@ public class DcMsg {
 
     public var downloadState: Int32 {
         return dc_msg_get_download_state(messagePointer)
-    }
-
-    public var viewtype: MessageViewType? {
-        switch dc_msg_get_viewtype(messagePointer) {
-        case 0:
-            return nil
-        case DC_MSG_AUDIO:
-            return .audio
-        case DC_MSG_FILE:
-            return .file
-        case DC_MSG_GIF:
-            return .gif
-        case DC_MSG_TEXT:
-            return .text
-        case DC_MSG_IMAGE:
-            return .image
-        case DC_MSG_STICKER:
-            return .image
-        case DC_MSG_VIDEO:
-            return .video
-        case DC_MSG_VOICE:
-            return .voice
-        case DC_MSG_WEBXDC:
-            return .webxdc
-        case DC_MSG_VIDEOCHAT_INVITATION:
-            return .videoChatInvitation
-        default:
-            return nil
-        }
     }
 
     public var fileURL: URL? {
@@ -287,8 +231,8 @@ public class DcMsg {
     }
 
     // DC_MSG_*
-    public var type: Int {
-        return Int(dc_msg_get_viewtype(messagePointer))
+    public var type: Int32 {
+        return dc_msg_get_viewtype(messagePointer)
     }
 
     // DC_STATE_*

--- a/deltachat-ios/DC/DcMsg.swift
+++ b/deltachat-ios/DC/DcMsg.swift
@@ -14,6 +14,7 @@ public class DcMsg {
         case video
         case voice
         case webxdc
+        case videoChatInvitation
 
         public var description: String {
             switch self {
@@ -26,6 +27,7 @@ public class DcMsg {
             case .video: return "Video"
             case .voice: return "Voice"
             case .webxdc: return "Webxdc"
+            case .videoChatInvitation: return "VideoChatInvitation"
             }
         }
     }
@@ -163,6 +165,8 @@ public class DcMsg {
             return .voice
         case DC_MSG_WEBXDC:
             return .webxdc
+        case DC_MSG_VIDEOCHAT_INVITATION:
+            return .videoChatInvitation
         default:
             return nil
         }

--- a/deltachat-ios/Model/GalleryItem.swift
+++ b/deltachat-ios/Model/GalleryItem.swift
@@ -25,12 +25,12 @@ class GalleryItem {
 
     private func loadThumbnail() {
         guard let url = msg.fileURL else { return }
-        switch msg.viewtype {
-        case .image, .gif:
+        switch msg.type {
+        case DC_MSG_IMAGE, DC_MSG_STICKER, DC_MSG_GIF:
             loadImageThumbnail(from: url)
-        case .video:
+        case DC_MSG_VIDEO:
             loadVideoThumbnail(from: url)
-        case .webxdc:
+        case DC_MSG_WEBXDC:
             loadWebxdcThumbnail(from: msg)
         default:
             return

--- a/deltachat-ios/View/Cell/GalleryCell.swift
+++ b/deltachat-ios/View/Cell/GalleryCell.swift
@@ -55,7 +55,7 @@ class GalleryCell: UICollectionViewCell {
         item.onImageLoaded = { [weak self] image in
             self?.imageView.image = image
         }
-        playButtonView.isHidden = item.msg.viewtype != .video
+        playButtonView.isHidden = item.msg.type != DC_MSG_VIDEO
         imageView.image = item.thumbnailImage
 
         contentView.isAccessibilityElement = true


### PR DESCRIPTION
this PR adds the missing viewtype for 'Video Chat Invitation' and adapts the condition to hide/show reactions accordingly.

moreover, it fixes the issue that reactions for 'Videos' are not shown

EDIT: also, this PR cleans up erroneous viewtype getters - we had two (!), in most cases, `msg.type` was used, which returns correct values. in rare cases, `msg.viewtype` was used that had errors. the latter is replaced by `msg.type` by this PR so we have only one thing - and are also closer to the android wrt naming and grep'ability
 
**for review:** "viewtype" is synonym to "message type", in core, in android and mostly on ios, we prefer the shorter form, however, but to keep this PR short and draw a line, i did not refactor all variable names and so on 

successor of #2084

closes #2089