### PR TITLE
Hide email in "New chat"-list for trusted contacts

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -912,7 +912,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 let dcContact = dcContext.getContact(id: chatContactIds[0])
                 if dcContact.isBot {
                     subtitle = String.localized("bot")
-                } else if !dcChat.isProtected {
+                } else if dcChat.isProtected == false {
                     subtitle = dcContact.email
                 } else {
                     subtitle = nil

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -209,6 +209,12 @@ class ContactCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        subtitleLabel.isHidden = false
+    }
+
     private func setupSubviews() {
         let margin: CGFloat = 10
         isAccessibilityElement = true
@@ -401,16 +407,12 @@ class ContactCell: UITableViewCell {
         case .contact(let contactData):
             let contact = cellViewModel.dcContext.getContact(id: contactData.contactId)
             titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)
-            
+
             if let chatId = contactData.chatId {
                 let chat = cellViewModel.dcContext.getChat(chatId: chatId)
                 if chat.isProtected {
                     subtitleLabel.isHidden = true
-                } else {
-                    subtitleLabel.isHidden = false
                 }
-            } else {
-                subtitleLabel.isHidden = false
             }
 
             if let profileImage = contact.profileImage {

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -401,6 +401,18 @@ class ContactCell: UITableViewCell {
         case .contact(let contactData):
             let contact = cellViewModel.dcContext.getContact(id: contactData.contactId)
             titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)
+            
+            if let chatId = contactData.chatId {
+                let chat = cellViewModel.dcContext.getChat(chatId: chatId)
+                if chat.isProtected {
+                    subtitleLabel.isHidden = true
+                } else {
+                    subtitleLabel.isHidden = false
+                }
+            } else {
+                subtitleLabel.isHidden = false
+            }
+
             if let profileImage = contact.profileImage {
                 avatar.setImage(profileImage)
             } else {

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -407,13 +407,7 @@ class ContactCell: UITableViewCell {
         case .contact(let contactData):
             let contact = cellViewModel.dcContext.getContact(id: contactData.contactId)
             titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)
-
-            if let chatId = contactData.chatId {
-                let chat = cellViewModel.dcContext.getChat(chatId: chatId)
-                if chat.isProtected {
-                    subtitleLabel.isHidden = true
-                }
-            }
+            subtitleLabel.isHidden = contact.isVerified
 
             if let profileImage = contact.profileImage {
                 avatar.setImage(profileImage)


### PR DESCRIPTION
Subtitle-Label gets hidden if `chat.isProtected`.
I'm not super happy with hiding the `subtitleLabel` but it's one of two reasonable approaches:

1. Hide the subtitleLabel
2. Override the `subtitle` of the ViewModel to be `nil`

Another option would have been to cleanup and declutter the `ViewModel`-stuff but this wouldn't have been pragmatic or reasonable.

Closes #2272.