### PR TITLE
use 'Cancel' instead of 'Back arrow' for server settings

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
@@ -230,7 +230,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
     }()
 
     lazy var certCheckCell: UITableViewCell = {
-        let certCheckType = CertificateCheckController.ValueConverter.convertHexToString(value: dcContext.certificateChecks)
+        let certCheckType = CertificateCheckController.ValueConverter.convertHexToString(value: certValue)
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.textLabel?.text = String.localized("login_certificate_checks")
         cell.detailTextLabel?.text = certCheckType
@@ -238,6 +238,8 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
         cell.accessoryType = .disclosureIndicator
         return cell
     }()
+
+    lazy var certValue: Int = dcContext.certificateChecks
 
     lazy var viewLogCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
@@ -589,6 +591,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
                 }
             }
         }
+        dcContext.certificateChecks = certValue
     }
 
     private func handleLoginSuccess() {
@@ -607,7 +610,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
     private func initSelectionCells() {
         imapSecurityCell.detailTextLabel?.text = SecurityConverter.getSocketName(value: Int32(dcContext.getConfigInt("mail_security")))
         smtpSecurityCell.detailTextLabel?.text = SecurityConverter.getSocketName(value: Int32(dcContext.getConfigInt("send_security")))
-        certCheckCell.detailTextLabel?.text = CertificateCheckController.ValueConverter.convertHexToString(value: dcContext.certificateChecks)
+        certCheckCell.detailTextLabel?.text = CertificateCheckController.ValueConverter.convertHexToString(value: certValue)
     }
 
     private func resignFirstResponderOnAllCells() {
@@ -677,7 +680,8 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
     }
 
     private func showCertCheckOptions() {
-        let certificateCheckController = CertificateCheckController(dcContext: dcContext, sectionTitle: String.localized("login_certificate_checks"))
+        let certificateCheckController = CertificateCheckController(initValue: certValue, sectionTitle: String.localized("login_certificate_checks"))
+        certificateCheckController.delegate = self
         navigationController?.pushViewController(certificateCheckController, animated: true)
     }
 
@@ -729,5 +733,11 @@ extension AccountSetupController: UITextFieldDelegate {
             })
             updateProviderInfo()
         }
+    }
+}
+
+extension AccountSetupController: CertificateCheckDelegate {
+    func onCertificateCheckChanged(newValue: Int) {
+        certValue = newValue
     }
 }

--- a/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
@@ -341,23 +341,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
         if sections[section] == basicSection {
             return String.localized("login_no_servers_hint")
         } else if sections[section] == advancedSection {
-            if advancedSectionShowing && dcContext.isConfigured() {
-                var info = String.localized("used_settings") + "\n"
-                info += "IMAP "
-                info += SecurityConverter.getSocketName(value: Int32(dcContext.getConfigInt("mail_security"))) + " "
-                info += (dcContext.getConfig("configured_mail_user") ?? "unset") + ":***@"
-                info += (dcContext.getConfig("configured_mail_server") ?? "unset") + ":"
-                info += (dcContext.getConfig("configured_mail_port") ?? "unset") + "\n"
-                info += "SMTP "
-                info += SecurityConverter.getSocketName(value: Int32(dcContext.getConfigInt("send_security"))) + " "
-                info += (dcContext.getConfig("configured_send_user") ?? "unset") + ":***@"
-                info += (dcContext.getConfig("configured_send_server") ?? "unset") +  ":"
-                info += (dcContext.getConfig("configured_send_port") ?? "unset") + "\n\n"
-                info += String.localized("login_subheader")
-                return info
-            } else {
-                return String.localized("login_subheader")
-            }
+            return String.localized("login_subheader")
         } else {
             return nil
         }

--- a/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
@@ -507,10 +507,6 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
         showProgressAlert(title: String.localized("login_header"), dcContext: dcContext)
     }
 
-    @objc func closeButtonPressed() {
-        dismiss(animated: true, completion: nil)
-    }
-
     // returns true if needed
     private func showOAuthAlertIfNeeded(emailAddress: String, handleCancel: (() -> Void)?) -> Bool {
         return false

--- a/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
@@ -247,12 +247,13 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
         return cell
     }()
 
