### PR TITLE
reorder settings

### DIFF
--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -17,6 +17,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         case manageKeys
         case videoChat
         case viewLog
+        case accountSettings
     }
 
     private var dcContext: DcContext
@@ -56,6 +57,14 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         let cell = ActionCell()
         cell.tag = CellTags.manageKeys.rawValue
         cell.actionTitle = String.localized("pref_manage_keys")
+        return cell
+    }()
+
+    private lazy var accountSettingsCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.textLabel?.text = String.localized("pref_password_and_account_settings")
+        cell.accessoryType = .disclosureIndicator
+        cell.tag = CellTags.accountSettings.rawValue
         return cell
     }()
 
@@ -212,7 +221,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         let serverSection = SectionConfigs(
             headerTitle: String.localized("pref_server"),
             footerTitle: String.localized("pref_only_fetch_mvbox_explain"),
-            cells: [sentboxWatchCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell])
+            cells: [accountSettingsCell, sentboxWatchCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell])
         return [viewLogSection, experimentalSection, appAccessSection, autocryptSection, serverSection]
     }()
 
@@ -280,6 +289,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         case .manageKeys: showManageKeysDialog()
         case .videoChat: showVideoChatInstance()
         case .viewLog: showLogViewController()
+        case .accountSettings: showAccountSettingsController()
         }
     }
 
