### PR TITLE
Make "Copy to clipboard" a more advanced option

### DIFF
--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -12,6 +12,12 @@ class ContactDetailViewController: UITableViewController {
         headerCell.onMuteButtonTapped = toggleMuteChat
         headerCell.onSearchButtonTapped = showSearch
         headerCell.setRecentlySeen(viewModel.contact.wasSeenRecently)
+
+        if viewModel.isSavedMessages == false && viewModel.isDeviceTalk == false {
+            let copyContactGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(ContactDetailViewController.showCopyToClipboard))
+            headerCell.labelsContainer.addGestureRecognizer(copyContactGestureRecognizer)
+        }
+
         return headerCell
     }()
 
@@ -323,6 +329,24 @@ class ContactDetailViewController: UITableViewController {
     }
 
     // MARK: - actions
+
+    @objc private func showCopyToClipboard() {
+        UIMenuController.shared.menuItems = [
+            UIMenuItem(title: String.localized("menu_copy_to_clipboard"), action: #selector(ContactDetailViewController.copyToClipboard))
+        ]
+
+        if #available(iOS 13.0, *) {
+            UIMenuController.shared.showMenu(from: headerCell.titleLabelContainer, rect: headerCell.titleLabelContainer.frame)
+        } else {
+            UIMenuController.shared.setTargetRect(headerCell.titleLabelContainer.frame, in: headerCell)
+            UIMenuController.shared.setMenuVisible(true, animated: true)
+        }
+    }
+
+    @objc private func copyToClipboard() {
+        UIPasteboard.general.string = viewModel.contact.email
+    }
+
     private func handleChatAction(indexPath: IndexPath) {
         let action = viewModel.chatActionFor(row: indexPath.row)
         switch action {

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -40,13 +40,6 @@ class ContactDetailViewController: UITableViewController {
         return cell
     }()
 
-    private lazy var copyToClipboardCell: ActionCell = {
-        let cell = ActionCell()
-        cell.actionTitle = String.localized("menu_copy_to_clipboard")
-        cell.actionColor = UIColor.systemBlue
-        return cell
-    }()
-
     private lazy var blockContactCell: ActionCell = {
         let cell = ActionCell()
         cell.actionTitle = viewModel.contact.isBlocked ? String.localized("menu_unblock_contact") : String.localized("menu_block_contact")
@@ -206,8 +199,6 @@ class ContactDetailViewController: UITableViewController {
                 return archiveChatCell
             case .showEncrInfo:
                 return showEncrInfoCell
-            case .copyToClipboard:
-                return copyToClipboardCell
             case .blockContact:
                 return blockContactCell
             case .clearChat:
@@ -341,9 +332,6 @@ class ContactDetailViewController: UITableViewController {
         case .showEncrInfo:
             tableView.deselectRow(at: indexPath, animated: false)
             showEncrInfoAlert()
-        case .copyToClipboard:
-            tableView.deselectRow(at: indexPath, animated: true)
-            UIPasteboard.general.string = viewModel.contact.email
         case .blockContact:
             tableView.deselectRow(at: indexPath, animated: false)
             toggleBlockContact()

--- a/deltachat-ios/View/ContactDetailHeader.swift
+++ b/deltachat-ios/View/ContactDetailHeader.swift
@@ -147,7 +147,6 @@ class ContactDetailHeader: UIView {
         horizontalStackView.axis = .horizontal
         horizontalStackView.distribution = .fillEqually
         horizontalStackView.alignment = .center
-        horizontalStackView.constraintAlignLeadingToAnchor(verticalStackView.trailingAnchor).isActive = true
         horizontalStackView.constraintAlignTrailingToAnchor(trailingAnchor, paddingTrailing: margin).isActive = true
         horizontalStackView.constraintCenterYTo(self).isActive = true
         horizontalStackView.spacing = margin

--- a/deltachat-ios/View/ContactDetailHeader.swift
+++ b/deltachat-ios/View/ContactDetailHeader.swift
@@ -68,7 +68,6 @@ class ContactDetailHeader: UIView {
         return imgView
     }()
 
-    // warum reagiert dieses label nich auf long press, was ist so besonders an dem?
     private lazy var subtitleLabel: UILabel = {
         let label = UILabel()
         label.lineBreakMode = .byTruncatingTail

--- a/deltachat-ios/View/ContactDetailHeader.swift
+++ b/deltachat-ios/View/ContactDetailHeader.swift
@@ -23,6 +23,7 @@ class ContactDetailHeader: UIView {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.lineBreakMode = .byTruncatingTail
+        label.isUserInteractionEnabled = true
         label.textColor = DcColors.defaultTextColor
         label.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1), for: .horizontal)
         label.adjustsFontForContentSizeCategory = true
@@ -31,11 +32,19 @@ class ContactDetailHeader: UIView {
         return label
     }()
 
-    private lazy var titleLabelContainer: UIStackView = {
+    private(set) lazy var titleLabelContainer: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [titleLabel, greenCheckmark, spacerView])
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.spacing = 4
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    private(set) lazy var labelsContainer: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabelContainer, subtitleLabel])
+        stackView.clipsToBounds = true
+        stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
@@ -59,12 +68,16 @@ class ContactDetailHeader: UIView {
         return imgView
     }()
 
+    // warum reagiert dieses label nich auf long press, was ist so besonders an dem?
     private lazy var subtitleLabel: UILabel = {
         let label = UILabel()
-        label.font = .preferredFont(forTextStyle: .subheadline)
-        label.textColor = UIColor(hexString: "848ba7")
         label.lineBreakMode = .byTruncatingTail
+        label.isUserInteractionEnabled = true
+        label.textColor = UIColor(hexString: "848ba7")
+        label.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1), for: .horizontal)
         label.adjustsFontForContentSizeCategory = true
+        label.font = .preferredFont(forTextStyle: .subheadline)
+        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
@@ -118,15 +131,13 @@ class ContactDetailHeader: UIView {
 
     private func setupSubviews() {
         let margin: CGFloat = 10
-        let verticalStackView = UIStackView(arrangedSubviews: [titleLabelContainer, subtitleLabel])
         let horizontalStackView = UIStackView(arrangedSubviews: [searchButton, muteButton])
 
         addSubview(avatar)
-        addSubview(verticalStackView)
+        addSubview(labelsContainer)
         addSubview(horizontalStackView)
 
         avatar.translatesAutoresizingMaskIntoConstraints = false
-        verticalStackView.translatesAutoresizingMaskIntoConstraints = false
         horizontalStackView.translatesAutoresizingMaskIntoConstraints = false
 
         addConstraints([
@@ -138,11 +149,9 @@ class ContactDetailHeader: UIView {
             greenCheckmark.widthAnchor.constraint(equalTo: greenCheckmark.heightAnchor),
         ])
 
-        verticalStackView.clipsToBounds = true
-        verticalStackView.leadingAnchor.constraint(equalTo: avatar.trailingAnchor, constant: margin).isActive = true
-        verticalStackView.centerYAnchor.constraint(equalTo: avatar.centerYAnchor).isActive = true
-        verticalStackView.trailingAnchor.constraint(equalTo: horizontalStackView.leadingAnchor, constant: -margin).isActive = true
-        verticalStackView.axis = .vertical
+        labelsContainer.leadingAnchor.constraint(equalTo: avatar.trailingAnchor, constant: margin).isActive = true
+        labelsContainer.centerYAnchor.constraint(equalTo: avatar.centerYAnchor).isActive = true
+        labelsContainer.trailingAnchor.constraint(equalTo: horizontalStackView.leadingAnchor, constant: -margin).isActive = true
 
         horizontalStackView.axis = .horizontal
         horizontalStackView.distribution = .fillEqually

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -23,7 +23,6 @@ class ContactDetailViewModel {
     enum ChatAction {
         case archiveChat
         case showEncrInfo
-        case copyToClipboard
         case blockContact
         case clearChat
         case deleteChat
@@ -98,14 +97,13 @@ class ContactDetailViewModel {
             chatActions = [.archiveChat]
             if !isDeviceTalk && !isSavedMessages {
                 chatActions.append(.showEncrInfo)
-                chatActions.append(.copyToClipboard)
                 chatActions.append(.blockContact)
             }
             chatActions.append(.clearChat)
             chatActions.append(.deleteChat)
         } else {
             chatOptions.append(.startChat)
-            chatActions = [.showEncrInfo, .copyToClipboard, .blockContact]
+            chatActions = [.showEncrInfo, .blockContact]
         }
     }
 


### PR DESCRIPTION
When user does a long-press (500ms) on either the name or the email-address, they see this fancy menu. This "Copy to clipboard" copies the email-address to the clipboard.

![2274](https://github.com/user-attachments/assets/c2ec92c7-74b0-4097-9434-d000ec6cd27e)

Also the menu-entry at the bottom of the list is gone.

Closes #2274 