### PR TITLE
Update Message-timestamp-updating

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -101,8 +101,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         return false
     }
 
-    private weak var timer: Timer?
-
     private lazy var navBarTap: UITapGestureRecognizer = {
         UITapGestureRecognizer(target: self, action: #selector(chatProfilePressed))
     }()
@@ -284,35 +282,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         return UIApplication.shared.statusBarFrame.height + navigationBarHeight
     }
 
-    private func startTimer() {
-        stopTimer()
-        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
-            // reload table
-            DispatchQueue.main.async { [weak self] in
-                guard let self,
-                      let appDelegate = UIApplication.shared.delegate as? AppDelegate
-                else { return }
-                
-                if appDelegate.appIsInForeground() {
-                    self.messageIds = self.dcContext.getChatMsgs(chatId: self.chatId)
-                    self.reloadData()
-                } else {
-                    logger.warning("startTimer() must not be executed in background")
-                }
-            }
-        }
-    }
-
     public func activateSearchOnAppear() {
         activateSearch = true
         navigationItem.searchController = self.searchController
-    }
-
-    private func stopTimer() {
-        if let timer = timer {
-            timer.invalidate()
-        }
-        timer = nil
     }
 
     private func configureEmptyStateView() {
@@ -568,10 +540,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     func handleUserVisibility(isVisible: Bool) {
         isVisibleToUser = isVisible
         if isVisible {
-            startTimer()
             markSeenMessagesInVisibleArea()
-        } else {
-            stopTimer()
         }
     }
 

--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -173,6 +173,7 @@ public class BaseMessageCell: UITableViewCell {
     let reactionsView: ReactionsView
 
     private var showSelectionBackground: Bool
+    private var timer: Timer?
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
 
@@ -439,7 +440,15 @@ public class BaseMessageCell: UITableViewCell {
             } else {
                 tintColor = DcColors.incomingMessageSecondaryTextColor
             }
+
             bottomLabel.update(message: msg, tintColor: tintColor)
+            let timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+                guard let self else { return }
+
+                self.bottomLabel.dateLabel.text = msg.formattedSentDate()
+            }
+
+            self.timer = timer
         }
 
         if let quoteText = msg.quoteText {
@@ -586,6 +595,8 @@ public class BaseMessageCell: UITableViewCell {
         actionButton.isEnabled = true
         showSelectionBackground = false
         reactionsView.prepareForReuse()
+        timer?.invalidate()
+        timer = nil
     }
 
     @objc func reactionsViewTapped(_ sender: Any?) {

--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -60,7 +60,7 @@ public class BaseMessageCell: UITableViewCell {
 
     public var showBottomLabelBackground: Bool {
         didSet {
-            bottomLabel.backgroundColor = showBottomLabelBackground ?
+            statusView.backgroundColor = showBottomLabelBackground ?
                 DcColors.systemMessageBackgroundColor :
                 UIColor(alpha: 0, red: 0, green: 0, blue: 0)
         }
@@ -158,7 +158,7 @@ public class BaseMessageCell: UITableViewCell {
         return button
     }()
 
-    let bottomLabel = StatusView()
+    let statusView = StatusView()
 
     lazy var messageBackgroundContainer: BackgroundContainer = {
         let container = BackgroundContainer()
@@ -180,7 +180,7 @@ public class BaseMessageCell: UITableViewCell {
         reactionsView = ReactionsView()
         reactionsView.translatesAutoresizingMaskIntoConstraints = false
 
-        bottomLabel.translatesAutoresizingMaskIntoConstraints = false
+        statusView.translatesAutoresizingMaskIntoConstraints = false
 
         showSelectionBackground = false
         showBottomLabelBackground = false
@@ -203,7 +203,7 @@ public class BaseMessageCell: UITableViewCell {
         messageBackgroundContainer.addSubview(mainContentView)
         messageBackgroundContainer.addSubview(topLabel)
         messageBackgroundContainer.addSubview(actionButton)
-        messageBackgroundContainer.addSubview(bottomLabel)
+        messageBackgroundContainer.addSubview(statusView)
         contentView.addSubview(avatarView)
 
         contentView.addConstraints([
@@ -216,10 +216,10 @@ public class BaseMessageCell: UITableViewCell {
             topLabel.constraintAlignTrailingMaxTo(messageBackgroundContainer, paddingTrailing: 8),
             messageBackgroundContainer.constraintAlignTopTo(contentView, paddingTop: 3),
             actionButton.constraintAlignLeadingTo(messageBackgroundContainer, paddingLeading: 12),
-            bottomLabel.constraintAlignLeadingMaxTo(messageBackgroundContainer, paddingLeading: 8),
-            bottomLabel.constraintAlignTrailingTo(messageBackgroundContainer, paddingTrailing: 8),
-            bottomLabel.constraintToBottomOf(actionButton, paddingTop: 8, priority: .defaultHigh),
-            bottomLabel.constraintAlignBottomTo(messageBackgroundContainer, paddingBottom: 6)
+            statusView.constraintAlignLeadingMaxTo(messageBackgroundContainer, paddingLeading: 8),
+            statusView.constraintAlignTrailingTo(messageBackgroundContainer, paddingTrailing: 8),
+            statusView.constraintToBottomOf(actionButton, paddingTop: 8, priority: .defaultHigh),
+            statusView.constraintAlignBottomTo(messageBackgroundContainer, paddingBottom: 6)
         ])
 
         leadingConstraint = messageBackgroundContainer.constraintAlignLeadingTo(contentView, paddingLeading: 6)
@@ -441,11 +441,11 @@ public class BaseMessageCell: UITableViewCell {
                 tintColor = DcColors.incomingMessageSecondaryTextColor
             }
 
-            bottomLabel.update(message: msg, tintColor: tintColor)
+            statusView.update(message: msg, tintColor: tintColor)
             let timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
                 guard let self else { return }
 
-                self.bottomLabel.dateLabel.text = msg.formattedSentDate()
+                self.statusView.dateLabel.text = msg.formattedSentDate()
             }
 
             self.timer = timer
@@ -586,7 +586,7 @@ public class BaseMessageCell: UITableViewCell {
         topLabel.attributedText = nil
         avatarView.reset()
         messageBackgroundContainer.prepareForReuse()
-        bottomLabel.prepareForReuse()
+        statusView.prepareForReuse()
         baseDelegate = nil
         messageLabel.text = nil
         messageLabel.attributedText = nil

--- a/deltachat-ios/Chat/Views/StatusView.swift
+++ b/deltachat-ios/Chat/Views/StatusView.swift
@@ -4,7 +4,7 @@ import DcCore
 
 public class StatusView: UIView {
     private let contentStackView: UIStackView
-    private let dateLabel: UILabel
+    let dateLabel: UILabel
     private let padlockView: UIImageView
     private let locationView: UIImageView
     private let stateView: UIImageView


### PR DESCRIPTION
- Timer moved from `ChatViewController` to `BaseMessageCell`: There's no need to reload the entire table just to update a label.
- Timer doesn't get stopped when app gets sent to background or restarted when app returns to foreground, they just continue to run once per minute updating the labels
- Closes #2220.