### PR TITLE
mute profiles

### DIFF
--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -38,7 +38,7 @@ class NotificationService: UNNotificationServiceExtension {
             if event.id == DC_EVENT_INCOMING_MSG {
                 let dcContext = dcAccounts.get(id: event.accountId)
                 let chat = dcContext.getChat(chatId: event.data1Int)
-                if !UserDefaults.standard.bool(forKey: "notifications_disabled") && !chat.isMuted {
+                if !dcContext.isMuted() && !chat.isMuted {
                     let msg = dcContext.getMessage(id: event.data2Int)
                     let sender = msg.getSenderName(dcContext.getContact(id: msg.fromContactId))
                     if chat.isGroup {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -147,9 +147,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 DispatchQueue.global().async { [weak self] in
                     guard let self else { return }
                     self.dcAccounts.maybeNetwork()
-                    if self.notifyToken == nil &&
-                        self.dcAccounts.getSelected().isConfigured() &&
-                        !UserDefaults.standard.bool(forKey: "notifications_disabled") {
+                    if self.notifyToken == nil && self.dcAccounts.getSelected().isConfigured() {
                         self.registerForNotifications()
                     }
                 }
@@ -175,7 +173,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             performFetch()
         }
 
-        if dcAccounts.getSelected().isConfigured() && !UserDefaults.standard.bool(forKey: "notifications_disabled") {
+        if dcAccounts.getSelected().isConfigured() {
             registerForNotifications()
         }
 

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -75,6 +75,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         dcAccounts.openDatabase(writeable: true)
         migrateToDcAccounts()
 
+        // migrating global notifications pref. to per-account config, added 2024-07, can be removed after some time
+        if UserDefaults.standard.bool(forKey: "notifications_disabled") {
+            for accountId in dcAccounts.getAll() {
+                dcAccounts.get(id: accountId).setMuted(true)
+            }
+            UserDefaults.standard.removeObject(forKey: "notifications_disabled")
+        }
+        // /migrating global notifications
+
         self.launchOptions = launchOptions
         continueDidFinishLaunchingWithOptions()
         return true

--- a/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
@@ -592,10 +592,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
     private func handleLoginSuccess() {
         // used when login hud successfully went through
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-
-        if !UserDefaults.standard.bool(forKey: "notifications_disabled") {
-            appDelegate.registerForNotifications()
-        }
+        appDelegate.registerForNotifications()
 
         initSelectionCells()
         if let onLoginSuccess = self.onLoginSuccess {

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -241,10 +241,7 @@ class InstantOnboardingViewController: UIViewController, ProgressAlertHandler {
 
     private func handleCreateSuccess() {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-        if !UserDefaults.standard.bool(forKey: "notifications_disabled") {
-            appDelegate.registerForNotifications()
-        }
-
+        appDelegate.registerForNotifications()
         appDelegate.reloadDcContext()
     }
 

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -140,14 +140,8 @@ class WelcomeViewController: UIViewController, ProgressAlertHandler {
 
     private func handleBackupRestoreSuccess() {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-
-        if !UserDefaults.standard.bool(forKey: "notifications_disabled") {
-            appDelegate.registerForNotifications()
-        }
-
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            appDelegate.reloadDcContext()
-        }
+        appDelegate.registerForNotifications()
+        appDelegate.reloadDcContext()
     }
 
     @objc private func cancelAccountCreation() {

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -327,7 +327,7 @@ class AccountCell: UITableViewCell {
         }
 
         let unreadMessages = dcContext.getFreshMessages().count
-        accountAvatar.setUnreadMessageCount(unreadMessages)
+        accountAvatar.setUnreadMessageCount(unreadMessages, isMuted: dcContext.isMuted())
 
         accountName.text = encrypted + title
         if unreadMessages > 0 {

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -246,27 +246,27 @@ class AccountCell: UITableViewCell {
         return 54
     }
 
-    var isLargeText: Bool {
+    private var isLargeText: Bool {
         return UIFont.preferredFont(forTextStyle: .body).pointSize > 36
     }
 
-    lazy var accountAvatar: InitialsBadge = {
+    private lazy var accountAvatar: InitialsBadge = {
         let avatar = InitialsBadge(size: 37)
         avatar.isAccessibilityElement = false
         return avatar
     }()
 
-    var selectedAccount: Int?
-    var accountId: Int?
+    private var selectedAccount: Int?
+    private var accountId: Int?
 
-    lazy var stateIndicator: UIImageView = {
+    private lazy var stateIndicator: UIImageView = {
         let view: UIImageView = UIImageView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFit
         return view
     }()
 
-    lazy var mutedIndicator: UIImageView = {
+    private lazy var mutedIndicator: UIImageView = {
         let view = UIImageView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.widthAnchor.constraint(equalToConstant: 16).isActive = true
@@ -277,7 +277,7 @@ class AccountCell: UITableViewCell {
         return view
     }()
 
-    lazy var accountName: UILabel = {
+    private lazy var accountName: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.preferredFont(for: .body, weight: .bold)
@@ -303,7 +303,7 @@ class AccountCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func setupSubviews() {
+    private func setupSubviews() {
         contentView.addSubview(accountAvatar)
         contentView.addSubview(mutedIndicator)
         contentView.addSubview(accountName)
@@ -327,7 +327,7 @@ class AccountCell: UITableViewCell {
         stateIndicator.isHidden = true
     }
 
-    public func updateCell(selectedAccount: Int, showAccountDeletion: Bool, dcContext: DcContext) {
+    func updateCell(selectedAccount: Int, showAccountDeletion: Bool, dcContext: DcContext) {
         let accountId = dcContext.id
         self.accountId = accountId
         self.selectedAccount = selectedAccount

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -271,7 +271,7 @@ class AccountCell: UITableViewCell {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.widthAnchor.constraint(equalToConstant: 16).isActive = true
         view.tintColor = DcColors.middleGray
-        view.image = #imageLiteral(resourceName: "volume_off").withRenderingMode(.alwaysTemplate)
+        view.image = UIImage(named: "volume_off")?.withRenderingMode(.alwaysTemplate)
         view.contentMode = .scaleAspectFit
         view.isAccessibilityElement = false
         return view

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -259,10 +259,21 @@ class AccountCell: UITableViewCell {
     var selectedAccount: Int?
     var accountId: Int?
 
-    public lazy var stateIndicator: UIImageView = {
+    lazy var stateIndicator: UIImageView = {
         let view: UIImageView = UIImageView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFit
+        return view
+    }()
+
+    lazy var mutedIndicator: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.widthAnchor.constraint(equalToConstant: 16).isActive = true
+        view.tintColor = DcColors.middleGray
+        view.image = #imageLiteral(resourceName: "volume_off").withRenderingMode(.alwaysTemplate)
+        view.contentMode = .scaleAspectFit
+        view.isAccessibilityElement = false
         return view
     }()
 
@@ -294,14 +305,17 @@ class AccountCell: UITableViewCell {
 
     func setupSubviews() {
         contentView.addSubview(accountAvatar)
+        contentView.addSubview(mutedIndicator)
         contentView.addSubview(accountName)
         contentView.addSubview(stateIndicator)
         let margins = contentView.layoutMarginsGuide
         contentView.addConstraints([
             accountAvatar.constraintCenterYTo(contentView),
             accountAvatar.constraintAlignLeadingToAnchor(margins.leadingAnchor),
+            mutedIndicator.constraintCenterYTo(contentView),
+            mutedIndicator.constraintToTrailingOf(accountAvatar, paddingLeading: 12),
             accountName.constraintAlignTopToAnchor(margins.topAnchor),
-            accountName.constraintToTrailingOf(accountAvatar, paddingLeading: 20),
+            accountName.constraintToTrailingOf(mutedIndicator, paddingLeading: 3),
             accountName.constraintAlignBottomToAnchor(margins.bottomAnchor),
             accountName.constraintAlignTrailingToAnchor(margins.trailingAnchor, paddingTrailing: 32, priority: .defaultLow),
             stateIndicator.constraintCenterYTo(contentView),
@@ -328,6 +342,8 @@ class AccountCell: UITableViewCell {
 
         let unreadMessages = dcContext.getFreshMessages().count
         accountAvatar.setUnreadMessageCount(unreadMessages, isMuted: dcContext.isMuted())
+
+        mutedIndicator.isHidden = !dcContext.isMuted()
 
         accountName.text = encrypted + title
         if unreadMessages > 0 {

--- a/deltachat-ios/Controller/ConnectivityViewController.swift
+++ b/deltachat-ios/Controller/ConnectivityViewController.swift
@@ -62,7 +62,7 @@ class ConnectivityViewController: WebViewViewController {
         let connectiviy = self.dcContext.getConnectivity()
         let pushState = dcContext.getPushState()
         let title = " <b>" + String.localized("pref_notifications") + ":</b> "
-        let notificationsEnabledInDC = !UserDefaults.standard.bool(forKey: "notifications_disabled")
+        let notificationsEnabledInDC = !dcContext.isMuted()
         var notificationsEnabledInSystem = false
         let semaphore = DispatchSemaphore(value: 0)
         DispatchQueue.global(qos: .userInitiated).async {

--- a/deltachat-ios/Controller/LogViewController.swift
+++ b/deltachat-ios/Controller/LogViewController.swift
@@ -83,8 +83,6 @@ public class LogViewController: UIViewController {
         let systemVersion = UIDevice.current.systemVersion
         info += "iosVersion=\(systemVersion)\n"
 
-        let notifyEnabled = !UserDefaults.standard.bool(forKey: "notifications_disabled")
-        info += "notify-enabled=\(notifyEnabled)\n"
         info += "any-database-encrypted=\(dcContext.isAnyDatabaseEncrypted())\n"
 
         if let appDelegate = UIApplication.shared.delegate as? AppDelegate {

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -244,6 +244,7 @@ internal final class SettingsViewController: UITableViewController {
         }
         UserDefaults.standard.synchronize()
         NotificationManager.updateBadgeCounters(forceZero: !sender.isOn)
+        NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: ["message_id": Int(0), "chat_id": Int(0)])
     }
 
     // MARK: - updates

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -47,7 +47,7 @@ internal final class SettingsViewController: UITableViewController {
 
     private lazy var notificationSwitch: UISwitch = {
         let switchControl = UISwitch()
-        switchControl.isOn = !UserDefaults.standard.bool(forKey: "notifications_disabled")
+        switchControl.isOn = !dcContext.isMuted()
         switchControl.addTarget(self, action: #selector(handleNotificationToggle(_:)), for: .valueChanged)
         return switchControl
     }()
@@ -234,7 +234,7 @@ internal final class SettingsViewController: UITableViewController {
 
     // MARK: - actions
     @objc private func handleNotificationToggle(_ sender: UISwitch) {
-        UserDefaults.standard.set(!sender.isOn, forKey: "notifications_disabled")
+        dcContext.setMuted(!sender.isOn)
         if sender.isOn {
             if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
                 appDelegate.registerForNotifications()

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -243,7 +243,7 @@ internal final class SettingsViewController: UITableViewController {
             NotificationManager.removeAllNotifications()
         }
         UserDefaults.standard.synchronize()
-        NotificationManager.updateBadgeCounters(forceZero: !sender.isOn)
+        NotificationManager.updateBadgeCounters()
         NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: ["message_id": Int(0), "chat_id": Int(0)])
     }
 

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -120,7 +120,10 @@ public class DcAccounts {
         let skipId = skipCurrent ? getSelected().id : -1
         for accountId in getAll() {
             if accountId != skipId {
-                freshCount += get(id: accountId).getFreshMessages().count
+                let dcContext = get(id: accountId)
+                if !dcContext.isMuted() {
+                    freshCount += dcContext.getFreshMessages().count
+                }
             }
         }
         return freshCount

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -526,6 +526,14 @@ public class DcContext {
         setConfig(key, String(value))
     }
 
+    public func isMuted() -> Bool {
+        return getConfigBool("is_muted")
+    }
+
+    public func setMuted(_ muted: Bool) {
+        setConfigBool("is_muted", muted)
+    }
+
     public func getUnreadMessages(chatId: Int) -> Int {
         return Int(dc_get_fresh_msg_cnt(contextPointer, UInt32(chatId)))
     }

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -75,16 +75,13 @@ public class NotificationManager {
     // MARK: - Notifications
 
     @objc private func handleMessagesNoticed(_ notification: Notification) {
-        guard UserDefaults.standard.bool(forKey: "notifications_disabled") == false,
-           let ui = notification.userInfo,
-              let chatId = ui["chat_id"] as? Int else { return }
-        
+        guard let ui = notification.userInfo,
+            let chatId = ui["chat_id"] as? Int else { return }
+
         NotificationManager.removeNotificationsForChat(dcContext: self.dcContext, chatId: chatId)
     }
 
     @objc private func handleIncomingMessageOnAnyAccount(_ notification: Notification) {
-        guard UserDefaults.standard.bool(forKey: "notifications_disabled") == false else { return }
-
         NotificationManager.updateBadgeCounters()
     }
 
@@ -101,7 +98,7 @@ public class NotificationManager {
             if let ui = notification.userInfo,
                let chatId = ui["chat_id"] as? Int,
                let messageId = ui["message_id"] as? Int,
-               !UserDefaults.standard.bool(forKey: "notifications_disabled") {
+               self.dcContext.isMuted() {
 
                 let chat = self.dcContext.getChat(chatId: chatId)
 

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -280,8 +280,8 @@ class ContactCell: UITableViewCell {
         avatar.setName(name)
     }
 
-    func setStatusIndicators(unreadCount: Int, status: Int, visibility: Int32, isLocationStreaming: Bool, isMuted: Bool, isContactRequest: Bool, isArchiveLink: Bool, isVerified: Bool) {
-        unreadMessageCounter.backgroundColor = isMuted || isArchiveLink ? DcColors.unreadBadgeMuted : DcColors.unreadBadge
+    func setStatusIndicators(unreadCount: Int, status: Int, visibility: Int32, isLocationStreaming: Bool, isChatMuted: Bool = false, isAccountMuted: Bool = false, isContactRequest: Bool, isArchiveLink: Bool, isVerified: Bool) {
+        unreadMessageCounter.backgroundColor = isChatMuted || isAccountMuted || isArchiveLink  ? DcColors.unreadBadgeMuted : DcColors.unreadBadge
         verifiedIndicator.isHidden = !isVerified
 
         if isLargeText {
@@ -327,7 +327,7 @@ class ContactCell: UITableViewCell {
         }
 
         contactRequest.isHidden = !isContactRequest
-        mutedIndicator.isHidden = !isMuted
+        mutedIndicator.isHidden = !isChatMuted
         locationStreamingIndicator.isHidden = !isLocationStreaming
     }
 
@@ -392,7 +392,8 @@ class ContactCell: UITableViewCell {
                                 status: chatData.summary.state,
                                 visibility: visibility,
                                 isLocationStreaming: chat.isSendingLocations,
-                                isMuted: chat.isMuted,
+                                isChatMuted: chat.isMuted,
+                                isAccountMuted: cellViewModel.dcContext.isMuted(),
                                 isContactRequest: isContactRequest,
                                 isArchiveLink: chatData.chatId == DC_CHAT_ID_ARCHIVED_LINK,
                                 isVerified: chat.isProtected)
@@ -411,7 +412,6 @@ class ContactCell: UITableViewCell {
                                 status: 0,
                                 visibility: 0,
                                 isLocationStreaming: false,
-                                isMuted: false,
                                 isContactRequest: false,
                                 isArchiveLink: false,
                                 isVerified: contact.isVerified)
@@ -430,7 +430,6 @@ class ContactCell: UITableViewCell {
             status: 0,
             visibility: 0,
             isLocationStreaming: false,
-            isMuted: false,
             isContactRequest: false,
             isArchiveLink: false,
             isVerified: false)

--- a/deltachat-ios/View/InitialsBadge.swift
+++ b/deltachat-ios/View/InitialsBadge.swift
@@ -46,7 +46,6 @@ public class InitialsBadge: UIView {
     
     private lazy var unreadMessageCounter: MessageCounter = {
         let view = MessageCounter(count: 0, size: 20)
-        view.backgroundColor = DcColors.unreadBadge
         view.isHidden = true
         view.isAccessibilityElement = false
         return view
@@ -136,9 +135,10 @@ public class InitialsBadge: UIView {
         recentlySeenView.isHidden = !seen
     }
     
-    public func setUnreadMessageCount(_ messageNo: Int) {
-        unreadMessageCounter.setCount(messageNo)
-        unreadMessageCounter.isHidden = messageNo == 0
+    public func setUnreadMessageCount(_ messageCount: Int, isMuted: Bool = false) {
+        unreadMessageCounter.setCount(messageCount)
+        unreadMessageCounter.backgroundColor = isMuted ? DcColors.unreadBadgeMuted : DcColors.unreadBadge
+        unreadMessageCounter.isHidden = messageCount == 0
     }
 
     public func reset() {


### PR DESCRIPTION
this PR allows to mute notifications for some profiles while leaving them on for others. 

muted profiles are indicated by a "mute" symbol and "grey badges" (instead of "blue") in the profile switcher, this is what is also done on desktop/android.

moreover, the "grey badges" are also used in the chatlist, to make clearer what is going on (however, without all chats having the "mute" symbol), this is a minor change, but overall, things appear more logical that away (blue badges summing up). let's see :)

the PR makes use of the new `isMuted()` API. if in doubt, we still register for notifications - a muted profile does not mean one does not want things being available instantly when opening the app. if one wants to disable notifications at all, one can still do this in the system settings, but usual iOS users won't care as push notifications are required virtually everywhere anyway. for saving battery, push notifications are anyways disabled.
also, a muted chatmail profile can still help a non-chatmail profile being updated faster this way.

however, we keep not registering for notifications for unconfigured profiles. reason is that the registration may result in a dialog-popup, we want that delayed to when the profile is really created.

closes #2238

<img width=320 src=https://github.com/user-attachments/assets/95515faf-d094-4d71-a9e2-eddc6be18935>
