### PR TITLE
Remove observers for events

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -1,31 +1,31 @@
 import UIKit
 import UserNotifications
 
-extension Notification.Name {
+public enum Event {
     // Messages
-    public static let messagesChanged = Notification.Name(rawValue: "eventMsgsChanged")
+    public static let messagesChanged = Notification.Name(rawValue: "messagesChanged")
     public static let messageReadDeliveredFailedReaction = Notification.Name(rawValue: "messageReadDeliveredFailedReaction")
-    public static let incomingMessage = Notification.Name(rawValue: "eventIncomingMsg")
-    public static let incomingMessageOnAnyAccount = Notification.Name(rawValue: "eventIncomingMsgAnyAccount")
-    public static let messagesNoticed = Notification.Name(rawValue: "eventMsgsNoticed")
+    public static let incomingMessage = Notification.Name(rawValue: "incomingMessage")
+    public static let incomingMessageOnAnyAccount = Notification.Name(rawValue: "incomingMessageOnAnyAccount")
+    public static let messagesNoticed = Notification.Name(rawValue: "messagesNoticed")
 
     // Chats
-    public static let chatModified = Notification.Name(rawValue: "eventChatModified")
+    public static let chatModified = Notification.Name(rawValue: "chatModified")
 
     // Contacts
-    public static let contactsChanged = Notification.Name(rawValue: "eventContactsChanged")
+    public static let contactsChanged = Notification.Name(rawValue: "contactsChanged")
 
     // Progress
-    public static let importExportProgress = Notification.Name(rawValue: "eventImexProgress")
-    public static let configurationProgress = Notification.Name(rawValue: "eventConfigureProgress")
+    public static let importExportProgress = Notification.Name(rawValue: "importExportProgress")
+    public static let configurationProgress = Notification.Name(rawValue: "configurationProgress")
 
-    public static let connectivityChanged = Notification.Name(rawValue: "eventConnectivityChanged")
+    public static let connectivityChanged = Notification.Name(rawValue: "connectivityChanged")
 
     // Webxdc
-    public static let webxdcStatusUpdate = Notification.Name(rawValue: "eventWebxdcStatusUpdate")
-    public static let webxdcRealtimeDataReceived = Notification.Name(rawValue: "eventWebxdcRealtimeData")
+    public static let webxdcStatusUpdate = Notification.Name(rawValue: "webxdcStatusUpdate")
+    public static let webxdcRealtimeDataReceived = Notification.Name(rawValue: "webxdcRealtimeDataReceived")
 
-    public static let ephemeralTimerModified =  Notification.Name(rawValue: "eventEphemeralTimerModified")
+    public static let ephemeralTimerModified =  Notification.Name(rawValue: "ephemeralTimerModified")
 }
 
 
@@ -59,7 +59,7 @@ public class DcEventHandler {
             DispatchQueue.main.async {
                 let done = Int(data1) == 1000
 
-                NotificationCenter.default.post(name: .configurationProgress, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.configurationProgress, object: nil, userInfo: [
                     "progress": Int(data1),
                     "error": Int(data1) == 0,
                     "done": done,
@@ -74,7 +74,7 @@ public class DcEventHandler {
 
         case DC_EVENT_IMEX_PROGRESS:
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .importExportProgress, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.importExportProgress, object: nil, userInfo: [
                     "progress": Int(data1),
                     "error": Int(data1) == 0,
                     "done": Int(data1) == 1000,
@@ -86,7 +86,7 @@ public class DcEventHandler {
 
             logger.info("📡[\(accountId)] msgs changed: \(data1), \(data2)")
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .messagesChanged, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: [
                     "message_id": Int(data2),
                     "chat_id": Int(data1),
                 ])
@@ -97,7 +97,7 @@ public class DcEventHandler {
 
             logger.info("📡[\(accountId)] msgs reaction/read/delivered/failed: \(data1), \(data2)")
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .messageReadDeliveredFailedReaction, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.messageReadDeliveredFailedReaction, object: nil, userInfo: [
                     "message_id": Int(data2),
                     "chat_id": Int(data1),
                 ])
@@ -108,7 +108,7 @@ public class DcEventHandler {
                 return
             }
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .messagesNoticed, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.messagesNoticed, object: nil, userInfo: [
                     "chat_id": Int(data1),
                 ])
             }
@@ -119,7 +119,7 @@ public class DcEventHandler {
             }
             logger.info("📡[\(accountId)] chat modified: \(data1)")
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .chatModified, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.chatModified, object: nil, userInfo: [
                     "chat_id": Int(data1),
                 ])
             }
@@ -129,21 +129,21 @@ public class DcEventHandler {
             }
             logger.info("📡[\(accountId)] ephemeral timer modified: \(data1)")
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .ephemeralTimerModified, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.ephemeralTimerModified, object: nil, userInfo: [
                     "chat_id": Int(data1),
                 ])
             }
 
         case DC_EVENT_INCOMING_MSG:
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .incomingMessageOnAnyAccount, object: nil)
+                NotificationCenter.default.post(name: Event.incomingMessageOnAnyAccount, object: nil)
             }
             if accountId != dcAccounts.getSelected().id {
                 return
             }
             logger.info("📡[\(accountId)] incoming message \(data2)")
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .incomingMessage, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.incomingMessage, object: nil, userInfo: [
                     "message_id": Int(data2),
                     "chat_id": Int(data1),
                 ])
