### PR TITLE
add profile on tap/scan QR code unconditionally

### DIFF
--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -281,11 +281,22 @@ extension QrPageController: QrCodeReaderDelegate {
             }))
             present(alert, animated: true, completion: nil)
 
-        case DC_QR_ACCOUNT, DC_QR_LOGIN, DC_QR_BACKUP:
-            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                _ = dcAccounts.add()
+        case DC_QR_ACCOUNT, DC_QR_LOGIN:
+            let msg = String.localizedStringWithFormat(String.localized(state == DC_QR_ACCOUNT ? "qraccount_ask_create_and_login_another" : "qrlogin_ask_login_another"), qrParsed.text1 ?? "")
+            let alert = UIAlertController(title: msg, message: nil, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+            alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: { _ in
+                guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+                _ = self.dcAccounts.add()
                 appDelegate.reloadDcContext(accountCode: code)
-            }
+            }))
+            present(alert, animated: true, completion: nil)
+
+        case DC_QR_BACKUP:
+            // alert is shown in WelcomeViewController
+            guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+            _ = dcAccounts.add()
+            appDelegate.reloadDcContext(accountCode: code)
 
         case DC_QR_WEBRTC_INSTANCE:
             guard let domain = qrParsed.text1 else { return }

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -283,7 +283,8 @@ extension QrPageController: QrCodeReaderDelegate {
 
         case DC_QR_ACCOUNT, DC_QR_LOGIN, DC_QR_BACKUP:
             if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                appDelegate.appCoordinator.presentWelcomeController(accountCode: code)
+                _ = dcAccounts.add()
+                appDelegate.reloadDcContext(accountCode: code)
             }
 
         case DC_QR_WEBRTC_INSTANCE:

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -197,7 +197,15 @@ class AppCoordinator: NSObject {
     func handleQRCode(_ code: String) {
         if code.lowercased().starts(with: "dcaccount:")
            || code.lowercased().starts(with: "dclogin:") {
-            presentWelcomeController(accountCode: code)
+            if dcAccounts.getSelected().isConfigured() {
+                // if account is configured it means we didn't come from Welcome screen nor from QR scanner,
+                // instead, user clicked a dcaccount:// URI directly, so we need to switch to a new account:
+                guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+                _ = dcAccounts.add()
+                appDelegate.reloadDcContext(accountCode: code)
+            } else {
+                presentWelcomeController(accountCode: code)
+            }
         } else {
             showTab(index: qrTab)
             if let navController = self.tabBarController.selectedViewController as? UINavigationController,


### PR DESCRIPTION
when tap/scan QR code after hitting "Add Profile", things are fine, a new profile was added explictly.

however, when tap/scan QR code when a profile is just opened normally (in chatlist or chat),
we need to add an account and not use the existing one.

(we cannot just always create an account when entering the viewController as we want things as name and avatar being persisted when switching shortly to the browser to select another chatmail server)

counterpart of https://github.com/deltachat/deltachat-android/pull/3112