### PR TITLE
when tapping 'Chats' multiple times, end search

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -412,7 +412,8 @@ class ChatListViewController: UITableViewController {
             tableView.rowHeight = ContactCell.cellHeight
         }
     }
-    private func quitSearch(animated: Bool) {
+
+    func quitSearch(animated: Bool) {
         searchController.searchBar.text = nil
         self.viewModel?.endSearch()
         searchController.dismiss(animated: animated) {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -305,9 +305,14 @@ extension AppCoordinator: UITabBarControllerDelegate {
         // if the chatlist is already visible when tapping, scroll chatlist to top
         if let navigationController = viewController as? UINavigationController,
            let chatListViewController = navigationController.viewControllers.first as? ChatListViewController,
+           let viewModel = chatListViewController.viewModel,
            let chatsTab = tabBarController.selectedViewController as? UINavigationController,
            chatsTab.topViewController == chatListViewController {
-            chatListViewController.tableView.scrollToTop(animated: true)
+            if viewModel.searchActive {
+                chatListViewController.quitSearch(animated: true) // this includes scrollToTop()
+            } else {
+                chatListViewController.tableView.scrollToTop(animated: true)
+            }
         }
 
         return true


### PR DESCRIPTION
when tapping 'Chats' when chats is already selected, the gist is to bring the view into kind of default - so that you see eg. the messages annonced by a badge counter.

PR #2127 did a scroll-to-top for this purpose,
this PR additionally ends search.

closes #2171