### PR TITLE
Hide scrollbutton when showing the menu (#2147)

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -20,6 +20,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     private var keepKeyboard: Bool = false
     private var wasInputBarFirstResponder = false
     private var reactionMessageId: Int?
+    private var contextMenuVisible = false
 
     private lazy var isGroupChat: Bool = {
         return dcContext.getChat(chatId: chatId).isGroup
@@ -699,9 +700,11 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }
 
     private func updateScrollDownButtonVisibility() {
-        messageInputBar.scrollDownButton.isHidden = messageIds.isEmpty || isLastRowVisible(checkTopCellPostion: true,
-                                                                                           checkBottomCellPosition: true,
-                                                                                           allowPartialVisibility: true)
+        let scrollDownButtonHidden = contextMenuVisible || messageIds.isEmpty || isLastRowVisible(checkTopCellPostion: true,
+                                                                                                  checkBottomCellPosition: true,
+                                                                                                  allowPartialVisibility: true)
+        
+        messageInputBar.scrollDownButton.isHidden = scrollDownButtonHidden
     }
 
     private func configureContactRequestBar() {
@@ -1884,6 +1887,9 @@ extension ChatViewController {
 
         cell.messageBackgroundContainer.isHidden = true
         cell.reactionsView.isHidden = true
+        contextMenuVisible = true
+
+        updateScrollDownButtonVisibility()
     }
 
     override func tableView(_ tableView: UITableView, willEndContextMenuInteraction configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
@@ -1900,6 +1906,9 @@ extension ChatViewController {
 
         cell.messageBackgroundContainer.isHidden = false
         cell.reactionsView.isHidden = false
+        contextMenuVisible = false
+
+        updateScrollDownButtonVisibility()
     }
 
     override func tableView(_ tableView: UITableView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {


### PR DESCRIPTION
I needed something small and easy to fix.

![simulator_screenshot_FAE55485-84A6-4675-9DB9-40CA170C254C](https://github.com/deltachat/deltachat-ios/assets/2580019/1bd713e3-6001-4885-8530-88212be013f7)

Fixes #2147 