### PR TITLE
emphasize 'Existing Password'

### DIFF
--- a/deltachat-ios/View/TextFieldCell.swift
+++ b/deltachat-ios/View/TextFieldCell.swift
@@ -174,7 +174,7 @@ class TextFieldCell: UITableViewCell {
     }
 
     static func makePasswordCell(delegate: UITextFieldDelegate? = nil) -> TextFieldCell {
-        let cell = TextFieldCell(description: String.localized("password"), placeholder: String.localized("existing_password"))
+        let cell = TextFieldCell(description: String.localized("existing_password"), placeholder: String.localized("password"))
         cell.textField.textContentType = UITextContentType.password
         cell.textField.isSecureTextEntry = true
         cell.textFieldDelegate = delegate


### PR DESCRIPTION
make clearer, this is not a password the user can define here, esp. when input is started or 'Password & Account' is opened later, this information was hidden.

we found out by complains / user testing in the past that the term 'Existing' is needed here,
cmp https://github.com/deltachat/deltachat-android/pull/1256 .

in case of chatmail creating accounts
by using new passwords for non-existing addreses,
this is a special, not recommended case anyways -
and you still cannot change passwords eg. on editing account setings.

<img width="408" alt="Screenshot 2024-05-16 at 16 00 18" src="https://github.com/deltachat/deltachat-ios/assets/9800740/6bf6d4e7-9b4d-44e9-a5a7-bbc6b0c57f31">
