### PR TITLE
Second Attempt at "Long Press to ask user to copy link" / Link-"context menu"

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2027,7 +2027,16 @@ extension ChatViewController {
         if tableView.isEditing || messageId == DC_MSG_ID_MARKER1 || messageId == DC_MSG_ID_DAYMARKER {
             return nil
         }
-
+        // Check if the long tap is on a link (or other message text element with custom long tap behavior)
+        if let msgcell = tableView.cellForRow(at: indexPath) as? BaseMessageCell {
+            let label = msgcell.messageLabel.label
+            let localTouchLocation = tableView.convert(point, to: label)
+            let handled = label.handleGesture(localTouchLocation, longTap: true)
+            if handled {
+                return nil
+            }
+        }
+        
         return UIContextMenuConfiguration(
             identifier: NSString(string: "\(messageId)"),
             previewProvider: nil,

--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -608,6 +608,7 @@ public class BaseMessageCell: UITableViewCell {
 
 // MARK: - MessageLabelDelegate
 extension BaseMessageCell: MessageLabelDelegate {
+
     public func didSelectAddress(_ addressComponents: [String: String]) {}
 
     public func didSelectDate(_ date: Date) {}
@@ -622,6 +623,12 @@ extension BaseMessageCell: MessageLabelDelegate {
     public func didSelectURL(_ url: URL) {
         if let tableView = self.superview as? UITableView, let indexPath = tableView.indexPath(for: self) {
             baseDelegate?.urlTapped(url: url, indexPath: indexPath)
+        }
+    }
+    
+    public func didLongPressURL(_ url: URL) {
+        if let tableView = self.superview as? UITableView, let indexPath = tableView.indexPath(for: self) {
+            baseDelegate?.urlLongTapped(url: url, indexPath: indexPath)
         }
     }
 
@@ -652,6 +659,7 @@ public protocol BaseMessageCellDelegate: AnyObject {
     func commandTapped(command: String, indexPath: IndexPath) // `/command`
     func phoneNumberTapped(number: String, indexPath: IndexPath)
     func urlTapped(url: URL, indexPath: IndexPath) // url is eg. `https://foo.bar`
+    func urlLongTapped(url: URL, indexPath: IndexPath) // url is eg. `https://foo.bar` or email address
     func imageTapped(indexPath: IndexPath, previewError: Bool)
     func avatarTapped(indexPath: IndexPath)
     func textTapped(indexPath: IndexPath)

--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -279,7 +279,7 @@ public class BaseMessageCell: UITableViewCell {
     open func handleTapGesture(_ gesture: UIGestureRecognizer) {
         guard gesture.state == .ended else { return }
         let touchLocation = gesture.location(in: messageLabel)
-        let isHandled = messageLabel.label.handleGesture(touchLocation)
+        let isHandled = messageLabel.label.handleGesture(touchLocation, longTap: false)
         if !isHandled, let tableView = self.superview as? UITableView, let indexPath = tableView.indexPath(for: self) {
             self.baseDelegate?.textTapped(indexPath: indexPath)
         }

--- a/deltachat-ios/Chat/Views/MessageLabel.swift
+++ b/deltachat-ios/Chat/Views/MessageLabel.swift
@@ -452,17 +452,59 @@ open class MessageLabel: UILabel {
 
     }
 
-  open func handleGesture(_ touchLocation: CGPoint) -> Bool {
+    open func handleGesture(_ touchLocation: CGPoint, longTap: Bool) -> Bool {
 
         guard let index = stringIndex(at: touchLocation) else { return false }
 
         for (detectorType, ranges) in rangesForDetectors {
             for (range, value) in ranges {
                 if range.contains(index) {
-                    handleGesture(for: detectorType, value: value)
+                    if longTap {
+                        return handleLongTapGesture(for: detectorType, value: value)
+                    } else {
+                        handleGesture(for: detectorType, value: value)
+                    }
                     return true
                 }
             }
+        }
+        return false
+    }
+    
+    /// @returns whether item was handled
+    private func handleLongTapGesture(for detectorType: DetectorType, value: NewMessageTextCheckingType) -> Bool {
+        switch value {
+//        case let .addressComponents(addressComponents):
+//            var transformedAddressComponents = [String: String]()
+//            guard let addressComponents = addressComponents else { return false }
+//            addressComponents.forEach { (key, value) in
+//                transformedAddressComponents[key.rawValue] = value
+//            }
+//            handleAddress(transformedAddressComponents)
+        case let .phoneNumber(phoneNumber):
+            guard let phoneNumber = phoneNumber else { return false }
+            handlePhoneNumber(phoneNumber)
+//        case let .date(date):
+//            guard let date = date else { return false }
+//            handleDate(date)
+        case let .link(url):
+            guard let url = url else { return false }
+            handleURL(url)
+
+//        case let .custom(pattern, match):
+//            guard let match = match else { return false }
+//            switch detectorType {
+//            case .hashtag:
+//                handleHashtag(match)
+//            case .mention:
+//                handleMention(match)
+//            case .command:
+//                handleCommand(match)
+//            default:
+//                handleCustom(pattern, match: match)
+//            }
+        default:
+            return false
         }
         return false
     }

--- a/deltachat-ios/Chat/Views/MessageLabel.swift
+++ b/deltachat-ios/Chat/Views/MessageLabel.swift
@@ -481,15 +481,16 @@ open class MessageLabel: UILabel {
 //                transformedAddressComponents[key.rawValue] = value
 //            }
 //            handleAddress(transformedAddressComponents)
-        case let .phoneNumber(phoneNumber):
-            guard let phoneNumber = phoneNumber else { return false }
-            handlePhoneNumber(phoneNumber)
+//        case let .phoneNumber(phoneNumber):
+//            guard let phoneNumber = phoneNumber else { return false }
+//            handlePhoneNumber(phoneNumber)
 //        case let .date(date):
 //            guard let date = date else { return false }
 //            handleDate(date)
         case let .link(url):
             guard let url = url else { return false }
-            handleURL(url)
+            handleLongPressURL(url)
+            return true
 
 //        case let .custom(pattern, match):
 //            guard let match = match else { return false }
@@ -506,7 +507,6 @@ open class MessageLabel: UILabel {
         default:
             return false
         }
-        return false
     }
 
     /// swiftlint:disable cyclomatic_complexity
@@ -560,6 +560,10 @@ open class MessageLabel: UILabel {
 
     private func handleURL(_ url: URL) {
         delegate?.didSelectURL(url)
+    }
+    
+    private func handleLongPressURL(_ url: URL) {
+        delegate?.didLongPressURL(url)
     }
 
     private func handlePhoneNumber(_ phoneNumber: String) {

--- a/deltachat-ios/Chat/Views/MessageLabelDelegate.swift
+++ b/deltachat-ios/Chat/Views/MessageLabelDelegate.swift
@@ -50,6 +50,9 @@ public protocol MessageLabelDelegate: AnyObject {
     /// - Parameters:
     ///   - url: The selected URL.
     func didSelectURL(_ url: URL)
+    
+    /// Triggerd when a long press occurs on a detected URL
+    func didLongPressURL(_ url: URL)
 
     /// Triggered when a tap occurs on detected transit information.
     ///

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -578,6 +578,7 @@ class ContactDetailViewController: UITableViewController {
 }
 
 extension ContactDetailViewController: MultilineLabelCellDelegate {
+    
     func phoneNumberTapped(number: String) {
         let sanitizedNumber = number.filter("0123456789".contains)
         if let phoneURL = URL(string: "tel://\(sanitizedNumber)") {
@@ -607,5 +608,10 @@ extension ContactDetailViewController: MultilineLabelCellDelegate {
         } else {
             UIApplication.shared.open(url)
         }
+    }
+    
+    func urlLongTapped(url: URL) {
+        // TODO: custom behaviour, also make sure it gets called, currently it's not implemented in the contacts detail table view
+        self.urlTapped(url: url)
     }
 }

--- a/deltachat-ios/View/MultilineLabelCell.swift
+++ b/deltachat-ios/View/MultilineLabelCell.swift
@@ -81,6 +81,10 @@ extension MultilineLabelCell: MessageLabelDelegate {
     public func didSelectURL(_ url: URL) {
         multilineDelegate?.urlTapped(url: url)
     }
+    
+    public func didLongPressURL(_ url: URL) {
+        multilineDelegate?.urlLongTapped(url: url)
+    }
 
     public func didSelectTransitInformation(_ transitInformation: [String: String]) {}
 
@@ -96,4 +100,5 @@ extension MultilineLabelCell: MessageLabelDelegate {
 public protocol MultilineLabelCellDelegate: AnyObject {
     func phoneNumberTapped(number: String)
     func urlTapped(url: URL)
+    func urlLongTapped(url: URL)
 }

--- a/deltachat-ios/View/MultilineLabelCell.swift
+++ b/deltachat-ios/View/MultilineLabelCell.swift
@@ -55,7 +55,7 @@ class MultilineLabelCell: UITableViewCell {
     open func handleTapGesture(_ gesture: UIGestureRecognizer) {
         guard gesture.state == .ended else { return }
         let touchLocation = gesture.location(in: label)
-        let isHandled = label.handleGesture(touchLocation)
+        let isHandled = label.handleGesture(touchLocation, longTap: false)
         if !isHandled {
             logger.info("status: tapped outside urls or phone numbers")
         }


### PR DESCRIPTION
- detect long tap on link (I finally found out how to do it 🎉 )
- add an action sheet

This still is a draft with probably rather bad code, but it already works.

- only works on iOS 13+ but I think thats ok
- [ ] I don't really like my time-based-workaround against false triggers of the normal tap handler.
- [ ] A. Would be cool to also use the ios context menu instead of the action sheet, but there is no real link element, it's just part of the UILabel, so probably complicated to make it look good
- [ ] B. or as an alternative to A we could also copy the design of the "copy link sheet" from whatsapp, it seems to be similar to the safari tab switcher or our account switcher.
- [ ] The jumping around of the message list when the sheet opens is not nice to look at

Optional:
- [ ] add small haptic feedback when opening the action sheet, that would already be included with A.
- [ ] Add a option to copy to phone numbers, maybe also a "create phone contact" action


Disclaimer: This is just me playing around because I want this feature (https://support.delta.chat/t/copy-a-link-from-a-message-on-long-press-in-ios/2755).
It is not currently a project priority.
