### PR TITLE
Send stickers on iOS 18

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2747,7 +2747,10 @@ extension ChatViewController: UITextViewDelegate {
 // MARK: - ChatInputTextViewPasteDelegate
 extension ChatViewController: ChatInputTextViewPasteDelegate {
     func onImagePasted(image: UIImage) {
-        let isSticker = image.size.equalTo(CGSize(width: 140, height: 140))
+
+        let preiOS18StickerSize = CGSize(width: 140, height: 140)
+        let iOS18StickerSize = CGSize(width: 160, height: 160)
+        let isSticker = image.size.equalTo(preiOS18StickerSize) || image.size.equalTo(iOS18StickerSize)
 
         if isSticker {
             sendSticker(image)

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -151,7 +151,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
                               AVNumberOfChannelsKey: 1] as [String: Any]
         let globallyUniqueString = ProcessInfo.processInfo.globallyUniqueString
         recordingFilePath = NSTemporaryDirectory().appending(globallyUniqueString).appending(".m4a")
-        _ = try? audioRecorder = AVAudioRecorder.init(url: URL(fileURLWithPath: recordingFilePath), settings: recordSettings)
+        audioRecorder = try? AVAudioRecorder.init(url: URL(fileURLWithPath: recordingFilePath), settings: recordSettings)
         audioRecorder?.delegate = self
         audioRecorder?.isMeteringEnabled = true
     }


### PR DESCRIPTION
This is more of a hotfix as the sticker-size changes (it seems). We should come up with a more sustainable fix. On another note: We should check UI on iPadOS 18.

Closes #2304.