### PR TITLE
tweak chatlist's swipe gestures

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -512,7 +512,7 @@ class ChatListViewController: UITableViewController {
         }
         pinAction.backgroundColor = UIColor.systemGreen
         if #available(iOS 13.0, *) {
-            pinAction.image = UIImage(systemName: pinned ? "pin.slash" : "pin")
+            pinAction.image = Utils.makeImageWithText(image: UIImage(systemName: pinned ? "pin.slash" : "pin"), text: pinTitle)
         }
 
         if dcContext.getUnreadMessages(chatId: chatId) > 0 {
@@ -521,6 +521,9 @@ class ChatListViewController: UITableViewController {
                 completionHandler(true)
             }
             markReadAction.backgroundColor = UIColor.systemBlue
+            if #available(iOS 13.0, *) {
+                markReadAction.image = Utils.makeImageWithText(image: UIImage(systemName: "checkmark.message"), text: String.localized("mark_as_read_short"))
+            }
 
             return UISwipeActionsConfiguration(actions: [markReadAction, pinAction])
         } else {
@@ -547,7 +550,7 @@ class ChatListViewController: UITableViewController {
         }
         archiveAction.backgroundColor = UIColor.lightGray
         if #available(iOS 13.0, *) {
-            archiveAction.image = UIImage(systemName: archived ? "tray.and.arrow.up" : "tray.and.arrow.down")
+            archiveAction.image = Utils.makeImageWithText(image: UIImage(systemName: archived ? "tray.and.arrow.up" : "tray.and.arrow.down"), text: archiveTitle)
         }
 
         let muteTitle = String.localized(chat.isMuted ? "menu_unmute" : "mute")
@@ -566,7 +569,7 @@ class ChatListViewController: UITableViewController {
         }
         muteAction.backgroundColor = UIColor.systemOrange
         if #available(iOS 13.0, *) {
-            muteAction.image = UIImage(systemName: chat.isMuted ? "speaker.wave.2" : "speaker.slash")
+            muteAction.image = Utils.makeImageWithText(image: UIImage(systemName: chat.isMuted ? "speaker.wave.2" : "speaker.slash"), text: muteTitle)
         }
 
         if viewModel.isMessageSearchResult(indexPath: indexPath) {
@@ -579,7 +582,7 @@ class ChatListViewController: UITableViewController {
             }
             deleteAction.backgroundColor = UIColor.systemRed
             if #available(iOS 13.0, *) {
-                deleteAction.image = UIImage(systemName: "trash")
+                deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("delete"))
             }
             return UISwipeActionsConfiguration(actions: [archiveAction, muteAction, deleteAction])
         }

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -495,6 +495,25 @@ class ChatListViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: false)
     }
 
+    override func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard let viewModel, let chatId = viewModel.chatIdFor(section: indexPath.section, row: indexPath.row) else { return nil }
+
+        if chatId==DC_CHAT_ID_ARCHIVED_LINK {
+            return nil
+        }
+        let chat = dcContext.getChat(chatId: chatId)
+
+        let pinned = chat.visibility==DC_CHAT_VISIBILITY_PINNED
+        let pinAction = UIContextualAction(style: .destructive, title: String.localized(pinned ? "unpin" : "pin")) { [weak self] _, _, completionHandler in
+            self?.viewModel?.pinChatToggle(chatId: chat.id)
+            self?.setEditing(false, animated: true)
+            completionHandler(true)
+        }
+        pinAction.backgroundColor = UIColor.systemGreen
+
+        return UISwipeActionsConfiguration(actions: [pinAction])
+    }
+
     override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let viewModel, let chatId = viewModel.chatIdFor(section: indexPath.section, row: indexPath.row) else { return nil }
 
@@ -512,23 +531,15 @@ class ChatListViewController: UITableViewController {
         }
         archiveAction.backgroundColor = UIColor.lightGray
 
-        let pinned = chat.visibility==DC_CHAT_VISIBILITY_PINNED
-        let pinAction = UIContextualAction(style: .destructive, title: String.localized(pinned ? "unpin" : "pin")) { [weak self] _, _, completionHandler in
-            self?.viewModel?.pinChatToggle(chatId: chat.id)
-            self?.setEditing(false, animated: true)
-            completionHandler(true)
-        }
-        pinAction.backgroundColor = UIColor.systemGreen
-
         if viewModel.isMessageSearchResult(indexPath: indexPath) {
-            return UISwipeActionsConfiguration(actions: [archiveAction, pinAction])
+            return UISwipeActionsConfiguration(actions: [archiveAction])
         } else {
             let deleteAction = UIContextualAction(style: .normal, title: String.localized("delete")) { [weak self] _, _, completionHandler in
                 self?.showDeleteChatConfirmationAlert(chatId: chatId)
                 completionHandler(true)
             }
             deleteAction.backgroundColor = UIColor.systemRed
-            return UISwipeActionsConfiguration(actions: [archiveAction, pinAction, deleteAction])
+            return UISwipeActionsConfiguration(actions: [archiveAction, deleteAction])
         }
     }
 

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -510,6 +510,9 @@ class ChatListViewController: UITableViewController {
             completionHandler(true)
         }
         pinAction.backgroundColor = UIColor.systemGreen
