### PR TITLE
Show number of unread messages in back-button (#2280)

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -105,6 +105,7 @@ public class DcEventHandler {
             
             NotificationCenter.default.post(name: Event.messagesNoticed, object: nil, userInfo: [
                 "chat_id": Int(data1),
+                "account_id": accountId
             ])
 
         case DC_EVENT_CHAT_MODIFIED:
@@ -129,7 +130,11 @@ public class DcEventHandler {
 
         case DC_EVENT_INCOMING_MSG:
             
-            NotificationCenter.default.post(name: Event.incomingMessageOnAnyAccount, object: nil)
+            NotificationCenter.default.post(name: Event.incomingMessageOnAnyAccount, object: nil, userInfo: [
+                "chat_id": Int(data1),
+                "account_id": accountId
+            ])
+            
             if accountId != dcAccounts.getSelected().id {
                 return
             }
@@ -138,6 +143,7 @@ public class DcEventHandler {
             NotificationCenter.default.post(name: Event.incomingMessage, object: nil, userInfo: [
                 "message_id": Int(data2),
                 "chat_id": Int(data1),
+                "account_id": accountId
             ])
 
         case DC_EVENT_CONTACTS_CHANGED:

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2780,3 +2780,15 @@ extension ChatViewController: ReactionsOverviewViewControllerDelegate {
         navigationController?.pushViewController(contactDetailController, animated: true)
     }
 }
+
+// MARK: - ChatListViewControllerDataSource
+
+extension ChatViewController: BackButtonUpdateable {
+    func shouldUpdateBackButton(_ viewController: UIViewController, chatId: Int, accountId: Int) -> Bool {
+        if chatId == self.chatId && accountId == dcContext.id {
+            return false
+        } else {
+            return true
+        }
+    }
+}

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -265,7 +265,6 @@ class ChatListViewController: UITableViewController {
                 return
             }
 
-            // we need chatId and everything
             let symbolName: String
             if numberOfUnreadMessages > 50 {
                 symbolName = "circle.fill"
@@ -868,7 +867,7 @@ class ChatListViewController: UITableViewController {
         }
         let chatViewController = ChatViewController(dcContext: dcContext, chatId: chatId, highlightedMsg: highlightedMsg)
         backButtonUpdateableDataSource = chatViewController
-        updateNextScreensBackButton()
+        updateNextScreensBackButton(accountId: dcContext.id, chatId: chatId)
 
         navigationController?.pushViewController(chatViewController, animated: animated)
     }

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -245,6 +245,7 @@ class ChatListViewController: UITableViewController {
         let numberOfUnreadMessages = DcAccounts.shared.getFreshMessageCount()
 
         if isArchive {
+            navigationItem.backBarButtonItem = nil
             navigationItem.backButtonTitle = String.localized("chat_archived_label")
         } else if numberOfUnreadMessages > 0, #available(iOS 13, *) {
             let symbolName: String
@@ -256,6 +257,7 @@ class ChatListViewController: UITableViewController {
 
             navigationItem.backBarButtonItem = UIBarButtonItem(image: UIImage(systemName: symbolName), style: .plain, target: nil, action: nil)
         } else { // if numberOfUnreadMessages == 0 or iOS 12
+            navigationItem.backBarButtonItem = nil
             navigationItem.backButtonTitle = String.localized("pref_chats")
         }
     }

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -534,8 +534,9 @@ class ContactDetailViewController: UITableViewController {
 
     // MARK: - coordinator
     private func showChat(chatId: Int) {
-        if let chatlistViewController = navigationController?.viewControllers[0] {
+        if let chatlistViewController = navigationController?.viewControllers[0] as? ChatListViewController {
             let chatViewController = ChatViewController(dcContext: viewModel.context, chatId: chatId)
+            chatlistViewController.backButtonUpdateableDataSource = chatViewController
             navigationController?.setViewControllers([chatlistViewController, chatViewController], animated: true)
         }
     }

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -318,9 +318,11 @@ class NewChatViewController: UITableViewController {
     }
 
     private func showChat(chatId: Int) {
-        let chatViewController = ChatViewController(dcContext: dcContext, chatId: chatId)
-        navigationController?.pushViewController(chatViewController, animated: true)
-        navigationController?.viewControllers.remove(at: 1)
+        if let chatlistViewController = navigationController?.viewControllers[0] as? ChatListViewController {
+            let chatViewController = ChatViewController(dcContext: dcContext, chatId: chatId)
+            chatlistViewController.backButtonUpdateableDataSource = chatViewController
+            navigationController?.setViewControllers([chatlistViewController, chatViewController], animated: true)
+        }
     }
 
     private func showContactDetail(contactId: Int) {

--- a/deltachat-ios/Controller/NewContactController.swift
+++ b/deltachat-ios/Controller/NewContactController.swift
@@ -119,8 +119,9 @@ class NewContactController: UITableViewController {
 
     // MARK: - coordinator
     private func showChat(chatId: Int) {
-        if let chatlistViewController = navigationController?.viewControllers[0] {
+        if let chatlistViewController = navigationController?.viewControllers[0] as? ChatListViewController {
             let chatViewController = ChatViewController(dcContext: dcContext, chatId: chatId)
+            chatlistViewController.backButtonUpdateableDataSource = chatViewController
             navigationController?.setViewControllers([chatlistViewController, chatViewController], animated: true)
         }
     }

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -305,8 +305,9 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
 
     // MARK: - coordinator
     private func showGroupChat(chatId: Int) {
-        if let chatlistViewController = navigationController?.viewControllers[0] {
+        if let chatlistViewController = navigationController?.viewControllers[0] as? ChatListViewController {
             let chatViewController = ChatViewController(dcContext: dcContext, chatId: chatId)
+            chatlistViewController.backButtonUpdateableDataSource = chatViewController
             navigationController?.setViewControllers([chatlistViewController, chatViewController], animated: true)
         }
     }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -121,9 +121,10 @@ class AppCoordinator: NSObject {
            let chatListViewController = rootController.viewControllers.first as? ChatListViewController {
             if let msgId = msgId, openHighlightedMsg {
                 let dcContext = dcAccounts.getSelected()
-                let chatVC = ChatViewController(dcContext: dcContext, chatId: chatId, highlightedMsg: msgId)
+                let chatViewController = ChatViewController(dcContext: dcContext, chatId: chatId, highlightedMsg: msgId)
+                chatListViewController.backButtonUpdateableDataSource = chatViewController
                 let webxdcVC = WebxdcViewController(dcContext: dcContext, messageId: msgId)
-                let controllers: [UIViewController] = [chatListViewController, chatVC, webxdcVC]
+                let controllers: [UIViewController] = [chatListViewController, chatViewController, webxdcVC]
                 rootController.setViewControllers(controllers, animated: animated)
             } else {
                 if clearViewControllerStack {


### PR DESCRIPTION
- These changes are iOS 13+ only.
- Adds an indicator with the number of unread messages to the back-button in chat if there are unread messages.

![Simulator Screenshot - iPhone 16 Pro - 2024-09-23 at 12 24 58](https://github.com/user-attachments/assets/a1335281-3558-4d5b-9505-7e0bbca68a48)

- If you have more than 50 unread messages, you'll just see a dot.
- ~~Also: Fix build Xcode 18~~