### PR TITLE
avoid title in UIContextualAction.image appearing twice

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -753,7 +753,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 .sd_flippedImage(withHorizontal: false, vertical: true)
             action.backgroundColor = .systemBlue
         }
-        action.accessibilityElements = nil
+        action.accessibilityLabel = String.localized("notify_reply_button")
         let configuration = UISwipeActionsConfiguration(actions: [action])
 
         return configuration

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -505,24 +505,30 @@ class ChatListViewController: UITableViewController {
 
         let pinned = chat.visibility==DC_CHAT_VISIBILITY_PINNED
         let pinTitle = String.localized(pinned ? "unpin" : "pin")
-        let pinAction = UIContextualAction(style: .destructive, title: pinTitle) { [weak self] _, _, completionHandler in
+        let pinAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
             self?.viewModel?.pinChatToggle(chatId: chat.id)
             self?.setEditing(false, animated: true)
             completionHandler(true)
         }
+        pinAction.accessibilityLabel = pinTitle
         pinAction.backgroundColor = UIColor.systemGreen
         if #available(iOS 13.0, *) {
             pinAction.image = Utils.makeImageWithText(image: UIImage(systemName: pinned ? "pin.slash" : "pin"), text: pinTitle)
+        } else {
+            pinAction.title = pinTitle
         }
 
         if dcContext.getUnreadMessages(chatId: chatId) > 0 {
-            let markReadAction = UIContextualAction(style: .destructive, title: String.localized("mark_as_read_short")) { [weak self] _, _, completionHandler in
+            let markReadAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
                 self?.dcContext.marknoticedChat(chatId: chatId)
                 completionHandler(true)
             }
+            markReadAction.accessibilityLabel = String.localized("mark_as_read_short")
             markReadAction.backgroundColor = UIColor.systemBlue
             if #available(iOS 13.0, *) {
                 markReadAction.image = Utils.makeImageWithText(image: UIImage(systemName: "checkmark.message"), text: String.localized("mark_as_read_short"))
+            } else {
+                markReadAction.title = String.localized("mark_as_read_short")
             }
 
             return UISwipeActionsConfiguration(actions: [markReadAction, pinAction])
@@ -543,18 +549,21 @@ class ChatListViewController: UITableViewController {
 
         let archived = chat.isArchived
         let archiveTitle: String = String.localized(archived ? "unarchive" : "archive")
-        let archiveAction = UIContextualAction(style: .destructive, title: archiveTitle) { [weak self] _, _, completionHandler in
+        let archiveAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
             self?.viewModel?.archiveChatToggle(chatId: chatId)
             self?.setEditing(false, animated: true)
             completionHandler(true)
         }
+        archiveAction.accessibilityLabel = archiveTitle
         archiveAction.backgroundColor = UIColor.lightGray
         if #available(iOS 13.0, *) {
             archiveAction.image = Utils.makeImageWithText(image: UIImage(systemName: archived ? "tray.and.arrow.up" : "tray.and.arrow.down"), text: archiveTitle)
+        } else {
+            archiveAction.title = archiveTitle
         }
 
         let muteTitle = String.localized(chat.isMuted ? "menu_unmute" : "mute")
-        let muteAction = UIContextualAction(style: .normal, title: muteTitle) { [weak self] _, _, completionHandler in
+        let muteAction = UIContextualAction(style: .normal, title: nil) { [weak self] _, _, completionHandler in
             guard let self else { return }
             if chat.isMuted {
                 dcContext.setChatMuteDuration(chatId: chatId, duration: 0)
@@ -567,22 +576,28 @@ class ChatListViewController: UITableViewController {
                 }
             }
         }
+        muteAction.accessibilityLabel = muteTitle
         muteAction.backgroundColor = UIColor.systemOrange
         if #available(iOS 13.0, *) {
             muteAction.image = Utils.makeImageWithText(image: UIImage(systemName: chat.isMuted ? "speaker.wave.2" : "speaker.slash"), text: muteTitle)
+        } else {
+            muteAction.title = muteTitle
         }
 
         if viewModel.isMessageSearchResult(indexPath: indexPath) {
             return UISwipeActionsConfiguration(actions: [archiveAction, muteAction])
         } else {
-            let deleteAction = UIContextualAction(style: .normal, title: String.localized("delete")) { [weak self] _, _, completionHandler in
+            let deleteAction = UIContextualAction(style: .normal, title: nil) { [weak self] _, _, completionHandler in
                 self?.showDeleteChatConfirmationAlert(chatId: chatId) {
                     completionHandler(true)
                 }
             }
+            deleteAction.accessibilityLabel = String.localized("delete")
             deleteAction.backgroundColor = UIColor.systemRed
             if #available(iOS 13.0, *) {
                 deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("delete"))
+            } else {
+                deleteAction.title = String.localized("delete")
             }
             return UISwipeActionsConfiguration(actions: [archiveAction, muteAction, deleteAction])
         }

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -601,7 +601,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         if chat.canSend && sections[indexPath.section] == .members && !isMemberManagementRow(row: indexPath.row) && getGroupMemberIdFor(indexPath.row) != DC_CONTACT_ID_SELF {
-            let deleteAction = UIContextualAction(style: .destructive, title: String.localized("remove_desktop")) { [weak self] _, _, completionHandler in
+            let deleteAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
                 guard let self else { return }
                 let contact = self.getGroupMember(at: indexPath.row)
                 let title = String.localizedStringWithFormat(String.localized(self.chat.isBroadcast ? "ask_remove_from_broadcast" : "ask_remove_members"), contact.nameNAddr)
@@ -615,8 +615,11 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
                 self.present(alert, animated: true, completion: nil)
             }
+            deleteAction.accessibilityLabel = String.localized("remove_desktop")
             if #available(iOS 13.0, *) {
                 deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("remove_desktop"))
