### PR TITLE
add 'learn more' button for managing keys

### DIFF
--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -398,7 +398,8 @@ internal final class AdvancedViewController: UITableViewController {
             self.present(alert, animated: true, completion: nil)
         }))
 
-        alert.addAction(UIAlertAction(title: String.localized("learn_more"), style: .default, handler: { _ in
+        alert.addAction(UIAlertAction(title: String.localized("learn_more"), style: .default, handler: { [weak self] _ in
+            guard let self else { return }
             self.navigationController?.pushViewController(HelpViewController(dcContext: self.dcContext, fragment: "#importkey"), animated: true)
         }))
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -398,6 +398,10 @@ internal final class AdvancedViewController: UITableViewController {
             self.present(alert, animated: true, completion: nil)
         }))
 
+        alert.addAction(UIAlertAction(title: String.localized("learn_more"), style: .default, handler: { _ in
+            self.navigationController?.pushViewController(HelpViewController(dcContext: self.dcContext, fragment: "#importkey"), animated: true)
+        }))
+
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         present(alert, animated: true, completion: nil)
     }


### PR DESCRIPTION
this PR makes the help - that describes key format, supported keys etc. - accessible directly from the "manage keys" section.

before, these information were harder to find.

<img width="300" alt="Screenshot 2024-10-02 at 19 44 52" src="https://github.com/user-attachments/assets/47c29640-c4a0-44e9-bb3a-1a1717a63e14">

the learn more buttons links to https://delta.chat/en/help#can-i-reuse-my-existing-private-key in the offline help (which is shipped with the app, no internet required)

came over this by the desktop issue  https://github.com/deltachat/deltachat-desktop/issues/4155 ,  counterpart of https://github.com/deltachat/deltachat-android/pull/3328