### PR TITLE
Send stickers as reply (#2285)

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1725,8 +1725,16 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         DispatchQueue.global().async { [weak self] in
             guard let self else { return }
             if let path = ImageFormat.saveImage(image: image, directory: .cachesDirectory) {
-                self.sendAttachmentMessage(viewType: DC_MSG_STICKER, filePath: path, message: nil)
+                if self.draft.draftMsg != nil {
+                    draft.setAttachment(viewType: DC_MSG_STICKER, path: path)
+                }
+                self.sendAttachmentMessage(viewType: DC_MSG_STICKER, filePath: path, message: nil, quoteMessage: self.draft.quoteMessage)
+
                 FileHelper.deleteFile(atPath: path)
+                self.draft.clear()
+                DispatchQueue.main.async {
+                    self.draftArea.quotePreview.cancel()
+                }
             }
         }
     }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1743,9 +1743,8 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         let msg = draft.draftMsg ?? dcContext.newMessage(viewType: viewType)
         msg.setFile(filepath: filePath)
         msg.text = (message ?? "").isEmpty ? nil : message
-        if quoteMessage != nil {
-            msg.quoteMessage = quoteMessage
-        }
+        msg.quoteMessage = quoteMessage
+
         dcContext.sendMessage(chatId: self.chatId, message: msg)
     }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1723,18 +1723,17 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func sendSticker(_ image: UIImage) {
         DispatchQueue.global().async { [weak self] in
-            guard let self else { return }
-            if let path = ImageFormat.saveImage(image: image, directory: .cachesDirectory) {
-                if self.draft.draftMsg != nil {
-                    draft.setAttachment(viewType: DC_MSG_STICKER, path: path)
-                }
-                self.sendAttachmentMessage(viewType: DC_MSG_STICKER, filePath: path, message: nil, quoteMessage: self.draft.quoteMessage)
+            guard let self, let path = ImageFormat.saveImage(image: image, directory: .cachesDirectory) else { return }
+            
+            if self.draft.draftMsg != nil {
+                self.draft.setAttachment(viewType: DC_MSG_STICKER, path: path)
+            }
+            self.sendAttachmentMessage(viewType: DC_MSG_STICKER, filePath: path, message: nil, quoteMessage: self.draft.quoteMessage)
 
-                FileHelper.deleteFile(atPath: path)
-                self.draft.clear()
-                DispatchQueue.main.async {
-                    self.draftArea.quotePreview.cancel()
-                }
+            FileHelper.deleteFile(atPath: path)
+            self.draft.clear()
+            DispatchQueue.main.async {
+                self.draftArea.quotePreview.cancel()
             }
         }
     }

--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -53,7 +53,7 @@ class ImageTextCell: BaseMessageCell {
         showBottomLabelBackground = !msg.hasHtml && hasEmptyText
         mainContentView.spacing = msg.text?.isEmpty ?? false ? 0 : 6
         topCompactView = msg.quoteText == nil ? true : false
-        isTransparent = msg.type == DC_MSG_STICKER
+        isTransparent = (msg.type == DC_MSG_STICKER && msg.quoteMessage == nil)
         topLabel.isHidden = msg.type == DC_MSG_STICKER
         contentImageIsPlaceholder = true
         tag = msg.id


### PR DESCRIPTION
Stickers didn't work correctly with drafts (when you reply, that's already a draft). Now it does.

Please enjoy some cats on this screenshot. I can find reasons to show the background color for reply-stickers — and against. For now I decided to just show them, we still can change that. At least the bug is fixed.

> replying with a sticker more times results in completely emtpy messages. this should not exist as well.

was just follow-up-issues.

<details>
<summary>Screenshot (with cats!)</summary>
![IMG_4608](https://github.com/user-attachments/assets/f9114dcb-32b1-43d3-af78-f8936154fa5e)
</details>

Closes #2285. 