### PR TITLE
Check if events must be on main

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -142,12 +142,11 @@ public class DcEventHandler {
                 return
             }
             logger.info("📡[\(accountId)] incoming message \(data2)")
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.incomingMessage, object: nil, userInfo: [
-                    "message_id": Int(data2),
-                    "chat_id": Int(data1),
-                ])
-            }
+            
+            NotificationCenter.default.post(name: Event.incomingMessage, object: nil, userInfo: [
+                "message_id": Int(data2),
+                "chat_id": Int(data1),
+            ])
 
         case DC_EVENT_CONTACTS_CHANGED:
             if accountId != dcAccounts.getSelected().id {

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -118,11 +118,10 @@ public class DcEventHandler {
                 return
             }
             logger.info("📡[\(accountId)] chat modified: \(data1)")
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.chatModified, object: nil, userInfo: [
-                    "chat_id": Int(data1),
-                ])
-            }
+
+            NotificationCenter.default.post(name: Event.chatModified, object: nil, userInfo: [
+                "chat_id": Int(data1),
+            ])
         case DC_EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED:
             if accountId != dcAccounts.getSelected().id {
                 return

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -128,11 +128,10 @@ public class DcEventHandler {
                 return
             }
             logger.info("📡[\(accountId)] ephemeral timer modified: \(data1)")
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.ephemeralTimerModified, object: nil, userInfo: [
-                    "chat_id": Int(data1),
-                ])
-            }
+
+            NotificationCenter.default.post(name: Event.ephemeralTimerModified, object: nil, userInfo: [
+                "chat_id": Int(data1),
+            ])
 
         case DC_EVENT_INCOMING_MSG:
             

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -56,20 +56,19 @@ public class DcEventHandler {
 
         case DC_EVENT_CONFIGURE_PROGRESS:
             logger.info("📡[\(accountId)] configure: \(Int(data1))")
-            DispatchQueue.main.async {
+
                 let done = Int(data1) == 1000
-
-                NotificationCenter.default.post(name: Event.configurationProgress, object: nil, userInfo: [
-                    "progress": Int(data1),
-                    "error": Int(data1) == 0,
-                    "done": done,
-                    "errorMessage": event.data2String,
-                ])
-
-                if done {
-                    UserDefaults.standard.set(true, forKey: Constants.Keys.deltachatUserProvidedCredentialsKey)
-                    UserDefaults.standard.synchronize()
-                }
+            
+            NotificationCenter.default.post(name: Event.configurationProgress, object: nil, userInfo: [
+                "progress": Int(data1),
+                "error": Int(data1) == 0,
+                "done": done,
+                "errorMessage": event.data2String,
+            ])
+            
+            if done {
+                UserDefaults.standard.set(true, forKey: Constants.Keys.deltachatUserProvidedCredentialsKey)
+                UserDefaults.standard.synchronize()
             }
 
         case DC_EVENT_IMEX_PROGRESS:

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -173,22 +173,19 @@ public class DcEventHandler {
                 return
             }
             logger.info("📡[\(accountId)] webxdc update")
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.webxdcStatusUpdate, object: nil, userInfo: [
-                    "message_id": Int(data1),
-                ])
-            }
+            NotificationCenter.default.post(name: Event.webxdcStatusUpdate, object: nil, userInfo: [
+                "message_id": Int(data1),
+            ])
 
         case DC_EVENT_WEBXDC_REALTIME_DATA:
             if accountId != dcAccounts.getSelected().id {
                 return
             }
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.webxdcRealtimeDataReceived, object: nil, userInfo: [
-                    "message_id": Int(data1),
-                    "data": event.data2Data,
-                ])
-            }
+
+            NotificationCenter.default.post(name: Event.webxdcRealtimeDataReceived, object: nil, userInfo: [
+                "message_id": Int(data1),
+                "data": event.data2Data,
+            ])
 
         default:
             break

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -78,6 +78,7 @@ public class DcEventHandler {
                 "done": Int(data1) == 1000,
                 "errorMessage": self.dcAccounts.get(id: accountId).lastErrorString,
             ])
