### PR TITLE
Make instant onboarding even nicer and more useful

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -91,7 +91,7 @@ class InstantOnboardingView: UIView {
         contentStackView.setCustomSpacing(16, after: nameTextField)
         contentStackView.setCustomSpacing(8, after: hintLabelWrapper)
         contentStackView.setCustomSpacing(16, after: privacyButtonWrapper)
-        contentStackView.setCustomSpacing(16, after: agreeButton)
+        contentStackView.setCustomSpacing(64, after: agreeButton)
 
         contentScrollView = UIScrollView()
         contentScrollView.translatesAutoresizingMaskIntoConstraints = false

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -11,6 +11,10 @@ class InstantOnboardingView: UIView {
     private let privacyButtonWrapper: UIView
     let agreeButton: UIButton
 
+    let otherOptionsButton: UIButton
+    let scanQRCodeButton: UIButton
+    private let bottomButtonStackview: UIStackView
+
     private let contentStackView: UIStackView
     private let contentScrollView: UIScrollView
 
@@ -59,10 +63,24 @@ class InstantOnboardingView: UIView {
         privacyButtonWrapper.translatesAutoresizingMaskIntoConstraints = false
         privacyButtonWrapper.addSubview(privacyButton)
 
-        contentStackView = UIStackView(arrangedSubviews: [imageButton, nameTextField, hintLabelWrapper, privacyButtonWrapper, agreeButton])
+        otherOptionsButton = UIButton(type: .system)
+        otherOptionsButton.translatesAutoresizingMaskIntoConstraints = false
+        otherOptionsButton.setTitle(String.localized("instant_onboarding_show_more_instances"), for: .normal)
+
+        scanQRCodeButton = UIButton(type: .system)
+        scanQRCodeButton.translatesAutoresizingMaskIntoConstraints = false
+        scanQRCodeButton.setTitle(String.localized("qrscan_title"), for: .normal)
+
+        bottomButtonStackview = UIStackView(arrangedSubviews: [otherOptionsButton, UIView(), scanQRCodeButton])
+        bottomButtonStackview.translatesAutoresizingMaskIntoConstraints = false
+        bottomButtonStackview.axis = .horizontal
+        bottomButtonStackview.distribution = .fill
+
+        contentStackView = UIStackView(arrangedSubviews: [imageButton, nameTextField, hintLabelWrapper, privacyButtonWrapper, agreeButton, UIView(), bottomButtonStackview])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .vertical
         contentStackView.alignment = .center
+        contentStackView.distribution = .fill
         contentStackView.setCustomSpacing(32, after: imageButton)
         contentStackView.setCustomSpacing(16, after: nameTextField)
         contentStackView.setCustomSpacing(8, after: hintLabelWrapper)
@@ -91,10 +109,10 @@ class InstantOnboardingView: UIView {
 
     private func setupConstraints() {
         let constraints = [
-            contentScrollView.topAnchor.constraint(equalTo: topAnchor),
+            contentScrollView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
             contentScrollView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
             safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: contentScrollView.trailingAnchor),
-            bottomAnchor.constraint(equalTo: contentScrollView.bottomAnchor),
+            safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: contentScrollView.bottomAnchor),
 
             contentStackView.topAnchor.constraint(equalTo: contentScrollView.topAnchor),
             contentStackView.leadingAnchor.constraint(equalTo: contentScrollView.leadingAnchor, constant: 16),
@@ -102,6 +120,7 @@ class InstantOnboardingView: UIView {
             contentScrollView.bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor),
 
             contentStackView.widthAnchor.constraint(equalTo: contentScrollView.widthAnchor, constant: -32),
+            contentStackView.heightAnchor.constraint(equalTo: contentScrollView.heightAnchor),
             nameTextField.widthAnchor.constraint(equalTo: contentStackView.widthAnchor),
             agreeButton.widthAnchor.constraint(equalTo: contentStackView.widthAnchor),
 
@@ -119,6 +138,8 @@ class InstantOnboardingView: UIView {
             hintLabel.leadingAnchor.constraint(equalTo: hintLabelWrapper.leadingAnchor),
             hintLabelWrapper.trailingAnchor.constraint(greaterThanOrEqualTo: hintLabel.trailingAnchor),
             hintLabelWrapper.bottomAnchor.constraint(equalTo: hintLabel.bottomAnchor),
+
+            bottomButtonStackview.widthAnchor.constraint(equalTo: contentStackView.widthAnchor)
         ]
 
         NSLayoutConstraint.activate(constraints)

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -52,7 +52,7 @@ class InstantOnboardingView: UIView {
         agreeButton.setTitle(String.localized("instant_onboarding_create"), for: .normal)
         agreeButton.translatesAutoresizingMaskIntoConstraints = false
         agreeButton.layer.cornerRadius = 8
-        agreeButton.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.3)
+        agreeButton.backgroundColor = UIColor.systemGray.withAlphaComponent(0.3)
         agreeButton.contentEdgeInsets.top = 8
         agreeButton.contentEdgeInsets.bottom = 8
         agreeButton.isEnabled = false

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -58,11 +58,6 @@ class InstantOnboardingView: UIView {
 
         privacyButton = UIButton(type: .system)
         privacyButton.translatesAutoresizingMaskIntoConstraints = false
-        if let customProvider {
-            privacyButton.setTitle(String.localized(stringID: "instant_onboarding_agree_instance", parameter: customProvider), for: .normal)
-        } else {
-            privacyButton.setTitle(String.localized("instant_onboarding_agree_default"), for: .normal)
-        }
         privacyButtonWrapper = UIView()
         privacyButtonWrapper.translatesAutoresizingMaskIntoConstraints = false
         privacyButtonWrapper.addSubview(privacyButton)
@@ -113,6 +108,7 @@ class InstantOnboardingView: UIView {
 
         setupConstraints()
         validateTextfield(text: nameTextField.text)
+        updateContent(with: customProvider)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -169,6 +165,14 @@ class InstantOnboardingView: UIView {
             agreeButton.backgroundColor = .systemBlue
         } else {
             agreeButton.backgroundColor = UIColor.systemGray.withAlphaComponent(0.3)
+        }
+    }
+
+    func updateContent(with customProvider: String?) {
+        if let customProvider {
+            privacyButton.setTitle(String.localized(stringID: "instant_onboarding_agree_instance", parameter: customProvider), for: .normal)
+        } else {
+            privacyButton.setTitle(String.localized("instant_onboarding_agree_default"), for: .normal)
         }
     }
 }

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -20,7 +20,7 @@ class InstantOnboardingView: UIView {
     let spacer: UIView
     let bottomSpacer: UIView
 
-    init(avatarImage: UIImage?, customProvider: String?) {
+    init(avatarImage: UIImage?, name: String?, customProvider: String?) {
 
         imageButton = UIButton()
         imageButton.translatesAutoresizingMaskIntoConstraints = false
@@ -35,6 +35,7 @@ class InstantOnboardingView: UIView {
         imageButton.contentHorizontalAlignment = .fill
 
         nameTextField = UITextField()
+        nameTextField.text = name
         nameTextField.translatesAutoresizingMaskIntoConstraints = false
         nameTextField.placeholder = String.localized("pref_your_name")
         nameTextField.borderStyle = .roundedRect
@@ -52,10 +53,8 @@ class InstantOnboardingView: UIView {
         agreeButton.setTitle(String.localized("instant_onboarding_create"), for: .normal)
         agreeButton.translatesAutoresizingMaskIntoConstraints = false
         agreeButton.layer.cornerRadius = 8
-        agreeButton.backgroundColor = UIColor.systemGray.withAlphaComponent(0.3)
         agreeButton.contentEdgeInsets.top = 8
         agreeButton.contentEdgeInsets.bottom = 8
-        agreeButton.isEnabled = false
 
         privacyButton = UIButton(type: .system)
         privacyButton.translatesAutoresizingMaskIntoConstraints = false
@@ -113,6 +112,7 @@ class InstantOnboardingView: UIView {
         addSubview(contentScrollView)
 
         setupConstraints()
+        validateTextfield(text: nameTextField.text)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -153,5 +153,22 @@ class InstantOnboardingView: UIView {
         ]
 
         NSLayoutConstraint.activate(constraints)
+    }
+
+    func validateTextfield(text: String?) {
+        let buttonShouldBeEnabled: Bool
+
+        if let text {
+            buttonShouldBeEnabled = (text.isEmpty == false)
+        } else {
+            buttonShouldBeEnabled = false
+        }
+        agreeButton.isEnabled = buttonShouldBeEnabled
+
+        if buttonShouldBeEnabled {
+            agreeButton.backgroundColor = .systemBlue
+        } else {
+            agreeButton.backgroundColor = UIColor.systemGray.withAlphaComponent(0.3)
+        }
     }
 }

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -16,7 +16,9 @@ class InstantOnboardingView: UIView {
     private let bottomButtonStackview: UIStackView
 
     private let contentStackView: UIStackView
-    private let contentScrollView: UIScrollView
+    private(set) var contentScrollView: UIScrollView
+    let spacer: UIView
+    let bottomSpacer: UIView
 
     init(avatarImage: UIImage?) {
 
@@ -71,12 +73,16 @@ class InstantOnboardingView: UIView {
         scanQRCodeButton.translatesAutoresizingMaskIntoConstraints = false
         scanQRCodeButton.setTitle(String.localized("qrscan_title"), for: .normal)
 
+        spacer = UIView()
+        bottomSpacer = UIView()
+        bottomSpacer.isHidden = true
+
         bottomButtonStackview = UIStackView(arrangedSubviews: [otherOptionsButton, UIView(), scanQRCodeButton])
         bottomButtonStackview.translatesAutoresizingMaskIntoConstraints = false
         bottomButtonStackview.axis = .horizontal
         bottomButtonStackview.distribution = .fill
 
-        contentStackView = UIStackView(arrangedSubviews: [imageButton, nameTextField, hintLabelWrapper, privacyButtonWrapper, agreeButton, UIView(), bottomButtonStackview])
+        contentStackView = UIStackView(arrangedSubviews: [imageButton, nameTextField, hintLabelWrapper, privacyButtonWrapper, agreeButton, spacer, bottomButtonStackview, bottomSpacer])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .vertical
         contentStackView.alignment = .center
@@ -85,6 +91,7 @@ class InstantOnboardingView: UIView {
         contentStackView.setCustomSpacing(16, after: nameTextField)
         contentStackView.setCustomSpacing(8, after: hintLabelWrapper)
         contentStackView.setCustomSpacing(16, after: privacyButtonWrapper)
+        contentStackView.setCustomSpacing(16, after: agreeButton)
 
         contentScrollView = UIScrollView()
         contentScrollView.translatesAutoresizingMaskIntoConstraints = false

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -20,7 +20,7 @@ class InstantOnboardingView: UIView {
     let spacer: UIView
     let bottomSpacer: UIView
 
-    init(avatarImage: UIImage?) {
+    init(avatarImage: UIImage?, customProvider: String?) {
 
         imageButton = UIButton()
         imageButton.translatesAutoresizingMaskIntoConstraints = false
@@ -59,8 +59,11 @@ class InstantOnboardingView: UIView {
 
         privacyButton = UIButton(type: .system)
         privacyButton.translatesAutoresizingMaskIntoConstraints = false
-        privacyButton.setTitle(String.localized("instant_onboarding_agree_default"), for: .normal)
-
+        if let customProvider {
+            privacyButton.setTitle(String.localized(stringID: "instant_onboarding_agree_instance", parameter: customProvider), for: .normal)
+        } else {
+            privacyButton.setTitle(String.localized("instant_onboarding_agree_default"), for: .normal)
+        }
         privacyButtonWrapper = UIView()
         privacyButtonWrapper.translatesAutoresizingMaskIntoConstraints = false
         privacyButtonWrapper.addSubview(privacyButton)

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -52,7 +52,7 @@ class InstantOnboardingView: UIView {
         agreeButton.setTitle(String.localized("instant_onboarding_create"), for: .normal)
         agreeButton.translatesAutoresizingMaskIntoConstraints = false
         agreeButton.layer.cornerRadius = 8
-        agreeButton.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.6)
+        agreeButton.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.3)
         agreeButton.contentEdgeInsets.top = 8
         agreeButton.contentEdgeInsets.bottom = 8
         agreeButton.isEnabled = false

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -82,7 +82,7 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         } else {
             customProvider = nil
         }
-        let contentView = InstantOnboardingView(avatarImage: dcContext.getSelfAvatarImage(), customProvider: customProvider)
+        let contentView = InstantOnboardingView(avatarImage: dcContext.getSelfAvatarImage(), name: dcContext.displayname, customProvider: customProvider)
         contentView.agreeButton.addTarget(self, action: #selector(InstantOnboardingViewController.acceptAndCreateButtonPressed), for: .touchUpInside)
         contentView.imageButton.addTarget(self, action: #selector(InstantOnboardingViewController.onAvatarTapped), for: .touchUpInside)
         contentView.privacyButton.addTarget(self, action: #selector(InstantOnboardingViewController.showPrivacy(_:)), for: .touchUpInside)
@@ -100,20 +100,19 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         self.view = contentView
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        dcContext.displayname = contentView?.nameTextField.text
+    }
+
     // MARK: - Notifications
 
     @objc func textDidChangeNotification(notification: Notification) {
         guard let textField = notification.object as? UITextField,
               let text = textField.text else { return }
 
-        let buttonShouldBeEnabled = (text.isEmpty == false)
-        contentView?.agreeButton.isEnabled = buttonShouldBeEnabled
-
-        if buttonShouldBeEnabled {
-            contentView?.agreeButton.backgroundColor = .systemBlue
-        } else {
-            contentView?.agreeButton.backgroundColor = UIColor.systemGray.withAlphaComponent(0.3)
-        }
+        contentView?.validateTextfield(text: text)
     }
 
     // MARK: - actions

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -4,10 +4,17 @@ import DcCore
 
 class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
 
-    private let dcContext: DcContext
+    private var dcContext: DcContext
     private let dcAccounts: DcAccounts
     weak var progressAlert: UIAlertController?
     var progressObserver: NSObjectProtocol?
+    private var qrCodeReader: QrCodeReaderController?
+    private var securityScopedResource: NSURL?
+    private var backupProgressObserver: NSObjectProtocol?
+    private lazy var canCancel: Bool = {
+        // "cancel" removes selected unconfigured account, so there needs to be at least one other account
+        return dcAccounts.getAll().count >= 2
+    }()
 
     var contentView: InstantOnboardingView? { view as? InstantOnboardingView }
 
@@ -137,7 +144,16 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
     }
 
     @objc private func scanQRCode(_ sender: UIButton) {
-        // TODO: Implement
+        let qrReader = QrCodeReaderController(title: String.localized("multidevice_receiver_title"),
+                    addHints: "➊ " + String.localized("multidevice_same_network_hint") + "\n\n"
+                        +     "➋ " + String.localized("multidevice_open_settings_on_other_device") + "\n\n"
+                        +     String.localized("multidevice_experimental_hint"),
+                    showTroubleshooting: true)
+        qrReader.delegate = self
+
+        navigationController?.pushViewController(qrReader, animated: true)
+
+        self.qrCodeReader = qrReader
     }
 
     @objc
@@ -167,7 +183,7 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         contentView.spacer.isHidden = true
         contentView.bottomSpacer.isHidden = false
     }
-    
+
     @objc private func keyboardWillHide(_ notification: Notification) {
         contentView.spacer.isHidden = false
         contentView.bottomSpacer.isHidden = true
@@ -206,9 +222,277 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
     }
 }
 
+// MARK: - MediaPickerDelegate
 extension InstantOnboardingViewController: MediaPickerDelegate {
     func onImageSelected(image: UIImage) {
         AvatarHelper.saveSelfAvatarImage(dcContext: dcContext, image: image)
         contentView?.imageButton.setImage(image, for: .normal)
+    }
+}
+
+// MARK: - QrCodeReaderDelegate
+extension InstantOnboardingViewController: QrCodeReaderDelegate {
+    func handleQrCode(_ code: String) {
+        let lot = dcContext.checkQR(qrCode: code)
+        if let domain = lot.text1, lot.state == DC_QR_ACCOUNT {
+            let title = String.localizedStringWithFormat(
+                String.localized(dcAccounts.getAll().count > 1 ? "qraccount_ask_create_and_login_another" : "qraccount_ask_create_and_login"),
+                domain)
+            confirmQrAccountAlert(title: title, qrCode: code)
+        } else if let email = lot.text1, lot.state == DC_QR_LOGIN {
+            let title = String.localizedStringWithFormat(
+                String.localized(dcAccounts.getAll().count > 1 ? "qrlogin_ask_login_another" : "qrlogin_ask_login"),
+                email)
+            confirmQrAccountAlert(title: title, qrCode: code)
+        } else if lot.state == DC_QR_BACKUP {
+             confirmSetupNewDevice(qrCode: code)
+        } else {
+            qrErrorAlert()
+        }
+    }
+
+    private func confirmQrAccountAlert(title: String, qrCode: String) {
+        let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
+
+        let okAction = UIAlertAction(
+            title: String.localized("ok"),
+            style: .default,
+            handler: { [weak self] _ in
+                guard let self else { return }
+                self.dismissQRReader()
+                self.createAccountFromQRCode(qrCode: qrCode)
+            }
+        )
+
+        let qrCancelAction = UIAlertAction(
+            title: String.localized("cancel"),
+            style: .cancel,
+            handler: { [weak self] _ in
+                guard let self else { return }
+                self.dismissQRReader()
+                // if an injected qrCodeData exists, the InstantOnboardingViewController was only opened to handle that
+                // cancelling the action should also dismiss the whole controller
+                if self.qrCodeData != nil {
+                    self.cancelAccountCreation()
+                }
+            }
+        )
+
+        alert.addAction(okAction)
+        alert.addAction(qrCancelAction)
+        if qrCodeReader != nil {
+            qrCodeReader?.present(alert, animated: true)
+        } else {
+            self.present(alert, animated: true)
+        }
+    }
+
+    private func confirmSetupNewDevice(qrCode: String) {
+        triggerLocalNetworkPrivacyAlert()
+        let alert = UIAlertController(title: String.localized("multidevice_receiver_title"),
+                                      message: String.localized("multidevice_receiver_scanning_ask"),
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(
+             title: String.localized("ok"),
+             style: .default,
+             handler: { [weak self] _ in
+                 guard let self else { return }
+                 if self.dcAccounts.getSelected().isConfigured() {
+                     UserDefaults.standard.setValue(self.dcAccounts.getSelected().id, forKey: Constants.Keys.lastSelectedAccountKey)
+                     _ = self.dcAccounts.add()
+                 }
+                 let accountId = self.dcAccounts.getSelected().id
+                 if accountId != 0 {
+                     self.dcContext = self.dcAccounts.get(id: accountId)
+                     self.dismissQRReader()
+                     self.addProgressHudBackupListener(importByFile: false)
+                     self.showProgressAlert(title: String.localized("multidevice_receiver_title"), dcContext: self.dcContext)
+                     self.dcAccounts.stopIo()
+                     DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                         guard let self else { return }
+                         logger.info("##### receiveBackup() with qr: \(qrCode)")
+                         let res = self.dcContext.receiveBackup(qrCode: qrCode)
+                         logger.info("##### receiveBackup() done with result: \(res)")
+                     }
+                 }
+             }
+        ))
+        alert.addAction(UIAlertAction(
+            title: String.localized("cancel"),
+            style: .cancel,
+            handler: { [weak self] _ in
+                self?.dcContext.stopOngoingProcess()
+                self?.dismissQRReader()
+            }
+        ))
+        if let qrCodeReader {
+            qrCodeReader.present(alert, animated: true)
+        } else {
+            self.present(alert, animated: true)
+        }
+    }
+
+    private func qrErrorAlert() {
+        let title = String.localized("qraccount_qr_code_cannot_be_used")
+        let alert = UIAlertController(title: title, message: dcContext.lastErrorString, preferredStyle: .alert)
+        let okAction = UIAlertAction(
+            title: String.localized("ok"),
+            style: .default,
+            handler: { [weak self] _ in
+                guard let self else { return }
+                if self.qrCodeData != nil {
+                    // if an injected qrCodeData exists, the WelcomeViewController was only opened to handle that
+                    // if the action failed the whole controller should be dismissed
+                    self.cancelAccountCreation()
+                } else {
+                    self.qrCodeReader?.startSession()
+                }
+            }
+        )
+        alert.addAction(okAction)
+        qrCodeReader?.present(alert, animated: true, completion: nil)
+    }
+
+    private func dismissQRReader() {
+        self.navigationController?.popViewController(animated: true)
+        self.qrCodeReader = nil
+    }
+
+    private func stopAccessingSecurityScopedResource() {
+        self.securityScopedResource?.stopAccessingSecurityScopedResource()
+        self.securityScopedResource = nil
+    }
+
+    private func createAccountFromQRCode(qrCode: String) {
+        if dcAccounts.getSelected().isConfigured() {
+            UserDefaults.standard.setValue(dcAccounts.getSelected().id, forKey: Constants.Keys.lastSelectedAccountKey)
+            _ = dcAccounts.add()
+        }
+        let accountId = dcAccounts.getSelected().id
+
+        if accountId != 0 {
+            dcContext = dcAccounts.get(id: accountId)
+            addProgressAlertListener(dcAccounts: self.dcAccounts,
+                                     progressName: eventConfigureProgress,
+                                     onSuccess: self.handleLoginSuccess)
+            showProgressAlert(title: String.localized("login_header"), dcContext: self.dcContext)
+            DispatchQueue.global().async { [weak self] in
+                guard let self else { return }
+                let success = self.dcContext.setConfigFromQR(qrCode: qrCode)
+                DispatchQueue.main.async {
+                    if success {
+                        self.dcAccounts.stopIo()
+                        self.dcContext.configure()
+                    } else {
+                        self.updateProgressAlert(error: self.dcContext.lastErrorString,
+                                                 completion: self.qrCodeData != nil ? self.cancelAccountCreation : nil)
+                    }
+                }
+            }
+        }
+    }
+
+    @objc private func cancelAccountCreation() {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        // take a bit care on account removal:
+        // remove only openend and unconfigured and make sure, there is another account
+        // (normally, both checks are not needed, however, some resilience wrt future program-flow-changes seems to be reasonable here)
+        let selectedAccount = dcAccounts.getSelected()
+        if selectedAccount.isOpen() && !selectedAccount.isConfigured() {
+            _ = dcAccounts.remove(id: selectedAccount.id)
+            KeychainManager.deleteAccountSecret(id: selectedAccount.id)
+            if self.dcAccounts.getAll().isEmpty {
+                _ = self.dcAccounts.add()
+            }
+        }
+
+        let lastSelectedAccountId = UserDefaults.standard.integer(forKey: Constants.Keys.lastSelectedAccountKey)
+        if lastSelectedAccountId != 0 {
+            _ = dcAccounts.select(id: lastSelectedAccountId)
+            dcAccounts.startIo()
+        }
+
+        appDelegate.reloadDcContext()
+    }
+
+    private func handleLoginSuccess() {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        if !UserDefaults.standard.bool(forKey: "notifications_disabled") {
+            appDelegate.registerForNotifications()
+        }
+
+        let profileInfoController = ProfileInfoViewController(context: self.dcContext)
+        profileInfoController.onClose = {
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                appDelegate.reloadDcContext()
+            }
+        }
+
+        navigationController?.setViewControllers([profileInfoController], animated: true)
+    }
+
+    private func addProgressHudBackupListener(importByFile: Bool) {
+        UIApplication.shared.isIdleTimerDisabled = true
+        backupProgressObserver = NotificationCenter.default.addObserver(
+            forName: eventImexProgress,
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            guard let self else { return }
+            if let ui = notification.userInfo {
+                if let error = ui["error"] as? Bool, error {
+                    UIApplication.shared.isIdleTimerDisabled = false
+                    if self.dcContext.isConfigured() {
+                        let accountId = self.dcContext.id
+                        _ = self.dcAccounts.remove(id: accountId)
+                        KeychainManager.deleteAccountSecret(id: accountId)
+                        _ = self.dcAccounts.add()
+                        self.dcContext = self.dcAccounts.getSelected()
+                        self.navigationItem.title = String.localized(self.canCancel ? "add_account" : "welcome_desktop")
+                    }
+                    self.updateProgressAlert(error: ui["errorMessage"] as? String)
+                    self.stopAccessingSecurityScopedResource()
+                    self.removeBackupProgressObserver()
+                } else if let done = ui["done"] as? Bool, done {
+                    UIApplication.shared.isIdleTimerDisabled = false
+                    self.dcAccounts.startIo()
+                    self.updateProgressAlertSuccess(completion: self.handleBackupRestoreSuccess)
+                    self.stopAccessingSecurityScopedResource()
+                } else if importByFile {
+                    self.updateProgressAlertValue(value: ui["progress"] as? Int)
+                } else {
+                    guard let permille = ui["progress"] as? Int else { return }
+                    var statusLineText = ""
+                    if permille <= 100 {
+                        statusLineText = String.localized("preparing_account")
+                    } else if permille <= 950 {
+                        let percent = ((permille-100)*100)/850
+                        statusLineText = String.localized("transferring") + " \(percent)%"
+                    } else {
+                        statusLineText = "Finishing..." // range not used, should not happen
+                    }
+                    self.updateProgressAlert(message: statusLineText)
+                }
+            }
+        }
+    }
+
+    private func removeBackupProgressObserver() {
+        if let backupProgressObserver {
+            NotificationCenter.default.removeObserver(backupProgressObserver)
+            self.backupProgressObserver = nil
+        }
+    }
+
+    private func handleBackupRestoreSuccess() {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+
+        if !UserDefaults.standard.bool(forKey: "notifications_disabled") {
+            appDelegate.registerForNotifications()
+        }
+
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.reloadDcContext()
+        }
     }
 }

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -233,102 +233,18 @@ extension InstantOnboardingViewController: MediaPickerDelegate {
 // MARK: - QrCodeReaderDelegate
 extension InstantOnboardingViewController: QrCodeReaderDelegate {
     func handleQrCode(_ code: String) {
-        let lot = dcContext.checkQR(qrCode: code)
-        if let domain = lot.text1, lot.state == DC_QR_ACCOUNT {
-            let title = String.localizedStringWithFormat(
-                String.localized(dcAccounts.getAll().count > 1 ? "qraccount_ask_create_and_login_another" : "qraccount_ask_create_and_login"),
-                domain)
-            confirmQrAccountAlert(title: title, qrCode: code)
-        } else if let email = lot.text1, lot.state == DC_QR_LOGIN {
-            let title = String.localizedStringWithFormat(
-                String.localized(dcAccounts.getAll().count > 1 ? "qrlogin_ask_login_another" : "qrlogin_ask_login"),
-                email)
-            confirmQrAccountAlert(title: title, qrCode: code)
-        } else if lot.state == DC_QR_BACKUP {
-             confirmSetupNewDevice(qrCode: code)
+        // update with new code
+        let parsedQrCode = dcContext.checkQR(qrCode: code)
+        if parsedQrCode.state == DC_QR_LOGIN || parsedQrCode.state == DC_QR_ACCOUNT,
+           let host = parsedQrCode.text1,
+           let url = URL(string: "https://\(host)") {
+            self.providerHostURL = url
+            self.qrCodeData = code
+
+            contentView?.updateContent(with: host)
+            dismissQRReader()
         } else {
             qrErrorAlert()
-        }
-    }
-
-    private func confirmQrAccountAlert(title: String, qrCode: String) {
-        let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-
-        let okAction = UIAlertAction(
-            title: String.localized("ok"),
-            style: .default,
-            handler: { [weak self] _ in
-                guard let self else { return }
-                self.dismissQRReader()
-                self.createAccountFromQRCode(qrCode: qrCode)
-            }
-        )
-
-        let qrCancelAction = UIAlertAction(
-            title: String.localized("cancel"),
-            style: .cancel,
-            handler: { [weak self] _ in
-                guard let self else { return }
-                self.dismissQRReader()
-                // if an injected qrCodeData exists, the InstantOnboardingViewController was only opened to handle that
-                // cancelling the action should also dismiss the whole controller
-                if self.qrCodeData != nil {
-                    self.cancelAccountCreation()
-                }
-            }
-        )
-
-        alert.addAction(okAction)
-        alert.addAction(qrCancelAction)
-        if qrCodeReader != nil {
-            qrCodeReader?.present(alert, animated: true)
-        } else {
-            self.present(alert, animated: true)
-        }
-    }
-
-    private func confirmSetupNewDevice(qrCode: String) {
-        triggerLocalNetworkPrivacyAlert()
-        let alert = UIAlertController(title: String.localized("multidevice_receiver_title"),
-                                      message: String.localized("multidevice_receiver_scanning_ask"),
-                                      preferredStyle: .alert)
-        alert.addAction(UIAlertAction(
-             title: String.localized("ok"),
-             style: .default,
-             handler: { [weak self] _ in
-                 guard let self else { return }
-                 if self.dcAccounts.getSelected().isConfigured() {
-                     UserDefaults.standard.setValue(self.dcAccounts.getSelected().id, forKey: Constants.Keys.lastSelectedAccountKey)
-                     _ = self.dcAccounts.add()
-                 }
-                 let accountId = self.dcAccounts.getSelected().id
-                 if accountId != 0 {
-                     self.dcContext = self.dcAccounts.get(id: accountId)
-                     self.dismissQRReader()
-                     self.addProgressHudBackupListener(importByFile: false)
-                     self.showProgressAlert(title: String.localized("multidevice_receiver_title"), dcContext: self.dcContext)
-                     self.dcAccounts.stopIo()
-                     DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                         guard let self else { return }
-                         logger.info("##### receiveBackup() with qr: \(qrCode)")
-                         let res = self.dcContext.receiveBackup(qrCode: qrCode)
-                         logger.info("##### receiveBackup() done with result: \(res)")
-                     }
-                 }
-             }
-        ))
-        alert.addAction(UIAlertAction(
-            title: String.localized("cancel"),
-            style: .cancel,
-            handler: { [weak self] _ in
-                self?.dcContext.stopOngoingProcess()
-                self?.dismissQRReader()
-            }
-        ))
-        if let qrCodeReader {
-            qrCodeReader.present(alert, animated: true)
-        } else {
-            self.present(alert, animated: true)
         }
     }
 
@@ -339,14 +255,7 @@ extension InstantOnboardingViewController: QrCodeReaderDelegate {
             title: String.localized("ok"),
             style: .default,
             handler: { [weak self] _ in
-                guard let self else { return }
-                if self.qrCodeData != nil {
-                    // if an injected qrCodeData exists, the WelcomeViewController was only opened to handle that
-                    // if the action failed the whole controller should be dismissed
-                    self.cancelAccountCreation()
-                } else {
-                    self.qrCodeReader?.startSession()
-                }
+                self?.qrCodeReader?.startSession()
             }
         )
         alert.addAction(okAction)
@@ -356,143 +265,5 @@ extension InstantOnboardingViewController: QrCodeReaderDelegate {
     private func dismissQRReader() {
         self.navigationController?.popViewController(animated: true)
         self.qrCodeReader = nil
-    }
-
-    private func stopAccessingSecurityScopedResource() {
-        self.securityScopedResource?.stopAccessingSecurityScopedResource()
-        self.securityScopedResource = nil
-    }
-
-    private func createAccountFromQRCode(qrCode: String) {
-        if dcAccounts.getSelected().isConfigured() {
-            UserDefaults.standard.setValue(dcAccounts.getSelected().id, forKey: Constants.Keys.lastSelectedAccountKey)
-            _ = dcAccounts.add()
-        }
-        let accountId = dcAccounts.getSelected().id
-
-        if accountId != 0 {
-            dcContext = dcAccounts.get(id: accountId)
-            addProgressAlertListener(dcAccounts: self.dcAccounts,
-                                     progressName: eventConfigureProgress,
-                                     onSuccess: self.handleLoginSuccess)
-            showProgressAlert(title: String.localized("login_header"), dcContext: self.dcContext)
-            DispatchQueue.global().async { [weak self] in
-                guard let self else { return }
-                let success = self.dcContext.setConfigFromQR(qrCode: qrCode)
-                DispatchQueue.main.async {
-                    if success {
-                        self.dcAccounts.stopIo()
-                        self.dcContext.configure()
-                    } else {
-                        self.updateProgressAlert(error: self.dcContext.lastErrorString,
-                                                 completion: self.qrCodeData != nil ? self.cancelAccountCreation : nil)
-                    }
-                }
-            }
-        }
-    }
-
-    @objc private func cancelAccountCreation() {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-        // take a bit care on account removal:
-        // remove only openend and unconfigured and make sure, there is another account
-        // (normally, both checks are not needed, however, some resilience wrt future program-flow-changes seems to be reasonable here)
-        let selectedAccount = dcAccounts.getSelected()
-        if selectedAccount.isOpen() && !selectedAccount.isConfigured() {
-            _ = dcAccounts.remove(id: selectedAccount.id)
-            KeychainManager.deleteAccountSecret(id: selectedAccount.id)
-            if self.dcAccounts.getAll().isEmpty {
-                _ = self.dcAccounts.add()
-            }
-        }
-
-        let lastSelectedAccountId = UserDefaults.standard.integer(forKey: Constants.Keys.lastSelectedAccountKey)
-        if lastSelectedAccountId != 0 {
-            _ = dcAccounts.select(id: lastSelectedAccountId)
-            dcAccounts.startIo()
-        }
-
-        appDelegate.reloadDcContext()
-    }
-
-    private func handleLoginSuccess() {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-        if !UserDefaults.standard.bool(forKey: "notifications_disabled") {
-            appDelegate.registerForNotifications()
-        }
-
-        let profileInfoController = ProfileInfoViewController(context: self.dcContext)
-        profileInfoController.onClose = {
-            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                appDelegate.reloadDcContext()
-            }
-        }
-
-        navigationController?.setViewControllers([profileInfoController], animated: true)
-    }
-
-    private func addProgressHudBackupListener(importByFile: Bool) {
-        UIApplication.shared.isIdleTimerDisabled = true
-        backupProgressObserver = NotificationCenter.default.addObserver(
-            forName: eventImexProgress,
-            object: nil,
-            queue: nil
-        ) { [weak self] notification in
-            guard let self else { return }
-            if let ui = notification.userInfo {
-                if let error = ui["error"] as? Bool, error {
-                    UIApplication.shared.isIdleTimerDisabled = false
-                    if self.dcContext.isConfigured() {
-                        let accountId = self.dcContext.id
-                        _ = self.dcAccounts.remove(id: accountId)
-                        KeychainManager.deleteAccountSecret(id: accountId)
-                        _ = self.dcAccounts.add()
-                        self.dcContext = self.dcAccounts.getSelected()
-                        self.navigationItem.title = String.localized(self.canCancel ? "add_account" : "welcome_desktop")
-                    }
-                    self.updateProgressAlert(error: ui["errorMessage"] as? String)
-                    self.stopAccessingSecurityScopedResource()
-                    self.removeBackupProgressObserver()
-                } else if let done = ui["done"] as? Bool, done {
-                    UIApplication.shared.isIdleTimerDisabled = false
-                    self.dcAccounts.startIo()
-                    self.updateProgressAlertSuccess(completion: self.handleBackupRestoreSuccess)
-                    self.stopAccessingSecurityScopedResource()
-                } else if importByFile {
-                    self.updateProgressAlertValue(value: ui["progress"] as? Int)
-                } else {
-                    guard let permille = ui["progress"] as? Int else { return }
-                    var statusLineText = ""
-                    if permille <= 100 {
-                        statusLineText = String.localized("preparing_account")
-                    } else if permille <= 950 {
-                        let percent = ((permille-100)*100)/850
-                        statusLineText = String.localized("transferring") + " \(percent)%"
-                    } else {
-                        statusLineText = "Finishing..." // range not used, should not happen
-                    }
-                    self.updateProgressAlert(message: statusLineText)
-                }
-            }
-        }
-    }
-
-    private func removeBackupProgressObserver() {
-        if let backupProgressObserver {
-            NotificationCenter.default.removeObserver(backupProgressObserver)
-            self.backupProgressObserver = nil
-        }
-    }
-
-    private func handleBackupRestoreSuccess() {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-
-        if !UserDefaults.standard.bool(forKey: "notifications_disabled") {
-            appDelegate.registerForNotifications()
-        }
-
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            appDelegate.reloadDcContext()
-        }
     }
 }

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -113,7 +113,7 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         if buttonShouldBeEnabled {
             contentView?.agreeButton.backgroundColor = .systemBlue
         } else {
-            contentView?.agreeButton.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.3)
+            contentView?.agreeButton.backgroundColor = UIColor.systemGray.withAlphaComponent(0.3)
         }
     }
 

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -66,8 +66,13 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
 
     override func loadView() {
         super.loadView()
-
-        let contentView = InstantOnboardingView(avatarImage: dcContext.getSelfAvatarImage())
+        let customProvider: String?
+        if qrCodeData != nil {
+            customProvider = providerHostURL.host
+        } else {
+            customProvider = nil
+        }
+        let contentView = InstantOnboardingView(avatarImage: dcContext.getSelfAvatarImage(), customProvider: customProvider)
         contentView.agreeButton.addTarget(self, action: #selector(InstantOnboardingViewController.acceptAndCreateButtonPressed), for: .touchUpInside)
         contentView.imageButton.addTarget(self, action: #selector(InstantOnboardingViewController.onAvatarTapped), for: .touchUpInside)
         contentView.privacyButton.addTarget(self, action: #selector(InstantOnboardingViewController.showPrivacy(_:)), for: .touchUpInside)

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -64,6 +64,16 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
+    deinit {
+        if let progressObserver {
+            NotificationCenter.default.removeObserver(progressObserver)
+        }
+
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: contentView?.nameTextField)
+    }
+
     override func loadView() {
         super.loadView()
         let customProvider: String?
@@ -88,17 +98,6 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         )
 
         self.view = contentView
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        if let progressObserver {
-            NotificationCenter.default.removeObserver(progressObserver)
-            self.progressObserver = nil
-        }
-
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: contentView?.nameTextField)
     }
 
     // MARK: - Notifications

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -113,7 +113,7 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         if buttonShouldBeEnabled {
             contentView?.agreeButton.backgroundColor = .systemBlue
         } else {
-            contentView?.agreeButton.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.6)
+            contentView?.agreeButton.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.3)
         }
     }
 
@@ -149,11 +149,7 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
     }
 
     @objc private func scanQRCode(_ sender: UIButton) {
-        let qrReader = QrCodeReaderController(title: String.localized("multidevice_receiver_title"),
-                    addHints: "➊ " + String.localized("multidevice_same_network_hint") + "\n\n"
-                        +     "➋ " + String.localized("multidevice_open_settings_on_other_device") + "\n\n"
-                        +     String.localized("multidevice_experimental_hint"),
-                    showTroubleshooting: true)
+        let qrReader = QrCodeReaderController(title: String.localized("scan_invitation_code"))
         qrReader.delegate = self
 
         navigationController?.pushViewController(qrReader, animated: true)

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -171,9 +171,10 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
 
     // MARK: - Notifications
     @objc private func keyboardWillShow(_ notification: Notification) {
-        guard let userInfo = notification.userInfo else { return }
+        guard let userInfo = notification.userInfo,
+              var keyboardFrame: CGRect = userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? CGRect,
+              let contentView = contentView else { return }
 
-        var keyboardFrame: CGRect = (userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as! NSValue).cgRectValue
         keyboardFrame = view.convert(keyboardFrame, from: nil)
 
         var contentInset = contentView.contentScrollView.contentInset
@@ -185,9 +186,9 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
     }
 
     @objc private func keyboardWillHide(_ notification: Notification) {
-        contentView.spacer.isHidden = false
-        contentView.bottomSpacer.isHidden = true
-        contentView.contentScrollView.contentInset = UIEdgeInsets.zero
+        contentView?.spacer.isHidden = false
+        contentView?.bottomSpacer.isHidden = true
+        contentView?.contentScrollView.contentInset = UIEdgeInsets.zero
     }
 
     // MARK: - action: configuration

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -20,7 +20,6 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         mediaPicker.delegate = self
         return mediaPicker
     }()
-
     
     /// Creates Instant Onboarding-Screen. You can inject some QR-Code-Data to change the chatmail provider
     /// If `qrCodeData` is `nil`, the default server is used, currently it's `nine.testrun.org`
@@ -51,6 +50,9 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
 
         hidesBottomBarWhenPushed = true
         title = String.localized("pref_profile_info_headline")
+
+        NotificationCenter.default.addObserver(self, selector: #selector(InstantOnboardingViewController.keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(InstantOnboardingViewController.keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -101,7 +103,6 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         } else {
             contentView?.agreeButton.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.6)
         }
-
     }
 
     // MARK: - actions
@@ -150,6 +151,27 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
 
         self.present(alert, animated: true, completion: nil)
+    }
+
+    // MARK: - Notifications
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        guard let userInfo = notification.userInfo else { return }
+
+        var keyboardFrame: CGRect = (userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as! NSValue).cgRectValue
+        keyboardFrame = view.convert(keyboardFrame, from: nil)
+
+        var contentInset = contentView.contentScrollView.contentInset
+        contentInset.bottom = keyboardFrame.size.height + 20
+
+        contentView.contentScrollView.contentInset = contentInset
+        contentView.spacer.isHidden = true
+        contentView.bottomSpacer.isHidden = false
+    }
+    
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        contentView.spacer.isHidden = false
+        contentView.bottomSpacer.isHidden = true
+        contentView.contentScrollView.contentInset = UIEdgeInsets.zero
     }
 
     // MARK: - action: configuration

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -62,6 +62,10 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         contentView.agreeButton.addTarget(self, action: #selector(InstantOnboardingViewController.acceptAndCreateButtonPressed), for: .touchUpInside)
         contentView.imageButton.addTarget(self, action: #selector(InstantOnboardingViewController.onAvatarTapped), for: .touchUpInside)
         contentView.privacyButton.addTarget(self, action: #selector(InstantOnboardingViewController.showPrivacy(_:)), for: .touchUpInside)
+        contentView.otherOptionsButton.addTarget(self, action: #selector(InstantOnboardingViewController.showOtherOptions(_:)), for: .touchUpInside)
+        contentView.scanQRCodeButton.addTarget(self, action: #selector(InstantOnboardingViewController.scanQRCode(_:)), for: .touchUpInside)
+
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(InstantOnboardingViewController.textDidChangeNotification(notification:)),
@@ -120,6 +124,19 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         if UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url)
         }
+    }
+
+    @objc private func showOtherOptions(_ sender: UIButton) {
+
+        guard let url = URL(string: "https://delta.chat/en/chatmail") else { return }
+
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    @objc private func scanQRCode(_ sender: UIButton) {
+        // TODO: Implement
     }
 
     @objc

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -449,12 +449,7 @@ class WelcomeContentView: UIView {
     }()
 
     private var container = UIView()
-
-    private var logoView: UIImageView = {
-        let image = #imageLiteral(resourceName: "background_intro")
-        let view = UIImageView(image: image)
-        return view
-    }()
+    private var logoView = UIImageView(image: UIImage(named: "dc_logo"))
 
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
@@ -571,7 +566,7 @@ class WelcomeContentView: UIView {
 
     private func calculateLogoHeight() -> CGFloat {
         if UIDevice.current.userInterfaceIdiom == .phone {
-            return  UIApplication.shared.statusBarOrientation.isLandscape ? UIScreen.main.bounds.height * 0.5 : UIScreen.main.bounds.width * 0.75
+            return  UIApplication.shared.statusBarOrientation.isLandscape ? UIScreen.main.bounds.height * 0.5 : UIScreen.main.bounds.width * 0.5
         } else {
             return 275
         }

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -388,7 +388,7 @@ extension WelcomeViewController: QrCodeReaderDelegate {
                 self?.dismissQRReader()
             }
         ))
-        if let qrCodeReader = qrCodeReader {
+        if let qrCodeReader {
             qrCodeReader.present(alert, animated: true)
         } else {
             self.present(alert, animated: true)

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -83,7 +83,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
         if canCancel {
             navigationItem.leftBarButtonItem = cancelButton
         }
-        if let accountCode = accountCode {
+        if let accountCode {
             handleQrCode(accountCode)
         }
     }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -223,7 +223,10 @@ class AppCoordinator: NSObject {
     }
 
     func presentWelcomeController(accountCode: String? = nil) {
-        loginNavController.setViewControllers([WelcomeViewController(dcAccounts: dcAccounts, accountCode: accountCode)], animated: true)
+        loginNavController.setViewControllers([
+            WelcomeViewController(dcAccounts: dcAccounts, accountCode: accountCode),
+            InstantOnboardingViewController(dcAccounts: dcAccounts, qrCodeData: accountCode)
+        ], animated: false)
         window.rootViewController = loginNavController
         window.makeKeyAndVisible()
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -223,10 +223,19 @@ class AppCoordinator: NSObject {
     }
 
     func presentWelcomeController(accountCode: String? = nil) {
-        loginNavController.setViewControllers([
-            WelcomeViewController(dcAccounts: dcAccounts, accountCode: accountCode),
-            InstantOnboardingViewController(dcAccounts: dcAccounts, qrCodeData: accountCode)
-        ], animated: false)
+
+        let viewControllers: [UIViewController]
+
+        if let accountCode {
+            viewControllers = [
+                WelcomeViewController(dcAccounts: dcAccounts, accountCode: accountCode),
+                InstantOnboardingViewController(dcAccounts: dcAccounts, qrCodeData: accountCode)
+            ]
+        } else {
+            viewControllers = [WelcomeViewController(dcAccounts: dcAccounts, accountCode: accountCode)]
+        }
+
+        loginNavController.setViewControllers(viewControllers, animated: false)
         window.rootViewController = loginNavController
         window.makeKeyAndVisible()
 


### PR DESCRIPTION
- Replaces the Logo on Welcome-screen to show the delta.chat-logo
- Adds a few buttons here and there (for provider change or QR-code-scanning)
- Speaking of which: Users can change their provider now using the "Explore other Options"-button
- Speaking of which: Users can scan a QR-Code now using the "Scan QR Code"-button (this will need some more testing
- Screenshots from an iPhone 15 Pro Max

![dc_2168](https://github.com/deltachat/deltachat-ios/assets/2580019/f122ec4e-b797-456b-a27f-d5f1e8e4de86)

successor of #2163, #2164