### PR TITLE
mark bots as such, improve chat-deletion confirmation

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1371,7 +1371,8 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }
 
     private func askToDeleteChat() {
-        let title = String.localized(stringID: "ask_delete_chat", parameter: 1)
+        let chat = dcContext.getChat(chatId: chatId)
+        let title = String.localizedStringWithFormat(String.localized("ask_delete_named_chat"), chat.name)
         confirmationAlert(title: title, actionTitle: String.localized("delete"), actionStyle: .destructive,
                           actionHandler: { [weak self] _ in
                             guard let self else { return }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -939,8 +939,15 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 subtitle = String.localized("device_talk_subtitle")
             } else if dcChat.isSelfTalk {
                 subtitle = String.localized("chat_self_talk_subtitle")
-            } else if !dcChat.isProtected && chatContactIds.count >= 1 {
-                subtitle = dcContext.getContact(id: chatContactIds[0]).email
+            } else if chatContactIds.count >= 1 {
+                let dcContact = dcContext.getContact(id: chatContactIds[0])
+                if dcContact.isBot {
+                    subtitle = String.localized("bot")
+                } else if !dcChat.isProtected {
+                    subtitle = dcContact.email
+                } else {
+                    subtitle = nil
+                }
             } else {
                 subtitle = nil
             }

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -746,11 +746,17 @@ class ChatListViewController: UITableViewController {
         if selected == 0 {
             return
         }
-        let alert = UIAlertController(
-            title: nil,
-            message: String.localized(stringID: "ask_delete_chat", parameter: selected),
-            preferredStyle: .safeActionSheet
-        )
+
+        let message: String
+        if selected == 1,
+           let chatIds = viewModel?.chatIdsFor(indexPaths: tableView.indexPathsForSelectedRows),
+           let chatId = chatIds.first {
+            message = String.localizedStringWithFormat(String.localized("ask_delete_named_chat"), dcContext.getChat(chatId: chatId).name)
+        } else {
+            message = String.localized(stringID: "ask_delete_chat", parameter: selected)
+        }
+
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .safeActionSheet)
         alert.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { [weak self] _ in
             guard let self, let viewModel = self.viewModel else { return }
             viewModel.deleteChats(indexPaths: self.tableView.indexPathsForSelectedRows)

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -742,18 +742,18 @@ class ChatListViewController: UITableViewController {
     }
 
     private func showDeleteMultipleChatConfirmationAlert() {
-        let selected = tableView.indexPathsForSelectedRows?.count ?? 0
-        if selected == 0 {
+        let selectedCount = tableView.indexPathsForSelectedRows?.count ?? 0
+        if selectedCount == 0 {
             return
         }
 
         let message: String
-        if selected == 1,
+        if selectedCount == 1,
            let chatIds = viewModel?.chatIdsFor(indexPaths: tableView.indexPathsForSelectedRows),
            let chatId = chatIds.first {
             message = String.localizedStringWithFormat(String.localized("ask_delete_named_chat"), dcContext.getChat(chatId: chatId).name)
         } else {
-            message = String.localized(stringID: "ask_delete_chat", parameter: selected)
+            message = String.localized(stringID: "ask_delete_chat", parameter: selectedCount)
         }
 
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .safeActionSheet)

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -135,7 +135,11 @@ class ContactDetailViewController: UITableViewController {
             navigationItem.rightBarButtonItem = UIBarButtonItem(
                 title: String.localized("global_menu_edit_desktop"),
                 style: .plain, target: self, action: #selector(editButtonPressed))
-            self.title = String.localized("tab_contact")
+            if self.viewModel.isBot {
+                self.title = String.localized("bot")
+            } else {
+                self.title = String.localized("tab_contact")
+            }
         } else {
             self.title = String.localized("profile")
         }

--- a/deltachat-ios/DC/DcContact.swift
+++ b/deltachat-ios/DC/DcContact.swift
@@ -72,6 +72,10 @@ public class DcContact {
         return Int(dc_contact_get_verifier_id(contactPointer))
     }
 
+    public var isBot: Bool {
+        return dc_contact_is_bot(contactPointer) != 0
+    }
+
     public var isBlocked: Bool {
         return dc_contact_is_blocked(contactPointer) == 1
     }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -39,6 +39,7 @@ class ContactDetailViewModel {
     let chatId: Int
     let isSavedMessages: Bool
     let isDeviceTalk: Bool
+    let isBot: Bool
     let greenCheckmark: Bool
     var lastSeen: Int64
     private var sharedChats: DcChatlist
@@ -61,6 +62,7 @@ class ContactDetailViewModel {
             isDeviceTalk = false
             greenCheckmark = dcContact.isVerified
         }
+        self.isBot = dcContact.isBot
         self.sharedChats = context.getChatlist(flags: 0, queryString: nil, queryId: contactId)
 
         sections.append(.chatOptions)


### PR DESCRIPTION
this PR brings two recent, minor android tweak to iOS:

- mark bots in chat titles and profiles as such (see image 1+2, https://github.com/deltachat/deltachat-android/pull/3220 on android)

- if only one chat is about to being deleted, ask for confirmation using the chat title, not the number (for multiple selection, we things are unchanged) (see image 3, https://github.com/deltachat/deltachat-android/pull/3219 on android)


<img width=250 src=https://github.com/user-attachments/assets/f9dc5bcc-df97-444f-892d-a6ff5a8568af>
<img width=250 src=https://github.com/user-attachments/assets/45776219-fbd9-4972-8356-1aad20c5b093>
<img width=250 src=https://github.com/user-attachments/assets/2360a96c-c1ba-4bfa-bb4e-235591a8808f>
