### PR TITLE
tweak scripts/clean-core.sh

### DIFF
--- a/scripts/clean-core.sh
+++ b/scripts/clean-core.sh
@@ -1,1 +1,8 @@
+cd deltachat-ios/libraries/deltachat-core-rust
+cargo clean
+cd -
+
 rm -rf deltachat-ios/libraries/deltachat-core-rust/target
+rm deltachat-ios/libraries/libdeltachat.a
+
+echo "now, in Xcode, run 'Product / Clean Build Folder'"


### PR DESCRIPTION
the idea of the script
is to prune all possible caches that may cause problems when updating core.

it is run usually before a release and to make sure a core is rebuild from scratch.