@@ -155,7 +155,7 @@ public class DcEventHandler {
             }
             logger.info("📡[\(accountId)] contact changed: \(data1)")
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .contactsChanged, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.contactsChanged, object: nil, userInfo: [
                     "contact_id": Int(data1)
                 ])
             }
@@ -166,7 +166,7 @@ public class DcEventHandler {
             }
             logger.info("📡[\(accountId)] connectivity changed")
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .connectivityChanged, object: nil)
+                NotificationCenter.default.post(name: Event.connectivityChanged, object: nil)
             }
 
         case DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE:
@@ -180,7 +180,7 @@ public class DcEventHandler {
             }
             logger.info("📡[\(accountId)] webxdc update")
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .webxdcStatusUpdate, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.webxdcStatusUpdate, object: nil, userInfo: [
                     "message_id": Int(data1),
                 ])
             }
@@ -190,7 +190,7 @@ public class DcEventHandler {
                 return
             }
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .webxdcRealtimeDataReceived, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.webxdcRealtimeDataReceived, object: nil, userInfo: [
                     "message_id": Int(data1),
                     "data": event.data2Data,
                 ])

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -271,7 +271,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         if let userDefaults = UserDefaults.shared, userDefaults.bool(forKey: UserDefaults.hasExtensionAttemptedToSend) {
             userDefaults.removeObject(forKey: UserDefaults.hasExtensionAttemptedToSend)
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .messagesChanged, object: nil, userInfo: [
+                NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: [
                     "message_id": Int(0),
                     "chat_id": Int(0),
                 ])

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -193,11 +193,11 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         super.init(nibName: nil, bundle: nil)
         hidesBottomBarWhenPushed = true
 
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleIncomingMessage(_:)), name: .incomingMessage, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleMessagesChanged(_:)), name: .messagesChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleMsgReadDeliveredReactionFailed(_:)), name: .messageReadDeliveredFailedReaction, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleChatModified(_:)), name: .chatModified, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleEphemeralTimerModified(_:)), name: .ephemeralTimerModified, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleIncomingMessage(_:)), name: Event.incomingMessage, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleMessagesChanged(_:)), name: Event.messagesChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleMsgReadDeliveredReactionFailed(_:)), name: Event.messageReadDeliveredFailedReaction, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleChatModified(_:)), name: Event.chatModified, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleEphemeralTimerModified(_:)), name: Event.ephemeralTimerModified, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.applicationDidBecomeActive(_:)), name: UIApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.applicationWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
 

