### PR TITLE
make use of notifications filtering entitlement

### DIFF
--- a/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
@@ -16,7 +16,7 @@ public extension UserDefaults {
     }
 
     static func setMainIoRunning(_ value: Bool = true) {
-        UserDefaults.pushToDebugArray(value ? "➡️" : "🛑")
+        UserDefaults.pushToDebugArray(value ? "▶️" : "⏸️")
         shared?.setValue(value, forKey: mainIoRunningKey)
     }
 

--- a/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
@@ -3,6 +3,7 @@ public extension UserDefaults {
     static var hasExtensionAttemptedToSend = "hasExtensionAttemptedToSend"
     static var hasSavedKeyToKeychain = "hasSavedKeyToKeychain"
     static var upgradedKeychainEntry = "upgradedKeychainEntry_"
+    static var debugArrayKey = "notify-fetch-info"
     static var mainAppRunningKey = "mainAppRunning"
     static var nseFetchingKey = "nseFetching"
 
@@ -15,6 +16,7 @@ public extension UserDefaults {
     }
 
     static func setMainAppRunning(_ value: Bool = true) {
+        UserDefaults.pushToDebugArray(value ? "➡️" : "🛑")
         shared?.setValue(value, forKey: mainAppRunningKey)
     }
 
@@ -24,5 +26,16 @@ public extension UserDefaults {
 
     static func setNseFetching(_ value: Bool = true) {
         shared?.setValue(value, forKey: nseFetchingKey)
+    }
+
+    static func pushToDebugArray(_ value: String) {
+        guard let shared else { return }
+        let values = shared.array(forKey: debugArrayKey)
+        var slidingValues = [String]()
+        if values != nil, let values = values as? [String] {
+            slidingValues = values.suffix(512)
+        }
+        slidingValues.append(DateUtils.getExtendedAbsTimeSpanString(timeStamp: Double(Date().timeIntervalSince1970)) + "|" + value)
+        shared.set(slidingValues, forKey: debugArrayKey)
     }
 }

--- a/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
@@ -4,20 +4,20 @@ public extension UserDefaults {
     static var hasSavedKeyToKeychain = "hasSavedKeyToKeychain"
     static var upgradedKeychainEntry = "upgradedKeychainEntry_"
     static var debugArrayKey = "notify-fetch-info"
-    static var mainAppRunningKey = "mainAppRunning"
+    static var mainIoRunningKey = "mainIoRunning"
     static var nseFetchingKey = "nseFetching"
 
     static var shared: UserDefaults? {
         return UserDefaults(suiteName: "group.chat.delta.ios")
     }
 
-    static var mainAppRunning: Bool {
-        return shared?.bool(forKey: mainAppRunningKey) ?? false
+    static var mainIoRunning: Bool {
+        return shared?.bool(forKey: mainIoRunningKey) ?? false
     }
 
-    static func setMainAppRunning(_ value: Bool = true) {
+    static func setMainIoRunning(_ value: Bool = true) {
         UserDefaults.pushToDebugArray(value ? "➡️" : "🛑")
-        shared?.setValue(value, forKey: mainAppRunningKey)
+        shared?.setValue(value, forKey: mainIoRunningKey)
     }
 
     static var nseFetching: Bool {

--- a/DcNotificationService/DcNotificationService.entitlements
+++ b/DcNotificationService/DcNotificationService.entitlements
@@ -10,5 +10,7 @@
 	<array>
 		<string>$(AppIdentifierPrefix)group.chat.delta.ios</string>
 	</array>
+	<key>com.apple.developer.usernotifications.filtering</key>
+	<true/>
 </dict>
 </plist>

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -9,7 +9,7 @@ class NotificationService: UNNotificationServiceExtension {
         let nowTimestamp = Double(Date().timeIntervalSince1970)
         UserDefaults.pushToDebugArray("🤜")
 
-        if UserDefaults.mainAppRunning {
+        if UserDefaults.mainIoRunning {
             UserDefaults.pushToDebugArray("ABORT4")
             contentHandler(silenceNotification())
             return

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -6,8 +6,11 @@ class NotificationService: UNNotificationServiceExtension {
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
         guard let bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent) else { return }
+        let nowTimestamp = Double(Date().timeIntervalSince1970)
+        UserDefaults.pushToDebugArray("🤜")
 
         if UserDefaults.mainAppRunning {
+            UserDefaults.pushToDebugArray("ABORT4")
             contentHandler(silenceNotification())
             return
         }
@@ -20,6 +23,7 @@ class NotificationService: UNNotificationServiceExtension {
         let eventEmitter = dcAccounts.getEventEmitter()
 
         if !dcAccounts.backgroundFetch(timeout: 25) {
+            UserDefaults.pushToDebugArray("ERR3")
             UserDefaults.setNseFetching(false)
             contentHandler(bestAttemptContent)
             return
@@ -56,6 +60,7 @@ class NotificationService: UNNotificationServiceExtension {
 
         if messageCount == 0 {
             dcAccounts.closeDatabase()
+            UserDefaults.pushToDebugArray(String(format: "OK0 %.3fs", Double(Date().timeIntervalSince1970) - nowTimestamp))
             contentHandler(silenceNotification())
         } else {
             bestAttemptContent.badge = dcAccounts.getFreshMessageCount() as NSNumber
@@ -74,6 +79,7 @@ class NotificationService: UNNotificationServiceExtension {
                 bestAttemptContent.relevanceScore = 1.0
             }
             UserDefaults.shared?.set(true, forKey: UserDefaults.hasExtensionAttemptedToSend) // force UI updates in case app was suspended
+            UserDefaults.pushToDebugArray(String(format: "OK1 %d %.3fs", messageCount, Double(Date().timeIntervalSince1970) - nowTimestamp))
             contentHandler(bestAttemptContent)
         }
     }
@@ -84,6 +90,7 @@ class NotificationService: UNNotificationServiceExtension {
 
         // For Delta Chat, it is just fine to do nothing - assume eg. bad network or mail servers not reachable,
         // then a "You have new messages" is the best that can be done.
+        UserDefaults.pushToDebugArray("ERR4")
         UserDefaults.setNseFetching(false)
     }
 

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -57,7 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         // The NSE ("Notification Service Extension") must not run at the same time as the app.
         // The other way round, the NSE is not started with the app running.
-        UserDefaults.setMainAppRunning()
+        UserDefaults.setMainIoRunning()
         var pollSeconds = 0
         while UserDefaults.nseFetching && pollSeconds < 30 {
             logger.info("➡️ wait for NSE to terminate")
@@ -241,7 +241,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func applicationWillEnterForeground(_: UIApplication) {
         logger.info("➡️ applicationWillEnterForeground")
         applicationInForeground = true
-        UserDefaults.setMainAppRunning()
+        UserDefaults.setMainIoRunning()
         dcAccounts.startIo()
 
         DispatchQueue.global().async { [weak self] in
@@ -282,7 +282,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // applicationDidBecomeActive() is called on initial app start _and_ after applicationWillEnterForeground()
     func applicationDidBecomeActive(_: UIApplication) {
         logger.info("➡️ applicationDidBecomeActive")
-        UserDefaults.setMainAppRunning()
+        UserDefaults.setMainIoRunning()
         applicationInForeground = true
     }
 
@@ -338,7 +338,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             } else if app.backgroundTimeRemaining < 10 {
                 logger.info("⬅️ few background time, \(app.backgroundTimeRemaining), stopping")
                 self.dcAccounts.stopIo()
-                UserDefaults.setMainAppRunning(false)
+                UserDefaults.setMainIoRunning(false)
 
                 // to avoid 0xdead10cc exceptions, scheduled jobs need to be done before we get suspended;
                 // we increase the probabilty that this happens by waiting a moment before calling unregisterBackgroundTask()
@@ -473,7 +473,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             logger.info("⬅️ finishing fetch by system urgency requests")
             UserDefaults.pushToDebugArray("ERR1")
             self?.dcAccounts.stopIo()
-            UserDefaults.setMainAppRunning(false)
+            UserDefaults.setMainIoRunning(false)
             completionHandler?(.newData)
             if backgroundTask != .invalid {
                 UIApplication.shared.endBackgroundTask(backgroundTask)
@@ -490,7 +490,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             self.dcAccounts.fetchSemaphore = DispatchSemaphore(value: 0)
 
             // backgroundFetch() pauses IO as needed
-            UserDefaults.setMainAppRunning()
+            UserDefaults.setMainIoRunning()
 
             if !self.dcAccounts.backgroundFetch(timeout: 20) {
                 logger.error("backgroundFetch failed")
@@ -498,7 +498,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             }
 
             if !appIsInForeground() {
-                UserDefaults.setMainAppRunning(false) // this also improves resilience: if we crashed before, NSE would never run otherwise
+                UserDefaults.setMainIoRunning(false) // this also improves resilience: if we crashed before, NSE would never run otherwise
             }
 
             // wait for DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE;
@@ -614,7 +614,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private func uninstallEventHandler() {
         shouldShutdownEventLoop = true
         dcAccounts.stopIo() // stopIo will generate atleast one event to the event handler can shut down
-        UserDefaults.setMainAppRunning(false)
+        UserDefaults.setMainIoRunning(false)
         eventShutdownSemaphore.wait()
         shouldShutdownEventLoop = false
     }

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -173,8 +173,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             increaseDebugCounter("notify-remote-launch")
             pushToDebugArray("📡'")
             performFetch()
-        } else {
-            NotificationManager.removeIrrelevantNotifications()
         }
 
         if dcAccounts.getSelected().isConfigured() && !UserDefaults.standard.bool(forKey: "notifications_disabled") {
@@ -256,8 +254,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             }
 
             AppDelegate.emitMsgsChangedIfShareExtensionWasUsed()
-
-            NotificationManager.removeIrrelevantNotifications()
         }
     }
 
@@ -441,8 +437,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     private func performFetch(completionHandler: ((UIBackgroundFetchResult) -> Void)? = nil) {
-        NotificationManager.removeIrrelevantNotifications()
-
         // `didReceiveRemoteNotification` as well as `performFetchWithCompletionHandler` might be called if we're in foreground,
         // in this case, there is no need to wait for things or do sth.
         if appIsInForeground() || UserDefaults.nseFetching {

--- a/deltachat-ios/Controller/LogViewController.swift
+++ b/deltachat-ios/Controller/LogViewController.swift
@@ -76,18 +76,6 @@ public class LogViewController: UIViewController {
 
         info += "\n" + dcContext.getInfo() + "\n"
 
-        for name in ["notify-remote-launch", "notify-remote-receive", "notify-local-wakeup"] {
-            let cnt = UserDefaults.standard.integer(forKey: name + "-count")
-
-            let startDbl = UserDefaults.standard.double(forKey: name + "-start")
-            let startStr = startDbl==0.0 ? "" : " since " + DateUtils.getExtendedRelativeTimeSpanString(timeStamp: startDbl)
-
-            let timestampDbl = UserDefaults.standard.double(forKey: name + "-last")
-            let timestampStr = timestampDbl==0.0 ? "" : ", last " + DateUtils.getExtendedRelativeTimeSpanString(timeStamp: timestampDbl)
-
-            info += "\(name)=\(cnt)x\(startStr)\(timestampStr)\n"
-        }
-
         info += "notify-timestamps="
         if let timestamps = UserDefaults.standard.array(forKey: Constants.Keys.notificationTimestamps) as? [Double] {
             for currTimestamp in timestamps {
@@ -96,12 +84,18 @@ public class LogViewController: UIViewController {
         }
         info += "\n"
 
-        info += "notify-fetch-info2="
-        if let infos = UserDefaults.standard.array(forKey: "notify-fetch-info2")  as? [String] {
+        info += UserDefaults.debugArrayKey + "="
+        if let infos = UserDefaults.shared?.array(forKey: UserDefaults.debugArrayKey)  as? [String] {
+            var lastTime = ""
             for currInfo in infos {
-                info += currInfo
-                    .replacingOccurrences(of: "📡", with: "\n📡")
-                    .replacingOccurrences(of: "🏠", with: "\n🏠") + " "
+                let currInfo = currInfo.split(separator: "|", maxSplits: 2)
+                if let time = currInfo.first, let value = currInfo.last {
+                    if time != lastTime {
+                        info += time + ":"
+                        lastTime = String(time)
+                    }
+                    info += value + " "
+                }
             }
         }
         info += "\n"

--- a/deltachat-ios/Controller/LogViewController.swift
+++ b/deltachat-ios/Controller/LogViewController.swift
@@ -91,7 +91,7 @@ public class LogViewController: UIViewController {
                 let currInfo = currInfo.split(separator: "|", maxSplits: 2)
                 if let time = currInfo.first, let value = currInfo.last {
                     if time != lastTime {
-                        info += time + ":"
+                        info += "\n" + time + " "
                         lastTime = String(time)
                     }
                     info += value + " "

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -59,20 +59,6 @@ public class NotificationManager {
         }
     }
 
-    public static func removeIrrelevantNotifications() {
-        let nc = UNUserNotificationCenter.current()
-        nc.getDeliveredNotifications { notifications in
-            var toRemove = [String]()
-            for notification in notifications {
-                let irrelevant = notification.request.content.userInfo["irrelevant"] as? Bool ?? false
-                if irrelevant {
-                    toRemove.append(notification.request.identifier)
-                }
-            }
-            nc.removeDeliveredNotifications(withIdentifiers: toRemove)
-        }
-    }
-
     private func initObservers() {
         anyIncomingMsgObserver = NotificationCenter.default.addObserver(
             forName: eventIncomingMsgAnyAccount,

--- a/deltachat-ios/deltachat-ios.entitlements
+++ b/deltachat-ios/deltachat-ios.entitlements
@@ -12,6 +12,8 @@
 	<array/>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+	<key>com.apple.developer.usernotifications.filtering</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.chat.delta.ios</string>


### PR DESCRIPTION
this PR makes use of the entitlement `com.apple.developer.usernotifications.filtering` that allows us to  _not_ show a notification [^1]

moreover, this PR moves debug-array-handling to shared defaults, so that push info can be added as well. this is esp. important when an notification is missing: we want to know if we have run and have eg. a sync-with-main-bug - or if some server has a hickup

code can be reviewed already, for testing, we need to apply filtering entitlement to appstore connect 

successor of https://github.com/deltachat/deltachat-ios/pull/2105

[^1]: without the entitlement `com.apple.developer.usernotifications.filtering`, in case an notification is irrelevant,
one needs to add it anyways as it is not possible to _not_ show a notification. to mitigate that situation, one can only not play a sound, do not light the display, and remove the notification asap - but it may stay for tens of minutes