### PR TITLE
Add Button to share Link to QR-Code-Screen (#2276)

### DIFF
--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -6,6 +6,7 @@ class QrPageController: UIPageViewController {
     private let dcAccounts: DcAccounts
     var progressObserver: NSObjectProtocol?
     let qrCodeReaderController: QrCodeReaderController
+    let qrViewController: QrViewController
 
     private var selectedIndex: Int = 0
 
@@ -53,10 +54,12 @@ class QrPageController: UIPageViewController {
         self.dcAccounts = dcAccounts
         self.dcContext = dcAccounts.getSelected()
 
+        qrViewController = QrViewController(dcContext: dcContext)
         qrCodeReaderController = QrCodeReaderController(title: String.localized("qrscan_title"))
         super.init(transitionStyle: .scroll, navigationOrientation: .horizontal, options: [:])
 
         qrCodeReaderController.delegate = self
+        qrViewController.qrCodeHint = self.qrCodeHint
     }
 
     required init?(coder: NSCoder) {
@@ -71,9 +74,8 @@ class QrPageController: UIPageViewController {
         navigationItem.titleView = qrSegmentControl
         navigationItem.rightBarButtonItem = moreButton
 
-        let qrController = QrViewController(dcContext: dcContext, qrCodeHint: qrCodeHint)
         setViewControllers(
-            [qrController],
+            [qrViewController],
             direction: .forward,
             animated: true,
             completion: nil
@@ -99,8 +101,7 @@ class QrPageController: UIPageViewController {
     // MARK: - actions
     @objc private func qrSegmentControlChanged(_ sender: UISegmentedControl) {
         if sender.selectedSegmentIndex == 0 {
-            let qrController = QrViewController(dcContext: dcContext, qrCodeHint: qrCodeHint)
-            setViewControllers([qrController], direction: .reverse, animated: true, completion: nil)
+            setViewControllers([qrViewController], direction: .reverse, animated: true, completion: nil)
         } else {
             setViewControllers([qrCodeReaderController], direction: .forward, animated: true, completion: nil)
         }
@@ -160,11 +161,9 @@ class QrPageController: UIPageViewController {
 
     // MARK: - update
     private func updateHintTextIfNeeded() {
-        for case let qrViewController as QrViewController in self.viewControllers ?? [] {
-            let newHint = qrCodeHint
-            if qrCodeHint != qrViewController.qrCodeHint {
-                qrViewController.qrCodeHint = newHint
-            }
+        let newHint = qrCodeHint
+        if newHint != qrViewController.qrCodeHint {
+            qrViewController.qrCodeHint = newHint
         }
     }
 
@@ -188,7 +187,7 @@ extension QrPageController: UIPageViewControllerDataSource, UIPageViewController
         if viewController is QrViewController {
             return nil
         } else {
-            return QrViewController(dcContext: dcContext, qrCodeHint: qrCodeHint)
+            return qrViewController
         }
     }
 

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -36,7 +36,7 @@ class QrViewController: UIViewController {
         qrContentView.translatesAutoresizingMaskIntoConstraints = false
 
         shareLinkButton = UIButton(type: .system)
-        shareLinkButton.setTitle("Share Invite Link", for: .normal)
+        shareLinkButton.setTitle(String.localized("share_invite_link"), for: .normal)
         shareLinkButton.translatesAutoresizingMaskIntoConstraints = false
 
         contentStackView = UIStackView(arrangedSubviews: [qrContentView, shareLinkButton, UIView()])

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -7,25 +7,9 @@ class QrViewController: UIViewController {
 
     private let dcContext: DcContext
     var onDismissed: (() -> Void)?
-    
-    private lazy var qrContentView: UIImageView = {
-        let svg = dcContext.getSecurejoinQrSVG(chatId: chatId)
-        let view = UIImageView()
-        view.contentMode = .scaleAspectFit
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.image = getQrImage(svg: svg)
-        return view
-    }()
+    private let qrContentView: UIImageView
 
-    private lazy var moreButton: UIBarButtonItem = {
-        let image: UIImage?
-        if #available(iOS 13.0, *) {
-            image = UIImage(systemName: "ellipsis.circle")
-        } else {
-            image = UIImage(named: "ic_more")
-        }
-        return UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(showMoreOptions))
-    }()
+    private let moreButton: UIBarButtonItem
 
     var qrCodeHint: String {
         willSet {
@@ -36,54 +20,84 @@ class QrViewController: UIViewController {
     }
     private let chatId: Int
 
-    init(dcContext: DcContext, chatId: Int? = 0, qrCodeHint: String?) {
+    init(dcContext: DcContext, chatId: Int = 0, qrCodeHint: String = "") {
         self.dcContext = dcContext
-        self.chatId = chatId ?? 0
-        self.qrCodeHint = qrCodeHint ?? ""
+        self.chatId = chatId
+        self.qrCodeHint = qrCodeHint
+
+        qrContentView = UIImageView()
+        qrContentView.contentMode = .scaleAspectFit
+        qrContentView.translatesAutoresizingMaskIntoConstraints = false
+
+        let moreButtonImage: UIImage?
+        if #available(iOS 13.0, *) {
+            moreButtonImage = UIImage(systemName: "ellipsis.circle")
+        } else {
+            moreButtonImage = UIImage(named: "ic_more")
+        }
+
+        moreButton = UIBarButtonItem(image: moreButtonImage, style: .plain, target: nil, action: nil)
+
         super.init(nibName: nil, bundle: nil)
+
+        view.backgroundColor = DcColors.defaultBackgroundColor
+
+        title = String.localized("qrshow_title")
+        navigationItem.rightBarButtonItem = moreButton
+        moreButton.action = #selector(QrViewController.showMoreOptions(_:))
+        moreButton.target = self
+
+        let svg = dcContext.getSecurejoinQrSVG(chatId: chatId)
+        qrContentView.image = getQrImage(svg: svg)
+        qrContentView.backgroundColor = .yellow
+
+        view.addSubview(qrContentView)
+
+        setupConstraints()
     }
 
-    required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    required init?(coder _: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setupConstraints() {
+
+        // TODO: Calculate qrContentView.height based on width-constraint and image-ratio.
+        
+        let qrImageRatio: CGFloat
+        if let image = qrContentView.image {
+            qrImageRatio = image.size.height / image.size.width
+        } else {
+            qrImageRatio = 1
+        }
+
+        let constraints = [
+            qrContentView.widthAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.75),
+            qrContentView.widthAnchor.constraint(lessThanOrEqualToConstant: 260),
+            qrContentView.heightAnchor.constraint(equalTo: qrContentView.widthAnchor, multiplier: qrImageRatio),
+            qrContentView.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor),
+            qrContentView.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+        ]
+
+        NSLayoutConstraint.activate(constraints)
     }
 
     // MARK: - lifecycle
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        title = String.localized("qrshow_title")
-        setupSubviews()
-        view.backgroundColor = DcColors.defaultBackgroundColor
-        navigationItem.rightBarButtonItem = moreButton
-    }
 
     override func viewDidDisappear(_ animated: Bool) {
         onDismissed?()
     }
 
-    // MARK: - setup
-    private func setupSubviews() {
-        view.addSubview(qrContentView)
-        let qrDefaultWidth = qrContentView.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.75)
-        qrDefaultWidth.priority = UILayoutPriority(500)
-        qrDefaultWidth.isActive = true
-        let qrMinWidth = qrContentView.widthAnchor.constraint(lessThanOrEqualToConstant: 260)
-        qrMinWidth.priority = UILayoutPriority(999)
-        qrMinWidth.isActive = true
-        qrContentView.heightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.heightAnchor, multiplier: 1.05).isActive = true
-        qrContentView.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor).isActive = true
-        qrContentView.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
-    }
-    
     func getQrImage(svg: String?) -> UIImage? {
-        if let svg = svg {
-            let svgData = svg.data(using: .utf8)
-            return SDImageSVGKCoder.shared.decodedImage(with: svgData, options: [:])
-        }
-        return nil
+        guard let svg else { return nil }
+
+        let svgData = svg.data(using: .utf8)
+        let image = SDImageSVGKCoder.shared.decodedImage(with: svgData, options: [:])
+        return image
     }
 
     // MARK: - actions
-    @objc private func showMoreOptions() {
+
+    // Only relevant for GroupChatDetails, for QR-Code-Tab, this gets handled by QrPageController
+    @objc private func showMoreOptions(_ sender: Any) {
         let alert = UIAlertController(title: String.localized("qrshow_title"), message: nil, preferredStyle: .safeActionSheet)
         alert.addAction(UIAlertAction(title: String.localized("menu_share"), style: .default, handler: share(_:)))
         alert.addAction(UIAlertAction(title: String.localized("menu_copy_to_clipboard"), style: .default, handler: copyToClipboard(_:)))

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -112,4 +112,10 @@ struct Utils {
         activityVC.popoverPresentationController?.sourceView = sourceView // iPad crashes without a source
         parentViewController.present(activityVC, animated: true, completion: nil)
     }
+
+    public static func share(url: URL, parentViewController: UIViewController, sourceView: UIView) {
+        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        activityVC.popoverPresentationController?.sourceView = sourceView // iPad crashes without a source
+        parentViewController.present(activityVC, animated: true, completion: nil)
+    }
 }


### PR DESCRIPTION
Adds a button to share the link hidden in the QR-code for both the QR-tab and also for Group-Details. Also: Some refactorings.

<details>
<summary>Screenshot</summary>
Looks like this in portrait (Have fun chatting with me):

![Simulator Screenshot - iPhone 15 Pro - 2024-09-04 at 15 11 56](https://github.com/user-attachments/assets/dceb036a-b7f8-462e-9f7d-b267aa56cd9a)

In landscape, it's centered horizontally, but the QR-code is scrollable.
</details>

Closes #2276.