### PR TITLE
do "device owner verification" for critical things

### DIFF
--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -315,7 +315,12 @@ internal final class AdvancedViewController: UITableViewController {
 
         case .videoChat: showVideoChatInstance()
         case .viewLog: showLogViewController()
-        case .accountSettings: showAccountSettingsController()
+
+        case .accountSettings:
+            Utils.authenticateDeviceOwner(reason: String.localized("pref_password_and_account_settings")) { [weak self] in
+                self?.showAccountSettingsController()
+            }
+
         case .defaultTagValue: break
         }
     }

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -307,7 +307,12 @@ internal final class AdvancedViewController: UITableViewController {
         switch cellTag {
         case .showEmails: showClassicMailController()
         case .sendAutocryptMessage: sendAutocryptSetupMessage()
-        case .manageKeys: showManageKeysDialog()
+
+        case .manageKeys:
+            Utils.authenticateDeviceOwner(reason: String.localized("pref_manage_keys")) { [weak self] in
+                self?.showManageKeysDialog()
+            }
+
         case .videoChat: showVideoChatInstance()
         case .viewLog: showLogViewController()
         case .accountSettings: showAccountSettingsController()

--- a/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
+++ b/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import DcCore
 import Intents
-import LocalAuthentication
 
 internal final class ChatsAndMediaViewController: UITableViewController {
 
@@ -158,7 +157,10 @@ internal final class ChatsAndMediaViewController: UITableViewController {
         case .mediaQuality: showMediaQuality()
         case .downloadOnDemand: showDownloadOnDemand()
         case .receiptConfirmation: break
-        case .exportBackup: authenticateAndCreateBackup()
+        case .exportBackup:
+            Utils.authenticateDeviceOwner(reason: String.localized("pref_backup_explain")) { [weak self] in
+                self?.createBackup()
+            }
         }
     }
 
@@ -171,27 +173,6 @@ internal final class ChatsAndMediaViewController: UITableViewController {
     }
 
     // MARK: - actions
-
-    private func authenticateAndCreateBackup() {
-        let localAuthenticationContext = LAContext()
-        var error: NSError?
-        if localAuthenticationContext.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-            let reason = String.localized("pref_backup_explain")
-            localAuthenticationContext.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { [weak self] success, error in
-                DispatchQueue.main.async {
-                    guard let self = self else { return }
-                    if success {
-                        self.createBackup()
-                    } else {
-                        logger.info("local authentication aborted: \(String(describing: error))")
-                    }
-                }
-            }
-        } else {
-            logger.info("local authentication unavailable: \(String(describing: error))")
-            createBackup()
-        }
-    }
 
     private func createBackup() {
         let alert = UIAlertController(title: String.localized("pref_backup_export_explain"), message: nil, preferredStyle: .safeActionSheet)

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import DcCore
 import Intents
-import LocalAuthentication
 
 internal final class SettingsViewController: UITableViewController {
 
@@ -288,23 +287,8 @@ internal final class SettingsViewController: UITableViewController {
             title: String.localized("perm_continue"),
             style: .default,
             handler: { [weak self] _ in
-                guard let self else { return }
-                let localAuthenticationContext = LAContext()
-                var error: NSError?
-                if localAuthenticationContext.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-                    let reason = String.localized("multidevice_this_creates_a_qr_code")
-                    localAuthenticationContext.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { [weak self] success, error in
-                        DispatchQueue.main.async {
-                            guard let self = self else { return }
-                            if success {
-                                self.navigationController?.pushViewController(BackupTransferViewController(dcAccounts: self.dcAccounts), animated: true)
-                            } else {
-                                logger.info("local authentication aborted: \(String(describing: error))")
-                            }
-                        }
-                    }
-                } else {
-                    logger.info("local authentication unavailable: \(String(describing: error))")
+                Utils.authenticateDeviceOwner(reason: String.localized("multidevice_this_creates_a_qr_code")) { [weak self] in
+                    guard let self else { return }
                     self.navigationController?.pushViewController(BackupTransferViewController(dcAccounts: self.dcAccounts), animated: true)
                 }
             }

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 import DcCore
-
+import LocalAuthentication
 
 extension URL {
     var isDeltaChatInvitation: Bool {
@@ -128,5 +128,24 @@ struct Utils {
         let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         activityVC.popoverPresentationController?.sourceView = sourceView // iPad crashes without a source
         parentViewController.present(activityVC, animated: true, completion: nil)
+    }
+
+    public static func authenticateDeviceOwner(reason: String, callback: @escaping () -> Void) {
+        let localAuthenticationContext = LAContext()
+        var error: NSError?
+        if localAuthenticationContext.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+            localAuthenticationContext.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, error in
+                DispatchQueue.main.async {
+                    if success {
+                        callback()
+                    } else {
+                        logger.info("local authentication aborted: \(String(describing: error))")
+                    }
+                }
+            }
+        } else {
+            logger.info("local authentication unavailable: \(String(describing: error))")
+            callback()
+        }
     }
 }

--- a/deltachat-ios/Info.plist
+++ b/deltachat-ios/Info.plist
@@ -106,6 +106,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Delta Chat uses Face ID to protect backup creation or settings up a second device.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>


### PR DESCRIPTION
this PR let's the user enter their system secret in case an "critical action" is performed. "critical actions" in this sense are actions that may be used to watch the user's profile in the future. the idea of this PR is to protect against handing the device out shortly to some person; that person should not be able to watch all future messages.

we're not picky about the method the user set for "device owner verification" - if the device is not protected, then it's that.

this is what we're doing on android as well.

this is how it will like when opening the "Password & Account" screen for most users:

https://github.com/user-attachments/assets/fca7cc54-de59-4623-9bde-f642a183b63f

closes #2278