### PR TITLE
notify reactions added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - offer to open http-links detected as proxy also in the browser (#6237)
+- Show notifications for reactions on own messages (#2331)
 
 
 ## v1.48.4

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -7,6 +7,7 @@ public enum Event {
     public static let messageReadDeliveredFailedReaction = Notification.Name(rawValue: "messageReadDeliveredFailedReaction")
     public static let incomingMessage = Notification.Name(rawValue: "incomingMessage")
     public static let incomingMessageOnAnyAccount = Notification.Name(rawValue: "incomingMessageOnAnyAccount")
+    public static let incomingReaction = Notification.Name(rawValue: "incomingReaction")
     public static let messagesNoticed = Notification.Name(rawValue: "messagesNoticed")
 
     // Chats
@@ -143,6 +144,15 @@ public class DcEventHandler {
                 "message_id": Int(data2),
                 "chat_id": Int(data1),
                 "account_id": accountId
+            ])
+
+        case DC_EVENT_INCOMING_REACTION:
+            logger.info("📡[\(accountId)] incoming reaction")
+            NotificationCenter.default.post(name: Event.incomingReaction, object: nil, userInfo: [
+                "account_id": Int(accountId),
+                "contact_id": Int(data1),
+                "msg_id": Int(data2),
+                "reaction": event.data2String
             ])
 
         case DC_EVENT_CONTACTS_CHANGED:

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -61,13 +61,9 @@ class NotificationService: UNNotificationServiceExtension {
                     let msg = dcContext.getMessage(id: event.data2Int)
                     let chat = dcContext.getChat(chatId: msg.chatId)
                     if !chat.isMuted {
-                        let sender = msg.getSenderName(dcContext.getContact(id: msg.fromContactId))
+                        let sender = msg.getSenderName(dcContext.getContact(id: event.data1Int))
                         let summary = (msg.summary(chars: 80) ?? "")
-                        if chat.isGroup {
-                            bestAttemptContent.title = chat.name
-                        } else {
-                            bestAttemptContent.title = sender
-                        }
+                        bestAttemptContent.title = chat.name
                         bestAttemptContent.body = String.localized(stringID: "reaction_by_other", parameter: sender, event.data2String, summary)
                         bestAttemptContent.userInfo["account_id"] = dcContext.id
                         bestAttemptContent.userInfo["chat_id"] = chat.id

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -61,7 +61,7 @@ class NotificationService: UNNotificationServiceExtension {
                     let msg = dcContext.getMessage(id: event.data2Int)
                     let chat = dcContext.getChat(chatId: msg.chatId)
                     if !chat.isMuted {
-                        let sender = msg.getSenderName(dcContext.getContact(id: event.data1Int))
+                        let sender = dcContext.getContact(id: event.data1Int).displayName
                         let summary = (msg.summary(chars: 80) ?? "")
                         bestAttemptContent.title = chat.name
                         bestAttemptContent.body = String.localized(stringID: "reaction_by_other", parameter: sender, event.data2String, summary)


### PR DESCRIPTION
this PR shows notifications for reactions to one's own messages.

requires a core with https://github.com/deltachat/deltachat-core-rust/pull/6072

this is how it looks like on the lock screen:

<img width=350 src=https://github.com/user-attachments/assets/84f13751-451f-4b54-9703-659df2d9c6a6>
<img width=339 src=https://github.com/user-attachments/assets/28ebb7e3-25dd-4e04-9f32-2cf88bd75dc4>

the accumulation is done when we discover multiple messages/reaction when processing a PUSH notification in the "notification service extension", where we can only modify the single, given notification, but not add additional ones (often, this accumulation is not needed, as PUSH notifications receive in time and one-per-one) 