@@ -330,6 +340,11 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
 
     private func showLogViewController() {
         let controller = LogViewController(dcContext: dcContext)
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
+    private func showAccountSettingsController() {
+        let controller = AccountSetupController(dcAccounts: dcAccounts, editView: true)
         navigationController?.pushViewController(controller, animated: true)
     }
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -12,6 +12,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
     }
 
     private enum CellTags: Int {
+        case showEmails
         case autocryptPreferences
         case sendAutocryptMessage
         case manageKeys
@@ -30,6 +31,15 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
     var progressObserver: NSObjectProtocol?
 
     // MARK: - cells
+    private lazy var showEmailsCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        cell.tag = CellTags.showEmails.rawValue
+        cell.textLabel?.text = String.localized("pref_show_emails")
+        cell.accessoryType = .disclosureIndicator
+        cell.detailTextLabel?.text = EmailOptionsViewController.getValString(val: dcContext.showEmails)
+        return cell
+    }()
+
     private lazy var autocryptSwitch: UISwitch = {
         let switchControl = UISwitch()
         switchControl.isOn = dcContext.e2eeEnabled
@@ -204,7 +214,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         let viewLogSection = SectionConfigs(
             headerTitle: nil,
             footerTitle: nil,
-            cells: [viewLogCell])
+            cells: [showEmailsCell, viewLogCell])
         let experimentalSection = SectionConfigs(
             headerTitle: String.localized("pref_experimental_features"),
             footerTitle: nil,
@@ -284,6 +294,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         tableView.deselectRow(at: indexPath, animated: false)
 
         switch cellTag {
+        case .showEmails: showClassicMailController()
         case .autocryptPreferences: break
         case .sendAutocryptMessage: sendAutocryptSetupMessage()
         case .manageKeys: showManageKeysDialog()
@@ -343,6 +354,11 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         navigationController?.pushViewController(controller, animated: true)
     }
 
+    private func showClassicMailController() {
+        let controller = EmailOptionsViewController(dcContext: dcContext)
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
     private func showAccountSettingsController() {
         let controller = AccountSetupController(dcAccounts: dcAccounts, editView: true)
         navigationController?.pushViewController(controller, animated: true)
@@ -396,6 +412,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
 
     // MARK: - updates
     private func updateCells() {
+        showEmailsCell.detailTextLabel?.text = EmailOptionsViewController.getValString(val: dcContext.showEmails)
         videoChatInstanceCell.detailTextLabel?.text = VideoChatInstanceViewController.getValString(val: dcContext.getConfig("webrtc_instance") ?? "")
     }
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -192,15 +192,10 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
     }()
 
     private lazy var sections: [SectionConfigs] = {
-        let autocryptSection = SectionConfigs(
-            headerTitle: String.localized("autocrypt"),
-            footerTitle: String.localized("autocrypt_explain"),
-            cells: [autocryptPreferencesCell, manageKeysCell, sendAutocryptMessageCell]
-        )
-        let folderSection = SectionConfigs(
-            headerTitle: String.localized("pref_imap_folder_handling"),
-            footerTitle: String.localized("pref_only_fetch_mvbox_explain"),
-            cells: [sentboxWatchCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell])
+        let viewLogSection = SectionConfigs(
+            headerTitle: nil,
+            footerTitle: nil,
+            cells: [viewLogCell])
         let experimentalSection = SectionConfigs(
             headerTitle: String.localized("pref_experimental_features"),
             footerTitle: nil,
@@ -209,11 +204,16 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
             headerTitle: String.localized("pref_app_access"),
             footerTitle: String.localized("pref_show_system_contacts_explain"),
             cells: [showSystemContactsCell])
-        let viewLogSection = SectionConfigs(
-            headerTitle: nil,
+        let autocryptSection = SectionConfigs(
+            headerTitle: String.localized("pref_encryption"),
             footerTitle: nil,
-            cells: [viewLogCell])
-        return [autocryptSection, folderSection, experimentalSection, appAccessSection, viewLogSection]
+            cells: [autocryptPreferencesCell, manageKeysCell, sendAutocryptMessageCell]
+        )
+        let serverSection = SectionConfigs(
+            headerTitle: String.localized("pref_server"),
+            footerTitle: String.localized("pref_only_fetch_mvbox_explain"),
+            cells: [sentboxWatchCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell])
+        return [viewLogSection, experimentalSection, appAccessSection, autocryptSection, serverSection]
     }()
 
     init(dcAccounts: DcAccounts) {

--- a/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
+++ b/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
@@ -11,7 +11,6 @@ internal final class ChatsAndMediaViewController: UITableViewController, Progres
     }
 
     private enum CellTags: Int {
-        case showEmails
         case blockedContacts
         case receiptConfirmation
         case exportBackup
@@ -28,14 +27,7 @@ internal final class ChatsAndMediaViewController: UITableViewController, Progres
     var progressObserver: NSObjectProtocol?
 
     // MARK: - cells
-    private lazy var showEmailsCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.tag = CellTags.showEmails.rawValue
-        cell.textLabel?.text = String.localized("pref_show_emails")
-        cell.accessoryType = .disclosureIndicator
-        cell.detailTextLabel?.text = EmailOptionsViewController.getValString(val: dcContext.showEmails)
-        return cell
-    }()
+
 
     private lazy var blockedContactsCell: UITableViewCell = {
         let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
@@ -109,7 +101,7 @@ internal final class ChatsAndMediaViewController: UITableViewController, Progres
         let preferencesSection = SectionConfigs(
             headerTitle: nil,
             footerTitle: String.localized("pref_read_receipts_explain"),
-            cells: [showEmailsCell, blockedContactsCell, mediaQualityCell, downloadOnDemandCell,
+            cells: [blockedContactsCell, mediaQualityCell, downloadOnDemandCell,
                     autodelCell, receiptConfirmationCell]
         )
         let exportBackupSection = SectionConfigs(
@@ -188,7 +180,6 @@ internal final class ChatsAndMediaViewController: UITableViewController, Progres
         tableView.deselectRow(at: indexPath, animated: false)
 
         switch cellTag {
-        case .showEmails: showClassicMail()
         case .blockedContacts: showBlockedContacts()
         case .autodel: showAutodelOptions()
         case .mediaQuality: showMediaQuality()
@@ -237,7 +228,6 @@ internal final class ChatsAndMediaViewController: UITableViewController, Progres
     }
 
     private func updateCells() {
-        showEmailsCell.detailTextLabel?.text = EmailOptionsViewController.getValString(val: dcContext.showEmails)
         mediaQualityCell.detailTextLabel?.text = MediaQualityViewController.getValString(val: dcContext.getConfigInt("media_quality"))
         downloadOnDemandCell.detailTextLabel?.text = DownloadOnDemandViewController.getValString(
             val: dcContext.getConfigInt("download_limit"))
@@ -245,11 +235,6 @@ internal final class ChatsAndMediaViewController: UITableViewController, Progres
     }
 
     // MARK: - coordinator
-    private func showClassicMail() {
-        let settingsClassicViewController = EmailOptionsViewController(dcContext: dcContext)
-        navigationController?.pushViewController(settingsClassicViewController, animated: true)
-    }
-
     private func  showMediaQuality() {
         let mediaQualityController = MediaQualityViewController(dcContext: dcContext)
         navigationController?.pushViewController(mediaQualityController, animated: true)

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -11,13 +11,7 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     private let section1Status = 2
     private let section1RowCount = 3
 
-    private let section2 = 1
-    private let section2AccountSettings = 0
-    private let section2RowCount = 1
-
-    private let sectionCount = 2
-
-    private let tagAccountSettingsCell = 1
+    private let sectionCount = 1
 
     private lazy var mediaPicker: MediaPicker? = {
         let mediaPicker = MediaPicker(dcContext: dcContext, navigationController: navigationController)
@@ -29,14 +23,6 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
         let cell = MultilineTextFieldCell(description: String.localized("pref_default_status_label"),
                                           multilineText: dcContext.selfstatus,
                                           placeholder: String.localized("pref_default_status_label"))
-        return cell
-    }()
-
-    private lazy var accountSettingsCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("pref_password_and_account_settings")
-        cell.accessoryType = .disclosureIndicator
-        cell.tag = tagAccountSettingsCell
         return cell
     }()
 
@@ -85,9 +71,8 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if section == section1 {
             return section1RowCount
-        } else {
-            return section2RowCount
         }
+        return 0
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -100,11 +85,10 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
             case section1Status:
                 return statusCell
             default:
-               return UITableViewCell()
+               break
             }
-        } else {
-            return accountSettingsCell
         }
+        return UITableViewCell()
     }
 
     override func tableView(_: UITableView, titleForFooterInSection section: Int) -> String? {
@@ -112,16 +96,6 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
             return String.localized("pref_who_can_see_profile_explain")
         } else {
             return nil
-        }
-    }
-
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let cell = tableView.cellForRow(at: indexPath) else { return }
-        if cell.tag == tagAccountSettingsCell {
-            tableView.deselectRow(at: indexPath, animated: false)
-            guard let nc = navigationController else { return }
-            let accountSetupVC = AccountSetupController(dcAccounts: dcAccounts, editView: true)
-            nc.pushViewController(accountSetupVC, animated: true)
         }
     }
 

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -2,16 +2,15 @@ import UIKit
 import DcCore
 
 class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
