### PR TITLE
Fix background notifications

### DIFF
--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -98,7 +98,7 @@ public class NotificationManager {
             if let ui = notification.userInfo,
                let chatId = ui["chat_id"] as? Int,
                let messageId = ui["message_id"] as? Int,
-               self.dcContext.isMuted() {
+               !self.dcContext.isMuted() {
 
                 let chat = self.dcContext.getChat(chatId: chatId)
 


### PR DESCRIPTION
broken in #2245

to test:
- close app
- send message to account
- now: receive notification
- previously: only badge number updated