### PR TITLE
ScrollView jumping improvements

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		30FDB70524D1C1000066C48D /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FDB6F824D1C1000066C48D /* ChatViewController.swift */; };
 		30FDB71F24D8170E0066C48D /* TextMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FDB71E24D8170E0066C48D /* TextMessageCell.swift */; };
 		30FDB72124D838240066C48D /* BaseMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FDB72024D838240066C48D /* BaseMessageCell.swift */; };
+		5F785F6E2CB9344F003FFFB9 /* ReusableCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */; };
 		7070FB9B2101ECBB000DC258 /* NewGroupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7070FB9A2101ECBB000DC258 /* NewGroupController.swift */; };
 		7092474120B3869500AF8799 /* ContactDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7092474020B3869500AF8799 /* ContactDetailViewController.swift */; };
 		70B8882E2091B8550074812E /* ContactCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B8882D2091B8550074812E /* ContactCell.swift */; };
@@ -432,6 +433,7 @@
 		30FDB6F824D1C1000066C48D /* ChatViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
 		30FDB71E24D8170E0066C48D /* TextMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextMessageCell.swift; sourceTree = "<group>"; };
 		30FDB72024D838240066C48D /* BaseMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseMessageCell.swift; sourceTree = "<group>"; };
+		5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableCellProtocol.swift; sourceTree = "<group>"; };
 		7070FB9A2101ECBB000DC258 /* NewGroupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGroupController.swift; sourceTree = "<group>"; };
 		7092474020B3869500AF8799 /* ContactDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDetailViewController.swift; sourceTree = "<group>"; };
 		70B8882D2091B8550074812E /* ContactCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCell.swift; sourceTree = "<group>"; };
@@ -827,6 +829,7 @@
 			isa = PBXGroup;
 			children = (
 				30FDB71E24D8170E0066C48D /* TextMessageCell.swift */,
+				5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */,
 				30FDB72024D838240066C48D /* BaseMessageCell.swift */,
 				30E348E024F53772005C93D1 /* ImageTextCell.swift */,
 				30E348E424F6647D005C93D1 /* FileTextCell.swift */,
@@ -1633,6 +1636,7 @@
 				30E83EFD289BF32C0035614C /* ShortcutManager.swift in Sources */,
 				305501742798CDE1008FD5CA /* WebxdcViewController.swift in Sources */,
 				3034929F25752FC800A523D0 /* MediaPreview.swift in Sources */,
+				5F785F6E2CB9344F003FFFB9 /* ReusableCellProtocol.swift in Sources */,
 				AE76E5EE242BF2EA003CF461 /* WelcomeViewController.swift in Sources */,
 				3052C60A253F082E007D13EA /* MessageLabelDelegate.swift in Sources */,
 				AE0AA9562478191900D42A7F /* GridCollectionViewFlowLayout.swift in Sources */,

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -266,11 +266,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         keyboardManager?.on(event: .willHide) { [weak self] notification in
             guard let self, !self.messageIds.isEmpty else { return }
             UIView.animate(withDuration: notification.timeInterval, delay: 0, options: notification.animationOptions) {
-                let bottomInset = self.inputAccessoryView?.frame.height ?? 0
-                // TODO: This can float messages to the top when they don't fill the screen but needs a bit more work because other parts of this file expect tableView.contentInset.top to be the keyboard inset, also the willset is called after this sometimes which undoes this
-//                let visibleHeight = self.tableView.bounds.height - self.tableView.safeAreaInsets.top - bottomInset
-//                let visiblePadding = max(0, visibleHeight - self.tableView.contentSize.height)
-                self.tableView.contentInset.top = bottomInset // + visiblePadding
+                self.tableView.contentInset.top = self.inputAccessoryView?.frame.height ?? 0
             }
         }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1006,7 +1006,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func scrollToLastUnseenMessage(animated: Bool) {
         if let markerMessageIndex = self.messageIds.firstIndex(of: Int(DC_MSG_ID_MARKER1)) {
-            // TODO: Test if this works now
             let indexPath = IndexPath(row: markerMessageIndex, section: 0)
             self.scrollToRow(at: indexPath, animated: animated)
         } else {
@@ -2469,8 +2468,7 @@ extension ChatViewController: InputBarAccessoryViewDelegate {
         }
         inputBar.inputTextView.text = String()
         inputBar.inputTextView.attributedText = nil
-        draft.clear() // TODO: Fix
-        // FIXME: This lags the scrollview
+        draft.clear()
         draftArea.cancel()
     }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -247,7 +247,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         // Binding to the tableView will enable interactive dismissal
         keyboardManager?.bind(to: tableView)
         keyboardManager?.on(event: .willShow) { [weak self] notification in
-            guard let self else { return }
+            guard let self, !self.messageIds.isEmpty else { return }
             let globalTableViewFrame = self.tableView.convert(tableView.bounds, to: tableView.window)
             let intersection = globalTableViewFrame.intersection(notification.endFrame)
             let inset = intersection.height
@@ -264,13 +264,13 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             }
         }
         keyboardManager?.on(event: .willHide) { [weak self] notification in
+            guard let self, !self.messageIds.isEmpty else { return }
             UIView.animate(withDuration: notification.timeInterval, delay: 0, options: notification.animationOptions) {
-                guard let self else { return }
                 let bottomInset = self.inputAccessoryView?.frame.height ?? 0
                 // TODO: This can float messages to the top when they don't fill the screen but needs a bit more work because other parts of this file expect tableView.contentInset.top to be the keyboard inset, also the willset is called after this sometimes which undoes this
 //                let visibleHeight = self.tableView.bounds.height - self.tableView.safeAreaInsets.top - bottomInset
 //                let visiblePadding = max(0, visibleHeight - self.tableView.contentSize.height)
-                self.tableView.contentInset.top = bottomInset //+ visiblePadding
+                self.tableView.contentInset.top = bottomInset // + visiblePadding
             }
         }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1521,8 +1521,8 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 sheet.preferredCornerRadius = 20
             }
         }
