### PR TITLE
Don't return empty image-cells

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -647,7 +647,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
         case DC_MSG_IMAGE, DC_MSG_GIF, DC_MSG_VIDEO, DC_MSG_STICKER:
             guard let imageCell = tableView.dequeueReusableCell(withIdentifier: ImageTextCell.reuseIdentifier, for: indexPath) as? ImageTextCell else { fatalError("No ImageTextCell") }
-            return imageCell
+            cell = imageCell
 
         case DC_MSG_FILE:
             if message.isSetupMessage {


### PR DESCRIPTION
unless you want them to be unconfigured :facepalm:

During cleanup (see #2201) I broke the image-cells. Instead of just setting them, I returned them immediately.