### PR TITLE
fix multi-account notifications

### DIFF
--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -131,6 +131,7 @@ public class DcEventHandler {
         case DC_EVENT_INCOMING_MSG:
             
             NotificationCenter.default.post(name: Event.incomingMessageOnAnyAccount, object: nil, userInfo: [
+                "message_id": Int(data2),
                 "chat_id": Int(data1),
                 "account_id": accountId
             ])


### PR DESCRIPTION
let NotificationManager handle notifications from any account, not only the selected one.

this fixes showing notifications from non-actice accounts in the first ~30 seconds the app goes to background.

after ~30 seconds, PUSH notifications take over using, they already handle multi-account correctly.

closes #2332