### PR TITLE
add 'select all' and 'mute' to chatlist

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		B29BE2FC2BAB93EC002DBF1F /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 306011B422E5E7FB00C1CE6F /* Localizable.stringsdict */; };
 		B2B730BC2B98B1FB006C5EF9 /* DcCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 304219D1243F588500516852 /* DcCore.framework */; };
 		B2C42570265C325C00B95377 /* MultilineLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C4256F265C325C00B95377 /* MultilineLabelCell.swift */; };
+		B2CDA6322CCDB3080024763F /* MuteDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2CDA6312CCDB3080024763F /* MuteDialog.swift */; };
 		B2D0E4952B93A4B200791949 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D0E4942B93A4B200791949 /* NotificationService.swift */; };
 		B2D0E4992B93A4B200791949 /* DcNotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B2D0E4922B93A4B200791949 /* DcNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B2D255972BEC2C9B00CCD7BC /* InstantOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D255962BEC2C9B00CCD7BC /* InstantOnboardingViewController.swift */; };
@@ -585,6 +586,7 @@
 		B2B9BC1126245F2200F35832 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B2B9BC1226245F2200F35832 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = cs; path = cs.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		B2C4256F265C325C00B95377 /* MultilineLabelCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineLabelCell.swift; sourceTree = "<group>"; };
+		B2CDA6312CCDB3080024763F /* MuteDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuteDialog.swift; sourceTree = "<group>"; };
 		B2D0E4922B93A4B200791949 /* DcNotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DcNotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2D0E4942B93A4B200791949 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		B2D0E4962B93A4B200791949 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1037,6 +1039,7 @@
 				3011E8042787365D00214221 /* KeychainManager.swift */,
 				30E83EFC289BF32C0035614C /* ShortcutManager.swift */,
 				30CE137728D9C40700158DF4 /* ChatDropInteraction.swift */,
+				B2CDA6312CCDB3080024763F /* MuteDialog.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -1659,6 +1662,7 @@
 				3080A00F277DDA4C00E74565 /* InputBarAccessoryView.swift in Sources */,
 				AE1988A523EB2FBA00B4CD5F /* Errors.swift in Sources */,
 				302D5454268B84CB00A8B271 /* VideoChatInstanceViewController.swift in Sources */,
+				B2CDA6322CCDB3080024763F /* MuteDialog.swift in Sources */,
 				3080A014277DDABA00E74565 /* KeyboardManager.swift in Sources */,
 				AEFBE22F23FEF23D0045327A /* ProviderInfoCell.swift in Sources */,
 				AE6EC5242497663200A400E4 /* UIImageView+Extensions.swift in Sources */,

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -936,4 +936,13 @@ extension ChatListViewController: ChatListEditingBarDelegate {
         viewModel?.archiveChatsToggle(indexPaths: tableView.indexPathsForSelectedRows)
         setLongTapEditing(false)
     }