+            } else {
+                deleteAction.title = String.localized("remove_desktop")
             }
             return UISwipeActionsConfiguration(actions: [deleteAction])
         }

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -201,7 +201,7 @@ class NewChatViewController: UITableViewController {
         if indexPath.section == sectionContacts {
             let contactId = contactIdByRow(indexPath.row)
 
-            let profileAction = UIContextualAction(style: .normal, title: String.localized("profile")) { [weak self] _, _, completionHandler in
+            let profileAction = UIContextualAction(style: .normal, title: nil) { [weak self] _, _, completionHandler in
                 guard let self else { return }
                 if self.searchController.isActive {
                     self.searchController.dismiss(animated: false) {
@@ -212,19 +212,25 @@ class NewChatViewController: UITableViewController {
                 }
                 completionHandler(true)
             }
+            profileAction.accessibilityLabel = String.localized("profile")
             profileAction.backgroundColor = UIColor.systemBlue
             if #available(iOS 13.0, *) {
                 profileAction.image = Utils.makeImageWithText(image: UIImage(systemName: "person.crop.circle"), text: String.localized("profile"))
+            } else {
+                profileAction.title = String.localized("profile")
             }
 
-            let deleteAction = UIContextualAction(style: .destructive, title: String.localized("delete")) { [weak self] _, _, completionHandler in
+            let deleteAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
                 guard let self else { return }
                 self.askToDeleteContact(contactId: contactIdByRow(indexPath.row), indexPath: indexPath) {
                     completionHandler(true)
                 }
             }
+            deleteAction.accessibilityLabel = String.localized("delete")
             if #available(iOS 13.0, *) {
                 deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("delete"))
+            } else {
+                deleteAction.title = String.localized("delete")
             }
 
             return UISwipeActionsConfiguration(actions: [profileAction, deleteAction])

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -235,13 +235,16 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
 
     override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         if sections[indexPath.section] == .members, groupContactIds[indexPath.row] != DC_CONTACT_ID_SELF {
-            let deleteAction = UIContextualAction(style: .destructive, title: String.localized("remove_desktop")) { [weak self] _, _, completionHandler in
+            let deleteAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
                 guard let self else { return }
                 self.removeGroupContactFromList(at: indexPath)
                 completionHandler(true)
             }
+            deleteAction.accessibilityLabel = String.localized("remove_desktop")
             if #available(iOS 13.0, *) {
                 deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("remove_desktop"))
+            } else {
+                deleteAction.title = String.localized("remove_desktop")
             }
             return UISwipeActionsConfiguration(actions: [deleteAction])
         } else {

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -53,6 +53,11 @@ struct Utils {
         return window?.safeAreaInsets.bottom ?? 0
     }
 
+    // Puts text below the given image and returns as a new image.
+    // The result is ready to be used with `UIContextualAction.image` -
+    // which shows the title otherwise only for large heightForRowAt (>= 91 in experiments).
+    // If you add an text to an image that way, set `UIContextualAction.title` to `nil` to be safe for cornercases - or if apple changes things -
+    // otherwise, one would see the title twice *drunk* :)
     @available(iOS 13.0, *)
     static func makeImageWithText(image: UIImage?, text: String) -> UIImage? {
         guard let image = image?.withTintColor(UIColor.white) else { return nil }


### PR DESCRIPTION
as we create image+text for UIContextualAction.image ourselves, make sure, the title is nil - iOS adds the title to images for larger row sizes, which are not well defined :)

even though, this seems fine in all cases i tried, not sure about some accessibility things, large fonts, scaling etc. - so that little fix makes me sleep better :)

nb: really looking forward to drop iOS 13 at some point