-        let source = self.navigationController ?? self
-        source.present(navigationController, animated: true)
+
+        present(navigationController, animated: true)
     }
 
     private func locationStreamingButtonPressed(_ action: UIAlertAction) {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -187,7 +187,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     private var emptyStateView: EmptyStateLabel = {
         let view =  EmptyStateLabel()
         view.isHidden = true
-        view.transform = CGAffineTransform(scaleX: 1, y: -1)
         return view
     }()
 
@@ -247,7 +246,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         // Binding to the tableView will enable interactive dismissal
         keyboardManager?.bind(to: tableView)
         keyboardManager?.on(event: .willShow) { [weak self] notification in
-            guard let self, !self.messageIds.isEmpty else { return }
+            guard let self else { return }
             let globalTableViewFrame = self.tableView.convert(tableView.bounds, to: tableView.window)
             let intersection = globalTableViewFrame.intersection(notification.endFrame)
             let inset = intersection.height
@@ -264,7 +263,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             }
         }
         keyboardManager?.on(event: .willHide) { [weak self] notification in
-            guard let self, !self.messageIds.isEmpty else { return }
+            guard let self else { return }
             UIView.animate(withDuration: notification.timeInterval, delay: 0, options: notification.animationOptions) {
                 self.tableView.contentInset.top = self.inputAccessoryView?.frame.height ?? 0
             }
@@ -302,7 +301,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }
 
     private func configureEmptyStateView() {
-        emptyStateView.addCenteredTo(parentView: view)
+        emptyStateView.addCenteredTo(parentView: backgroundContainer, evadeKeyboard: true)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1250,7 +1250,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in self.shouldBecomeFirstResponder = true }))
 
         shouldBecomeFirstResponder = false
