### PR TITLE
Cleanup dequeue

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -205,7 +205,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         super.viewDidLoad()
         tableView.backgroundView = backgroundContainer
         tableView.register(TextMessageCell.self, forCellReuseIdentifier: "text")
-        tableView.register(ImageTextCell.self, forCellReuseIdentifier: "image")
+        tableView.register(ImageTextCell.self, forCellReuseIdentifier: ImageTextCell.reuseIdentifier)
         tableView.register(FileTextCell.self, forCellReuseIdentifier: "file")
         tableView.register(InfoMessageCell.self, forCellReuseIdentifier: InfoMessageCell.reuseIdentifier)
         tableView.register(AudioMessageCell.self, forCellReuseIdentifier: "audio")
@@ -595,7 +595,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: InfoMessageCell.reuseIdentifier, for: indexPath) as? InfoMessageCell else {
                 fatalError("WTF?! Wrong Cell, expected InfoMessageCell")
             }
-            
+
             if messageIds.count > indexPath.row + 1 {
                 var nextMessageId = messageIds[indexPath.row + 1]
                 if nextMessageId == DC_MSG_ID_MARKER1 && messageIds.count > indexPath.row + 2 {
@@ -643,7 +643,8 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             return videoInviteCell
 
         case DC_MSG_IMAGE, DC_MSG_GIF, DC_MSG_VIDEO, DC_MSG_STICKER:
-            cell = tableView.dequeueReusableCell(withIdentifier: "image", for: indexPath) as? ImageTextCell ?? ImageTextCell()
+            guard let imageCell = tableView.dequeueReusableCell(withIdentifier: ImageTextCell.reuseIdentifier, for: indexPath) as? ImageTextCell else { fatalError("No ImageTextCell") }
+            return imageCell
 
         case DC_MSG_FILE:
             if message.isSetupMessage {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -660,9 +660,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 cell = fileCell
             }
         case DC_MSG_WEBXDC:
-            guard let xdcCell = tableView.dequeueReusableCell(withIdentifier: WebxdcCell.reuseIdentifier, for: indexPath) as? WebxdcCell else { return fatalError("No WebxdcCell") }
+            guard let xdcCell = tableView.dequeueReusableCell(withIdentifier: WebxdcCell.reuseIdentifier, for: indexPath) as? WebxdcCell else { fatalError("No WebxdcCell") }
 
-            cell = xdsCell
+            cell = xdcCell
         case DC_MSG_AUDIO, DC_MSG_VOICE:
             if message.isUnsupportedMediaFile {
                 guard let fileCell = tableView.dequeueReusableCell(withIdentifier: FileTextCell.reuseIdentifier, for: indexPath) as? FileTextCell else { fatalError("No FileTextCell") }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -208,7 +208,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         tableView.register(ImageTextCell.self, forCellReuseIdentifier: ImageTextCell.reuseIdentifier)
         tableView.register(FileTextCell.self, forCellReuseIdentifier: FileTextCell.reuseIdentifier)
         tableView.register(InfoMessageCell.self, forCellReuseIdentifier: InfoMessageCell.reuseIdentifier)
-        tableView.register(AudioMessageCell.self, forCellReuseIdentifier: "audio")
+        tableView.register(AudioMessageCell.self, forCellReuseIdentifier: AudioMessageCell.reuseIdentifier)
         tableView.register(VideoInviteCell.self, forCellReuseIdentifier: VideoInviteCell.reuseIdentifier)
         tableView.register(WebxdcCell.self, forCellReuseIdentifier: "webxdc")
         tableView.register(ContactCardCell.self, forCellReuseIdentifier: ContactCardCell.reuseIdentifier)
@@ -667,9 +667,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
                 cell = fileCell
             } else {
-                let audioMessageCell: AudioMessageCell = tableView.dequeueReusableCell(
-                    withIdentifier: "audio",
-                    for: indexPath) as? AudioMessageCell ?? AudioMessageCell()
+                guard let audioMessageCell: AudioMessageCell = tableView.dequeueReusableCell(
+                    withIdentifier: AudioMessageCell.reuseIdentifier,
+                    for: indexPath) as? AudioMessageCell else { fatalError("No AudioMessageCell") }
+
                 audioController.update(audioMessageCell, with: message.id)
                 cell = audioMessageCell
             }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -210,7 +210,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         tableView.register(InfoMessageCell.self, forCellReuseIdentifier: InfoMessageCell.reuseIdentifier)
         tableView.register(AudioMessageCell.self, forCellReuseIdentifier: AudioMessageCell.reuseIdentifier)
         tableView.register(VideoInviteCell.self, forCellReuseIdentifier: VideoInviteCell.reuseIdentifier)
-        tableView.register(WebxdcCell.self, forCellReuseIdentifier: "webxdc")
+        tableView.register(WebxdcCell.self, forCellReuseIdentifier: WebxdcCell.reuseIdentifier)
         tableView.register(ContactCardCell.self, forCellReuseIdentifier: ContactCardCell.reuseIdentifier)
         tableView.rowHeight = UITableView.automaticDimension
         tableView.separatorStyle = .none
@@ -660,7 +660,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 cell = fileCell
             }
         case DC_MSG_WEBXDC:
-                cell = tableView.dequeueReusableCell(withIdentifier: "webxdc", for: indexPath) as? WebxdcCell ?? WebxdcCell()
+            guard let xdcCell = tableView.dequeueReusableCell(withIdentifier: WebxdcCell.reuseIdentifier, for: indexPath) as? WebxdcCell else { return fatalError("No WebxdcCell") }
+
+            cell = xdsCell
         case DC_MSG_AUDIO, DC_MSG_VOICE:
             if message.isUnsupportedMediaFile {
                 guard let fileCell = tableView.dequeueReusableCell(withIdentifier: FileTextCell.reuseIdentifier, for: indexPath) as? FileTextCell else { fatalError("No FileTextCell") }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -209,7 +209,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         tableView.register(FileTextCell.self, forCellReuseIdentifier: "file")
         tableView.register(InfoMessageCell.self, forCellReuseIdentifier: InfoMessageCell.reuseIdentifier)
         tableView.register(AudioMessageCell.self, forCellReuseIdentifier: "audio")
-        tableView.register(VideoInviteCell.self, forCellReuseIdentifier: "video_invite")
+        tableView.register(VideoInviteCell.self, forCellReuseIdentifier: VideoInviteCell.reuseIdentifier)
         tableView.register(WebxdcCell.self, forCellReuseIdentifier: "webxdc")
         tableView.register(ContactCardCell.self, forCellReuseIdentifier: ContactCardCell.reuseIdentifier)
         tableView.rowHeight = UITableView.automaticDimension
@@ -637,7 +637,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         let cell: BaseMessageCell
         switch message.type {
         case DC_MSG_VIDEOCHAT_INVITATION:
-            let videoInviteCell = tableView.dequeueReusableCell(withIdentifier: "video_invite", for: indexPath) as? VideoInviteCell ?? VideoInviteCell()
+            guard let videoInviteCell = tableView.dequeueReusableCell(withIdentifier: VideoInviteCell.reuseIdentifier, for: indexPath) as? VideoInviteCell
+            else { fatalError("VideoInviteCell expected") }
+
             videoInviteCell.showSelectionBackground(tableView.isEditing)
             videoInviteCell.update(dcContext: dcContext, msg: message)
             return videoInviteCell

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -207,7 +207,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         tableView.register(TextMessageCell.self, forCellReuseIdentifier: "text")
         tableView.register(ImageTextCell.self, forCellReuseIdentifier: "image")
         tableView.register(FileTextCell.self, forCellReuseIdentifier: "file")
-        tableView.register(InfoMessageCell.self, forCellReuseIdentifier: "info")
+        tableView.register(InfoMessageCell.self, forCellReuseIdentifier: InfoMessageCell.reuseIdentifier)
         tableView.register(AudioMessageCell.self, forCellReuseIdentifier: "audio")
         tableView.register(VideoInviteCell.self, forCellReuseIdentifier: "video_invite")
         tableView.register(WebxdcCell.self, forCellReuseIdentifier: "webxdc")
@@ -592,7 +592,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
         let id = messageIds[indexPath.row]
         if id == DC_MSG_ID_DAYMARKER {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "info", for: indexPath) as? InfoMessageCell ?? InfoMessageCell()
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: InfoMessageCell.reuseIdentifier, for: indexPath) as? InfoMessageCell else {
+                fatalError("WTF?! Wrong Cell, expected InfoMessageCell")
+            }
+            
             if messageIds.count > indexPath.row + 1 {
                 var nextMessageId = messageIds[indexPath.row + 1]
                 if nextMessageId == DC_MSG_ID_MARKER1 && messageIds.count > indexPath.row + 2 {
@@ -607,7 +610,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             return cell
         } else if id == DC_MSG_ID_MARKER1 {
             // unread messages marker
-            let cell = tableView.dequeueReusableCell(withIdentifier: "info", for: indexPath) as? InfoMessageCell ?? InfoMessageCell()
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: InfoMessageCell.reuseIdentifier, for: indexPath) as? InfoMessageCell else {
+                fatalError("WTF?! Wrong Cell, expected InfoMessageCell")
+            }
+
             let freshMsgsCount = self.messageIds.count - (indexPath.row + 1)
             cell.update(text: String.localized(stringID: "chat_n_new_messages", parameter: freshMsgsCount))
             return cell
@@ -615,7 +621,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         
         let message = dcContext.getMessage(id: id)
         if message.isInfo {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "info", for: indexPath) as? InfoMessageCell ?? InfoMessageCell()
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: InfoMessageCell.reuseIdentifier, for: indexPath) as? InfoMessageCell else {
+                fatalError("WTF?! Wrong Cell, expected InfoMessageCell")
+            }
+
             cell.showSelectionBackground(tableView.isEditing)
             if message.infoType == DC_INFO_WEBXDC_INFO_MESSAGE, let parent = message.parent {
                 cell.update(text: message.text, image: parent.getWebxdcPreviewImage())

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -204,7 +204,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.backgroundView = backgroundContainer
-        tableView.register(TextMessageCell.self, forCellReuseIdentifier: "text")
+        tableView.register(TextMessageCell.self, forCellReuseIdentifier: TextMessageCell.reuseIdentifier)
         tableView.register(ImageTextCell.self, forCellReuseIdentifier: ImageTextCell.reuseIdentifier)
         tableView.register(FileTextCell.self, forCellReuseIdentifier: "file")
         tableView.register(InfoMessageCell.self, forCellReuseIdentifier: InfoMessageCell.reuseIdentifier)
@@ -650,8 +650,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
         case DC_MSG_FILE:
             if message.isSetupMessage {
-                cell = tableView.dequeueReusableCell(withIdentifier: "text", for: indexPath) as? TextMessageCell ?? TextMessageCell()
+                guard let textCell = tableView.dequeueReusableCell(withIdentifier: TextMessageCell.reuseIdentifier, for: indexPath) as? TextMessageCell else { fatalError("No TextMessageCell") }
                 message.text = String.localized("autocrypt_asm_click_body")
+
+                cell = textCell
             } else {
                 cell = tableView.dequeueReusableCell(withIdentifier: "file", for: indexPath) as? FileTextCell ?? FileTextCell()
             }
@@ -670,7 +672,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         case DC_MSG_VCARD:
             cell = tableView.dequeueReusableCell(withIdentifier: ContactCardCell.reuseIdentifier, for: indexPath) as? ContactCardCell ?? ContactCardCell()
         default:
-            cell = tableView.dequeueReusableCell(withIdentifier: "text", for: indexPath) as? TextMessageCell ?? TextMessageCell()
+            guard let textCell = tableView.dequeueReusableCell(withIdentifier: TextMessageCell.reuseIdentifier, for: indexPath) as? TextMessageCell else { fatalError("No TextMessageCell") }
+
+            cell = textCell
         }
 
         var showAvatar = isGroupChat && !message.isFromCurrentSender

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -206,7 +206,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         tableView.backgroundView = backgroundContainer
         tableView.register(TextMessageCell.self, forCellReuseIdentifier: TextMessageCell.reuseIdentifier)
         tableView.register(ImageTextCell.self, forCellReuseIdentifier: ImageTextCell.reuseIdentifier)
-        tableView.register(FileTextCell.self, forCellReuseIdentifier: "file")
+        tableView.register(FileTextCell.self, forCellReuseIdentifier: FileTextCell.reuseIdentifier)
         tableView.register(InfoMessageCell.self, forCellReuseIdentifier: InfoMessageCell.reuseIdentifier)
         tableView.register(AudioMessageCell.self, forCellReuseIdentifier: "audio")
         tableView.register(VideoInviteCell.self, forCellReuseIdentifier: VideoInviteCell.reuseIdentifier)
@@ -655,13 +655,17 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
                 cell = textCell
             } else {
-                cell = tableView.dequeueReusableCell(withIdentifier: "file", for: indexPath) as? FileTextCell ?? FileTextCell()
+                guard let fileCell = tableView.dequeueReusableCell(withIdentifier: FileTextCell.reuseIdentifier, for: indexPath) as? FileTextCell else { fatalError("No FileTextCell") }
+
+                cell = fileCell
             }
         case DC_MSG_WEBXDC:
                 cell = tableView.dequeueReusableCell(withIdentifier: "webxdc", for: indexPath) as? WebxdcCell ?? WebxdcCell()
         case DC_MSG_AUDIO, DC_MSG_VOICE:
             if message.isUnsupportedMediaFile {
-                cell = tableView.dequeueReusableCell(withIdentifier: "file", for: indexPath) as? FileTextCell ?? FileTextCell()
+                guard let fileCell = tableView.dequeueReusableCell(withIdentifier: FileTextCell.reuseIdentifier, for: indexPath) as? FileTextCell else { fatalError("No FileTextCell") }
+
+                cell = fileCell
             } else {
                 let audioMessageCell: AudioMessageCell = tableView.dequeueReusableCell(
                     withIdentifier: "audio",

--- a/deltachat-ios/Chat/Views/Cells/AudioMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/AudioMessageCell.swift
@@ -11,6 +11,8 @@ public protocol AudioMessageCellDelegate: AnyObject {
 
 public class AudioMessageCell: BaseMessageCell {
 
+    static let reuseIdentifier = "AudioMessageCell"
+
     public weak var delegate: AudioMessageCellDelegate?
 
     lazy var audioPlayerView: AudioPlayerView = {

--- a/deltachat-ios/Chat/Views/Cells/FileTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/FileTextCell.swift
@@ -5,7 +5,7 @@ import SDWebImage
 
 public class FileTextCell: BaseMessageCell {
 
-    static let reuseIdentifier = "FileTextCell"
+    class var reuseIdentifier: String { "FileTextCell" }
 
     private var spacerHeight: NSLayoutConstraint?
     var spacerWidth: NSLayoutConstraint?

--- a/deltachat-ios/Chat/Views/Cells/FileTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/FileTextCell.swift
@@ -5,6 +5,8 @@ import SDWebImage
 
 public class FileTextCell: BaseMessageCell {
 
+    static let reuseIdentifier = "FileTextCell"
+
     private var spacerHeight: NSLayoutConstraint?
     var spacerWidth: NSLayoutConstraint?
 

--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -4,6 +4,9 @@ import DcCore
 import SDWebImage
 
 class ImageTextCell: BaseMessageCell {
+
+    static let reuseIdentifier = "ImageTextCell"
+
     let minImageWidth: CGFloat = 125
     var imageHeightConstraint: NSLayoutConstraint?
     var imageWidthConstraint: NSLayoutConstraint?

--- a/deltachat-ios/Chat/Views/Cells/InfoMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/InfoMessageCell.swift
@@ -3,6 +3,8 @@ import DcCore
 
 class InfoMessageCell: UITableViewCell {
 
+    static let reuseIdentifier = "InfoMessageCell"
+
     private var showSelectionBackground: Bool
     private var trailingConstraint: NSLayoutConstraint?
     private var trailingConstraintEditingMode: NSLayoutConstraint?

--- a/deltachat-ios/Chat/Views/Cells/TextMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/TextMessageCell.swift
@@ -4,6 +4,8 @@ import UIKit
 
 class TextMessageCell: BaseMessageCell {
 
+    static let reuseIdentifier = "TextMessageCell"
+
     override func setupSubviews() {
         super.setupSubviews()
         mainContentView.addArrangedSubview(messageLabel)

--- a/deltachat-ios/Chat/Views/Cells/VideoInviteCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/VideoInviteCell.swift
@@ -4,6 +4,8 @@ import DcCore
 
 public class VideoInviteCell: UITableViewCell {
 
+    static let reuseIdentifier = "VideoInviteCell"
+
     private lazy var messageBackgroundContainer: BackgroundContainer = {
         let container = BackgroundContainer()
         container.image = UIImage(color: DcColors.systemMessageBackgroundColor)

--- a/deltachat-ios/Chat/Views/Cells/WebxdcCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/WebxdcCell.swift
@@ -3,6 +3,8 @@ import DcCore
 
 public class WebxdcCell: FileTextCell {
 
+    static let reuseIdentifier = "WebxdcCell"
+
     override func setupSubviews() {
         super.setupSubviews()
         fileView.fileImageView.isUserInteractionEnabled = true

--- a/deltachat-ios/Chat/Views/Cells/WebxdcCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/WebxdcCell.swift
@@ -3,7 +3,7 @@ import DcCore
 
 public class WebxdcCell: FileTextCell {
 
-    static let reuseIdentifier = "WebxdcCell"
+    override class var reuseIdentifier: String { "WebxdcCell" }
 
     override func setupSubviews() {
         super.setupSubviews()

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -91,9 +91,8 @@ class AccountSwitchViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == accountSection {
-            guard let cell: AccountCell = tableView.dequeueReusableCell(withIdentifier: AccountCell.reuseIdentifier, for: indexPath) as? AccountCell else {
-                safe_fatalError("unsupported cell type")
-                return UITableViewCell()
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: AccountCell.reuseIdentifier, for: indexPath) as? AccountCell else {
+                fatalError("No AccountCell")
             }
 
             let selectedAccountId = dcAccounts.getSelected().id

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -8,10 +8,6 @@ class ChatListViewController: UITableViewController {
     var isArchive: Bool
     private var accountSwitchTransitioningDelegate: PartialScreenModalTransitioningDelegate!
 
-    private let chatCellReuseIdentifier = "chat_cell"
-    private let deadDropCellReuseIdentifier = "deaddrop_cell"
-    private let contactCellReuseIdentifier = "contact_cell"
-
     private var msgChangedObserver: NSObjectProtocol?
     private var msgsNoticedObserver: NSObjectProtocol?
     private var incomingMsgObserver: NSObjectProtocol?
@@ -40,9 +36,7 @@ class ChatListViewController: UITableViewController {
         return searchController
     }()
 
-    private lazy var archiveCell: ContactCell = {
-        return ContactCell()
-    }()
+    private let archiveCell = ContactCell()
 
     private lazy var newButton: UIBarButtonItem = {
         let button = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.compose, target: self, action: #selector(didPressNewChat))
@@ -307,9 +301,7 @@ class ChatListViewController: UITableViewController {
 
     // MARK: - configuration
     private func configureTableView() {
-        tableView.register(ContactCell.self, forCellReuseIdentifier: chatCellReuseIdentifier)
-        tableView.register(ContactCell.self, forCellReuseIdentifier: deadDropCellReuseIdentifier)
-        tableView.register(ContactCell.self, forCellReuseIdentifier: contactCellReuseIdentifier)
+        tableView.register(ContactCell.self, forCellReuseIdentifier: ContactCell.reuseIdentifier)
         tableView.rowHeight = ContactCell.cellHeight
         tableView.allowsMultipleSelectionDuringEditing = true
     }
@@ -415,9 +407,8 @@ class ChatListViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let viewModel = viewModel else {
-            return UITableViewCell()
-        }
+        guard let viewModel else { return UITableViewCell() }
+
         let cellData = viewModel.cellDataFor(section: indexPath.section, row: indexPath.row)
         switch cellData.type {
         case .chat(let chatData):
@@ -427,22 +418,21 @@ class ChatListViewController: UITableViewController {
                 chatCell.updateCell(cellViewModel: cellData)
                 chatCell.delegate = self
                 return chatCell
-            } else if let chatCell = tableView.dequeueReusableCell(withIdentifier: chatCellReuseIdentifier, for: indexPath) as? ContactCell {
+            } else if let chatCell = tableView.dequeueReusableCell(withIdentifier: ContactCell.reuseIdentifier, for: indexPath) as? ContactCell {
                 chatCell.updateCell(cellViewModel: cellData)
                 chatCell.delegate = self
                 return chatCell
             }
         case .contact:
             safe_assert(viewModel.searchActive)
-            if let contactCell = tableView.dequeueReusableCell(withIdentifier: contactCellReuseIdentifier, for: indexPath) as? ContactCell {
+            if let contactCell = tableView.dequeueReusableCell(withIdentifier: ContactCell.reuseIdentifier, for: indexPath) as? ContactCell {
                 contactCell.updateCell(cellViewModel: cellData)
                 return contactCell
             }
         case .profile:
-            safe_fatalError("CellData type profile not allowed")
+            assertionFailure("CellData type profile not allowed")
+            return UITableViewCell()
         }
-        safe_fatalError("Could not find/dequeue or recycle UITableViewCell.")
-        return UITableViewCell()
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -431,8 +431,10 @@ class ChatListViewController: UITableViewController {
             }
         case .profile:
             assertionFailure("CellData type profile not allowed")
-            return UITableViewCell()
         }
+
+        assertionFailure("This should never happen")
+        return UITableViewCell()
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -61,9 +61,8 @@ class GroupChatDetailViewController: UIViewController {
 
     lazy var tableView: UITableView = {
         let table = UITableView(frame: .zero, style: .grouped)
-        table.register(UITableViewCell.self, forCellReuseIdentifier: "tableCell")
-        table.register(ActionCell.self, forCellReuseIdentifier: "actionCell")
-        table.register(ContactCell.self, forCellReuseIdentifier: "contactCell")
+        table.register(ActionCell.self, forCellReuseIdentifier: ActionCell.reuseIdentifier)
+        table.register(ContactCell.self, forCellReuseIdentifier: ContactCell.reuseIdentifier)
         table.delegate = self
         table.dataSource = self
         table.tableHeaderView = groupHeader
@@ -502,9 +501,8 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
             }
         case .members:
             if isMemberManagementRow(row: row) {
-                guard let actionCell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath) as? ActionCell else {
-                safe_fatalError("could not dequeue action cell")
-                break
+                guard let actionCell = tableView.dequeueReusableCell(withIdentifier: ActionCell.reuseIdentifier, for: indexPath) as? ActionCell else {
+                    fatalError("could not dequeue action cell")
                 }
                 if row == membersRowAddMembers {
                     actionCell.actionTitle = String.localized(chat.isBroadcast ? "add_recipients" : "group_add_members")
@@ -516,9 +514,8 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 return actionCell
             }
 
-            guard let contactCell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath) as? ContactCell else {
-                safe_fatalError("could not dequeue contactCell cell")
-                break
+            guard let contactCell = tableView.dequeueReusableCell(withIdentifier: ContactCell.reuseIdentifier, for: indexPath) as? ContactCell else {
+                fatalError("could not dequeue contactCell cell")
             }
             let contactId: Int = getGroupMemberIdFor(row)
             let cellData = ContactCellData(
@@ -544,8 +541,6 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 return copyToClipboardCell
             }
         }
-        // should never get here
-        return UITableViewCell(frame: .zero)
     }
 
     func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/deltachat-ios/Controller/MessageInfoViewController.swift
+++ b/deltachat-ios/Controller/MessageInfoViewController.swift
@@ -11,7 +11,7 @@ class MessageInfoViewController: UITableViewController {
         self.message = message
         super.init(style: .grouped)
 
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: reuseIdentifier)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: MessageInfoViewController.reuseIdentifier)
     }
 
     required init?(coder _: NSCoder) {
@@ -30,7 +30,7 @@ class MessageInfoViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: MessageInfoViewController.reuseIdentifier, for: indexPath)
 
         if indexPath.section == 0 {
             if indexPath.row == 0 {

--- a/deltachat-ios/Controller/MessageInfoViewController.swift
+++ b/deltachat-ios/Controller/MessageInfoViewController.swift
@@ -4,11 +4,14 @@ import DcCore
 class MessageInfoViewController: UITableViewController {
     var dcContext: DcContext
     var message: DcMsg
+    private static let reuseIdentifier = "MessageInfoCell"
 
     init(dcContext: DcContext, message: DcMsg) {
         self.dcContext = dcContext
         self.message = message
         super.init(style: .grouped)
+
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: reuseIdentifier)
     }
 
     required init?(coder _: NSCoder) {
@@ -22,21 +25,12 @@ class MessageInfoViewController: UITableViewController {
 
     // MARK: - Table view data source
 
-    override func numberOfSections(in _: UITableView) -> Int {
-        return 1
-    }
-
     override func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 1 // number of rows in section
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell
-        if let c = tableView.dequeueReusableCell(withIdentifier: "MessageInfoCell") {
-            cell = c
-        } else {
-            cell = UITableViewCell(style: .default, reuseIdentifier: "MessageInfoCell")
-        }
+        let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
 
         if indexPath.section == 0 {
             if indexPath.row == 0 {

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -94,8 +94,8 @@ class NewChatViewController: UITableViewController {
         if #available(iOS 11.0, *) {
             navigationItem.hidesSearchBarWhenScrolling = false
         }
-        tableView.register(ActionCell.self, forCellReuseIdentifier: "actionCell")
-        tableView.register(ContactCell.self, forCellReuseIdentifier: "contactCell")
+        tableView.register(ActionCell.self, forCellReuseIdentifier: ActionCell.reuseIdentifier)
+        tableView.register(ContactCell.self, forCellReuseIdentifier: ContactCell.reuseIdentifier)
         tableView.sectionHeaderHeight = UITableView.automaticDimension
     }
 
@@ -129,29 +129,28 @@ class NewChatViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let section = indexPath.section
         let row = indexPath.row
-
+        
         if section == sectionNew {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
-            if let actionCell = cell as? ActionCell {
-                switch newOptions[row] {
-                case .scanQRCode:
-                    actionCell.actionTitle = String.localized("menu_new_contact")
-                case .newGroup:
-                    actionCell.actionTitle = String.localized("menu_new_group")
-                case .newBroadcastList:
-                    actionCell.actionTitle = String.localized("new_broadcast_list")
-                case .newContact:
-                    actionCell.actionTitle = String.localized("menu_new_classic_contact")
-                }
+            guard let actionCell = tableView.dequeueReusableCell(withIdentifier: ActionCell.reuseIdentifier, for: indexPath) as? ActionCell else { fatalError("No Action Cell") }
+            
+            switch newOptions[row] {
+            case .scanQRCode:
+                actionCell.actionTitle = String.localized("menu_new_contact")
+            case .newGroup:
+                actionCell.actionTitle = String.localized("menu_new_group")
+            case .newBroadcastList:
+                actionCell.actionTitle = String.localized("new_broadcast_list")
+            case .newContact:
+                actionCell.actionTitle = String.localized("menu_new_classic_contact")
             }
-            return cell
+            
+            return actionCell
         } else {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath)
-            if let contactCell = cell as? ContactCell {
-                let contactCellViewModel = self.contactViewModelBy(row: indexPath.row)
-                contactCell.updateCell(cellViewModel: contactCellViewModel)
-            }
-            return cell
+            guard let contactCell = tableView.dequeueReusableCell(withIdentifier: ContactCell.reuseIdentifier, for: indexPath) as? ContactCell else { fatalError("ContactCell expected") }
+
+            let contactCellViewModel = self.contactViewModelBy(row: indexPath.row)
+            contactCell.updateCell(cellViewModel: contactCellViewModel)
+            return contactCell
         }
     }
 

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -100,8 +100,8 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
         }
         doneButton = UIBarButtonItem(title: String.localized("create"), style: .done, target: self, action: #selector(doneButtonPressed))
         navigationItem.rightBarButtonItem = doneButton
-        tableView.register(ContactCell.self, forCellReuseIdentifier: "contactCell")
-        tableView.register(ActionCell.self, forCellReuseIdentifier: "actionCell")
+        tableView.register(ContactCell.self, forCellReuseIdentifier: ContactCell.reuseIdentifier)
+        tableView.register(ActionCell.self, forCellReuseIdentifier: ActionCell.reuseIdentifier)
         self.hideKeyboardOnTap()
         checkDoneButton()
     }
@@ -159,31 +159,28 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
                 return groupNameCell
             }
         case .invite:
-            let cell = tableView.dequeueReusableCell(withIdentifier: "actionCell", for: indexPath)
+            guard let actionCell = tableView.dequeueReusableCell(withIdentifier: ActionCell.reuseIdentifier, for: indexPath) as? ActionCell else { fatalError("No ActionCell") }
             if inviteRows[row] == .addMembers {
-                if let actionCell = cell as? ActionCell {
-                    actionCell.actionTitle = String.localized(createBroadcast ? "add_recipients" : "group_add_members")
-                    actionCell.actionColor = UIColor.systemBlue
-                    actionCell.isUserInteractionEnabled = true
-                }
+                actionCell.actionTitle = String.localized(createBroadcast ? "add_recipients" : "group_add_members")
+                actionCell.actionColor = UIColor.systemBlue
+                actionCell.isUserInteractionEnabled = true
             }
-            return cell
+            return actionCell
         case .members:
-            let cell = tableView.dequeueReusableCell(withIdentifier: "contactCell", for: indexPath)
-            if let contactCell = cell as? ContactCell {
-                let contact = dcContext.getContact(id: groupContactIds[row])
-                let displayName = contact.displayName
-                contactCell.titleLabel.text = displayName
-                contactCell.subtitleLabel.text = contact.email
-                contactCell.avatar.setName(displayName)
-                contactCell.avatar.setColor(contact.color)
-                if let profileImage = contact.profileImage {
-                    contactCell.avatar.setImage(profileImage)
-                }
-                contactCell.setVerified(isVerified: contact.isVerified)
-                contactCell.selectionStyle = .none
+            guard let contactCell = tableView.dequeueReusableCell(withIdentifier: ContactCell.reuseIdentifier, for: indexPath) as? ContactCell else { fatalError("No ContactCell") }
+
+            let contact = dcContext.getContact(id: groupContactIds[row])
+            let displayName = contact.displayName
+            contactCell.titleLabel.text = displayName
+            contactCell.subtitleLabel.text = contact.email
+            contactCell.avatar.setName(displayName)
+            contactCell.avatar.setColor(contact.color)
+            if let profileImage = contact.profileImage {
+                contactCell.avatar.setImage(profileImage)
             }
-            return cell
+            contactCell.setVerified(isVerified: contact.isVerified)
+            contactCell.selectionStyle = .none
+            return contactCell
         }
     }
 


### PR DESCRIPTION
- Crash if dequeued cell can't be casted (i.e. someone forgot to register that very cell)
- use static `reuseIdentifier` for cells instead of strings
- Use this pattern everywhere (and cleanup here and there)