--- a/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
@@ -480,7 +480,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
 
     private func login(emailAddress: String, password: String, skipAdvanceSetup: Bool = false) {
         progressObserver = NotificationCenter.default.addObserver(
-            forName: .configurationProgress,
+            forName: Event.configurationProgress,
             object: nil,
             queue: nil
         ) { [weak self] notification in

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -224,7 +224,7 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
 
     // MARK: - action: configuration
     @objc private func acceptAndCreateButtonPressed() {
-        addProgressAlertListener(dcAccounts: self.dcAccounts, progressName: .configurationProgress, onSuccess: self.handleCreateSuccess)
+        addProgressAlertListener(dcAccounts: self.dcAccounts, progressName: Event.configurationProgress, onSuccess: self.handleCreateSuccess)
         showProgressAlert(title: String.localized("add_account"), dcContext: self.dcContext)
 
         DispatchQueue.global().async { [weak self] in

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -12,7 +12,6 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
     var progressObserver: NSObjectProtocol?
     private var qrCodeReader: QrCodeReaderController?
     private var securityScopedResource: NSURL?
-    private var backupProgressObserver: NSObjectProtocol?
     private lazy var canCancel: Bool = {
         // "cancel" removes selected unconfigured account, so there needs to be at least one other account
         return dcAccounts.getAll().count >= 2
@@ -70,10 +69,6 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
         if let progressObserver {
             NotificationCenter.default.removeObserver(progressObserver)
         }
-
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: contentView?.nameTextField)
     }
 
     override func loadView() {

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -190,7 +190,7 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
     private func addProgressHudBackupListener(importByFile: Bool) {
         UIApplication.shared.isIdleTimerDisabled = true
         backupProgressObserver = NotificationCenter.default.addObserver(
-            forName: .importExportProgress,
+            forName: Event.importExportProgress,
             object: nil,
             queue: nil
         ) { [weak self] notification in

--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -155,7 +155,7 @@ class BackupTransferViewController: UIViewController {
             UIApplication.shared.isIdleTimerDisabled = false
         } else {
             UIApplication.shared.isIdleTimerDisabled = true
-            imexObserver = NotificationCenter.default.addObserver(forName: .importExportProgress, object: nil, queue: nil) { [weak self] notification in
+            imexObserver = NotificationCenter.default.addObserver(forName: Event.importExportProgress, object: nil, queue: nil) { [weak self] notification in
                 self?.handleImportExportProgress(notification)
             }
         }

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -106,14 +106,14 @@ class ChatListViewController: UITableViewController {
             self.view.backgroundColor = UIColor.systemBackground
         }
 
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleIncomingMessageOnAnyAccount(_:)), name: .incomingMessageOnAnyAccount, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleIncomingMessage(_:)), name: .incomingMessage, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleMessagesChanged(_:)), name: .messagesChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleConnectivityChanged(_:)), name: .connectivityChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleContactsChanged(_:)), name: .contactsChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleMsgReadDeliveredReactionFailed(_:)), name: .messageReadDeliveredFailedReaction, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleMessagesNoticed(_:)), name: .messagesNoticed, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleChatModified(_:)), name: .chatModified, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleIncomingMessageOnAnyAccount(_:)), name: Event.incomingMessageOnAnyAccount, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleIncomingMessage(_:)), name: Event.incomingMessage, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleMessagesChanged(_:)), name: Event.messagesChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleConnectivityChanged(_:)), name: Event.connectivityChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleContactsChanged(_:)), name: Event.contactsChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleMsgReadDeliveredReactionFailed(_:)), name: Event.messageReadDeliveredFailedReaction, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleMessagesNoticed(_:)), name: Event.messagesNoticed, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.handleChatModified(_:)), name: Event.chatModified, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.applicationDidBecomeActive(_:)), name: UIApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(ChatListViewController.applicationWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
     }

