### PR TITLE
for chatmail accounts, hide some not useful settings

### DIFF
--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -12,8 +12,8 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
     }
 
     private enum CellTags: Int {
+        case defaultTagValue = 0
         case showEmails
-        case autocryptPreferences
         case sendAutocryptMessage
         case manageKeys
         case videoChat
@@ -49,7 +49,6 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
 
     private lazy var autocryptPreferencesCell: UITableViewCell = {
         let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-        cell.tag = CellTags.autocryptPreferences.rawValue
         cell.textLabel?.text = String.localized("autocrypt_prefer_e2ee")
         cell.accessoryView = autocryptSwitch
         cell.selectionStyle = .none
@@ -307,12 +306,12 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
 
         switch cellTag {
         case .showEmails: showClassicMailController()
-        case .autocryptPreferences: break
         case .sendAutocryptMessage: sendAutocryptSetupMessage()
         case .manageKeys: showManageKeysDialog()
         case .videoChat: showVideoChatInstance()
         case .viewLog: showLogViewController()
         case .accountSettings: showAccountSettingsController()
+        case .defaultTagValue: break
         }
     }
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -57,14 +57,14 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
     }()
 
     private lazy var sendAutocryptMessageCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
         cell.tag = CellTags.sendAutocryptMessage.rawValue
         cell.textLabel?.text = String.localized("autocrypt_send_asm_title")
         return cell
     }()
 
     private lazy var manageKeysCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
         cell.tag = CellTags.manageKeys.rawValue
         cell.textLabel?.text = String.localized("pref_manage_keys")
         return cell

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -221,7 +221,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
             cells: [videoChatInstanceCell, broadcastListsCell, locationStreamingCell])
 
         if dcContext.isChatmail {
-            let autocryptSection = SectionConfigs(
+            let encryptionSection = SectionConfigs(
                 headerTitle: String.localized("pref_encryption"),
                 footerTitle: nil,
                 cells: [manageKeysCell, sendAutocryptMessageCell])
@@ -229,13 +229,13 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
                 headerTitle: String.localized("pref_server"),
                 footerTitle: nil,
                 cells: [accountSettingsCell])
-            return [viewLogSection, experimentalSection, autocryptSection, serverSection]
+            return [viewLogSection, experimentalSection, encryptionSection, serverSection]
         } else {
             let appAccessSection = SectionConfigs(
                 headerTitle: String.localized("pref_app_access"),
                 footerTitle: String.localized("pref_show_system_contacts_explain"),
                 cells: [showSystemContactsCell])
-            let autocryptSection = SectionConfigs(
+            let encryptionSection = SectionConfigs(
                 headerTitle: String.localized("pref_encryption"),
                 footerTitle: nil,
                 cells: [autocryptPreferencesCell, manageKeysCell, sendAutocryptMessageCell])
@@ -243,7 +243,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
                 headerTitle: String.localized("pref_server"),
                 footerTitle: String.localized("pref_only_fetch_mvbox_explain"),
                 cells: [accountSettingsCell, sentboxWatchCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell])
-            return [viewLogSection, experimentalSection, appAccessSection, autocryptSection, serverSection]
+            return [viewLogSection, experimentalSection, appAccessSection, encryptionSection, serverSection]
         }
     }()
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -56,17 +56,17 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         return cell
     }()
 
-    private lazy var sendAutocryptMessageCell: ActionCell = {
-        let cell = ActionCell()
+    private lazy var sendAutocryptMessageCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.tag = CellTags.sendAutocryptMessage.rawValue
-        cell.actionTitle = String.localized("autocrypt_send_asm_title")
+        cell.textLabel?.text = String.localized("autocrypt_send_asm_title")
         return cell
     }()
 
