### PR TITLE
realtime channels

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -13,6 +13,7 @@ public let eventEphemeralTimerModified =  Notification.Name(rawValue: "eventEphe
 public let eventMsgsNoticed = Notification.Name(rawValue: "eventMsgsNoticed")
 public let eventConnectivityChanged = Notification.Name(rawValue: "eventConnectivityChanged")
 public let eventWebxdcStatusUpdate = Notification.Name(rawValue: "eventWebxdcStatusUpdate")
+public let eventWebxdcRealtimeData = Notification.Name(rawValue: "eventWebxdcRealtimeData")
 
 public class DcEventHandler {
     let dcAccounts: DcAccounts
@@ -171,6 +172,18 @@ public class DcEventHandler {
             DispatchQueue.main.async {
                 NotificationCenter.default.post(name: eventWebxdcStatusUpdate, object: nil, userInfo: [
                     "message_id": Int(data1),
+                ])
+            }
+
+        case DC_EVENT_WEBXDC_REALTIME_DATA:
+            if accountId != dcAccounts.getSelected().id {
+                return
+            }
+            logger.info("📡[\(accountId)] webxdc realtime data")
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: eventWebxdcRealtimeData, object: nil, userInfo: [
+                    "message_id": Int(data1),
+                    // TODO: forward data from data2 (length + bytes)
                 ])
             }
 

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -179,11 +179,10 @@ public class DcEventHandler {
             if accountId != dcAccounts.getSelected().id {
                 return
             }
-            logger.info("📡[\(accountId)] webxdc realtime data")
             DispatchQueue.main.async {
                 NotificationCenter.default.post(name: eventWebxdcRealtimeData, object: nil, userInfo: [
                     "message_id": Int(data1),
-                    // TODO: forward data from data2 (length + bytes)
+                    "data": event.data2Data,
                 ])
             }
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -201,6 +201,23 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         })
     }()
 
+    lazy var realtimeChannelsCell: SwitchCell = {
+        return SwitchCell(
+            textLabel: "Realtime Channels",
+            on: dcContext.getConfigBool("webxdc_realtime_enabled"),
+            action: { cell in
+                self.dcContext.setConfigBool("webxdc_realtime_enabled", cell.isOn)
+                if cell.isOn {
+                    let alert = UIAlertController(title: "Thanks for trying out the experimental feature 🧪 \"Realtime Channels\"",
+                        message: "\"Realtime Channels\" allow to create direct connections between devices.\n\n"
+                               + "If you want to quit the experimental feature, you can disable it at \"Settings / Advanced\".",
+                        preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: nil))
+                    self.navigationController?.present(alert, animated: true, completion: nil)
+                }
+        })
+    }()
+
     private lazy var viewLogCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.tag = CellTags.viewLog.rawValue
