### PR TITLE
Fix warning (#2227)

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -925,6 +925,8 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }
 
     private func updateTitle() {
+        titleView.translatesAutoresizingMaskIntoConstraints = false
+        
         if tableView.isEditing {
             navigationItem.titleView = nil
             let cnt = tableView.indexPathsForSelectedRows?.count ?? 0


### PR DESCRIPTION
Took me a little to figure this out.
What didn't work:

- Rewriting `ChatTitleView` without computed properties
- Different ways for spacing

Fixes #2227. 