### PR TITLE
send images as sticker not only when they have the 140x140 dimensions, but also when they have transparent corner(s)

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2760,8 +2760,7 @@ extension ChatViewController: UITextViewDelegate {
 // MARK: - ChatInputTextViewPasteDelegate
 extension ChatViewController: ChatInputTextViewPasteDelegate {
     func onImagePasted(image: UIImage) {
-        let isSticker = image.size.equalTo(CGSize(width: 140, height: 140))
-
+        let isSticker = image.size.equalTo(CGSize(width: 140, height: 140)) || image.hasTransparentCorner()
         if isSticker {
             sendSticker(image)
         } else {
@@ -2800,7 +2799,12 @@ extension ChatViewController: WebxdcSelectorDelegate {
 // MARK: - ChatDropInteractionDelegate
 extension ChatViewController: ChatDropInteractionDelegate {
     func onImageDragAndDropped(image: UIImage) {
-        stageImage(image)
+        let isSticker = image.size.equalTo(CGSize(width: 140, height: 140)) || image.hasTransparentCorner()
+        if isSticker {
+            sendSticker(image)
+        } else {
+            stageImage(image)
+        }
     }
 
     func onVideoDragAndDropped(url: NSURL) {


### PR DESCRIPTION
also add the send as sticker logic to darg and droping an image into a chat, this makes it super convinient to create stickers from images with iOS's AI selection feature.
(long press to select your favorite pet or person then hold the object and use a second finger to navigate to the chat you want to send it to.)
