### PR TITLE
duplicate app-icon badge counter to chat's tab-bar-item

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -284,6 +284,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.info("➡️ applicationDidBecomeActive")
         UserDefaults.setMainIoRunning()
         applicationInForeground = true
+        NotificationManager.updateBadgeCounters()
     }
 
     func applicationWillResignActive(_: UIApplication) {

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -246,7 +246,7 @@ internal final class SettingsViewController: UITableViewController {
             NotificationManager.removeAllNotifications()
         }
         UserDefaults.standard.synchronize()
-        NotificationManager.updateApplicationIconBadge(forceZero: !sender.isOn)
+        NotificationManager.updateBadgeCounters(forceZero: !sender.isOn)
     }
 
     // MARK: - updates

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -230,7 +230,7 @@ class AppCoordinator: NSObject {
         // the applicationIconBadgeNumber is remembered by the system even on reinstalls (just tested on ios 13.3.1),
         // to avoid appearing an old number of a previous installation, we reset the counter manually.
         // but even when this changes in ios, we need the reset as we allow account-deletion also in-app.
-        NotificationManager.updateApplicationIconBadge(forceZero: true)
+        NotificationManager.updateBadgeCounters(forceZero: true)
     }
 
     func presentTabBarController() {
@@ -271,6 +271,7 @@ class AppCoordinator: NSObject {
                                                   createChatsNavigationController(),
                                                   createSettingsNavigationController()], animated: false)
         presentTabBarController()
+        NotificationManager.updateBadgeCounters()
     }
 }
 

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -22,9 +22,19 @@ public class NotificationManager {
         dcContext = dcAccounts.getSelected()
     }
 
-    public static func updateApplicationIconBadge(forceZero: Bool = false) {
+    public static func updateBadgeCounters(forceZero: Bool = false) {
         DispatchQueue.main.async {
-            UIApplication.shared.applicationIconBadgeNumber = forceZero ? 0 : DcAccounts.shared.getFreshMessageCount()
+            let number = forceZero ? 0 : DcAccounts.shared.getFreshMessageCount()
+
+            // update badge counter on iOS homescreen
+            UIApplication.shared.applicationIconBadgeNumber = number
+
+            // update badge counter on our tabbar
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+               let appCoordinator = appDelegate.appCoordinator,
+               let chatsNavigationController = appCoordinator.tabBarController.viewControllers?[appCoordinator.chatsTab] {
+                chatsNavigationController.tabBarItem.badgeValue = number > 0 ? "\(number)" : nil
+            }
         }
     }
 
@@ -55,7 +65,7 @@ public class NotificationManager {
                 nc.removeDeliveredNotifications(withIdentifiers: toRemove)
             }
 
-            NotificationManager.updateApplicationIconBadge()
+            NotificationManager.updateBadgeCounters()
         }
     }
 
@@ -65,7 +75,7 @@ public class NotificationManager {
             object: nil, queue: OperationQueue.main
         ) { _ in
             if !UserDefaults.standard.bool(forKey: "notifications_disabled") {
-                NotificationManager.updateApplicationIconBadge()
+                NotificationManager.updateBadgeCounters()
             }
         }
 


### PR DESCRIPTION
to make it easier to notice new messages,
this PR shows the number of unread messages in the chat's tab-bar item -
and not only on the app-icon on the homescreen.

this is esp. useful as [tapping the icon scrolls up now](https://github.com/deltachat/deltachat-ios/pull/2127),
giving users and intuitive way to get to the new chats.

both badge counters will show the same number in the same layout.
if notifications are disabled, both counters are hidden
(the badges beside chats stay)

in practise, this feels totally normal and correctly,
this behavior is known from many other apps on iOS.
(i was also trying to show only the number of the active account,
that is more confusing, also in some tiny tests with some ppl.
i also tried other colors, but the default color seems the way to go here)

this also resets the counter on app start,                                      
maybe fixing some rare bugs where the counter is wrong on the app icon 

closes #2130

<img width=300 src=https://github.com/deltachat/deltachat-ios/assets/9800740/84515516-7a01-4078-9d9c-a29462b0ef90>

note, that the badge counters are not strictly event driven as they may be updates also when the app is not running by the [NSE](https://github.com/deltachat/deltachat-ios/pull/2105)