### PR TITLE
vcard timestamp is optional

### DIFF
--- a/deltachat-ios/DC/DcVcard.swift
+++ b/deltachat-ios/DC/DcVcard.swift
@@ -17,7 +17,7 @@ public struct DcVcardContact: Decodable {
     public let color: String
 
     // Last update timestamp.
-    public let timestamp: Int64
+    public let timestamp: Int64?
 }
 
 struct DcVcardContactResult: Decodable {


### PR DESCRIPTION
parsing must not fail if the timestamp is missing