### PR TITLE
Stage images, but send stickers (#2128)

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2657,7 +2657,13 @@ extension ChatViewController: UITextViewDelegate {
 // MARK: - ChatInputTextViewPasteDelegate
 extension ChatViewController: ChatInputTextViewPasteDelegate {
     func onImagePasted(image: UIImage) {
-        sendSticker(image)
+        let isSticker = image.size.equalTo(CGSize(width: 140, height: 140))
+
+        if isSticker {
+            sendSticker(image)
+        } else {
+            stageImage(image)
+        }
     }
 }
 


### PR DESCRIPTION
~~`isSticker` with checking on image sizes feels so wrong, if someone has a better idea how to differ between stickers and images: I'm all ears!~~

After a short debate we decided to check for size for now. If that doesn't work well enough,  we'll consider adding a check for a transparent pixel on `[0, 0]`