-    private lazy var manageKeysCell: ActionCell = {
-        let cell = ActionCell()
+    private lazy var manageKeysCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.tag = CellTags.manageKeys.rawValue
-        cell.actionTitle = String.localized("pref_manage_keys")
+        cell.textLabel?.text = String.localized("pref_manage_keys")
         return cell
     }()
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -219,20 +219,32 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
             headerTitle: String.localized("pref_experimental_features"),
             footerTitle: nil,
             cells: [videoChatInstanceCell, broadcastListsCell, locationStreamingCell])
-        let appAccessSection = SectionConfigs(
-            headerTitle: String.localized("pref_app_access"),
-            footerTitle: String.localized("pref_show_system_contacts_explain"),
-            cells: [showSystemContactsCell])
-        let autocryptSection = SectionConfigs(
-            headerTitle: String.localized("pref_encryption"),
-            footerTitle: nil,
-            cells: [autocryptPreferencesCell, manageKeysCell, sendAutocryptMessageCell]
-        )
-        let serverSection = SectionConfigs(
-            headerTitle: String.localized("pref_server"),
-            footerTitle: String.localized("pref_only_fetch_mvbox_explain"),
-            cells: [accountSettingsCell, sentboxWatchCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell])
-        return [viewLogSection, experimentalSection, appAccessSection, autocryptSection, serverSection]
+
+        if dcContext.isChatmail {
+            let autocryptSection = SectionConfigs(
+                headerTitle: String.localized("pref_encryption"),
+                footerTitle: nil,
+                cells: [manageKeysCell, sendAutocryptMessageCell])
+            let serverSection = SectionConfigs(
+                headerTitle: String.localized("pref_server"),
+                footerTitle: nil,
+                cells: [accountSettingsCell])
+            return [viewLogSection, experimentalSection, autocryptSection, serverSection]
+        } else {
+            let appAccessSection = SectionConfigs(
+                headerTitle: String.localized("pref_app_access"),
+                footerTitle: String.localized("pref_show_system_contacts_explain"),
+                cells: [showSystemContactsCell])
+            let autocryptSection = SectionConfigs(
+                headerTitle: String.localized("pref_encryption"),
+                footerTitle: nil,
+                cells: [autocryptPreferencesCell, manageKeysCell, sendAutocryptMessageCell])
+            let serverSection = SectionConfigs(
+                headerTitle: String.localized("pref_server"),
+                footerTitle: String.localized("pref_only_fetch_mvbox_explain"),
+                cells: [accountSettingsCell, sentboxWatchCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell])
+            return [viewLogSection, experimentalSection, appAccessSection, autocryptSection, serverSection]
+        }
     }()
 
     init(dcAccounts: DcAccounts) {

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -682,4 +682,8 @@ public class DcContext {
         get { return getConfigInt("show_emails") }
         set { setConfigInt("show_emails", newValue) }
     }
+
+    public var isChatmail: Bool {
+        return getConfigInt("is_chatmail") == 1
+    }
 }

--- a/deltachat-ios/Handler/DeviceContactsHandler.swift
+++ b/deltachat-ios/Handler/DeviceContactsHandler.swift
@@ -78,7 +78,7 @@ class DeviceContactsHandler {
     }
 
     public func importDeviceContacts() {
-        if dcContext.getConfigBool("ui.ios.show_system_contacts") && CNContactStore.authorizationStatus(for: .contacts) == .authorized {
+        if dcContext.getConfigBool("ui.ios.show_system_contacts") && !dcContext.isChatmail && CNContactStore.authorizationStatus(for: .contacts) == .authorized {
             addContactsToCore()
         }
     }


### PR DESCRIPTION
counterpart of https://github.com/deltachat/deltachat-android/pull/3050 ,   see there for discussion and reasoning

this is how the advanced settings look like now: left classicmail, right chatmail ... so much cleaner :)

<img width=270 src=https://github.com/deltachat/deltachat-ios/assets/9800740/335db13c-3ea4-40f5-ab9d-52b4bceaf255> <img width=270  src=https://github.com/deltachat/deltachat-ios/assets/9800740/757f94ba-4634-45ba-a4d2-4e2656b80e9e>