-//        messageInputBar.inputTextView.resignFirstResponder()
 
         self.present(alert, animated: true, completion: {
             // unfortunately, voiceMessageAction.accessibilityHint does not work,

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -352,8 +352,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
         messageInputBar.scrollDownButton.isHidden = true
 
-        // being pushed
-        if isMovingToParent {
+        if isMovingToParent { // being pushed
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 self.tableView.contentInset.top = self.inputAccessoryView?.bounds.height ?? 0
                 if let msgId = self.highlightedMsg, self.messageIds.firstIndex(of: msgId) != nil {

--- a/deltachat-ios/Chat/InputBarAccessoryView/Extensions/NSNotification+Extensions.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/Extensions/NSNotification+Extensions.swift
@@ -49,8 +49,7 @@ internal extension NSNotification {
     }
     
     var timeInterval: TimeInterval? {
-        guard let value = userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber else { return nil }
-        return TimeInterval(truncating: value)
+        userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
     }
     
     var animationCurve: UIView.AnimationCurve? {
@@ -60,19 +59,8 @@ internal extension NSNotification {
     }
     
     var animationOptions: UIView.AnimationOptions {
-        guard let curve = animationCurve else { return [] }
-        switch curve {
-        case .easeIn:
-            return .curveEaseIn
-        case .easeOut:
-            return .curveEaseOut
-        case .easeInOut:
-            return .curveEaseInOut
-        case .linear:
-            return .curveLinear
-        @unknown default:
-            return .curveLinear
-        }
+        guard let animationCurve = userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt else { return .curveLinear }
+        return UIView.AnimationOptions(rawValue: animationCurve << 16)
     }
     
     var startFrame: CGRect? {

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarAccessoryView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarAccessoryView.swift
@@ -738,6 +738,7 @@ open class InputBarAccessoryView: UIView {
     ///   - view: New view
     ///   - animated: If the layout should be animated
     open func setMiddleContentView(_ view: UIView?, animated: Bool) {
+        guard view !== middleContentView else { return }
         middleContentView?.removeFromSuperview()
         middleContentView = view
         guard let view = view else { return }
@@ -832,7 +833,8 @@ open class InputBarAccessoryView: UIView {
     ///   - newValue: New widthAnchor constant
     ///   - animated: If the layout should be animated
     open func setLeftStackViewWidthConstant(to newValue: CGFloat, animated: Bool) {
-        performLayout(animated) { 
+        guard leftStackViewWidthConstant != newValue else { return }
+        performLayout(animated) {
             self.leftStackViewWidthConstant = newValue
             self.layoutStackViews([.left])
             self.layoutContainerViewIfNeeded()
@@ -845,7 +847,8 @@ open class InputBarAccessoryView: UIView {
     ///   - newValue: New widthAnchor constant
     ///   - animated: If the layout should be animated
     open func setRightStackViewWidthConstant(to newValue: CGFloat, animated: Bool) {
-        performLayout(animated) { 
+        guard rightStackViewWidthConstant != newValue else { return }
+        performLayout(animated) {
             self.rightStackViewWidthConstant = newValue
             self.layoutStackViews([.right])
             self.layoutContainerViewIfNeeded()
@@ -858,6 +861,7 @@ open class InputBarAccessoryView: UIView {
     ///   - newValue: New boolean value
     ///   - animated: If the layout should be animated
     open func setShouldForceMaxTextViewHeight(to newValue: Bool, animated: Bool) {
+        guard shouldForceTextViewMaxHeight != newValue else { return }
         performLayout(animated) {
             self.shouldForceTextViewMaxHeight = newValue
             self.textViewHeightAnchor?.isActive = newValue

--- a/deltachat-ios/Chat/Views/Cells/AudioMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/AudioMessageCell.swift
@@ -9,7 +9,7 @@ public protocol AudioMessageCellDelegate: AnyObject {
 
 }
 
-public class AudioMessageCell: BaseMessageCell {
+public class AudioMessageCell: BaseMessageCell, ReusableCell {
 
     static let reuseIdentifier = "AudioMessageCell"
 

--- a/deltachat-ios/Chat/Views/Cells/ContactCardCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ContactCardCell.swift
@@ -3,7 +3,7 @@ import UIKit
 import DcCore
 import SDWebImage
 
-public class ContactCardCell: BaseMessageCell {
+public class ContactCardCell: BaseMessageCell, ReusableCell {
 
     static let reuseIdentifier = "ContactCardCell"
 

--- a/deltachat-ios/Chat/Views/Cells/FileTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/FileTextCell.swift
@@ -3,7 +3,7 @@ import UIKit
 import DcCore
 import SDWebImage
 
-public class FileTextCell: BaseMessageCell {
+public class FileTextCell: BaseMessageCell, ReusableCell {
 
     class var reuseIdentifier: String { "FileTextCell" }
 

--- a/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/ImageTextCell.swift
@@ -3,7 +3,7 @@ import UIKit
 import DcCore
 import SDWebImage
 
-class ImageTextCell: BaseMessageCell {
+class ImageTextCell: BaseMessageCell, ReusableCell {
 
     static let reuseIdentifier = "ImageTextCell"
 

--- a/deltachat-ios/Chat/Views/Cells/InfoMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/InfoMessageCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 import DcCore
 
-class InfoMessageCell: UITableViewCell {
+class InfoMessageCell: UITableViewCell, ReusableCell {
 
     static let reuseIdentifier = "InfoMessageCell"
 

--- a/deltachat-ios/Chat/Views/Cells/ReusableCellProtocol.swift
+++ b/deltachat-ios/Chat/Views/Cells/ReusableCellProtocol.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+protocol ReusableCell: UITableViewCell {
+    static var reuseIdentifier: String { get }
+}

--- a/deltachat-ios/Chat/Views/Cells/TextMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/TextMessageCell.swift
@@ -2,7 +2,7 @@ import Foundation
 import DcCore
 import UIKit
 
-class TextMessageCell: BaseMessageCell {
+class TextMessageCell: BaseMessageCell, ReusableCell {
 
     static let reuseIdentifier = "TextMessageCell"
 

--- a/deltachat-ios/Chat/Views/Cells/VideoInviteCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/VideoInviteCell.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 import DcCore
 
-public class VideoInviteCell: UITableViewCell {
+public class VideoInviteCell: UITableViewCell, ReusableCell {
 
     static let reuseIdentifier = "VideoInviteCell"
 

--- a/deltachat-ios/View/EmptyStateLabel.swift
+++ b/deltachat-ios/View/EmptyStateLabel.swift
@@ -17,12 +17,19 @@ class EmptyStateLabel: PaddingTextView {
         translatesAutoresizingMaskIntoConstraints = false
     }
 
-    func addCenteredTo(parentView: UIView) {
+    func addCenteredTo(parentView: UIView, evadeKeyboard: Bool = false) {
         parentView.addSubview(self)
         leadingAnchor.constraint(equalTo: parentView.leadingAnchor, constant: 40).isActive = true
         trailingAnchor.constraint(equalTo: parentView.trailingAnchor, constant: -40).isActive = true
-        centerYAnchor.constraint(equalTo: parentView.safeAreaLayoutGuide.centerYAnchor).isActive = true
-        centerXAnchor.constraint(equalTo: parentView.safeAreaLayoutGuide.centerXAnchor).isActive = true
+        let safeArea = parentView.safeAreaLayoutGuide
+        centerXAnchor.constraint(equalTo: safeArea.centerXAnchor).isActive = true
+        let centerYConstraint = centerYAnchor.constraint(equalTo: safeArea.centerYAnchor)
+        centerYConstraint.isActive = true
+        if #available(iOS 15.0, *), evadeKeyboard {
+            centerYConstraint.priority = .defaultHigh
+            bottomAnchor.constraint(lessThanOrEqualTo: parentView.keyboardLayoutGuide.topAnchor, constant: -40).isActive = true
+        }
+
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
In this PR I flipped the scrollView so now new messages automatically cause the rest of the messages to move up so we no longer need to programmatically scroll down when messages are sent and/or received.

### Fixes:
- #2232
- #2307 - since the scrollview in this PR starts with the newest message at the top (virtual top, actual bottom, because the tableView is flipped) this issue will never occur because even if the vc doesn't scroll anywhere, it will be showing your latest messages.
- Probably: #2305
- #2311
- When sending a long message, the chat doesn't scroll down to bottom of last message.
- #2233
- Maybe: #2161

### Intended changes:
- Less twitching when receiving/sending messages
- Smooth scrolling when searching
- No longer show inputAccessoryView when presenting other views (without having to resign firstResponder)

### Side effects:
**Messages are not refreshed until user stops editing** 
This is because we rely on selectedIndexPaths to keep which messages are selected, which can get out of sync with the actual message list when new messages are received or when they are automatically deleted. This was already the case before with deleted messages (eg through auto deletion) but is now also the case for new messages because messages are now pushed at the beginning of the indexPaths instead of at the end (because tableView is flipped).

This can be mitigated by tracking selected messages instead of relying on selectedIndexPaths.

**Messages don't float to the top when you have only few messages**
Since tableView now starts at the bottom, when you only have like 2 messages they are at the bottom instead of at the top.

This can totally be mitigated with a bit more effort.

**Empty state view is a bit higher up**
I think this is due to safeArea change to tableView but it is not a bad change because now it is still visible when keyboard is up (on iPhone SE anyway)


### Notes:

- I feel like it would be better if we did not use inputAccessoryViews that switch between keyboard and view controller attachment but instead just a normal view which we animate to always stay above the keyboard. This would eliminate the need for much of the first responder juggling we do right now and also eliminate the edge case where the input view is hidden when you don't expect it.

- Would be really nice to have tests that can confirm if the keyboard comes back after actions when expected.