### PR TITLE
'message info' just shows the file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 * use stricter TLS checks for HTTPS downloads (eg. Autoconfig)
 * improve logging for failed QR code scans, AEAP, Autocrypt and sending errors
 * show more context for the "Cannot establish guaranteed..." info message
-* show original file name in "Message Info"
+* show file name in "Message Info"
 * fix PUSH notifications not working during the frist 30 seconds after putting app to background
 * fix: show correct number of messages affected by "Clear Chat"
 * fix: recognize stickers sent from the keyboard as such also on iOS 18


### PR DESCRIPTION
from the view of the user, this is just the 'file name'. calling it 'original file name' there is maybe correct internally, as we add a random number for $reasons.
however, some users were alarmed about what the heck is transferred here.