### PR TITLE
Show contact when tapping on their name in Reactions-overview

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2842,8 +2842,6 @@ extension ChatViewController: SendContactViewControllerDelegate {
 
 extension ChatViewController: ReactionsOverviewViewControllerDelegate {
     func showContact(_ viewController: UIViewController, with contactId: Int) {
-        // dismiss, but push contact-screen
-
         viewController.dismiss(animated: true)
 
         let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2462,6 +2462,7 @@ extension ChatViewController: BaseMessageCellDelegate {
         guard let reactions = dcContext.getMessageReactions(messageId: messageIds[indexPath.row]) else { return }
 
         let reactionsOverview = ReactionsOverviewViewController(reactions: reactions, context: dcContext)
+        reactionsOverview.delegate = self
         let navigationController = UINavigationController(rootViewController: reactionsOverview)
         if #available(iOS 15.0, *) {
             if let sheet = navigationController.sheetPresentationController {
@@ -2834,5 +2835,18 @@ extension ChatViewController: SendContactViewControllerDelegate {
         else { return }
 
         stageVCard(url: vcardURL)
+    }
+}
+
+// MARK: - ReactionsOverviewViewControllerDelegate
+
+extension ChatViewController: ReactionsOverviewViewControllerDelegate {
+    func showContact(_ viewController: UIViewController, with contactId: Int) {
+        // dismiss, but push contact-screen
+
+        viewController.dismiss(animated: true)
+
+        let contactDetailController = ContactDetailViewController(dcContext: dcContext, contactId: contactId)
+        navigationController?.pushViewController(contactDetailController, animated: true)
     }
 }

--- a/deltachat-ios/Chat/Reactions/ReactionsOverviewTableViewCell.swift
+++ b/deltachat-ios/Chat/Reactions/ReactionsOverviewTableViewCell.swift
@@ -6,8 +6,6 @@ class ReactionsOverviewTableViewCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-
-        selectionStyle = .none
     }
     
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }

--- a/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
+++ b/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
@@ -1,12 +1,18 @@
 import UIKit
 import DcCore
 
+protocol ReactionsOverviewViewControllerDelegate: AnyObject {
+    func showContact(_ viewController: UIViewController, with contactId: Int)
+}
+
 class ReactionsOverviewViewController: UIViewController {
 
     private let tableView: UITableView
     private let reactions: DcReactions
     private let contactIds: [Int]
     private let context: DcContext
+
+    weak var delegate: ReactionsOverviewViewControllerDelegate?
 
     init(reactions: DcReactions, context: DcContext) {
 
@@ -24,6 +30,7 @@ class ReactionsOverviewViewController: UIViewController {
         setupConstraints()
 
         tableView.dataSource = self
+        tableView.delegate = self
 
         title = String.localized("reactions")
 
@@ -69,5 +76,18 @@ extension ReactionsOverviewViewController: UITableViewDataSource {
         }
 
         return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension ReactionsOverviewViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let contactId = contactIds[indexPath.row]
+
+        //TODO: Handle me
+
+        delegate?.showContact(self, with: contactId)
     }
 }

--- a/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
+++ b/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
@@ -86,8 +86,9 @@ extension ReactionsOverviewViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
         let contactId = contactIds[indexPath.row]
 
-        //TODO: Handle me
-
-        delegate?.showContact(self, with: contactId)
+        let isMe = (context.id == contactId)
+        if isMe == false {
+            delegate?.showContact(self, with: contactId)
+        }
     }
 }


### PR DESCRIPTION
When a user taps on the reactions next to a message, they see how (other) users reacted. When they tap on one of the user names, that user's profile opens (except it's me, than nothing happens)

Closes #2259