### PR TITLE
Switch menu entries and put them in submenus (#2193)

### DIFF
--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -316,10 +316,29 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
             actionProvider: { [weak self] _ in
                 guard let self else { return nil }
 
-                let menu = UIMenu(children: [
-                    UIAction.menuAction(localizationKey: "delete", attributes: [.destructive], systemImageName: "trash", indexPath: indexPath, action: { self.askToDeleteItem(at: $0 ) }),
-                    UIAction.menuAction(localizationKey: "show_in_chat", systemImageName: "doc.text.magnifyingglass", indexPath: indexPath, action: { self.redirectToMessage(of: $0 ) })
-                ])
+                let menu = UIMenu(
+                    children: [
+                        UIMenu(
+                            options: [.displayInline],
+                            children: [UIAction.menuAction(localizationKey: "show_in_chat",
+                                                           systemImageName: "doc.text.magnifyingglass",
+                                                           indexPath: indexPath,
+                                                           action: {
+                                                               self.redirectToMessage(of: $0 )
+                                                           })]
+                        ),
+                        UIMenu(
+                            options: [.displayInline],
+                            children: [UIAction.menuAction(localizationKey: "delete",
+                                                           attributes: [.destructive],
+                                                           systemImageName: "trash",
+                                                           indexPath: indexPath,
+                                                           action: {
+                                                               self.askToDeleteItem(at: $0 )
+                                                           })]
+                        ),
+                    ]
+                )
                 return menu
             }
         )


### PR DESCRIPTION
Original idea was to switch order of entries, but I thought: Why not adding that thin line? Anyway, it looks like this now:

![Simulator Screenshot - iPhone 15 - 2024-06-04 at 15 51 52](https://github.com/deltachat/deltachat-ios/assets/2580019/a6201d0b-e913-466f-97bf-a7a846128fae)

Fixes #2193 