### PR TITLE
use unified logging system, share log

### DIFF
--- a/DcCore/DcCore/DC/Logger.swift
+++ b/DcCore/DcCore/DC/Logger.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 let logger = DcLogger()
 
@@ -7,23 +8,39 @@ public func getDcLogger() -> DcLogger {
 }
 
 public class DcLogger {
+    public static let subsystem = "chat.delta"
+    static let category = "deltachat"
+    let osLog: AnyObject?
 
     public init() {
-    }
-
-    public func debug(_ message: String) {
-        print("💚 \(message)")
-    }
-
-    public func info(_ message: String) {
-        print("💙 \(message)")
-    }
-
-    public func warning(_ message: String) {
-        print("🧡 \(message)")
+        if #available(iOS 14.0, *) {
+            osLog = Logger(subsystem: DcLogger.subsystem, category: DcLogger.category) as AnyObject
+        } else {
+            osLog = nil
+        }
     }
 
     public func error(_ message: String) {
-        print("❤️ \(message)")
+        if #available(iOS 14.0, *) {
+            (osLog as? Logger)?.error("❤️ \(message, privacy: .public)") // "public" is needed to show lines; core takes care of privacy
+        } else {
+            os_log("❤️ %{public}s", log: .default, type: .error, message)
+        }
+    }
+
+    public func warning(_ message: String) {
+        if #available(iOS 14.0, *) {
+            (osLog as? Logger)?.warning("🧡 \(message, privacy: .public)")
+        } else {
+            os_log("🧡 %{public}s", log: .default, type: .default /* there is no .warning */, message)
+        }
+    }
+
+    public func info(_ message: String) {
+        if #available(iOS 14.0, *) {
+            (osLog as? Logger)?.notice("💙 \(message, privacy: .public)") // info() is not persisted
+        } else {
+            os_log("💙 %{public}s", log: .default, type: .default /* .default equals notice() and is persisted */, message)
+        }
     }
 }

--- a/DcCore/DcCore/DC/Logger.swift
+++ b/DcCore/DcCore/DC/Logger.swift
@@ -43,4 +43,15 @@ public class DcLogger {
             os_log("💙 %{public}s", log: .default, type: .default /* .default equals notice() and is persisted */, message)
         }
     }
+
+    // debug() marked as DEBUG as these lines are for, well debugging. and should not being released. otherwise, use info()
+    #if DEBUG
+    public func debug(_ message: String) {
+        if #available(iOS 14.0, *) {
+            (osLog as? Logger)?.debug("💚 \(message, privacy: .public)")
+        } else {
+            os_log("💚 %{public}s", log: .default, type: .debug, message)
+        }
+    }
+    #endif
 }

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -27,17 +27,17 @@ public class DcEventHandler {
         let accountId = event.accountId
 
         if event.id >= DC_EVENT_ERROR && event.id <= 499 {
-            logger.error("📡[\(accountId)] \(event.data2String)")
+            logger.error("[\(accountId)] \(event.data2String)")
             return
         }
 
         switch event.id {
 
         case DC_EVENT_INFO:
-            logger.info("📡[\(accountId)] \(event.data2String)")
+            logger.info("[\(accountId)] \(event.data2String)")
 
         case DC_EVENT_WARNING:
-            logger.warning("📡[\(accountId)] \(event.data2String)")
+            logger.warning("[\(accountId)] \(event.data2String)")
 
         case DC_EVENT_CONFIGURE_PROGRESS:
             logger.info("📡[\(accountId)] configure: \(Int(data1))")
@@ -66,9 +66,6 @@ public class DcEventHandler {
                     "errorMessage": self.dcAccounts.get(id: accountId).lastErrorString,
                 ])
             }
-
-        case DC_EVENT_IMAP_CONNECTED, DC_EVENT_SMTP_CONNECTED:
-            logger.info("📡[\(accountId)] network: \(event.data2String)")
 
         case DC_EVENT_MSGS_CHANGED, DC_EVENT_REACTIONS_CHANGED, DC_EVENT_MSG_READ, DC_EVENT_MSG_DELIVERED, DC_EVENT_MSG_FAILED:
             if accountId != dcAccounts.getSelected().id {
@@ -127,9 +124,6 @@ public class DcEventHandler {
                     "chat_id": Int(data1),
                 ])
             }
