### PR TITLE
Improve "Add second device instructions" for small screens

### DIFF
--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -200,8 +200,6 @@ class BackupTransferViewController: UIViewController {
 
     // MARK: - setup
     private func setupSubviews() {
-
-
         let qrDefaultWidth = qrContentView.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.75)
         qrDefaultWidth.priority = UILayoutPriority(500)
         qrDefaultWidth.isActive = true


### PR DESCRIPTION
This PR puts most of the views into a StackView/ScrollView so that it scrolls on small screens (or large fonts or looooong texts)

<details>
<summary>Screenshots</summary>

iPhone SE 3rd gen.:

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-27 at 23 44 03](https://github.com/deltachat/deltachat-ios/assets/2580019/07435439-22f1-4f2d-8791-d7c1c769ddb4)

iPhone 15 Pro Max:

![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-27 at 23 45 03](https://github.com/deltachat/deltachat-ios/assets/2580019/fb9156fb-448a-4624-b2bb-d4cbd8f0e6a1)

</details >

Closes #2136.