@@ -217,7 +234,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
         let experimentalSection = SectionConfigs(
             headerTitle: String.localized("pref_experimental_features"),
             footerTitle: nil,
-            cells: [videoChatInstanceCell, broadcastListsCell, locationStreamingCell])
+            cells: [videoChatInstanceCell, broadcastListsCell, locationStreamingCell, realtimeChannelsCell])
 
         if dcContext.isChatmail {
             let encryptionSection = SectionConfigs(

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -17,6 +17,7 @@ class WebxdcViewController: WebViewViewController {
     var messageId: Int
     var msgChangedObserver: NSObjectProtocol?
     var webxdcUpdateObserver: NSObjectProtocol?
+    var webxdcRealtimeDataObserver: NSObjectProtocol?
     var webxdcName: String = ""
     var sourceCodeUrl: String?
     private var allowInternet: Bool = false
@@ -326,6 +327,17 @@ class WebxdcViewController: WebViewViewController {
             }
         }
 
+        webxdcRealtimeDataObserver = nc.addObserver(
+            forName: eventWebxdcRealtimeData,
+            object: nil,
+            queue: OperationQueue.main
+        ) { [weak self] notification in
+            guard let self, let userInfo = notification.userInfo, let messageId = userInfo["message_id"] as? Int else { return }
+            if messageId == self.messageId, let data = userInfo["data"] as? Data {
+                // TODO: pass to js-land
+            }
+        }
+
         msgChangedObserver = nc.addObserver(
             forName: eventMsgsChangedReadDeliveredFailed,
             object: nil,
@@ -342,6 +354,9 @@ class WebxdcViewController: WebViewViewController {
         let nc = NotificationCenter.default
         if let webxdcUpdateObserver = webxdcUpdateObserver {
             nc.removeObserver(webxdcUpdateObserver)
+        }
+        if let webxdcRealtimeDataObserver {
+            nc.removeObserver(webxdcRealtimeDataObserver)
         }
         if let msgChangedObserver = msgChangedObserver {
             nc.removeObserver(msgChangedObserver)

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -6,7 +6,6 @@ class WebxdcViewController: WebViewViewController {
     
     enum WebxdcHandler: String {
         case log  = "log"
-        case setUpdateListener = "setUpdateListener"
         case sendStatusUpdate = "sendStatusUpdateHandler"
         case sendToChat = "sendToChat"
         case sendRealtimeAdvertisement = "sendRealtimeAdvertisement"
@@ -229,7 +228,6 @@ class WebxdcViewController: WebViewViewController {
         let contentController = WKUserContentController()
         
         contentController.add(self, name: WebxdcHandler.sendStatusUpdate.rawValue)
-        contentController.add(self, name: WebxdcHandler.setUpdateListener.rawValue)
         contentController.add(self, name: WebxdcHandler.log.rawValue)
         contentController.add(self, name: WebxdcHandler.sendToChat.rawValue)
         contentController.add(self, name: WebxdcHandler.sendRealtimeAdvertisement.rawValue)
@@ -457,7 +455,7 @@ class WebxdcViewController: WebViewViewController {
 
 extension WebxdcViewController: WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        let handler = WebxdcHandler(rawValue: message.name)
+        guard let handler = WebxdcHandler(rawValue: message.name) else { return }
         switch handler {
         case .log:
             guard let msg = message.body as? String else {
@@ -510,9 +508,6 @@ extension WebxdcViewController: WKScriptMessageHandler {
 
         case .leaveRealtime:
             dcContext.leaveWebxdcRealtime(messageId: messageId)
-
-        default:
-            break
         }
     }
 }

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -107,7 +107,7 @@ class WebxdcViewController: WebViewViewController {
                 if ((!data) instanceof Uint8Array) {
                   throw new Error('realtime listener data must be a Uint8Array')
                 }
-                // TODO: InternalJSApi.sendRealtimeData(JSON.stringify(Array.from(data)));
+                webkit.messageHandlers.sendRealtimeData.postMessage(Array.from(data));
               },
               __receive: (data) => {
                 if (listener) {
@@ -504,7 +504,9 @@ extension WebxdcViewController: WKScriptMessageHandler {
             dcContext.sendWebxdcRealtimeAdvertisement(messageId: messageId)
 
         case .sendRealtimeData:
-            dcContext.sendWebxdcRealtimeData(messageId: messageId)
+            if let jsonIntArray = message.body as? [UInt8] {
+                // TODO: dcContext.sendWebxdcRealtimeData(messageId: messageId)
+            }
 
         case .leaveRealtime:
             dcContext.leaveWebxdcRealtime(messageId: messageId)

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -5,12 +5,12 @@ import DcCore
 class WebxdcViewController: WebViewViewController {
     
     enum WebxdcHandler: String {
-        case log  = "log"
-        case sendStatusUpdate = "sendStatusUpdateHandler"
-        case sendToChat = "sendToChat"
-        case sendRealtimeAdvertisement = "sendRealtimeAdvertisement"
-        case sendRealtimeData = "sendRealtimeData"
-        case leaveRealtime = "leaveRealtime"
+        case log
+        case sendStatusUpdate
+        case sendToChat
+        case sendRealtimeAdvertisement
+        case sendRealtimeData
+        case leaveRealtime
     }
     let INTERNALSCHEMA = "webxdc"
     
@@ -144,7 +144,7 @@ class WebxdcViewController: WebViewViewController {
                     payload: payload,
                     descr: descr
                 };
-                webkit.messageHandlers.sendStatusUpdateHandler.postMessage(parameter);
+                webkit.messageHandlers.sendStatusUpdate.postMessage(parameter);
             },
 
             sendToChat: async (message) => {

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -504,8 +504,8 @@ extension WebxdcViewController: WKScriptMessageHandler {
             dcContext.sendWebxdcRealtimeAdvertisement(messageId: messageId)
 
         case .sendRealtimeData:
-            if let jsonIntArray = message.body as? [UInt8] {
-                // TODO: dcContext.sendWebxdcRealtimeData(messageId: messageId)
+            if let uint8Array = message.body as? [UInt8] {
+                dcContext.sendWebxdcRealtimeData(messageId: messageId, uint8Array: uint8Array)
             }
 
         case .leaveRealtime:

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -86,6 +86,18 @@ public class DcContext {
         return Int(dc_init_webxdc_integration(contextPointer, UInt32(chatId)))
     }
 
+    public func sendWebxdcRealtimeAdvertisement(messageId: Int) {
+        DcAccounts.shared.blockingCall(method: "send_webxdc_realtime_advertisement", params: [id as AnyObject, messageId as AnyObject])
+    }
+
+    public func sendWebxdcRealtimeData(messageId: Int) { // TODO: pass data when we know the format
+        DcAccounts.shared.blockingCall(method: "send_webxdc_realtime_data", params: [id as AnyObject, messageId as AnyObject])
+    }
+
+    public func leaveWebxdcRealtime(messageId: Int) {
+        DcAccounts.shared.blockingCall(method: "leave_webxdc_realtime", params: [id as AnyObject, messageId as AnyObject])
+    }
+
     public func sendVideoChatInvitation(chatId: Int) -> Int {
         return Int(dc_send_videochat_invitation(contextPointer, UInt32(chatId)))
     }

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -90,8 +90,8 @@ public class DcContext {
         DcAccounts.shared.blockingCall(method: "send_webxdc_realtime_advertisement", params: [id as AnyObject, messageId as AnyObject])
     }
 
-    public func sendWebxdcRealtimeData(messageId: Int) { // TODO: pass data when we know the format
-        DcAccounts.shared.blockingCall(method: "send_webxdc_realtime_data", params: [id as AnyObject, messageId as AnyObject])
+    public func sendWebxdcRealtimeData(messageId: Int, uint8Array: [UInt8]) {
+        DcAccounts.shared.blockingCall(method: "send_webxdc_realtime_data", params: [id as AnyObject, messageId as AnyObject, uint8Array as AnyObject])
     }
 
     public func leaveWebxdcRealtime(messageId: Int) {

--- a/deltachat-ios/DC/DcEvent.swift
+++ b/deltachat-ios/DC/DcEvent.swift
@@ -37,4 +37,11 @@ public class DcEvent {
         dc_str_unref(cString)
         return swiftString
     }
+
+    public var data2Data: Data {
+        guard let cPtr = dc_event_get_data2_str(eventPointer) else { return Data() }
+        let data = Data(bytes: cPtr, count: data2Int)
+        dc_str_unref(cPtr)
+        return data
+    }
 }


### PR DESCRIPTION
this PR adds "realtime webxdc channel APIs" to iOS as an experimental option.

see https://webxdc.org/docs/spec/joinRealtimeChannel.html for what the  API is about and https://github.com/deltachat/deltachat-android/pull/3108 for a reference implementation.

the code is quite similar to android, @adbenitez will probably find at home ;) on the iOS side, i did what we did before when adding APIs, i only did two small "cleanup" commits.

nb: we're not saying "Realtime _Webxdc_ Channels" for reasons, eg. we're not using the word "Webxdc" in the whole app.

closes #2212 

https://github.com/deltachat/deltachat-ios/assets/9800740/d922fd88-6ac5-4fa4-b048-1691931b6d04

