### PR TITLE
clear chat: do not count or delete daymarker

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -938,7 +938,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         guard !tableView.isEditing else {
             return refreshMessagesAfterEditing = true
         }
-        messageIds = dcContext.getChatMsgs(chatId: chatId).reversed()
+        messageIds = dcContext.getChatMsgs(chatId: chatId, flags: DC_GCM_ADDDAYMARKER).reversed()
         reloadData()
         showEmptyStateView(messageIds.isEmpty)
     }
@@ -953,7 +953,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func loadMessages() {
         // update message ids
-        var msgIds = dcContext.getChatMsgs(chatId: chatId)
+        var msgIds = dcContext.getChatMsgs(chatId: chatId, flags: DC_GCM_ADDDAYMARKER)
         let freshMsgsCount = self.dcContext.getUnreadMessages(chatId: self.chatId)
         if freshMsgsCount > 0 && msgIds.count >= freshMsgsCount {
             let index = msgIds.count - freshMsgsCount

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -440,7 +440,7 @@ class ContactDetailViewController: UITableViewController {
     // MARK: alerts
 
     private func showClearChatConfirmationAlert() {
-        let msgIds = viewModel.context.getChatMsgs(chatId: viewModel.chatId)
+        let msgIds = viewModel.context.getChatMsgs(chatId: viewModel.chatId, flags: 0)
         if !msgIds.isEmpty {
             let alert = UIAlertController(
                 title: nil,

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -669,7 +669,7 @@ extension GroupChatDetailViewController {
     }
 
     private func showClearChatConfirmationAlert() {
-        let msgIds = dcContext.getChatMsgs(chatId: chatId)
+        let msgIds = dcContext.getChatMsgs(chatId: chatId, flags: 0)
         if !msgIds.isEmpty {
             let alert = UIAlertController(
                 title: nil,

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -102,9 +102,9 @@ public class DcContext {
         return Int(dc_send_videochat_invitation(contextPointer, UInt32(chatId)))
     }
 
-    public func getChatMsgs(chatId: Int) -> [Int] {
+    public func getChatMsgs(chatId: Int, flags: Int32) -> [Int] {
         let start = CFAbsoluteTimeGetCurrent()
-        let cMessageIds = dc_get_chat_msgs(contextPointer, UInt32(chatId), UInt32(DC_GCM_ADDDAYMARKER), 0)
+        let cMessageIds = dc_get_chat_msgs(contextPointer, UInt32(chatId), UInt32(flags), 0)
         let diff = CFAbsoluteTimeGetCurrent() - start
         logger.info("⏰ getChatMsgs: \(diff) s")
 


### PR DESCRIPTION
this PR fixes the calculation of the number of messages to delete on "clear chat".

unconditionally adding the flag DC_GCM_ADD_DAYMARKER was just wrong.

closes #2324 