### PR TITLE
fix crashes when sharing on iPads

### DIFF
--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -281,8 +281,10 @@ extension FilesViewController {
     }
 
     func shareAttachment(of indexPath: IndexPath) {
-        let msgId = fileMessageIds[indexPath.row]
-        Utils.share(message: dcContext.getMessage(id: msgId), parentViewController: self, sourceView: self.view)
+        if let cell = tableView.cellForRow(at: indexPath) {
+            let msgId = fileMessageIds[indexPath.row]
+            Utils.share(message: dcContext.getMessage(id: msgId), parentViewController: self, sourceView: cell.contentView)
+        }
     }
 }
 

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -123,7 +123,7 @@ class QrPageController: UIPageViewController {
 
     @objc func share(_ action: UIAlertAction) {
         if let inviteLink = Utils.getInviteLink(context: dcContext, chatId: 0) {
-            Utils.share(url: inviteLink, parentViewController: self)
+            Utils.share(url: inviteLink, parentViewController: self, sourceItem: moreButton)
         }
     }
 

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -94,7 +94,7 @@ class QrViewController: UIViewController {
 
     @objc func share(_ action: UIAlertAction) {
         if let inviteLink = Utils.getInviteLink(context: dcContext, chatId: chatId) {
-            Utils.share(url: inviteLink, parentViewController: self)
+            Utils.share(url: inviteLink, parentViewController: self, sourceItem: moreButton)
         }
     }
 

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -414,7 +414,7 @@ class WebxdcViewController: WebViewViewController {
     }
 
     private func shareWebxdc(_ action: UIAlertAction) {
-        Utils.share(message: dcContext.getMessage(id: messageId), parentViewController: self, sourceView: self.view)
+        Utils.share(message: dcContext.getMessage(id: messageId), parentViewController: self, sourceItem: moreButton)
     }
 }
 

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -54,7 +54,7 @@ struct Utils {
         return nil
     }
 
-    public static func share(message: DcMsg, parentViewController: UIViewController, sourceView: UIView) {
+    public static func share(message: DcMsg, parentViewController: UIViewController, sourceView: UIView? = nil, sourceItem: UIBarButtonItem? = nil) {
         guard let fileURL = message.fileURL else { return }
         let objectsToShare: [Any]
         if message.type == DC_MSG_WEBXDC {
@@ -70,13 +70,21 @@ struct Utils {
 
         let activityVC = UIActivityViewController(activityItems: objectsToShare, applicationActivities: nil)
         activityVC.excludedActivityTypes = [.copyToPasteboard]
-        activityVC.popoverPresentationController?.sourceView = sourceView
+        if let sourceItem {
+            activityVC.popoverPresentationController?.barButtonItem = sourceItem
+        } else if let sourceView {
+            activityVC.popoverPresentationController?.sourceView = sourceView
+        } else {
+            logger.error("set sourceView or sourceItem to avoid iPad crashes")
+            return
+        }
         parentViewController.present(activityVC, animated: true, completion: nil)
     }
 
-    public static func share(url: String, parentViewController: UIViewController) {
+    public static func share(url: String, parentViewController: UIViewController, sourceItem: UIBarButtonItem) {
         if let url = URL(string: url) {
             let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+            activityVC.popoverPresentationController?.barButtonItem = sourceItem
             parentViewController.present(activityVC, animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
iPads require some "real" source button given to UIActivityViewController

setting source to a "large, dummy view" does not work for iPads, at least not in the simulator (the share dialog will be somewhere outside the display).

and setting _no source_ leads to crashes.

so, seems, one really needs to set tapped button for iPad.

in a subsequent PR, when also sharing of https://github.com/deltachat/deltachat-ios/pull/2126 is merged, we can consider streamlining the (then) three `share` functions


<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/156ea7c8-3f40-4d68-b81d-0417e3f065a8> <img  width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/703461c7-7ea6-4823-9477-fd094e0dea12>

_without this PR, the share dialgo does not show up correctly_