### PR TITLE
tweak onboarding

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -71,7 +71,7 @@ class InstantOnboardingView: UIView {
         contentStackView.setCustomSpacing(16, after: imageButton)
         contentStackView.setCustomSpacing(16, after: nameTextField)
         contentStackView.setCustomSpacing(8, after: hintLabelWrapper)
-        contentStackView.setCustomSpacing(16, after: privacyButtonWrapper)
+        contentStackView.setCustomSpacing(32, after: privacyButtonWrapper)
         contentStackView.setCustomSpacing(16, after: agreeButton)
 
         contentScrollView = UIScrollView()

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -32,6 +32,7 @@ class InstantOnboardingView: UIView {
 
         nameTextField = UITextField()
         nameTextField.text = name
+        nameTextField.textAlignment = .center
         nameTextField.translatesAutoresizingMaskIntoConstraints = false
         nameTextField.placeholder = String.localized("pref_your_name")
         nameTextField.borderStyle = .roundedRect

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -115,7 +115,6 @@ class InstantOnboardingView: UIView {
             contentStackView.widthAnchor.constraint(equalTo: contentScrollView.widthAnchor, constant: -32),
             contentStackView.heightAnchor.constraint(lessThanOrEqualTo: contentScrollView.heightAnchor),
             nameTextField.widthAnchor.constraint(equalTo: contentStackView.widthAnchor),
-            agreeButton.widthAnchor.constraint(equalTo: contentStackView.widthAnchor),
 
             imageButton.widthAnchor.constraint(equalToConstant: 100),
             imageButton.heightAnchor.constraint(equalToConstant: 100),

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -147,8 +147,10 @@ class InstantOnboardingView: UIView {
 
         if buttonShouldBeEnabled {
             agreeButton.backgroundColor = .systemBlue
+            otherOptionsButton.setTitleColor(.systemBlue, for: .normal)
         } else {
             agreeButton.backgroundColor = UIColor.systemGray.withAlphaComponent(0.3)
+            otherOptionsButton.setTitleColor(UIColor.systemGray.withAlphaComponent(0.5), for: .normal)
         }
     }
 

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -39,6 +39,7 @@ class InstantOnboardingView: UIView {
         hintLabel = UILabel()
         hintLabel.translatesAutoresizingMaskIntoConstraints = false
         hintLabel.numberOfLines = 0
+        hintLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
         hintLabel.text = String.localized("set_name_and_avatar_explain")
 
         hintLabelWrapper = UIView()

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -49,10 +49,11 @@ class InstantOnboardingView: UIView {
 
         agreeButton = UIButton()
         agreeButton.setTitle(String.localized("instant_onboarding_create"), for: .normal)
+        agreeButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+        agreeButton.setTitleColor(.white, for: .normal)
         agreeButton.translatesAutoresizingMaskIntoConstraints = false
-        agreeButton.layer.cornerRadius = 8
-        agreeButton.contentEdgeInsets.top = 8
-        agreeButton.contentEdgeInsets.bottom = 8
+        agreeButton.layer.cornerRadius = 5
+        agreeButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 15, bottom: 8, right: 15)
 
         privacyButton = UIButton(type: .system)
         privacyButton.translatesAutoresizingMaskIntoConstraints = false
@@ -62,6 +63,7 @@ class InstantOnboardingView: UIView {
 
         otherOptionsButton = UIButton(type: .system)
         otherOptionsButton.setTitle(String.localized("instant_onboarding_show_more_instances"), for: .normal)
+        otherOptionsButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         otherOptionsButton.translatesAutoresizingMaskIntoConstraints = false
 
         contentStackView = UIStackView(arrangedSubviews: [imageButton, nameTextField, hintLabelWrapper, privacyButtonWrapper, agreeButton, otherOptionsButton])

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -83,8 +83,8 @@ class InstantOnboardingView: UIView {
         super.init(frame: .zero)
 
         if #available(iOS 13.0, *) {
-            backgroundColor = .systemGroupedBackground
-            nameTextField.backgroundColor = .systemBackground
+            backgroundColor = .systemBackground
+            nameTextField.backgroundColor = .secondarySystemBackground
         } else {
             backgroundColor = .systemGray
         }

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -153,7 +153,7 @@ class InstantOnboardingView: UIView {
         if let customProvider {
             privacyButton.setTitle(String.localized(stringID: "instant_onboarding_agree_instance", parameter: customProvider), for: .normal)
         } else {
-            privacyButton.setTitle(String.localized("instant_onboarding_agree_default"), for: .normal)
+            privacyButton.setTitle(String.localized(stringID: "instant_onboarding_agree_default2", parameter: InstantOnboardingViewController.defaultChatmailDomain), for: .normal)
         }
     }
 }

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -4,6 +4,8 @@ import DcCore
 
 class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
 
+    static let defaultChatmailDomain: String = "nine.testrun.org"
+
     private var dcContext: DcContext
     private let dcAccounts: DcAccounts
     weak var progressAlert: UIAlertController?
@@ -29,7 +31,7 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
     }()
     
     /// Creates Instant Onboarding-Screen. You can inject some QR-Code-Data to change the chatmail provider
-    /// If `qrCodeData` is `nil`, the default server is used, currently it's `nine.testrun.org`
+    /// If `qrCodeData` is `nil`, the default server is used
     /// - Parameters:
     ///   - dcAccounts: Account to be used
     ///   - qrCodeData: DeltaChat QR Code Data
@@ -45,11 +47,11 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
                 self.providerHostURL = url
                 self.qrCodeData = qrCodeData
             } else {
-                self.providerHostURL = URL(string: "https://nine.testrun.org")!
+                self.providerHostURL = URL(string: "https://" + InstantOnboardingViewController.defaultChatmailDomain)!
                 self.qrCodeData = nil
             }
         } else {
-            self.providerHostURL = URL(string: "https://nine.testrun.org")!
+            self.providerHostURL = URL(string: "https://" + InstantOnboardingViewController.defaultChatmailDomain)!
             self.qrCodeData = nil
         }
 

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -459,12 +459,11 @@ class WelcomeContentView: UIView {
 
     private lazy var signUpButton: UIButton = {
         let button = UIButton(type: .roundedRect)
-        let title = String.localized("onboarding_create_instant_account").uppercased()
+        let title = String.localized("onboarding_create_instant_account")
         button.setTitle(title, for: .normal)
         button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         button.setTitleColor(.white, for: .normal)
-        button.backgroundColor = DcColors.primary
-        let insets = button.contentEdgeInsets
+        button.backgroundColor = .systemBlue
         button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 15, bottom: 8, right: 15)
         button.layer.cornerRadius = 5
         button.clipsToBounds = true

--- a/deltachat-ios/Controller/AddGroupMembersViewController.swift
+++ b/deltachat-ios/Controller/AddGroupMembersViewController.swift
@@ -7,7 +7,7 @@ class AddGroupMembersViewController: GroupMembersViewController {
     private var isBroadcast: Bool = false
 
     private lazy var sections: [AddGroupMemberSections] = {
-        if isVerifiedGroup {
+        if isVerifiedGroup || dcContext.isChatmail {
             return [.memberList]
         } else {
             return [.newContact, .memberList]
@@ -24,7 +24,7 @@ class AddGroupMembersViewController: GroupMembersViewController {
     private lazy var newContactCell: ActionCell = {
         let cell = ActionCell()
         cell.actionColor = UIColor.systemBlue
-        cell.actionTitle = String.localized("menu_new_contact")
+        cell.actionTitle = String.localized("menu_new_classic_contact")
         return cell
     }()
 


### PR DESCRIPTION
this PR adds the domain to the "privacy policy" and tweaks colors and sizes.  
it is all tiny changes only, however, esp. in combination with the welcome screen, it looks more coherent, closes #2180

moreover, this PR removes the option to add contacts to groups by "email address" for chatmail-profiles, closes #2181

before / after:

<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/034ceebf-41eb-4417-a523-de8353d0900a>
<img width=320 src=https://github.com/deltachat/deltachat-ios/assets/9800740/203e5e61-dd55-48b5-b654-9d866d460087>