--- a/deltachat-ios/Controller/ConnectivityViewController.swift
+++ b/deltachat-ios/Controller/ConnectivityViewController.swift
@@ -12,7 +12,7 @@ class ConnectivityViewController: WebViewViewController {
 
         // set connectivity changed observer before we actually init html,
         // otherwise, we may miss events and the html is not correct.
-        NotificationCenter.default.addObserver(self, selector: #selector(ConnectivityViewController.handleConnectivityChanged(_:)), name: .connectivityChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ConnectivityViewController.handleConnectivityChanged(_:)), name: Event.connectivityChanged, object: nil)
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(ConnectivityViewController.handleLowerPowerModeChanged(_:)),
                                                name: NSNotification.Name.NSProcessInfoPowerStateDidChange,

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -119,8 +119,8 @@ class ContactDetailViewController: UITableViewController {
         self.viewModel = ContactDetailViewModel(dcContext: dcContext, contactId: contactId)
         super.init(style: .grouped)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(ContactDetailViewController.handleContactsChanged(_:)), name: .contactsChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ContactDetailViewController.handleIncomingMessage(_:)), name: .incomingMessage, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ContactDetailViewController.handleContactsChanged(_:)), name: Event.contactsChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ContactDetailViewController.handleIncomingMessage(_:)), name: Event.incomingMessage, object: nil)
     }
 
     required init?(coder _: NSCoder) {

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -44,9 +44,9 @@ class FilesViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         self.title = title
 
-        NotificationCenter.default.addObserver(self, selector: #selector(FilesViewController.handleMessagesChanged(_:)), name: .messagesChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(FilesViewController.handleMessageReadDeliveredFailedReaction(_:)), name: .messageReadDeliveredFailedReaction, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(FilesViewController.handleIncomingMessage(_:)), name: .incomingMessage, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(FilesViewController.handleMessagesChanged(_:)), name: Event.messagesChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(FilesViewController.handleMessageReadDeliveredFailedReaction(_:)), name: Event.messageReadDeliveredFailedReaction, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(FilesViewController.handleIncomingMessage(_:)), name: Event.incomingMessage, object: nil)
 
     }
 

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -12,10 +12,6 @@ class FilesViewController: UIViewController {
     private let dcContext: DcContext
     private let chatId: Int
 
-    private var msgChangedObserver: NSObjectProtocol?
-    private var msgReadDelivedReactionFailedObserver: NSObjectProtocol?
-    private var incomingMsgObserver: NSObjectProtocol?
-
     private lazy var tableView: UITableView = {
         let table = UITableView(frame: .zero, style: .plain)
         table.register(DocumentGalleryFileCell.self, forCellReuseIdentifier: DocumentGalleryFileCell.reuseIdentifier)
@@ -47,6 +43,11 @@ class FilesViewController: UIViewController {
         self.type3 = type3
         super.init(nibName: nil, bundle: nil)
         self.title = title
+
+        NotificationCenter.default.addObserver(self, selector: #selector(FilesViewController.handleMessagesChanged(_:)), name: .messagesChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(FilesViewController.handleMessageReadDeliveredFailedReaction(_:)), name: .messageReadDeliveredFailedReaction, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(FilesViewController.handleIncomingMessage(_:)), name: .incomingMessage, object: nil)
+
     }
 
     required init?(coder: NSCoder) {
@@ -62,15 +63,6 @@ class FilesViewController: UIViewController {
         }
     }
 
-    override func willMove(toParent parent: UIViewController?) {
-        super.willMove(toParent: parent)
-        if parent == nil {
-            removeObservers()
-        } else {
-            addObservers()
-        }
-    }
-
     // MARK: - setup
     private func setupSubviews() {
         view.addSubview(tableView)
@@ -83,32 +75,16 @@ class FilesViewController: UIViewController {
         emptyStateView.addCenteredTo(parentView: view)
     }
 
-    private func addObservers() {
-        msgChangedObserver = NotificationCenter.default.addObserver(
-            forName: .messagesChanged, object: nil, queue: nil) { [weak self] notification in
-                self?.handleMessagesChanged(notification)
-            }
-        msgReadDelivedReactionFailedObserver = NotificationCenter.default.addObserver(
-            forName: .messageReadDeliveredFailedReaction, object: nil, queue: nil) { [weak self] _ in
-                self?.refreshInBg()
-            }
-        incomingMsgObserver = NotificationCenter.default.addObserver(
-            forName: .incomingMessage, object: nil, queue: nil) { [weak self] _ in
-                self?.refreshInBg()
-            }
-    }
-
-    private func removeObservers() {
-        if let msgChangedObserver = self.msgChangedObserver {
-            NotificationCenter.default.removeObserver(msgChangedObserver)
-        }
-        if let incomingMsgObserver = self.incomingMsgObserver {
-            NotificationCenter.default.removeObserver(incomingMsgObserver)
-        }
-    }
-
     // MARK: - Notifications
     @objc private func handleMessagesChanged(_ notification: Notification) {
+        refreshInBg()
+    }
+
+    @objc private func handleMessageReadDeliveredFailedReaction(_ notification: Notification) {
+        refreshInBg()
+    }
+
+    @objc private func handleIncomingMessage(_ notification: Notification) {
         refreshInBg()
     }
 

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -50,9 +50,12 @@ class GalleryViewController: UIViewController {
         self.chatId = chatId
         super.init(nibName: nil, bundle: nil)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(GalleryViewController.handleMessagesChanged(_:)), name: .messagesChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(GalleryViewController.handleMessageReadDeliveredFailedReaction(_:)), name: .messageReadDeliveredFailedReaction, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(GalleryViewController.handleIncomingMessage(_:)), name: .incomingMessage, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(GalleryViewController.handleMessagesChanged(_:)), name: Event.messagesChanged, object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(GalleryViewController.handleMessageReadDeliveredFailedReaction(_:)),
+                                               name: Event.messageReadDeliveredFailedReaction,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(GalleryViewController.handleIncomingMessage(_:)), name: Event.incomingMessage, object: nil)
     }
 
     required init?(coder: NSCoder) {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -167,9 +167,9 @@ class GroupChatDetailViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         setupSubviews()
 
-        NotificationCenter.default.addObserver(self, selector: #selector(GroupChatDetailViewController.handleIncomingMessage(_:)), name: .incomingMessage, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(GroupChatDetailViewController.handleChatModified(_:)), name: .chatModified, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(GroupChatDetailViewController.handleEphemeralTimerModified(_:)), name: .ephemeralTimerModified, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(GroupChatDetailViewController.handleIncomingMessage(_:)), name: Event.incomingMessage, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(GroupChatDetailViewController.handleChatModified(_:)), name: Event.chatModified, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(GroupChatDetailViewController.handleEphemeralTimerModified(_:)), name: Event.ephemeralTimerModified, object: nil)
     }
 
     required init?(coder _: NSCoder) {

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -296,8 +296,8 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        if let backupProgressObserver = self.progressObserver {
-            NotificationCenter.default.removeObserver(backupProgressObserver)
+        if let progressObserver {
+            NotificationCenter.default.removeObserver(progressObserver)
         }
     }
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -288,7 +288,7 @@ internal final class AdvancedViewController: UITableViewController, ProgressAler
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        addProgressAlertListener(dcAccounts: dcAccounts, progressName: .importExportProgress) { [weak self] in
+        addProgressAlertListener(dcAccounts: dcAccounts, progressName: Event.importExportProgress) { [weak self] in
             guard let self else { return }
             self.progressAlert?.dismiss(animated: true)
         }

--- a/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
+++ b/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
@@ -154,8 +154,8 @@ internal final class ChatsAndMediaViewController: UITableViewController, Progres
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         let nc = NotificationCenter.default
-        if let backupProgressObserver = self.progressObserver {
-            nc.removeObserver(backupProgressObserver)
+        if let progressObserver {
+            nc.removeObserver(progressObserver)
         }
     }
 

--- a/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
+++ b/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
@@ -137,7 +137,7 @@ internal final class ChatsAndMediaViewController: UITableViewController, Progres
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        addProgressAlertListener(dcAccounts: dcAccounts, progressName: .importExportProgress) { [weak self] in
+        addProgressAlertListener(dcAccounts: dcAccounts, progressName: Event.importExportProgress) { [weak self] in
             guard let self else { return }
 
             self.progressAlert?.dismiss(animated: true) {

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -150,7 +150,7 @@ internal final class SettingsViewController: UITableViewController {
 
         // set connectivity changed observer before we acutally init `connectivityCell.detailTextLabel` in `updateCells()`,
         // otherwise, we may miss events and the label is not correct.
-        NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.handleConnectivityChanged(_:)), name: .connectivityChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.handleConnectivityChanged(_:)), name: Event.connectivityChanged, object: nil)
     }
 
     required init?(coder _: NSCoder) {

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -277,10 +277,13 @@ class WebxdcViewController: WebViewViewController {
         self.shortcutManager = ShortcutManager(dcContext: dcContext, messageId: messageId)
         super.init(dcContext: dcContext)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(WebxdcViewController.handleMessagesChanged(_:)), name: .messagesChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(WebxdcViewController.handleMessageReadDeliveredReactionFailed(_:)), name: .messageReadDeliveredFailedReaction, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(WebxdcViewController.handleWebxdcStatusUpdate(_:)), name: .webxdcStatusUpdate, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(WebxdcViewController.handleWebxdcRealtimeDataReceived(_:)), name: .webxdcRealtimeDataReceived, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(WebxdcViewController.handleMessagesChanged(_:)), name: Event.messagesChanged, object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(WebxdcViewController.handleMessageReadDeliveredReactionFailed(_:)),
+                                               name: Event.messageReadDeliveredFailedReaction,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(WebxdcViewController.handleWebxdcStatusUpdate(_:)), name: Event.webxdcStatusUpdate, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(WebxdcViewController.handleWebxdcRealtimeDataReceived(_:)), name: Event.webxdcRealtimeDataReceived, object: nil)
     }
     
     required init?(coder: NSCoder) {

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -5,17 +5,16 @@ import UIKit
 
 public class NotificationManager {
 
-    var anyIncomingMsgObserver: NSObjectProtocol?
-    var incomingMsgObserver: NSObjectProtocol?
-    var msgsNoticedObserver: NSObjectProtocol?
-
     private let dcAccounts: DcAccounts
     private var dcContext: DcContext
 
     init(dcAccounts: DcAccounts) {
         self.dcAccounts = dcAccounts
         self.dcContext = dcAccounts.getSelected()
-        initObservers()
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(NotificationManager.handleIncomingMessageOnAnyAccount(_:)), name: .incomingMessageOnAnyAccount, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(NotificationManager.handleIncomingMessage(_:)), name: .incomingMessage, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(NotificationManager.handleMessagesNoticed(_:)), name: .messagesNoticed, object: nil)
     }
 
     deinit {
@@ -70,29 +69,6 @@ public class NotificationManager {
             }
 
             NotificationManager.updateBadgeCounters()
-        }
-    }
-
-    private func initObservers() {
-        anyIncomingMsgObserver = NotificationCenter.default.addObserver(
-            forName: .incomingMessageOnAnyAccount,
-            object: nil, queue: OperationQueue.main
-        ) { [weak self] notification in
-            self?.handleIncomingMessageOnAnyAccount(notification)
-        }
-
-        incomingMsgObserver = NotificationCenter.default.addObserver(
-            forName: .incomingMessage,
-            object: nil, queue: OperationQueue.main
-        ) { [weak self] notification in
-            self?.handleIncomingMessage(notification)
-        }
-
-        msgsNoticedObserver =  NotificationCenter.default.addObserver(
-            forName: .messagesNoticed,
-            object: nil, queue: OperationQueue.main
-        ) { [weak self] notification in
-            self?.handleMessagesNoticed(notification)
         }
     }
 

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -12,9 +12,9 @@ public class NotificationManager {
         self.dcAccounts = dcAccounts
         self.dcContext = dcAccounts.getSelected()
         
-        NotificationCenter.default.addObserver(self, selector: #selector(NotificationManager.handleIncomingMessageOnAnyAccount(_:)), name: .incomingMessageOnAnyAccount, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(NotificationManager.handleIncomingMessage(_:)), name: .incomingMessage, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(NotificationManager.handleMessagesNoticed(_:)), name: .messagesNoticed, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(NotificationManager.handleIncomingMessageOnAnyAccount(_:)), name: Event.incomingMessageOnAnyAccount, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(NotificationManager.handleIncomingMessage(_:)), name: Event.incomingMessage, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(NotificationManager.handleMessagesNoticed(_:)), name: Event.messagesNoticed, object: nil)
     }
 
     deinit {


### PR DESCRIPTION
- Fix some leftovers from #2234
- Migrate over everything but Progress-observers from closures to methods. This way there's no need to remove the observers manually.
- Clean up `DispatchQueue.Main`-handling (at least in `ChatViewController`) (Caller site decides)

------

- As discussed: Observers in `ProgressAlertHandler` are not part of this PR as I need to come up with an alternative approach to that Protocol-extension and closures. Let me think about it a little longer.