### PR TITLE
add option to 'mark all selected chats read'

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -574,13 +574,13 @@ class ChatListViewController: UITableViewController {
         }
     }
 
-    func setLongTapEditing(_ editing: Bool, initialIndexPath: [IndexPath]? = nil) {
+    func setLongTapEditing(_ editing: Bool, initialIndexPath: IndexPath? = nil) {
         setEditing(editing, animated: true)
         if editing {
+            tableView.selectRow(at: initialIndexPath, animated: true, scrollPosition: .none)
             addEditingView()
             if let viewModel = viewModel {
-                editingBar.showUnpinning = viewModel.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows) ||
-                                           viewModel.hasOnlyPinnedChatsSelected(in: initialIndexPath)
+                editingBar.showUnpinning = viewModel.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows)
             }
         } else {
             removeEditingView()
@@ -691,7 +691,7 @@ class ChatListViewController: UITableViewController {
             return false
         }
         titleView.accessibilityHint = nil
-        let cnt = tableView.indexPathsForSelectedRows?.count ?? 1
+        let cnt = tableView.indexPathsForSelectedRows?.count ?? 0
         titleView.text = String.localized(stringID: "n_selected", parameter: cnt)
         navigationItem.setLeftBarButton(cancelButton, animated: true)
         navigationItem.setRightBarButton(markReadButton, animated: true)
@@ -925,9 +925,7 @@ extension ChatListViewController: ContactCellDelegate {
             guard let chatList = viewModel?.chatList else { return }
             if chatList.getChatId(index: indexPath.row) != Int(DC_CHAT_ID_ARCHIVED_LINK) {
                 UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                setLongTapEditing(true, initialIndexPath: [indexPath])
-                tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
-                updateMarkReadButton()
+                setLongTapEditing(true, initialIndexPath: indexPath)
             }
         }
     }

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -234,6 +234,14 @@ class ChatListViewModel: NSObject {
         }
     }
 
+    func markUnreadSelectedChats(in indexPaths: [IndexPath]?) {
+        let chatIds = chatIdsFor(indexPaths: indexPaths)
+        for chatId in chatIds {
+            dcContext.marknoticedChat(chatId: chatId)
+            NotificationManager.removeNotificationsForChat(dcContext: dcContext, chatId: chatId)
+        }
+    }
+
     func deleteChat(chatId: Int) {
         dcContext.deleteChat(chatId: chatId)
         NotificationManager.removeNotificationsForChat(dcContext: dcContext, chatId: chatId)
@@ -259,6 +267,16 @@ class ChatListViewModel: NSObject {
     func pinChat(chatId: Int, pinned: Bool, notifyListener: Bool = false) {
         self.dcContext.setChatVisibility(chatId: chatId, visibility: pinned ? DC_CHAT_VISIBILITY_NORMAL : DC_CHAT_VISIBILITY_PINNED)
         updateChatList(notifyListener: notifyListener)
+    }
+
+    func hasAnyUnreadChatSelected(in indexPaths: [IndexPath]?) -> Bool {
+        let chatIds = chatIdsFor(indexPaths: indexPaths)
+        for chatId in chatIds {
+            if dcContext.getUnreadMessages(chatId: chatId) > 0 {
+                return true
+            }
+        }
+        return false
     }
 
     func hasOnlyPinnedChatsSelected(in indexPaths: [IndexPath]?) -> Bool {


### PR DESCRIPTION
the first commit adds an option to mark selected chats as read at the position already known from marking archive as read. the option is only available if there is at least one unread chat selected - otherwise, the option is disabled.

the second commit cleans up a bit, removing a probably unneeded hack, see commit message for details.

counterpart of https://github.com/deltachat/deltachat-android/pull/3130

<img width=300 src=https://github.com/deltachat/deltachat-ios/assets/9800740/790d3e35-3a0c-4525-b0e6-2e4e93e1555e>