+
         case DC_EVENT_MSGS_CHANGED:
             guard accountId == dcAccounts.getSelected().id else { return }
 

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -85,12 +85,11 @@ public class DcEventHandler {
             guard accountId == dcAccounts.getSelected().id else { return }
 
             logger.info("📡[\(accountId)] msgs changed: \(data1), \(data2)")
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: [
-                    "message_id": Int(data2),
-                    "chat_id": Int(data1),
-                ])
-            }
+            
+            NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: [
+                "message_id": Int(data2),
+                "chat_id": Int(data1),
+            ])
 
         case DC_EVENT_REACTIONS_CHANGED, DC_EVENT_MSG_READ, DC_EVENT_MSG_DELIVERED, DC_EVENT_MSG_FAILED:
             guard accountId == dcAccounts.getSelected().id else { return }

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -107,11 +107,10 @@ public class DcEventHandler {
             if accountId != dcAccounts.getSelected().id {
                 return
             }
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.messagesNoticed, object: nil, userInfo: [
-                    "chat_id": Int(data1),
-                ])
-            }
+            
+            NotificationCenter.default.post(name: Event.messagesNoticed, object: nil, userInfo: [
+                "chat_id": Int(data1),
+            ])
 
         case DC_EVENT_CHAT_MODIFIED:
             if accountId != dcAccounts.getSelected().id {

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -96,12 +96,11 @@ public class DcEventHandler {
             guard accountId == dcAccounts.getSelected().id else { return }
 
             logger.info("📡[\(accountId)] msgs reaction/read/delivered/failed: \(data1), \(data2)")
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.messageReadDeliveredFailedReaction, object: nil, userInfo: [
-                    "message_id": Int(data2),
-                    "chat_id": Int(data1),
-                ])
-            }
+
+            NotificationCenter.default.post(name: Event.messageReadDeliveredFailedReaction, object: nil, userInfo: [
+                "message_id": Int(data2),
+                "chat_id": Int(data1),
+            ])
 
         case DC_EVENT_MSGS_NOTICED:
             if accountId != dcAccounts.getSelected().id {

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -56,8 +56,8 @@ public class DcEventHandler {
 
         case DC_EVENT_CONFIGURE_PROGRESS:
             logger.info("📡[\(accountId)] configure: \(Int(data1))")
-
-                let done = Int(data1) == 1000
+            
+            let done = Int(data1) == 1000
             
             NotificationCenter.default.post(name: Event.configurationProgress, object: nil, userInfo: [
                 "progress": Int(data1),
@@ -68,9 +68,8 @@ public class DcEventHandler {
             
             if done {
                 UserDefaults.standard.set(true, forKey: Constants.Keys.deltachatUserProvidedCredentialsKey)
-                UserDefaults.standard.synchronize()
             }
-
+            
         case DC_EVENT_IMEX_PROGRESS:
             
             NotificationCenter.default.post(name: Event.importExportProgress, object: nil, userInfo: [

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -117,6 +117,7 @@ public class DcEventHandler {
             NotificationCenter.default.post(name: Event.chatModified, object: nil, userInfo: [
                 "chat_id": Int(data1),
             ])
+
         case DC_EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED:
             if accountId != dcAccounts.getSelected().id {
                 return
@@ -155,7 +156,7 @@ public class DcEventHandler {
                 return
             }
             logger.info("📡[\(accountId)] connectivity changed")
-                NotificationCenter.default.post(name: Event.connectivityChanged, object: nil)
+            NotificationCenter.default.post(name: Event.connectivityChanged, object: nil)
 
         case DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE:
             if let sem = dcAccounts.fetchSemaphore {

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -73,14 +73,13 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_IMEX_PROGRESS:
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.importExportProgress, object: nil, userInfo: [
-                    "progress": Int(data1),
-                    "error": Int(data1) == 0,
-                    "done": Int(data1) == 1000,
-                    "errorMessage": self.dcAccounts.get(id: accountId).lastErrorString,
-                ])
-            }
+            
+            NotificationCenter.default.post(name: Event.importExportProgress, object: nil, userInfo: [
+                "progress": Int(data1),
+                "error": Int(data1) == 0,
+                "done": Int(data1) == 1000,
+                "errorMessage": self.dcAccounts.get(id: accountId).lastErrorString,
+            ])
         case DC_EVENT_MSGS_CHANGED:
             guard accountId == dcAccounts.getSelected().id else { return }
 

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -135,14 +135,13 @@ public class DcEventHandler {
             }
 
         case DC_EVENT_INCOMING_MSG:
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.incomingMessageOnAnyAccount, object: nil)
-            }
+            
+            NotificationCenter.default.post(name: Event.incomingMessageOnAnyAccount, object: nil)
             if accountId != dcAccounts.getSelected().id {
                 return
             }
             logger.info("📡[\(accountId)] incoming message \(data2)")
-            
+
             NotificationCenter.default.post(name: Event.incomingMessage, object: nil, userInfo: [
                 "message_id": Int(data2),
                 "chat_id": Int(data1),

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -71,7 +71,6 @@ public class DcEventHandler {
             }
             
         case DC_EVENT_IMEX_PROGRESS:
-            
             NotificationCenter.default.post(name: Event.importExportProgress, object: nil, userInfo: [
                 "progress": Int(data1),
                 "error": Int(data1) == 0,

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -151,11 +151,10 @@ public class DcEventHandler {
                 return
             }
             logger.info("📡[\(accountId)] contact changed: \(data1)")
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.contactsChanged, object: nil, userInfo: [
-                    "contact_id": Int(data1)
-                ])
-            }
+                
+            NotificationCenter.default.post(name: Event.contactsChanged, object: nil, userInfo: [
+                "contact_id": Int(data1)
+            ])
 
         case DC_EVENT_CONNECTIVITY_CHANGED:
             if accountId != dcAccounts.getSelected().id {

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -161,9 +161,7 @@ public class DcEventHandler {
                 return
             }
             logger.info("📡[\(accountId)] connectivity changed")
-            DispatchQueue.main.async {
                 NotificationCenter.default.post(name: Event.connectivityChanged, object: nil)
-            }
 
         case DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE:
             if let sem = dcAccounts.fetchSemaphore {

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -278,12 +278,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     static func emitMsgsChangedIfShareExtensionWasUsed() {
         if let userDefaults = UserDefaults.shared, userDefaults.bool(forKey: UserDefaults.hasExtensionAttemptedToSend) {
             userDefaults.removeObject(forKey: UserDefaults.hasExtensionAttemptedToSend)
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: [
-                    "message_id": Int(0),
-                    "chat_id": Int(0),
-                ])
-            }
+
+            NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: [
+                "message_id": Int(0),
+                "chat_id": Int(0),
+            ])
         }
     }
 

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -238,9 +238,11 @@ class InstantOnboardingViewController: UIViewController {
     }
 
     private func handleCreateSuccess() {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-        appDelegate.registerForNotifications()
-        appDelegate.reloadDcContext()
+        DispatchQueue.main.async {
+            guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+            appDelegate.registerForNotifications()
+            appDelegate.reloadDcContext()
+        }
     }
 
     private func storeImageAndName() {

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -182,7 +182,7 @@ class WelcomeViewController: UIViewController {
         backupProgressObserver = NotificationCenter.default.addObserver(
             forName: Event.importExportProgress,
             object: nil,
-            queue: nil
+            queue: OperationQueue.main
         ) { [weak self] notification in
             self?.handleImportExportProgress(notification, importByFile: importByFile)
         }

--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -166,43 +166,46 @@ class BackupTransferViewController: UIViewController {
     @objc private func handleImportExportProgress(_ notification: Notification) {
         guard let ui = notification.userInfo, let permille = ui["progress"] as? Int, isFinishing == false else { return }
 
-        var statusLineText: String?
-        var hideQrCode = false
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            
+            var statusLineText: String?
+            var hideQrCode = false
 
-        if permille == 0 {
-            if self.transferState != TranferState.error {
-                self.transferState = TranferState.error
-                self.showLastErrorAlert("Error")
+            if permille == 0 {
+                if self.transferState != TranferState.error {
+                    self.transferState = TranferState.error
+                    self.showLastErrorAlert("Error")
+                }
+                hideQrCode = true
+            } else if permille <= 350 {
+                statusLineText = nil
+            } else if permille <= 400 {
+                statusLineText = nil
+            } else if permille <= 450 {
+                statusLineText = String.localized("receiver_connected")
+                hideQrCode = true
+            } else if permille < 1000 {
+                let percent = (permille-450)/5
+                statusLineText = String.localized("transferring") + " \(percent)%" // TODO: use a scrollbar, show precide percentage only for receiver
+                hideQrCode = true
+            } else if permille == 1000 {
+                self.transferState = TranferState.success
+                self.navigationItem.leftBarButtonItem = nil // "Cancel" no longer fits as things are done
+                statusLineText = String.localized("done") + " 😀"
+                hideQrCode = true
             }
-            hideQrCode = true
-        } else if permille <= 350 {
-            statusLineText = nil
-        } else if permille <= 400 {
-            statusLineText = nil
-        } else if permille <= 450 {
-            statusLineText = String.localized("receiver_connected")
-            hideQrCode = true
-        } else if permille < 1000 {
-            let percent = (permille-450)/5
-            statusLineText = String.localized("transferring") + " \(percent)%" // TODO: use a scrollbar, show precide percentage only for receiver
-            hideQrCode = true
-        } else if permille == 1000 {
-            self.transferState = TranferState.success
-            self.navigationItem.leftBarButtonItem = nil // "Cancel" no longer fits as things are done
-            statusLineText = String.localized("done") + " 😀"
-            hideQrCode = true
-        }
 
-        if let statusLineText = statusLineText {
-            self.statusLine.text = statusLineText
-        }
+            if let statusLineText = statusLineText {
+                self.statusLine.text = statusLineText
+            }
 
-        if hideQrCode && !self.qrContentView.isHidden {
-            self.statusLine.textAlignment = .center
-            experimentalLine.isHidden = true
-            self.qrContentView.isHidden = true
+            if hideQrCode && !self.qrContentView.isHidden {
+                self.statusLine.textAlignment = .center
+                experimentalLine.isHidden = true
+                self.qrContentView.isHidden = true
+            }
         }
-
     }
 
     // MARK: - setup

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -227,7 +227,9 @@ class ChatListViewController: UITableViewController {
     }
 
     @objc private func handleIncomingMessageOnAnyAccount(_ notification: Notification) {
-        updateAccountButton()
+        DispatchQueue.main.async {
+            updateAccountButton()
+        }
     }
 
     private func setupSubviews() {

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -227,8 +227,8 @@ class ChatListViewController: UITableViewController {
     }
 
     @objc private func handleIncomingMessageOnAnyAccount(_ notification: Notification) {
-        DispatchQueue.main.async {
-            updateAccountButton()
+        DispatchQueue.main.async { [weak self] in
+            self?.updateAccountButton()
         }
     }
 

--- a/deltachat-ios/Controller/FullMessageViewController.swift
+++ b/deltachat-ios/Controller/FullMessageViewController.swift
@@ -95,7 +95,6 @@ class FullMessageViewController: WebViewViewController {
 
     @objc func alwaysActionPressed(_ action: UIAlertAction) {
         UserDefaults.standard.set(true, forKey: "html_load_remote_content")
-        UserDefaults.standard.synchronize()
         loadContentOnce = false
         loadUnrestricedHtml()
     }
@@ -103,7 +102,6 @@ class FullMessageViewController: WebViewViewController {
     @objc func onceActionPressed(_ action: UIAlertAction) {
         if !isHalfBlocked {
             UserDefaults.standard.set(false, forKey: "html_load_remote_content")
-            UserDefaults.standard.synchronize()
         }
         loadContentOnce = true
         loadUnrestricedHtml()
@@ -112,7 +110,6 @@ class FullMessageViewController: WebViewViewController {
     @objc func neverActionPressed(_ action: UIAlertAction) {
         if !isHalfBlocked {
             UserDefaults.standard.set(false, forKey: "html_load_remote_content")
-            UserDefaults.standard.synchronize()
         }
         loadContentOnce = false
         loadRestrictedHtml()

--- a/deltachat-ios/Controller/Settings/BackgroundOptionsViewController.swift
+++ b/deltachat-ios/Controller/Settings/BackgroundOptionsViewController.swift
@@ -141,7 +141,6 @@ class BackgroundOptionsViewController: UIViewController, MediaPickerDelegate {
     @objc private func onDefaultSelected() {
         setDefault(backgroundContainer)
         UserDefaults.standard.set(nil, forKey: Constants.Keys.backgroundImageName)
-        UserDefaults.standard.synchronize()
     }
 
     private func setDefault(_ imageView: UIImageView) {
@@ -156,7 +155,6 @@ class BackgroundOptionsViewController: UIViewController, MediaPickerDelegate {
     func onImageSelected(image: UIImage) {
         if let path = ImageFormat.saveImage(image: image, name: Constants.backgroundImageName) {
             UserDefaults.standard.set(URL(fileURLWithPath: path).lastPathComponent, forKey: Constants.Keys.backgroundImageName)
-            UserDefaults.standard.synchronize()
             backgroundContainer.sd_setImage(with: URL(fileURLWithPath: path), placeholderImage: nil, options: .refreshCached, completed: nil)
         } else {
             logger.error("failed to save background image")

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -242,7 +242,7 @@ internal final class SettingsViewController: UITableViewController {
         } else {
             NotificationManager.removeAllNotifications()
         }
-        UserDefaults.standard.synchronize()
+        
         NotificationManager.updateBadgeCounters()
         NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: ["message_id": Int(0), "chat_id": Int(0)])
     }

--- a/deltachat-ios/Handler/ProgressAlertHandler.swift
+++ b/deltachat-ios/Handler/ProgressAlertHandler.swift
@@ -37,24 +37,29 @@ class ProgressAlertHandler {
     @objc private func handleNotification(_ notification: Notification) {
         guard let ui = notification.userInfo else { return }
 
-        if ui["error"] as? Bool ?? false {
-            dcAccounts.startIo()
+        DispatchQueue.main.async { [weak self] in
 
-            var errorMessage: String? = ui["errorMessage"] as? String
-            // override if we need to check for connectiviy issues
-            if checkForInternetConnectivity,
-               let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-               let reachability = appDelegate.reachability,
-               reachability.connection == .unavailable {
-                errorMessage = String.localized("login_error_no_internet_connection")
+            guard let self else { return }
+
+            if ui["error"] as? Bool ?? false {
+                dcAccounts.startIo()
+                
+                var errorMessage: String? = ui["errorMessage"] as? String
+                // override if we need to check for connectiviy issues
+                if checkForInternetConnectivity,
+                   let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+                   let reachability = appDelegate.reachability,
+                   reachability.connection == .unavailable {
+                    errorMessage = String.localized("login_error_no_internet_connection")
+                }
+                
+                self.updateProgressAlert(error: errorMessage)
+            } else if ui["done"] as? Bool ?? false {
+                dcAccounts.startIo()
+                self.updateProgressAlertSuccess(completion: onSuccess)
+            } else {
+                self.updateProgressAlertValue(value: ui["progress"] as? Int)
             }
-
-            self.updateProgressAlert(error: errorMessage)
-        } else if ui["done"] as? Bool ?? false {
-            dcAccounts.startIo()
-            self.updateProgressAlertSuccess(completion: onSuccess)
-        } else {
-            self.updateProgressAlertValue(value: ui["progress"] as? Int)
         }
     }
 


### PR DESCRIPTION
More minor refactorings. I checked every notification posted in `events.swift` if posting on main was necessary and it turned out: Most of the stuff gets already handled on main (except one or two, I fixed that).

Closes #2242.