### PR TITLE
show show inputAccessoryView also when it is "half blocked"

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -159,7 +159,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }()
 
     override var inputAccessoryView: UIView? {
-        if dcChat.canSend {
+        if dcChat.canSend || dcChat.isHalfBlocked {
             return messageInputBar
         } else {
             return nil


### PR DESCRIPTION
show inputAccessoryView also when it is used to display block/accept or info/accept buttons (["half blocked" as introduced for "guaranteed e2ee"](https://github.com/deltachat/deltachat-ios/pull/1946))

closes #2091 