### PR TITLE
allow pasting qr-codes without selecting 'scan'

### DIFF
--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -115,9 +115,8 @@ class QrPageController: UIPageViewController {
             alert.addAction(UIAlertAction(title: String.localized("menu_share"), style: .default, handler: share(_:)))
             alert.addAction(UIAlertAction(title: String.localized("menu_copy_to_clipboard"), style: .default, handler: copyToClipboard(_:)))
             alert.addAction(UIAlertAction(title: String.localized("withdraw_qr_code"), style: .default, handler: withdrawQrCode(_:)))
-        } else {
-            alert.addAction(UIAlertAction(title: String.localized("paste_from_clipboard"), style: .default, handler: pasteFromClipboard(_:)))
         }
+        alert.addAction(UIAlertAction(title: String.localized("paste_from_clipboard"), style: .default, handler: pasteFromClipboard(_:)))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         self.present(alert, animated: true, completion: nil)
     }


### PR DESCRIPTION
this PR shows 'paste QR code from clipboard' on both of the 'QR code' tabs.

i have seen it several times where ppl want to paste a qr code and were searching for the option;
it seems superfluous - and one tap more - if one is force to select 'scan' before.

@adbenitez maybe also sth. for andoid