### PR TITLE
Add search to send-contact-list (#2209)

### DIFF
--- a/deltachat-ios/Chat/Send Contact/SendContactViewController.swift
+++ b/deltachat-ios/Chat/Send Contact/SendContactViewController.swift
@@ -82,11 +82,10 @@ extension SendContactViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        searchController.isActive = false
-
         let contactId = filteredContactIds[indexPath.row]
         delegate?.contactSelected(self, contactId: contactId)
 
+        searchController.isActive = false
         dismiss(animated: true)
     }
 }


### PR DESCRIPTION
Steals some of stuff from `GroupMemberViewController`, but I don't think a new component makes a lot of sense here. 
It uses the Core(tm) for search and to the user it looks like this:

![2209](https://github.com/deltachat/deltachat-ios/assets/2580019/df8fa20c-3d5c-48b6-8463-69f9f41ea714)

Closes #2209.