### PR TITLE
improve "Edit Name" dialog

### DIFF
--- a/deltachat-ios/Controller/EditContactController.swift
+++ b/deltachat-ios/Controller/EditContactController.swift
@@ -19,6 +19,7 @@ class EditContactController: UITableViewController {
         nameCell.textField.text = dcContact.editedName
         nameCell.textField.enablesReturnKeyAutomatically = false
         nameCell.textField.returnKeyType = .done
+        nameCell.useFullWidth()
         nameCell.placeholder = String.localizedStringWithFormat(String.localized("edit_name_placeholder"), authNameOrAddr)
 
         title = String.localized("menu_edit_name")

--- a/deltachat-ios/View/TextFieldCell.swift
+++ b/deltachat-ios/View/TextFieldCell.swift
@@ -137,6 +137,11 @@ class TextFieldCell: UITableViewCell {
         textField.text = text
     }
 
+    func useFullWidth() {
+        title.isHidden = true
+        textField.textAlignment = .left
+    }
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         if previousTraitCollection?.preferredContentSizeCategory !=
             traitCollection.preferredContentSizeCategory {


### PR DESCRIPTION
this PR sets placeholder and footer according to suggestions at https://github.com/deltachat/deltachat-ios/issues/2286

moreover, the title is changed to "Edit Name" and the email address is hidden (as on android/desktop - the dialog focuses on the nickname)

i first tried to follow the way of subclassing NewContactController, however that became even more hacky as before (cells would needed to be var, first reponder check in base class would needed to be changed etc.). not worth few lines of saved code. 

therefore, i made `EditContactController` self-contained and independet. it is 20 lines more, but straight-forward and no hacks so one does not need to check what in the super-class happens all the time.

closes #2286

<img width=340 src=https://github.com/user-attachments/assets/318331d8-fcb1-41e4-b769-2dee661fc6d9>
<img width=340 src=https://github.com/user-attachments/assets/8fb77176-de2b-4328-a7c2-786f69e7adeb>

before / after - note the improved placeholder and footer and the general cleanup :)
