### PR TITLE
support DC_QR_BACKUP2

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -233,7 +233,7 @@ class WelcomeViewController: UIViewController {
 extension WelcomeViewController: QrCodeReaderDelegate {
     func handleQrCode(_ code: String) {
         let lot = dcContext.checkQR(qrCode: code)
-        if lot.state == DC_QR_BACKUP {
+        if lot.state == DC_QR_BACKUP || lot.state == DC_QR_BACKUP2 {
              confirmSetupNewDevice(qrCode: code)
         } else {
             qrErrorAlert()

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -292,7 +292,7 @@ extension QrPageController: QrCodeReaderDelegate {
             }))
             present(alert, animated: true, completion: nil)
 
-        case DC_QR_BACKUP:
+        case DC_QR_BACKUP, DC_QR_BACKUP2:
             // alert is shown in WelcomeViewController
             guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
             _ = dcAccounts.add()

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -236,7 +236,7 @@ class AppCoordinator: NSObject {
 
         if let accountCode {
             let qr = dcAccounts.getSelected().checkQR(qrCode: accountCode)
-            if qr.state == DC_QR_BACKUP {
+            if qr.state == DC_QR_BACKUP || qr.state == DC_QR_BACKUP2 {
                 viewControllers = [WelcomeViewController(dcAccounts: dcAccounts, accountCode: accountCode)]
             } else {
                 viewControllers = [


### PR DESCRIPTION
BACKUP2-qr-codes are generated by newer cores,
they of course should also be supported when scanning QR codes.

counterpart of https://github.com/deltachat/deltachat-android/pull/3173