-
-        case DC_EVENT_SMTP_MESSAGE_SENT:
-            logger.info("📡[\(accountId)] smtp sent: \(event.data2String)")
 
         case DC_EVENT_SECUREJOIN_INVITER_PROGRESS:
             if accountId != dcAccounts.getSelected().id {

--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -106,7 +106,6 @@ class ShareViewController: SLComposeServiceViewController {
 
         if selectedChatId == nil {
             selectedChatId = dcContext.getChatIdByContactId(contactId: Int(DC_CONTACT_ID_SELF))
-            logger.debug("selected chatID: \(String(describing: selectedChatId))")
         }
 
         let contact = dcContext.getContact(id: Int(DC_CONTACT_ID_SELF))
@@ -194,7 +193,6 @@ class ShareViewController: SLComposeServiceViewController {
 
             item?.title = String.localized("forward_to")
             item?.value = selectedChat?.name
-            logger.debug("configurationItems chat name: \(String(describing: selectedChat?.name))")
             item?.tapHandler = {
                 let chatListController = ChatListController(dcContext: self.dcContext, chatListDelegate: self)
                 self.pushConfigurationViewController(chatListController)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -591,12 +591,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     override func didMove(toParent parent: UIViewController?) {
         super.didMove(toParent: parent)
         if parent == nil {
-            logger.debug(">>> ChatViewController - chat observer: remove")
             removeObservers()
             draft.save(context: dcContext)
             keyboardManager = nil
         } else {
-            logger.debug(">>> ChatViewController - chat observer: setup")
             setupObservers()
         }
     }
@@ -2249,7 +2247,6 @@ extension ChatViewController: BaseMessageCellDelegate {
         if let phoneURL = URL(string: "tel://\(sanitizedNumber)") {
             UIApplication.shared.open(phoneURL, options: [:], completionHandler: nil)
         }
-        logger.debug("phone number tapped \(sanitizedNumber)")
     }
 
     @objc func commandTapped(command: String, indexPath: IndexPath) {
@@ -2267,7 +2264,6 @@ extension ChatViewController: BaseMessageCellDelegate {
             return
         }
         if Utils.isEmail(url: url) {
-            logger.debug("tapped on contact")
             let email = Utils.getEmailFrom(url)
             self.askToChatWith(email: email)
         } else {
@@ -2457,7 +2453,6 @@ extension ChatViewController: ChatEditingDelegate {
 // MARK: - ChatSearchDelegate
 extension ChatViewController: ChatSearchDelegate {
     func onSearchPreviousPressed() {
-        logger.debug("onSearch Previous Pressed")
         if searchResultIndex == 0 && !searchMessageIds.isEmpty {
             searchResultIndex = searchMessageIds.count - 1
         } else {
@@ -2469,7 +2464,6 @@ extension ChatViewController: ChatSearchDelegate {
     }
 
     func onSearchNextPressed() {
-        logger.debug("onSearch Next Pressed")
         if searchResultIndex == searchMessageIds.count - 1 {
             searchResultIndex = 0
         } else {
@@ -2484,7 +2478,6 @@ extension ChatViewController: ChatSearchDelegate {
 // MARK: UISearchResultUpdating
 extension ChatViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
-        logger.debug("searchbar: \(String(describing: searchController.searchBar.text))")
         debounceTimer?.invalidate()
         debounceTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { _ in
             let searchText = searchController.searchBar.text ?? ""

--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -649,7 +649,6 @@ extension BaseMessageCell: MessageLabelDelegate {
 
     public func didSelectURL(_ url: URL) {
         if let tableView = self.superview as? UITableView, let indexPath = tableView.indexPath(for: self) {
-            logger.debug("did select URL")
             baseDelegate?.urlTapped(url: url, indexPath: indexPath)
         }
     }
@@ -662,7 +661,6 @@ extension BaseMessageCell: MessageLabelDelegate {
 
     public func didSelectCommand(_ command: String) {
         if let tableView = self.superview as? UITableView, let indexPath = tableView.indexPath(for: self) {
-            logger.debug("did select command \(command)")
             baseDelegate?.commandTapped(command: command, indexPath: indexPath)
         }
     }

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -216,7 +216,6 @@ class AccountSwitchViewController: UITableViewController {
     }
 
     @objc private func editAction() {
-        logger.debug("edit Action")
         title = String.localized("delete_account")
         navigationItem.setLeftBarButton(nil, animated: true)
         navigationItem.setRightBarButton(cancelEditButton, animated: true)
@@ -225,7 +224,6 @@ class AccountSwitchViewController: UITableViewController {
     }
 
     @objc private func cancelEditAction() {
-        logger.debug("cancel Action")
         title = String.localized("switch_account")
         navigationItem.setLeftBarButton(editButton, animated: false)
         navigationItem.setRightBarButton(doneButton, animated: false)
@@ -234,7 +232,6 @@ class AccountSwitchViewController: UITableViewController {
     }
 
     @objc private func doneAction() {
-        logger.debug("done Action")
         dismiss(animated: true)
     }
 }

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -220,7 +220,6 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func recordingButtonAction() {
-        logger.debug("start recording")
         self.setToolbarItems([flexItem, cancelRecordingButton, flexItem, pauseButton, flexItem], animated: true)
         cancelRecordingButton.isEnabled = true
         doneButton.isEnabled = true
@@ -242,21 +241,18 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func continueRecordingButtonAction() {
-        logger.debug("continue recording")
         self.setToolbarItems([flexItem, cancelRecordingButton, flexItem, pauseButton, flexItem], animated: true)
         isRecordingPaused = false
         audioRecorder?.record()
     }
 
     @objc func pauseRecordingButtonAction() {
-        logger.debug("pause")
         isRecordingPaused = true
         audioRecorder?.pause()
         self.setToolbarItems([flexItem, cancelRecordingButton, flexItem, continueRecordingButton, flexItem], animated: true)
     }
 
     @objc func cancelRecordingAction() {
-        logger.debug("cancel recording")
         isRecordingPaused = false
         cancelRecordingButton.isEnabled = false
         doneButton.isEnabled = false
@@ -266,13 +262,11 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func cancelAction() {
-        logger.debug("cancel Action")
         cancelRecordingAction()
         dismiss(animated: true, completion: nil)
     }
 
     @objc func doneAction() {
-        logger.debug("done with Action")
         isRecordingPaused = false
         audioRecorder?.stop()
         if let delegate = self.delegate {

--- a/deltachat-ios/Controller/LogViewController.swift
+++ b/deltachat-ios/Controller/LogViewController.swift
@@ -7,6 +7,18 @@ public class LogViewController: UIViewController {
     private let dcContext: DcContext
     private let loadingIndicator = "\n\nLoading log ..."
 
+    private lazy var shareButton: UIBarButtonItem = {
+        let button: UIBarButtonItem
+        if #available(iOS 13.0, *) {
+            button = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"), style: .plain, target: self, action: #selector(shareButtonPressed))
+        } else {
+            button = UIBarButtonItem(title: String.localized("menu_share"), style: .plain, target: self, action: #selector(shareButtonPressed))
+        }
+        button.accessibilityLabel = String.localized("menu_share")
+        button.isEnabled = false
+        return button
+    }()
+
     private lazy var logText: UITextView = {
         let label = UITextView()
         label.contentInset = UIEdgeInsets(top: 12, left: 0, bottom: 0, right: 0)
@@ -44,9 +56,12 @@ public class LogViewController: UIViewController {
                     guard let self else { return }
                     let debugVariables = self.logText.text.replacingOccurrences(of: self.loadingIndicator, with: "")
                     self.logText.text = debugVariables + "\n" + log
+                    self.shareButton.isEnabled = true
                 }
             }
         }
+
+        navigationItem.rightBarButtonItem = shareButton
     }
 
     @objc
@@ -140,5 +155,13 @@ public class LogViewController: UIViewController {
         log += "\n\nTo get the full log, use Console.app on a Mac."
 
         return log
+    }
+
+    // MARK: - actions
+
+    @objc private func shareButtonPressed() {
+        if let text = logText.text {
+            Utils.share(text: text, parentViewController: self, sourceItem: shareButton)
+        }
     }
 }

--- a/deltachat-ios/Controller/WebViewViewController.swift
+++ b/deltachat-ios/Controller/WebViewViewController.swift
@@ -157,7 +157,6 @@ class WebViewViewController: UIViewController, WKNavigationDelegate {
     private func updateAccessoryBar() {
         handleSearchResultCount { [weak self] result in
             guard let self else { return }
-            logger.debug("found \(result) elements")
             self.searchAccessoryBar.isEnabled = result > 0
             self.handleCurrentlySelected { [weak self] position in
                 self?.searchAccessoryBar.updateSearchResult(sum: result, position: position == -1 ? 0 : position + 1)
@@ -238,7 +237,6 @@ extension WebViewViewController: UISearchBarDelegate, UISearchControllerDelegate
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         debounceTimer?.invalidate()
         debounceTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { [weak self] _ in
-            logger.debug("search for \(searchText)")
             if searchText.isEmpty {
                 self?.removeAllHighlights()
             } else {
@@ -266,12 +264,10 @@ extension WebViewViewController: UISearchBarDelegate, UISearchControllerDelegate
 
 extension WebViewViewController: ChatSearchDelegate {
     func onSearchPreviousPressed() {
-        logger.debug("onSearchPrevious pressed")
         self.searchPrevious()
     }
 
     func onSearchNextPressed() {
-        logger.debug("onSearchNextPressed pressed")
         self.searchNext()
     }
 }

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -323,12 +323,10 @@ class WebxdcViewController: WebViewViewController {
                 decisionHandler(.cancel)
                 return
             } else if url.scheme != INTERNALSCHEMA {
-                logger.debug("cancel loading: \(url)")
                 decisionHandler(.cancel)
                 return
             }
         }
-        logger.debug("loading: \(String(describing: navigationAction.request.url))")
         decisionHandler(.allow)
     }
     
@@ -427,8 +425,8 @@ extension WebxdcViewController: WKScriptMessageHandler {
                 logger.error("could not convert param \(message.body) to string")
                 return
             }
-            logger.debug("webxdc log msg: "+msg)
-            
+            logger.info("webxdc log msg: " + msg)
+
         case .sendStatusUpdate:
             guard let dict = message.body as? [String: AnyObject],
                   let payloadDict = dict["payload"] as?  [String: AnyObject],
@@ -466,7 +464,7 @@ extension WebxdcViewController: WKScriptMessageHandler {
             }
 
         default:
-            logger.debug("another method was called")
+            break
         }
     }
 }
@@ -523,8 +521,6 @@ extension WebxdcViewController: WKURLSchemeHandler {
             urlSchemeTask.didReceive(response)
             urlSchemeTask.didReceive(data)
             urlSchemeTask.didFinish()
-        } else {
-            logger.debug("not loading \(String(describing: urlSchemeTask.request.url))")
         }
     }
     

--- a/deltachat-ios/Helper/LocationManager.swift
+++ b/deltachat-ios/Helper/LocationManager.swift
@@ -65,15 +65,11 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        logger.debug("LOCATION: didUpdateLocations")
-
         guard let newLocation = locations.last else {
-            logger.debug("LOCATION: new location is emtpy")
             return
         }
 
         let isBetter = isBetterLocation(newLocation: newLocation, lastLocation: lastLocation)
-        logger.debug("LOCATION: isBetterLocation: \(isBetter)")
         if isBetter {
             if dcContext.isSendingLocationsToChat(chatId: 0) {
                 dcContext.setLocation(latitude: newLocation.coordinate.latitude,
@@ -96,7 +92,6 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        logger.debug("LOCATION MANAGER: didChangeAuthorization: \(status)")
         switch status {
         case .denied, .restricted:
             disableLocationStreamingInAllChats()
@@ -150,17 +145,14 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     }
 
     func isMoreAccurate(newLocation: CLLocation, lastLocation: CLLocation) -> Bool {
-//        logger.debug("LOCATION: isMoreAccurate \(lastLocation.horizontalAccuracy - newLocation.horizontalAccuracy > 0)")
         return lastLocation.horizontalAccuracy - newLocation.horizontalAccuracy > 0
     }
 
     func hasLocationChanged(newLocation: CLLocation, lastLocation: CLLocation) -> Bool {
-//        logger.debug("LOCATION: hasLocationChanged \(newLocation.distance(from: lastLocation) > 10)")
         return newLocation.distance(from: lastLocation) > 10
     }
 
     func hasLocationSignificantlyChanged(newLocation: CLLocation, lastLocation: CLLocation) -> Bool {
-//        logger.debug("LOCATION: hasLocationSignificantlyChanged \(newLocation.distance(from: lastLocation) > 30)")
         return newLocation.distance(from: lastLocation) > 30
     }
 
@@ -169,7 +161,6 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
      */
     func isNewLocationOutdated(newLocation: CLLocation) -> Bool {
         let timeDelta = DateUtils.getRelativeTimeInSeconds(timeStamp: Double(newLocation.timestamp.timeIntervalSince1970))
- //       logger.debug("LOCATION: isLocationOutdated timeDelta: \(timeDelta) -> \(Double(Time.fiveMinutes)) -> \(timeDelta < Double(Time.fiveMinutes))")
         return timeDelta > Double(Time.fiveMinutes)
     }
     

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -14,22 +14,16 @@ protocol MediaPickerDelegate: AnyObject {
 
 extension MediaPickerDelegate {
     func onImageSelected(image: UIImage) {
-        logger.debug("image selected")
     }
     func onImageSelected(url: NSURL) {
-        logger.debug("image selected: \(url)")
     }
     func onVideoSelected(url: NSURL) {
-        logger.debug("video selected: \(url)")
     }
     func onVoiceMessageRecorded(url: NSURL) {
-        logger.debug("voice message recorded: \(url)")
     }
     func onVoiceMessageRecorderClosed() {
-        logger.debug("Voice Message recorder closed.")
     }
     func onDocumentSelected(url: NSURL) {
-        logger.debug("document selected: \(url)")
     }
 }
 

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -80,4 +80,10 @@ struct Utils {
             parentViewController.present(activityVC, animated: true, completion: nil)
         }
     }
+
+    public static func share(text: String, parentViewController: UIViewController, sourceItem: UIBarButtonItem) {
+        let activityVC = UIActivityViewController(activityItems: [text], applicationActivities: nil)
+        activityVC.popoverPresentationController?.barButtonItem = sourceItem // iPad crashes without a source
+        parentViewController.present(activityVC, animated: true, completion: nil)
+    }
 }


### PR DESCRIPTION
this PR switches logging from `print()` to ["unified logging system"](https://developer.apple.com/documentation/os/logging/generating_log_messages_from_your_code) with the following advantages:

- logs are persisted, at least for some time (depending on device speed and memory)
- non-devs can stream logs using Console.app on mac
- logs can be downloaded later using `log collect`
- we can show the log again at "Settings / Advanced" (requires iOS 15)

some further hints:

- instead of using apples method to redact sensitive data from the log, we aim to not add sensitive data at all (what _sensitive is_, is another discussion :)
- apple recommends to delay building final output string for performance reasons. we cannot easily make use of that as most strings come directly from the core. however, compared to what is added _by others_ to the log, the few lines from us are very probably not a performance issue. it is also not different to before, so this PR does not worsen things
- this PR also removes some log spam, eg. old debug entries (debug/printf should be used during an active debugging session only and removed afterwards)
- we keep the hearts for now, as it still makes things easier to recognize, esp. when mixed in Console.app with other things

finally, this PR adds a "share" button so that the log can be easily sent via other channels, copied etc.

<img width=720 src=https://github.com/deltachat/deltachat-ios/assets/9800740/4fb7cc2f-354f-44d0-ad3c-50ab4b0c06b9>

<img width=240 src=https://github.com/deltachat/deltachat-ios/assets/9800740/270c656f-9a4e-4f17-9d90-1ae629f81fcd> &nbsp; <img width=370 src=https://github.com/deltachat/deltachat-ios/assets/9800740/fcacb2da-5e82-4644-836b-9d86d0e7678b>


targets https://support.delta.chat/t/two-small-tweaks-to-improve-the-log-screen-in-dc-ios/2991
