### PR TITLE
prepare 1.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Delta Chat iOS Changelog
 
+## v1.44.0 Testflight
+2024-03
+
+* real PUSH notification if supported by providers as chatmail
+* send any emoji as reaction 💕
+* enlarge the account switcher by swiping up
+* offer "Select more" in read-only chats as well
+* sync self-avatar and self-signature text across devices
+* recognize "Trash" folder by name in case it is not flagged as such by the server
+* send group avatars inline so that they do not appear as unexpected attachments
+* fix: scroll down on opening chat
+* fix sending sync messages on updating self-name etc.
+* fix sometimes slow reconnects
+* more bug fixes
+* update translations and local help
+* update to core 1.136.2
+
+
 ## v1.43.1 Testflight
 2024-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.44.0 Testflight
 2024-03
 
-* real PUSH notification if supported by providers as chatmail
+* PUSH notification if supported by providers as chatmail
 * send any emoji as reaction 💕
 * enlarge the account switcher by swiping up
 * offer "Select more" in read-only chats as well

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -1768,7 +1768,7 @@
 				CODE_SIGN_ENTITLEMENTS = DcShare/DcShare.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1782,7 +1782,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.43.1;
+				MARKETING_VERSION = 1.44.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (
@@ -1813,7 +1813,7 @@
 				CODE_SIGN_ENTITLEMENTS = DcShare/DcShare.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1827,7 +1827,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.43.1;
+				MARKETING_VERSION = 1.44.0;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -1980,7 +1980,7 @@
 				CODE_SIGN_ENTITLEMENTS = "deltachat-ios/deltachat-ios.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -1999,7 +1999,7 @@
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/deltachat-ffi",
 					"$(PROJECT_DIR)/deltachat-ios/libraries",
 				);
-				MARKETING_VERSION = 1.43.1;
+				MARKETING_VERSION = 1.44.0;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-isystem",
@@ -2052,7 +2052,7 @@
 				CODE_SIGN_ENTITLEMENTS = "deltachat-ios/deltachat-ios.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEVELOPMENT_TEAM = 8Y86453UA8;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -2071,7 +2071,7 @@
 					"$(PROJECT_DIR)/deltachat-ios/libraries/deltachat-core-rust/deltachat-ffi",
 					"$(PROJECT_DIR)/deltachat-ios/libraries",
 				);
-				MARKETING_VERSION = 1.43.1;
+				MARKETING_VERSION = 1.44.0;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-isystem",

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -145,16 +145,13 @@ class ChatListViewController: UITableViewController {
 
         if dcContext.isAnyDatabaseEncrypted() {
             let msg = dcContext.newMessage(viewType: DC_MSG_TEXT)
-            msg.text = "⚠️ \"Encrypted Accounts\" now unsupported\n\n"
-            +   "Thanks for trying out experimental \"Encrypted Accounts\". "
-            +   "Due to maintenance challenges, few impact (the system encrypts accounts anyways) "
-            +   "and the need to focus on other improvements, we are discontinuing this experiment for now.\n\n"
-            +   "👉 To exit the experiment and avoid problems:\n\n"
+            msg.text = "⚠️ \"Encrypted Accounts\" are unsupported!\n\n"
+            +   "👉 To exit the experiment and avoid problems in future versions:\n\n"
             +   "- Open encrypted account in the account switcher (marked by \"⚠️\")\n\n"
             +   "- Do \"Settings / Chats and Media / Export Backup\"\n\n"
             +   "- In the account switcher, do \"Add Account / Restore from Backup\"\n\n"
             +   "- If successful, you'll have the account duplicated. Only then, delete the encrypted one marked by \"⚠️\""
-            dcContext.addDeviceMessage(label: "ios-encrypted-accounts-unsupported5", msg: msg)
+            dcContext.addDeviceMessage(label: "ios-encrypted-accounts-unsupported6", msg: msg)
         }
     }
 

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -134,10 +134,14 @@ class ChatListViewController: UITableViewController {
 
         // update messages - for new messages, do not reuse or modify strings but create new ones.
         // it is not needed to keep all past update messages, however, when deleted, also the strings should be deleted.
-        let deviceMsgLabel = "update_1_42b_ios2"
+        let deviceMsgLabel = "update_1_44c_ios2"
         if !dcAccounts.isFreshlyAdded(id: dcContext.id) {
             let msg = dcContext.newMessage(viewType: DC_MSG_TEXT)
-            msg.text = String.localized("update_1_42_common") + "\n\n" + String.localized("more_info_desktop") +  ": https://get.delta.chat/#changelogs"
+            msg.text = "What\'s new:\n\n"
+            +   "❤️ Yeah! This was long-awaited: Long tap a message to react\n\n"
+            +   "🫸 PUSH notifications if suported by providers as https://nine.testrun.org\n\n"
+            +   "🔗 If you cannot scan QR codes, share them as invite links\n\n"
+            +   "… and TONS of bugfixes … https://get.delta.chat/#changelogs"
             dcContext.addDeviceMessage(label: deviceMsgLabel, msg: msg)
         } else {
             dcContext.addDeviceMessage(label: deviceMsgLabel, msg: nil)

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -137,11 +137,7 @@ class ChatListViewController: UITableViewController {
         let deviceMsgLabel = "update_1_44c_ios2"
         if !dcAccounts.isFreshlyAdded(id: dcContext.id) {
             let msg = dcContext.newMessage(viewType: DC_MSG_TEXT)
-            msg.text = "What\'s new:\n\n"
-            +   "❤️ Yeah! This was long-awaited: Long tap a message to react\n\n"
-            +   "🫸 PUSH notifications if suported by providers as https://nine.testrun.org\n\n"
-            +   "🔗 If you cannot scan QR codes, share them as invite links\n\n"
-            +   "… and TONS of bugfixes … https://get.delta.chat/#changelogs"
+            msg.text = String.localizedStringWithFormat(String.localized("update_1_44_ios"), "https://get.delta.chat/#changelogs")
             dcContext.addDeviceMessage(label: deviceMsgLabel, msg: msg)
         } else {
             dcContext.addDeviceMessage(label: deviceMsgLabel, msg: nil)


### PR DESCRIPTION
this PR also adds a "What's new" device message:

<img width=320  src=https://github.com/deltachat/deltachat-ios/assets/9800740/864c9880-f165-41e2-89cc-6cf1e6b0eee8>

counterpart of https://github.com/deltachat/deltachat-android/pull/2974