+    private var cancelButton: UIBarButtonItem {
+        let button =  UIBarButtonItem(title: String.localized("cancel"), style: .plain, target: self, action: #selector(cancelButtonPressed))
+        return button
+    }
+
     private lazy var loginButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(
-            title: String.localized("login_title"),
-            style: .done,
-            target: self,
-            action: #selector(loginButtonPressed))
+        let button = UIBarButtonItem(title: String.localized("login_title"), style: .done, target: self, action: #selector(loginButtonPressed))
         button.isEnabled = !dcContext.isConfigured()
         return button
     }()
@@ -282,6 +283,7 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
         } else {
             title = String.localized("login_header")
         }
+        navigationItem.leftBarButtonItem = cancelButton
         navigationItem.rightBarButtonItem = loginButton
         emailCell.setText(text: dcContext.addr ?? nil)
         passwordCell.setText(text: dcContext.mailPw ?? nil)
@@ -412,6 +414,10 @@ class AccountSetupController: UITableViewController, ProgressAlertHandler {
             tableView.deleteRows(at: advancedIndexPaths, with: .fade)
         }
         tableView.reloadData() // needed to force a redraw
+    }
+
+    @objc private func cancelButtonPressed() {
+        navigationController?.popViewController(animated: true)
     }
 
     @objc private func loginButtonPressed() {

--- a/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
+++ b/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
@@ -15,16 +15,6 @@ class CertificateCheckController: UITableViewController {
     var selectedIndex: Int?
     weak var delegate: CertificateCheckDelegate?
 
-    var okButton: UIBarButtonItem {
-        let button =  UIBarButtonItem(title: String.localized("ok"), style: .done, target: self, action: #selector(okButtonPressed))
-        return button
-    }
-
-    var cancelButton: UIBarButtonItem {
-        let button =  UIBarButtonItem(title: String.localized("cancel"), style: .plain, target: self, action: #selector(cancelButtonPressed))
-        return button
-    }
-
     var staticCells: [UITableViewCell] {
         return options.map({
             let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
@@ -44,13 +34,6 @@ class CertificateCheckController: UITableViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        navigationItem.rightBarButtonItem = okButton
-        navigationItem.leftBarButtonItem = cancelButton
     }
 
     // MARK: - Table view data source
@@ -89,18 +72,10 @@ class CertificateCheckController: UITableViewController {
             currentValue = options[newIndex]
         }
         selectedIndex = index
-    }
-
-    @objc private func okButtonPressed() {
         delegate?.onCertificateCheckChanged(newValue: currentValue)
-        navigationController?.popViewController(animated: true)
     }
 
-    @objc private func cancelButtonPressed() {
-        navigationController?.popViewController(animated: true)
-    }
-
-   class ValueConverter {
+    class ValueConverter {
         static func convertHexToString(value: Int) -> String {
             switch value {
             case Int(DC_CERTCK_AUTO):

--- a/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
+++ b/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
@@ -1,6 +1,10 @@
 import UIKit
 import DcCore
 
+protocol CertificateCheckDelegate: AnyObject {
+    func onCertificateCheckChanged(newValue: Int)
+}
+
 class CertificateCheckController: UITableViewController {
 
     var options = [Int(DC_CERTCK_AUTO),
@@ -9,7 +13,7 @@ class CertificateCheckController: UITableViewController {
 
     var currentValue: Int
     var selectedIndex: Int?
-    let dcContext: DcContext
+    weak var delegate: CertificateCheckDelegate?
 
     var okButton: UIBarButtonItem {
         let button =  UIBarButtonItem(title: String.localized("ok"), style: .done, target: self, action: #selector(okButtonPressed))
@@ -29,9 +33,8 @@ class CertificateCheckController: UITableViewController {
         })
     }
 
-    init(dcContext: DcContext, sectionTitle: String?) {
-        self.dcContext = dcContext
-        self.currentValue = dcContext.certificateChecks
+    init(initValue: Int, sectionTitle: String?) {
+        self.currentValue = initValue
         for (index, value) in options.enumerated() where currentValue == value {
             selectedIndex = index
         }
@@ -76,7 +79,6 @@ class CertificateCheckController: UITableViewController {
     }
 
     private func selectItem(at index: Int? ) {
-        // TODO: callback to AccountSetupController here
         if let oldIndex = selectedIndex {
             let cell = tableView.cellForRow(at: IndexPath.init(row: oldIndex, section: 0))
             cell?.accessoryType = .none
@@ -90,7 +92,7 @@ class CertificateCheckController: UITableViewController {
     }
 
     @objc private func okButtonPressed() {
-        dcContext.certificateChecks = currentValue // TODO: setting here is too soon
+        delegate?.onCertificateCheckChanged(newValue: currentValue)
         navigationController?.popViewController(animated: true)
     }
 

--- a/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
+++ b/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
@@ -7,12 +7,9 @@ protocol CertificateCheckDelegate: AnyObject {
 
 class CertificateCheckController: UITableViewController {
 
-    var options = [Int(DC_CERTCK_AUTO),
-                   Int(DC_CERTCK_STRICT),
-                   Int(DC_CERTCK_ACCEPT_INVALID_CERTIFICATES)]
-
-    var currentValue: Int
-    var selectedIndex: Int?
+    private let options = [Int(DC_CERTCK_AUTO), Int(DC_CERTCK_STRICT), Int(DC_CERTCK_ACCEPT_INVALID_CERTIFICATES)]
+    private var currentValue: Int
+    private var selectedIndex: Int?
     weak var delegate: CertificateCheckDelegate?
 
     var staticCells: [UITableViewCell] {

--- a/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
+++ b/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
@@ -76,6 +76,7 @@ class CertificateCheckController: UITableViewController {
     }
 
     private func selectItem(at index: Int? ) {
+        // TODO: callback to AccountSetupController here
         if let oldIndex = selectedIndex {
             let cell = tableView.cellForRow(at: IndexPath.init(row: oldIndex, section: 0))
             cell?.accessoryType = .none
@@ -89,7 +90,7 @@ class CertificateCheckController: UITableViewController {
     }
 
     @objc private func okButtonPressed() {
-        dcContext.certificateChecks = currentValue
+        dcContext.certificateChecks = currentValue // TODO: setting here is too soon
         navigationController?.popViewController(animated: true)
     }
 

--- a/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
+++ b/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
@@ -2,7 +2,7 @@ import UIKit
 import DcCore
 
 protocol SecuritySettingsDelegate: AnyObject {
-    func onSecuritySettingsChanged(type: SecurityType, newValue: Int)
+    func onSecuritySettingsChanged(newValue: Int)
 }
 
 class SecuritySettingsController: UITableViewController {
@@ -10,7 +10,6 @@ class SecuritySettingsController: UITableViewController {
     private var options: [Int32] = [DC_SOCKET_AUTO, DC_SOCKET_SSL, DC_SOCKET_STARTTLS, DC_SOCKET_PLAIN]
 
     private var selectedIndex: Int
-    private var securityType: SecurityType
     weak var delegate: SecuritySettingsDelegate?
 
     private var okButton: UIBarButtonItem {
@@ -31,8 +30,7 @@ class SecuritySettingsController: UITableViewController {
         }
     }
 
-    init(initValue: Int, title: String, type: SecurityType) {
-        self.securityType = type
+    init(initValue: Int, title: String) {
         selectedIndex = options.firstIndex(of: Int32(initValue)) ?? 0
         super.init(style: .grouped)
         self.title = title
@@ -72,22 +70,17 @@ class SecuritySettingsController: UITableViewController {
         if let cell = tableView.cellForRow(at: indexPath) {
             cell.accessoryType = .checkmark
         }
-        selectedIndex = indexPath.row // TODO: callback to AccountSetupController here
+        selectedIndex = indexPath.row
     }
 
     @objc func okButtonPressed() {
-        delegate?.onSecuritySettingsChanged(type: securityType, newValue: Int(options[selectedIndex]))
+        delegate?.onSecuritySettingsChanged(newValue: Int(options[selectedIndex]))
         navigationController?.popViewController(animated: true)
     }
 
     @objc func cancelButtonPressed() {
         navigationController?.popViewController(animated: true)
     }
-}
-
-enum SecurityType {
-     case IMAPSecurity
-     case SMTPSecurity
 }
 
 class SecurityConverter {

--- a/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
+++ b/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
@@ -75,15 +75,15 @@ class SecuritySettingsController: UITableViewController {
         if let cell = tableView.cellForRow(at: indexPath) {
             cell.accessoryType = .checkmark
         }
-        selectedIndex = indexPath.row
+        selectedIndex = indexPath.row // TODO: callback to AccountSetupController here
     }
 
     @objc func okButtonPressed() {
         switch securityType {
         case .IMAPSecurity:
-            dcContext.setConfigInt("mail_security", Int(options[selectedIndex]))
+            dcContext.setConfigInt("mail_security", Int(options[selectedIndex])) // TODO: setting here is too soon
         case .SMTPSecurity:
-            dcContext.setConfigInt("send_security", Int(options[selectedIndex]))
+            dcContext.setConfigInt("send_security", Int(options[selectedIndex])) // TODO: setting here is too soon
         }
         navigationController?.popViewController(animated: true)
     }

--- a/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
+++ b/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
@@ -12,16 +12,6 @@ class SecuritySettingsController: UITableViewController {
     private var selectedIndex: Int
     weak var delegate: SecuritySettingsDelegate?
 
-    private var okButton: UIBarButtonItem {
-        let button =  UIBarButtonItem(title: String.localized("ok"), style: .done, target: self, action: #selector(okButtonPressed))
-        return button
-    }
-
-    private var cancelButton: UIBarButtonItem {
-        let button =  UIBarButtonItem(title: String.localized("cancel"), style: .plain, target: self, action: #selector(cancelButtonPressed))
-        return button
-    }
-
     private var staticCells: [UITableViewCell] {
         return options.map {
             let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
@@ -38,12 +28,6 @@ class SecuritySettingsController: UITableViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        navigationItem.rightBarButtonItem = okButton
-        navigationItem.leftBarButtonItem = cancelButton
     }
 
     // MARK: - Table view data source
@@ -71,15 +55,7 @@ class SecuritySettingsController: UITableViewController {
             cell.accessoryType = .checkmark
         }
         selectedIndex = indexPath.row
-    }
-
-    @objc func okButtonPressed() {
         delegate?.onSecuritySettingsChanged(newValue: Int(options[selectedIndex]))
-        navigationController?.popViewController(animated: true)
-    }
-
-    @objc func cancelButtonPressed() {
-        navigationController?.popViewController(animated: true)
     }
 }
 

--- a/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
+++ b/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
@@ -7,8 +7,7 @@ protocol SecuritySettingsDelegate: AnyObject {
 
 class SecuritySettingsController: UITableViewController {
 
-    private var options: [Int32] = [DC_SOCKET_AUTO, DC_SOCKET_SSL, DC_SOCKET_STARTTLS, DC_SOCKET_PLAIN]
-
+    private let options: [Int32] = [DC_SOCKET_AUTO, DC_SOCKET_SSL, DC_SOCKET_STARTTLS, DC_SOCKET_PLAIN]
     private var selectedIndex: Int
     weak var delegate: SecuritySettingsDelegate?
 


### PR DESCRIPTION
this PR fixes the issue that selecting "IMAP Security", "SMTP Security" and "Certificate Checks" are persisted in core even if no "Log In" was tried. this leads to inconsistent views. even more inconsistency was added as the text fields are persisted correctly on "Log In", so, the user never knows which field was cancelled and which not.

the reason was, that `SecuritySettingsController` and `CertificateChecksController` persisted the value too soon in core when hitting "OK" in the controller.

this PR calls a delegate instead which sets a value in the `AccountSetupController`. only if finally "Log In" is hit, the values are persisted in core together with the value from the text fields.

the code of the whole controller is a little bit messy, this PR does not clean up there as things actually are working so far. instead, the PR fixes the issue on point, keeping other flows and conventions.

finally, the PR removes some unimportant summary which is available better in "view log", adds simple "back" buttons to subsequent dialogs and renames the main "back" button to cancel (which was the original reason of #2246, i thought the rename is easy :)

<img width=320 src=https://github.com/user-attachments/assets/a748281e-9794-438d-8d58-d9831c276458>

closes #2246 

