### PR TITLE
ChatViewController never got deallocated

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -794,7 +794,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         messageInputBar.setRightStackViewWidthConstant(to: 0, animated: false)
         messageInputBar.padding = UIEdgeInsets(top: 6, left: 0, bottom: 6, right: 0)
         messageInputBar.setStackViewItems([], forStack: .top, animated: false)
-        messageInputBar.onScrollDownButtonPressed = scrollToBottom
+        messageInputBar.onScrollDownButtonPressed = { [weak self] in
+            self?.scrollToBottom()
+        }
         inputAccessoryView = messageInputBar
     }
 
@@ -1250,7 +1252,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         configureInputBarItems()
         messageInputBar.inputTextView.delegate = self
         messageInputBar.inputTextView.imagePasteDelegate = self
-        messageInputBar.onScrollDownButtonPressed = scrollToBottom
+        messageInputBar.onScrollDownButtonPressed = { [weak self] in
+            self?.scrollToBottom()
+        }
         messageInputBar.inputTextView.setDropInteractionDelegate(delegate: self)
         messageInputBar.isTranslucent = true
     }


### PR DESCRIPTION
This came up during Notifications-refactoring: Instances of `ChatViewController` were never deallocated. An easy way to find out is a [Symbolic Breakpoint](https://sarunw.com/posts/easy-way-to-detect-retain-cycle-in-view-controller/) and later Memory Graph.

The reason for this was that the `ChatViewController` references an `InputBarAccessoryView` (the `messageInputBar`) which itself has a closure `onScrollDownButtonPressed` which itself hold a strong reference to the `scrollToBottom`-function of in instance of `ChatViewController` (that although disappearing, never deallocated).

I changed `onScrollDownButtonPressed` to have its own closure that holds a `weak` reference to `self` and calls `scrollToBottom`.

This was a nice, fun little puzzle to solve.