+
+    private struct SectionConfigs {
+        let headerTitle: String?
+        let footerTitle: String?
+        let cells: [UITableViewCell]
+    }
+
     private let dcContext: DcContext
     private let dcAccounts: DcAccounts
-
-    private let section1 = 0
-    private let section1Name = 0
-    private let section1Avatar = 1
-    private let section1Status = 2
-    private let section1RowCount = 3
-
-    private let sectionCount = 1
 
     private lazy var mediaPicker: MediaPicker? = {
         let mediaPicker = MediaPicker(dcContext: dcContext, navigationController: navigationController)
@@ -36,6 +35,15 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
         cell.textFieldDelegate = self
         cell.textField.returnKeyType = .default
         return cell
+    }()
+
+    private lazy var sections: [SectionConfigs] = {
+        let nameSection = SectionConfigs(
+            headerTitle: nil,
+            footerTitle: String.localized("pref_who_can_see_profile_explain"),
+            cells: [nameCell, avatarSelectionCell, statusCell]
+        )
+        return [nameSection]
     }()
 
     init(dcAccounts: DcAccounts) {
@@ -65,38 +73,23 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
 
     // MARK: - Table view data source
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return sectionCount
+        return sections.count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if section == section1 {
-            return section1RowCount
-        }
-        return 0
+        return sections[section].cells.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.section == section1 {
-            switch indexPath.row {
-            case section1Avatar:
-                return avatarSelectionCell
-            case section1Name:
-                return nameCell
-            case section1Status:
-                return statusCell
-            default:
-               break
-            }
-        }
-        return UITableViewCell()
+        return sections[indexPath.section].cells[indexPath.row]
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return sections[section].headerTitle
     }
 
     override func tableView(_: UITableView, titleForFooterInSection section: Int) -> String? {
-        if section == section1 {
-            return String.localized("pref_who_can_see_profile_explain")
-        } else {
-            return nil
-        }
+        return sections[section].footerTitle
     }
 
     // MARK: - actions


### PR DESCRIPTION
- creates a dedicated "experimental" section and stops using a button as a sort of headline and mixing the section with "not experimental, but not recommended" reading address book

- sync settings positions with android,  taking new chatmail into account

- moreover, when on that, use less error-prone settings array (copy pattern used elsewhere as well)

closes https://github.com/deltachat/deltachat-ios/issues/2162