+
+    func onMorePressed() {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
+        alert.addAction(UIAlertAction(title: String.localized("menu_select_all"), style: .default) { [weak self] _ in
+            guard let self else { return }
+        })
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+        present(alert, animated: true, completion: nil)
+    }
 }

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -957,10 +957,17 @@ extension ChatListViewController: ChatListEditingBarDelegate {
         if viewModel?.hasAnyUnmutedChatSelected(in: tableView.indexPathsForSelectedRows) ?? false {
             alert.addAction(UIAlertAction(title: String.localized("menu_mute"), style: .default) { [weak self] _ in
                 guard let self else { return }
+                MuteDialog.show(viewController: self) { [weak self] duration in
+                    guard let self else { return }
+                    viewModel?.setMuteDurations(in: tableView.indexPathsForSelectedRows, duration: duration)
+                    setLongTapEditing(false)
+                }
             })
         } else {
             alert.addAction(UIAlertAction(title: String.localized("menu_unmute"), style: .default) { [weak self] _ in
                 guard let self else { return }
+                viewModel?.setMuteDurations(in: tableView.indexPathsForSelectedRows, duration: 0)
+                setLongTapEditing(false)
             })
         }
         alert.addAction(UIAlertAction(title: String.localized("menu_select_all"), style: .default) { [weak self] _ in

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -954,6 +954,15 @@ extension ChatListViewController: ChatListEditingBarDelegate {
 
     func onMorePressed() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
+        if viewModel?.hasAnyUnmutedChatSelected(in: tableView.indexPathsForSelectedRows) ?? false {
+            alert.addAction(UIAlertAction(title: String.localized("menu_mute"), style: .default) { [weak self] _ in
+                guard let self else { return }
+            })
+        } else {
+            alert.addAction(UIAlertAction(title: String.localized("menu_unmute"), style: .default) { [weak self] _ in
+                guard let self else { return }
+            })
+        }
         alert.addAction(UIAlertAction(title: String.localized("menu_select_all"), style: .default) { [weak self] _ in
             guard let self else { return }
             selectAll()

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -454,13 +454,11 @@ class ChatListViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
-        if tableView.isEditing,
-           let viewModel = viewModel {
-            editingBar.showUnpinning = viewModel.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows)
+        if tableView.isEditing {
             if tableView.indexPathsForSelectedRows == nil {
                 setLongTapEditing(false)
             } else {
-                updateTitle()
+                updateTitleAndEditingBar()
             }
         }
     }
@@ -471,8 +469,7 @@ class ChatListViewController: UITableViewController {
             return
         }
         if tableView.isEditing {
-            editingBar.showUnpinning = viewModel.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows)
-            updateTitle()
+            updateTitleAndEditingBar()
             return
         }
 
@@ -559,13 +556,26 @@ class ChatListViewController: UITableViewController {
         if editing {
             tableView.selectRow(at: initialIndexPath, animated: true, scrollPosition: .none)
             addEditingView()
-            if let viewModel = viewModel {
-                editingBar.showUnpinning = viewModel.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows)
-            }
+            updateTitleAndEditingBar()
         } else {
             removeEditingView()
+            updateTitle()
         }
-        updateTitle()
+    }
+
+    private func selectAll() {
+        if !tableView.isEditing {
+            return
+        }
+
+        for section in 0..<tableView.numberOfSections {
+            let numberOfRows = tableView.numberOfRows(inSection: section)
+            for row in 0..<numberOfRows {
+                tableView.selectRow(at: IndexPath(row: row, section: section), animated: false, scrollPosition: .none)
+            }
+        }
+
+        updateTitleAndEditingBar()
     }
 
     private func addEditingView() {
@@ -636,6 +646,11 @@ class ChatListViewController: UITableViewController {
     }
 
     // MARK: updates
+    private func updateTitleAndEditingBar() {
+        editingBar.showUnpinning = viewModel?.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows)
+        updateTitle()
+    }
+
     private func updateTitle() {
         titleView.accessibilityHint = String.localized("a11y_connectivity_hint")
         if RelayHelper.shared.isForwarding() {
@@ -941,6 +956,7 @@ extension ChatListViewController: ChatListEditingBarDelegate {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
         alert.addAction(UIAlertAction(title: String.localized("menu_select_all"), style: .default) { [weak self] _ in
             guard let self else { return }
+            selectAll()
         })
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         present(alert, animated: true, completion: nil)

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -423,7 +423,12 @@ class ContactDetailViewController: UITableViewController {
             headerCell.setMuted(isMuted: viewModel.chatIsMuted)
             self.navigationController?.popViewController(animated: true)
         } else {
-            showMuteAlert()
+            MuteDialog.show(viewController: self) { [weak self] duration in
+                guard let self else { return }
+                viewModel.context.setChatMuteDuration(chatId: viewModel.chatId, duration: duration)
+                headerCell.setMuted(isMuted: viewModel.chatIsMuted)
+                navigationController?.popViewController(animated: true)
+            }
         }
     }
 
@@ -482,29 +487,6 @@ class ContactDetailViewController: UITableViewController {
     private func showEphemeralMessagesController() {
         let ephemeralMessagesController = EphemeralMessagesViewController(dcContext: viewModel.context, chatId: viewModel.chatId)
         navigationController?.pushViewController(ephemeralMessagesController, animated: true)
-    }
-
-    private func showMuteAlert() {
-        let alert = UIAlertController(title: String.localized("mute"), message: nil, preferredStyle: .safeActionSheet)
-        let forever = -1
-        addDurationSelectionAction(to: alert, key: "mute_for_one_hour", duration: Time.oneHour)
-        addDurationSelectionAction(to: alert, key: "mute_for_two_hours", duration: Time.twoHours)
-        addDurationSelectionAction(to: alert, key: "mute_for_one_day", duration: Time.oneDay)
-        addDurationSelectionAction(to: alert, key: "mute_for_seven_days", duration: Time.oneWeek)
-        addDurationSelectionAction(to: alert, key: "mute_forever", duration: forever)
-
-        let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil)
-        alert.addAction(cancelAction)
-        present(alert, animated: true, completion: nil)
-    }
-
-    private func addDurationSelectionAction(to alert: UIAlertController, key: String, duration: Int) {
-        let action = UIAlertAction(title: String.localized(key), style: .default, handler: { _ in
-            self.viewModel.context.setChatMuteDuration(chatId: self.viewModel.chatId, duration: duration)
-            self.headerCell.setMuted(isMuted: self.viewModel.chatIsMuted)
-            self.navigationController?.popViewController(animated: true)
-        })
-        alert.addAction(action)
     }
 
     private func toggleBlockContact() {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -326,7 +326,12 @@ class GroupChatDetailViewController: UIViewController {
             groupHeader.setMuted(isMuted: false)
             navigationController?.popViewController(animated: true)
         } else {
-            showMuteAlert()
+            MuteDialog.show(viewController: self) { [weak self] duration in
+                guard let self else { return }
+                dcContext.setChatMuteDuration(chatId: self.chatId, duration: duration)
+                groupHeader.setMuted(isMuted: true)
+                navigationController?.popViewController(animated: true)
+            }
         }
     }
 
@@ -644,29 +649,6 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
 
 // MARK: - alerts
 extension GroupChatDetailViewController {
-
-    private func showMuteAlert() {
-        let alert = UIAlertController(title: String.localized("mute"), message: nil, preferredStyle: .safeActionSheet)
-        let forever = -1
-        addDurationSelectionAction(to: alert, key: "mute_for_one_hour", duration: Time.oneHour)
-        addDurationSelectionAction(to: alert, key: "mute_for_two_hours", duration: Time.twoHours)
-        addDurationSelectionAction(to: alert, key: "mute_for_one_day", duration: Time.oneDay)
-        addDurationSelectionAction(to: alert, key: "mute_for_seven_days", duration: Time.oneWeek)
-        addDurationSelectionAction(to: alert, key: "mute_forever", duration: forever)
-
-        let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil)
-        alert.addAction(cancelAction)
-        present(alert, animated: true, completion: nil)
-    }
-
-    private func addDurationSelectionAction(to alert: UIAlertController, key: String, duration: Int) {
-        let action = UIAlertAction(title: String.localized(key), style: .default, handler: { _ in
-            self.dcContext.setChatMuteDuration(chatId: self.chatId, duration: duration)
-            self.groupHeader.setMuted(isMuted: true)
-            self.navigationController?.popViewController(animated: true)
-        })
-        alert.addAction(action)
-    }
 
     private func showClearChatConfirmationAlert() {
         let msgIds = dcContext.getChatMsgs(chatId: chatId, flags: 0)

--- a/deltachat-ios/Helper/MuteDialog.swift
+++ b/deltachat-ios/Helper/MuteDialog.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+struct MuteDialog {
+    public static func show(viewController: UIViewController, callback: @escaping (_ duration: Int) -> Void) {
+        let forever = -1
+        let options: [(name: String, duration: Int)] = [
+            ("mute_for_one_hour", Time.oneHour),
+            ("mute_for_two_hours", Time.twoHours),
+            ("mute_for_one_day", Time.oneDay),
+            ("mute_for_seven_days", Time.oneWeek),
+            ("mute_forever", forever),
+        ]
+
+        let alert = UIAlertController(title: String.localized("mute"), message: nil, preferredStyle: .safeActionSheet)
+        for (name, duration) in options {
+            alert.addAction(UIAlertAction(title: String.localized(name), style: .default, handler: { _ in
+                callback(duration)
+            }))
+        }
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+        viewController.present(alert, animated: true, completion: nil)
+    }
+}

--- a/deltachat-ios/View/ChatListEditingBar.swift
+++ b/deltachat-ios/View/ChatListEditingBar.swift
@@ -4,6 +4,7 @@ public protocol ChatListEditingBarDelegate: AnyObject {
     func onPinButtonPressed()
     func onDeleteButtonPressed()
     func onArchiveButtonPressed()
+    func onMorePressed()
 }
 
 class ChatListEditingBar: UIView {
@@ -39,7 +40,7 @@ class ChatListEditingBar: UIView {
     }()
 
     private lazy var mainContentView: UIStackView = {
-        let view = UIStackView(arrangedSubviews: [pinButton, archiveButton, deleteButton])
+        let view = UIStackView(arrangedSubviews: [pinButton, archiveButton, deleteButton, moreButton])
         view.axis = .horizontal
         view.distribution = .fillEqually
         view.alignment = .fill
@@ -57,6 +58,10 @@ class ChatListEditingBar: UIView {
 
     private lazy var pinButton: UIButton = {
         return createUIButton(imageName: "pin", imageDescription: String.localized("pin"))
+    }()
+
+    private lazy var moreButton: UIButton = {
+        return createUIButton(imageName: "ellipsis.circle", imageDescription: String.localized("pin"))
     }()
 
     public override init(frame: CGRect) {
@@ -110,6 +115,8 @@ class ChatListEditingBar: UIView {
         let archiveBtnGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(archiveButtonPressed))
         archiveBtnGestureRecognizer.numberOfTapsRequired = 1
         archiveButton.addGestureRecognizer(archiveBtnGestureRecognizer)
+
+        moreButton.addTarget(self, action: #selector(ChatListEditingBar.onMorePressed), for: .touchUpInside)
     }
 
     @objc func pinButtonPressed() {
@@ -124,4 +131,7 @@ class ChatListEditingBar: UIView {
         delegate?.onArchiveButtonPressed()
     }
 
+    @objc func onMorePressed() {
+        delegate?.onMorePressed()
+    }
 }

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -279,6 +279,16 @@ class ChatListViewModel: NSObject {
         return false
     }
 
+    func hasAnyUnmutedChatSelected(in indexPaths: [IndexPath]?) -> Bool {
+        let chatIds = chatIdsFor(indexPaths: indexPaths)
+        for chatId in chatIds {
+            if !dcContext.getChat(chatId: chatId).isMuted {
+                return true
+            }
+        }
+        return false
+    }
+
     func hasOnlyPinnedChatsSelected(in indexPaths: [IndexPath]?) -> Bool {
         let chatIds = chatIdsFor(indexPaths: indexPaths)
         return hasOnlyPinnedChatsSelected(chatIds: chatIds)

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -234,6 +234,13 @@ class ChatListViewModel: NSObject {
         }
     }
 
+    func setMuteDurations(in indexPaths: [IndexPath]?, duration: Int) {
+        let chatIds = chatIdsFor(indexPaths: indexPaths)
+        for chatId in chatIds {
+            dcContext.setChatMuteDuration(chatId: chatId, duration: duration)
+        }
+    }
+
     func markUnreadSelectedChats(in indexPaths: [IndexPath]?) {
         let chatIds = chatIdsFor(indexPaths: indexPaths)
         for chatId in chatIds {


### PR DESCRIPTION
this PR adds some features recently added to Android: 

-  'Mute/Unmute' chats directly from the chatlist; also in multi-select mode

-  'Select All' chats - so that you can eg. archive, mute, unmute or even delete all chats (deleting all chats sounds more dangerous as it is, there are quite some taps needed - it is easier to delete the whole app accidentally :)

<img width=320 src=https://github.com/user-attachments/assets/078dc0cd-018a-4b07-8ae9-e31e2c4afef0>

moreover, the PR cleans up the old "mute dialogs", using the new approach.

of course, among other things, there are also ideas to a mute to the swipe-action as well, but this is another thing :)