+        if #available(iOS 13.0, *) {
+            pinAction.image = UIImage(systemName: pinned ? "pin.slash" : "pin")
+        }
 
         return UISwipeActionsConfiguration(actions: [pinAction])
     }
@@ -530,6 +533,9 @@ class ChatListViewController: UITableViewController {
             completionHandler(true)
         }
         archiveAction.backgroundColor = UIColor.lightGray
+        if #available(iOS 13.0, *) {
+            archiveAction.image = UIImage(systemName: archived ? "tray.and.arrow.up" : "tray.and.arrow.down")
+        }
 
         let muteAction = UIContextualAction(style: .normal, title: String.localized(chat.isMuted ? "menu_unmute" : "mute")) { [weak self] _, _, completionHandler in
             guard let self else { return }
@@ -545,6 +551,9 @@ class ChatListViewController: UITableViewController {
             }
         }
         muteAction.backgroundColor = UIColor.systemOrange
+        if #available(iOS 13.0, *) {
+            muteAction.image = UIImage(systemName: chat.isMuted ? "speaker.wave.2" : "speaker.slash")
+        }
 
         if viewModel.isMessageSearchResult(indexPath: indexPath) {
             return UISwipeActionsConfiguration(actions: [archiveAction, muteAction])
@@ -554,6 +563,9 @@ class ChatListViewController: UITableViewController {
                 completionHandler(true)
             }
             deleteAction.backgroundColor = UIColor.systemRed
+            if #available(iOS 13.0, *) {
+                deleteAction.image = UIImage(systemName: "trash")
+            }
             return UISwipeActionsConfiguration(actions: [archiveAction, muteAction, deleteAction])
         }
     }

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -559,8 +559,9 @@ class ChatListViewController: UITableViewController {
             return UISwipeActionsConfiguration(actions: [archiveAction, muteAction])
         } else {
             let deleteAction = UIContextualAction(style: .normal, title: String.localized("delete")) { [weak self] _, _, completionHandler in
-                self?.showDeleteChatConfirmationAlert(chatId: chatId)
-                completionHandler(true)
+                self?.showDeleteChatConfirmationAlert(chatId: chatId) {
+                    completionHandler(true)
+                }
             }
             deleteAction.backgroundColor = UIColor.systemRed
             if #available(iOS 13.0, *) {
@@ -841,7 +842,7 @@ class ChatListViewController: UITableViewController {
     }
 
     // MARK: - alerts
-    private func showDeleteChatConfirmationAlert(chatId: Int) {
+    private func showDeleteChatConfirmationAlert(chatId: Int, callback: (() -> Void)? = nil) {
         let alert = UIAlertController(
             title: nil,
             message: String.localizedStringWithFormat(String.localized("ask_delete_named_chat"), dcContext.getChat(chatId: chatId).name),
@@ -849,6 +850,7 @@ class ChatListViewController: UITableViewController {
         )
         alert.addAction(UIAlertAction(title: String.localized("menu_delete_chat"), style: .destructive, handler: { _ in
             self.deleteChat(chatId: chatId, animated: true)
+            callback?()
         }))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         self.present(alert, animated: true, completion: nil)

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -514,7 +514,19 @@ class ChatListViewController: UITableViewController {
             pinAction.image = UIImage(systemName: pinned ? "pin.slash" : "pin")
         }
 
-        return UISwipeActionsConfiguration(actions: [pinAction])
+        if dcContext.getUnreadMessages(chatId: chatId) > 0 {
+            let markReadAction = UIContextualAction(style: .destructive, title: String.localized("mark_as_read_short")) { [weak self] _, _, completionHandler in
+                self?.dcContext.marknoticedChat(chatId: chatId)
+                completionHandler(true)
+            }
+            markReadAction.backgroundColor = UIColor.systemBlue
+
+            return UISwipeActionsConfiguration(actions: [markReadAction, pinAction])
+        } else {
+            let actions = UISwipeActionsConfiguration(actions: [pinAction])
+            actions.performsFirstActionWithFullSwipe = false
+            return actions
+        }
     }
 
     override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -535,13 +535,11 @@ class ChatListViewController: UITableViewController {
             guard let self else { return }
             if chat.isMuted {
                 dcContext.setChatMuteDuration(chatId: chatId, duration: 0)
-                setEditing(false, animated: true) // hack as handleMultiSelectionTitle() checks isEditing that is also true for swipe-editing
                 completionHandler(true)
             } else {
                 MuteDialog.show(viewController: self) { [weak self] duration in
                     guard let self else { return }
                     dcContext.setChatMuteDuration(chatId: chatId, duration: duration)
-                    setEditing(false, animated: true)
                     completionHandler(true)
                 }
             }
@@ -649,7 +647,13 @@ class ChatListViewController: UITableViewController {
             view.isHidden = false
         }
     }
-    
+
+    /// Check if the view is in row-selection mode.
+    /// isEditing alone is not sufficient as also true during swipe-edit.
+    private func hasEditingView() -> Bool {
+        return tableView.isEditing && editingConstraints != nil
+    }
+
     private func updateAccountButton() {
         let unreadMessages = dcAccounts.getFreshMessageCount(skipCurrent: true)
         accountButtonAvatar.setUnreadMessageCount(unreadMessages)
@@ -722,7 +726,7 @@ class ChatListViewController: UITableViewController {
     }
 
     func handleMultiSelectionTitle() -> Bool {
-        if !tableView.isEditing {
+        if !hasEditingView() {
             return false
         }
         titleView.accessibilityHint = nil

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -531,15 +531,32 @@ class ChatListViewController: UITableViewController {
         }
         archiveAction.backgroundColor = UIColor.lightGray
 
+        let muteAction = UIContextualAction(style: .normal, title: String.localized(chat.isMuted ? "menu_unmute" : "mute")) { [weak self] _, _, completionHandler in
+            guard let self else { return }
+            if chat.isMuted {
+                dcContext.setChatMuteDuration(chatId: chatId, duration: 0)
+                setEditing(false, animated: true) // hack as handleMultiSelectionTitle() checks isEditing that is also true for swipe-editing
+                completionHandler(true)
+            } else {
+                MuteDialog.show(viewController: self) { [weak self] duration in
+                    guard let self else { return }
+                    dcContext.setChatMuteDuration(chatId: chatId, duration: duration)
+                    setEditing(false, animated: true)
+                    completionHandler(true)
+                }
+            }
+        }
+        muteAction.backgroundColor = UIColor.systemOrange
+
         if viewModel.isMessageSearchResult(indexPath: indexPath) {
-            return UISwipeActionsConfiguration(actions: [archiveAction])
+            return UISwipeActionsConfiguration(actions: [archiveAction, muteAction])
         } else {
             let deleteAction = UIContextualAction(style: .normal, title: String.localized("delete")) { [weak self] _, _, completionHandler in
                 self?.showDeleteChatConfirmationAlert(chatId: chatId)
                 completionHandler(true)
             }
             deleteAction.backgroundColor = UIColor.systemRed
-            return UISwipeActionsConfiguration(actions: [archiveAction, deleteAction])
+            return UISwipeActionsConfiguration(actions: [archiveAction, muteAction, deleteAction])
         }
     }
 

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -504,7 +504,8 @@ class ChatListViewController: UITableViewController {
         let chat = dcContext.getChat(chatId: chatId)
 
         let pinned = chat.visibility==DC_CHAT_VISIBILITY_PINNED
-        let pinAction = UIContextualAction(style: .destructive, title: String.localized(pinned ? "unpin" : "pin")) { [weak self] _, _, completionHandler in
+        let pinTitle = String.localized(pinned ? "unpin" : "pin")
+        let pinAction = UIContextualAction(style: .destructive, title: pinTitle) { [weak self] _, _, completionHandler in
             self?.viewModel?.pinChatToggle(chatId: chat.id)
             self?.setEditing(false, animated: true)
             completionHandler(true)
@@ -536,10 +537,10 @@ class ChatListViewController: UITableViewController {
             return nil
         }
         let chat = dcContext.getChat(chatId: chatId)
-        let archived = chat.isArchived
-        let archiveActionTitle: String = String.localized(archived ? "unarchive" : "archive")
 
-        let archiveAction = UIContextualAction(style: .destructive, title: archiveActionTitle) { [weak self] _, _, completionHandler in
+        let archived = chat.isArchived
+        let archiveTitle: String = String.localized(archived ? "unarchive" : "archive")
+        let archiveAction = UIContextualAction(style: .destructive, title: archiveTitle) { [weak self] _, _, completionHandler in
             self?.viewModel?.archiveChatToggle(chatId: chatId)
             self?.setEditing(false, animated: true)
             completionHandler(true)
@@ -549,7 +550,8 @@ class ChatListViewController: UITableViewController {
             archiveAction.image = UIImage(systemName: archived ? "tray.and.arrow.up" : "tray.and.arrow.down")
         }
 
-        let muteAction = UIContextualAction(style: .normal, title: String.localized(chat.isMuted ? "menu_unmute" : "mute")) { [weak self] _, _, completionHandler in
+        let muteTitle = String.localized(chat.isMuted ? "menu_unmute" : "mute")
+        let muteAction = UIContextualAction(style: .normal, title: muteTitle) { [weak self] _, _, completionHandler in
             guard let self else { return }
             if chat.isMuted {
                 dcContext.setChatMuteDuration(chatId: chatId, duration: 0)

--- a/deltachat-ios/Helper/MuteDialog.swift
+++ b/deltachat-ios/Helper/MuteDialog.swift
@@ -11,7 +11,7 @@ struct MuteDialog {
             ("mute_forever", forever),
         ]
 
-        let alert = UIAlertController(title: String.localized("mute"), message: nil, preferredStyle: .safeActionSheet)
+        let alert = UIAlertController(title: String.localized("menu_mute"), message: nil, preferredStyle: .safeActionSheet)
         for (name, duration) in options {
             alert.addAction(UIAlertAction(title: String.localized(name), style: .default, handler: { _ in
                 callback(duration)

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -53,6 +53,27 @@ struct Utils {
         return window?.safeAreaInsets.bottom ?? 0
     }
 
+    @available(iOS 13.0, *)
+    static func makeImageWithText(image: UIImage?, text: String) -> UIImage? {
+        guard let image = image?.withTintColor(UIColor.white) else { return nil }
+
+        let spacing: CGFloat = 4
+        let textAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 14), .foregroundColor: UIColor.white]
+
+        let textSize = text.size(withAttributes: textAttributes)
+        let width = max(image.size.width, textSize.width)
+        let height = image.size.height + spacing + textSize.height
+
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height))
+        return renderer.image { _ in
+            let imageOrigin = CGPoint(x: (renderer.format.bounds.width - image.size.width) / 2, y: 0)
+            image.draw(at: imageOrigin)
+
+            let textOrigin = CGPoint(x: (renderer.format.bounds.width - textSize.width) / 2, y: image.size.height + spacing)
+            text.draw(at: textOrigin, withAttributes: textAttributes)
+        }
+    }
+
     public static func getInviteLink(context: DcContext, chatId: Int) -> String? {
         // convert `OPENPGP4FPR:FPR#a=ADDR&n=NAME&...` to `https://i.delta.chat/#FPR&a=ADDR&n=NAME&...`
         if var data = context.getSecurejoinQr(chatId: chatId), let hashRange = data.range(of: "#") {


### PR DESCRIPTION
this PR makes **"mute chat" easier accessible**, by adding it directly to a swipe gesture.

this is also what many other messengers are doing.

as more than three swipe gestures per side are questionable, we moved "pin" to the left side, together with new **mark read** - also that is known by many other messengers and apps.

moreover, the PR sets **images** - ~~iOS _only_ renders the images if title+images are set, quite some other apps are adding the title via a special image (see eg. [here](https://forzfilm.medium.com/how-to-set-image-and-label-in-trailing-swipe-action-with-custom-font-ios11-4a49d4794669)), however, i think, it is fine to stay with what the system thinks is useful here - the images are quite self-explaining and "easy", using system-images helps on that. and in the action bar, we're using the same images. we can iterate on that, surely :)~~ EDIT: we decided to go for image+text 

this is how the swipe actions look like now:

<img width=300 src=https://github.com/user-attachments/assets/f5f20c87-928d-47b1-8061-50fb03186a94>
<img width=300 src=https://github.com/user-attachments/assets/9e0facd6-337b-4d07-b917-2251e1e6172f>


what is also new, is that **context is preserved** when tapping an action that is followed by a dialog:

<img width=300 src=https://github.com/user-attachments/assets/57157ee0-12d9-4cde-96f6-de2f3cd69c66>
<img width=300 src=https://github.com/user-attachments/assets/6b43e5c2-e59d-4205-a256-0b32373c2697>

<details>
<summary>old view for comparison</summary>

<img width=300 src=https://github.com/user-attachments/assets/c68e57d5-3650-4181-bfe9-1250cbacfb48>

what's also gone is the pretty bad green-red contrast :)



</details>