### PR TITLE
 do not expect special value for backup transfer progress

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -216,13 +216,9 @@ class WelcomeViewController: UIViewController {
         } else {
             guard let permille = ui["progress"] as? Int else { return }
             var statusLineText = ""
-            if permille <= 100 {
-                statusLineText = String.localized("preparing_account")
-            } else if permille <= 950 {
-                let percent = ((permille-100)*100)/850
+            if permille < 1000 {
+                let percent: Int = permille/10
                 statusLineText = String.localized("transferring") + " \(percent)%"
-            } else {
-                statusLineText = "Finishing..." // range not used, should not happen
             }
             progressAlertHandler.updateProgressAlert(message: statusLineText)
         }

--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -178,16 +178,9 @@ class BackupTransferViewController: UIViewController {
                     self.showLastErrorAlert("Error")
                 }
                 hideQrCode = true
-            } else if permille <= 350 {
-                statusLineText = nil
-            } else if permille <= 400 {
-                statusLineText = nil
-            } else if permille <= 450 {
-                statusLineText = String.localized("receiver_connected")
-                hideQrCode = true
             } else if permille < 1000 {
-                let percent = (permille-450)/5
-                statusLineText = String.localized("transferring") + " \(percent)%" // TODO: use a scrollbar, show precide percentage only for receiver
+                let percent: Int = permille/10
+                statusLineText = String.localized("transferring") + " \(percent)%"
                 hideQrCode = true
             } else if permille == 1000 {
                 self.transferState = TranferState.success


### PR DESCRIPTION
'backup' and 'add second device' do not longer have special values but use the whole range smoothly

counterpart of https://github.com/deltachat/deltachat-android/pull/3333

