### PR TITLE
move multi-select pin/mute to overflow menu, name "archived"

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -721,7 +721,6 @@ class ChatListViewController: UITableViewController {
 
     // MARK: updates
     private func updateTitleAndEditingBar() {
-        editingBar.showUnpinning = viewModel?.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows)
         updateTitle()
     }
 
@@ -1013,11 +1012,6 @@ extension ChatListViewController: ContactCellDelegate {
 
 // MARK: - ChatListEditingBarDelegate
 extension ChatListViewController: ChatListEditingBarDelegate {
-    func onPinButtonPressed() {
-        viewModel?.pinChatsToggle(indexPaths: tableView.indexPathsForSelectedRows)
-        setLongTapEditing(false)
-    }
-
     func onDeleteButtonPressed() {
         showDeleteMultipleChatConfirmationAlert()
     }
@@ -1029,6 +1023,15 @@ extension ChatListViewController: ChatListEditingBarDelegate {
 
     func onMorePressed() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
+
+        let onlyPinndedSelected = viewModel?.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows) ?? false
+        let pinTitle = String.localized(onlyPinndedSelected ? "unpin" : "pin")
+        alert.addAction(UIAlertAction(title: pinTitle, style: .default) { [weak self] _ in
+            guard let self else { return }
+            viewModel?.pinChatsToggle(indexPaths: tableView.indexPathsForSelectedRows)
+            setLongTapEditing(false)
+        })
+
         if viewModel?.hasAnyUnmutedChatSelected(in: tableView.indexPathsForSelectedRows) ?? false {
             alert.addAction(UIAlertAction(title: String.localized("menu_mute"), style: .default) { [weak self] _ in
                 guard let self else { return }
@@ -1045,6 +1048,7 @@ extension ChatListViewController: ChatListEditingBarDelegate {
                 setLongTapEditing(false)
             })
         }
+
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         present(alert, animated: true, completion: nil)
     }

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -722,7 +722,6 @@ class ChatListViewController: UITableViewController {
     // MARK: updates
     private func updateTitleAndEditingBar() {
         editingBar.showUnpinning = viewModel?.hasOnlyPinnedChatsSelected(in: tableView.indexPathsForSelectedRows)
-        editingBar.showMute = viewModel?.hasAnyUnmutedChatSelected(in: tableView.indexPathsForSelectedRows)
         updateTitle()
     }
 
@@ -1028,16 +1027,25 @@ extension ChatListViewController: ChatListEditingBarDelegate {
         setLongTapEditing(false)
     }
 
-    func onMutePressed() {
+    func onMorePressed() {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
         if viewModel?.hasAnyUnmutedChatSelected(in: tableView.indexPathsForSelectedRows) ?? false {
-            MuteDialog.show(viewController: self) { [weak self] duration in
+            alert.addAction(UIAlertAction(title: String.localized("menu_mute"), style: .default) { [weak self] _ in
                 guard let self else { return }
-                viewModel?.setMuteDurations(in: tableView.indexPathsForSelectedRows, duration: duration)
-                setLongTapEditing(false)
-            }
+                MuteDialog.show(viewController: self) { [weak self] duration in
+                    guard let self else { return }
+                    viewModel?.setMuteDurations(in: tableView.indexPathsForSelectedRows, duration: duration)
+                    setLongTapEditing(false)
+                }
+            })
         } else {
-            viewModel?.setMuteDurations(in: tableView.indexPathsForSelectedRows, duration: 0)
-            setLongTapEditing(false)
+            alert.addAction(UIAlertAction(title: String.localized("menu_unmute"), style: .default) { [weak self] _ in
+                guard let self else { return }
+                viewModel?.setMuteDurations(in: tableView.indexPathsForSelectedRows, duration: 0)
+                setLongTapEditing(false)
+            })
         }
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+        present(alert, animated: true, completion: nil)
     }
 }

--- a/deltachat-ios/Extensions/Extensions.swift
+++ b/deltachat-ios/Extensions/Extensions.swift
@@ -114,6 +114,21 @@ extension UILabel {
     }
 }
 
+extension UIButton {
+    func fixImageAndTitleSpacing() {
+        let spacing = 6.0
+        let insetAmount = spacing / 2
+        let isRTL = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
+        if isRTL {
+           imageEdgeInsets = UIEdgeInsets(top: 0, left: insetAmount, bottom: 0, right: -insetAmount)
+           titleEdgeInsets = UIEdgeInsets(top: 0, left: -insetAmount, bottom: 0, right: insetAmount)
+        } else {
+           imageEdgeInsets = UIEdgeInsets(top: 0, left: -insetAmount, bottom: 0, right: insetAmount)
+           titleEdgeInsets = UIEdgeInsets(top: 0, left: insetAmount, bottom: 0, right: -insetAmount)
+        }
+    }
+}
+
 extension NSData {
     func sha1() -> String {
          var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))

--- a/deltachat-ios/View/ChatListEditingBar.swift
+++ b/deltachat-ios/View/ChatListEditingBar.swift
@@ -4,7 +4,7 @@ public protocol ChatListEditingBarDelegate: AnyObject {
     func onPinButtonPressed()
     func onDeleteButtonPressed()
     func onArchiveButtonPressed()
-    func onMutePressed()
+    func onMorePressed()
 }
 
 class ChatListEditingBar: UIView {
@@ -29,15 +29,6 @@ class ChatListEditingBar: UIView {
         }
     }
 
-    var showMute: Bool? {
-        didSet {
-            guard let showMute = showMute else { return }
-            let imageName = showMute ? "speaker.slash" : "speaker.wave.2"
-            let description = showMute ? String.localized("mute") :  String.localized("menu_unmute")
-            configureButtonLayout(muteButton, imageName: imageName, imageDescription: description)
-        }
-    }
-
     private lazy var blurView: UIVisualEffectView = {
         var blurEffect = UIBlurEffect(style: .light)
         if #available(iOS 13, *) {
@@ -49,7 +40,7 @@ class ChatListEditingBar: UIView {
     }()
 
     private lazy var mainContentView: UIStackView = {
-        let view = UIStackView(arrangedSubviews: [pinButton, archiveButton, deleteButton, muteButton])
+        let view = UIStackView(arrangedSubviews: [pinButton, archiveButton, deleteButton, moreButton])
         view.axis = .horizontal
         view.distribution = .fillEqually
         view.alignment = .fill
@@ -69,8 +60,8 @@ class ChatListEditingBar: UIView {
         return createUIButton(imageName: "pin", imageDescription: String.localized("pin"))
     }()
 
-    private lazy var muteButton: UIButton = {
-        return createUIButton(imageName: "ellipsis.circle", imageDescription: String.localized("mute"))
+    private lazy var moreButton: UIButton = {
+        return createUIButton(imageName: "ellipsis.circle", imageDescription: String.localized("pin"))
     }()
 
     public override init(frame: CGRect) {
@@ -125,7 +116,7 @@ class ChatListEditingBar: UIView {
         archiveBtnGestureRecognizer.numberOfTapsRequired = 1
         archiveButton.addGestureRecognizer(archiveBtnGestureRecognizer)
 
-        muteButton.addTarget(self, action: #selector(ChatListEditingBar.onMutePressed), for: .touchUpInside)
+        moreButton.addTarget(self, action: #selector(ChatListEditingBar.onMorePressed), for: .touchUpInside)
     }
 
     @objc func pinButtonPressed() {
@@ -140,7 +131,7 @@ class ChatListEditingBar: UIView {
         delegate?.onArchiveButtonPressed()
     }
 
-    @objc func onMutePressed() {
-        delegate?.onMutePressed()
+    @objc func onMorePressed() {
+        delegate?.onMorePressed()
     }
 }

--- a/deltachat-ios/View/ChatListEditingBar.swift
+++ b/deltachat-ios/View/ChatListEditingBar.swift
@@ -13,9 +13,8 @@ class ChatListEditingBar: UIView {
     var showArchive: Bool? {
         didSet {
             guard let showArchive = showArchive else { return }
-            let imageName = showArchive ? "tray.and.arrow.down" : "tray.and.arrow.up"
             let description = showArchive ? String.localized("archive") : String.localized("unarchive")
-            configureButtonLayout(archiveButton, imageName: imageName, imageDescription: description)
+            configureButtonLayout(archiveButton, imageName: nil, imageDescription: description)
         }
     }
 
@@ -30,9 +29,9 @@ class ChatListEditingBar: UIView {
     }()
 
     private lazy var mainContentView: UIStackView = {
-        let view = UIStackView(arrangedSubviews: [archiveButton, deleteButton, moreButton])
+        let view = UIStackView(arrangedSubviews: [archiveButton, UIView(), deleteButton, moreButton])
         view.axis = .horizontal
-        view.distribution = .fillEqually
+        view.distribution = .fill
         view.alignment = .fill
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
@@ -43,7 +42,7 @@ class ChatListEditingBar: UIView {
     }()
 
     private lazy var archiveButton: UIButton = {
-        return createUIButton(imageName: "tray.and.arrow.down", imageDescription: String.localized("archive"))
+        return createUIButton(imageName: nil, imageDescription: String.localized("archive"))
     }()
 
     private lazy var moreButton: UIButton = {
@@ -59,24 +58,25 @@ class ChatListEditingBar: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func createUIButton(imageName: String, imageDescription: String, tintColor: UIColor = .systemBlue) -> UIButton {
+    private func createUIButton(imageName: String?, imageDescription: String, tintColor: UIColor = .systemBlue) -> UIButton {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.isUserInteractionEnabled = true
-        button.imageView?.contentMode = .scaleAspectFit
         configureButtonLayout(button, imageName: imageName, imageDescription: imageDescription, tintColor: tintColor)
         return button
     }
     
-    private func configureButtonLayout(_ button: UIButton, imageName: String, imageDescription: String, tintColor: UIColor = .systemBlue) {
-        if #available(iOS 13.0, *) {
+    private func configureButtonLayout(_ button: UIButton, imageName: String?, imageDescription: String, tintColor: UIColor = .systemBlue) {
+        if let imageName, #available(iOS 13.0, *) {
             button.setImage(UIImage(systemName: imageName), for: .normal)
             button.tintColor = tintColor
+            button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         } else {
             button.setTitle(imageDescription, for: .normal)
             button.setTitleColor(tintColor, for: .normal)
+            button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+            button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         }
-        button.accessibilityLabel = description
+        button.accessibilityLabel = imageDescription
     }
 
     private func configureSubviews() {
@@ -85,8 +85,8 @@ class ChatListEditingBar: UIView {
         blurView.fillSuperview()
         addConstraints([
             mainContentView.constraintAlignTopTo(self),
-            mainContentView.constraintAlignLeadingTo(self),
-            mainContentView.constraintAlignTrailingTo(self),
+            mainContentView.constraintAlignLeadingTo(self, paddingLeading: 8),
+            mainContentView.constraintAlignTrailingTo(self, paddingTrailing: 8),
             mainContentView.constraintAlignBottomTo(self, paddingBottom: Utils.getSafeBottomLayoutInset())
         ])
 

--- a/deltachat-ios/View/ChatListEditingBar.swift
+++ b/deltachat-ios/View/ChatListEditingBar.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 public protocol ChatListEditingBarDelegate: AnyObject {
-    func onPinButtonPressed()
     func onDeleteButtonPressed()
     func onArchiveButtonPressed()
     func onMorePressed()
@@ -10,15 +9,6 @@ public protocol ChatListEditingBarDelegate: AnyObject {
 class ChatListEditingBar: UIView {
 
     weak var delegate: ChatListEditingBarDelegate?
-
-    var showUnpinning: Bool? {
-        didSet {
-            guard let showUnpinning = showUnpinning else { return }
-            let imageName = showUnpinning ? "pin.slash" : "pin"
-            let description = showUnpinning ? String.localized("unpin") :  String.localized("pin")
-            configureButtonLayout(pinButton, imageName: imageName, imageDescription: description)
-        }
-    }
 
     var showArchive: Bool? {
         didSet {
@@ -40,7 +30,7 @@ class ChatListEditingBar: UIView {
     }()
 
     private lazy var mainContentView: UIStackView = {
-        let view = UIStackView(arrangedSubviews: [pinButton, archiveButton, deleteButton, moreButton])
+        let view = UIStackView(arrangedSubviews: [archiveButton, deleteButton, moreButton])
         view.axis = .horizontal
         view.distribution = .fillEqually
         view.alignment = .fill
@@ -56,12 +46,8 @@ class ChatListEditingBar: UIView {
         return createUIButton(imageName: "tray.and.arrow.down", imageDescription: String.localized("archive"))
     }()
 
-    private lazy var pinButton: UIButton = {
-        return createUIButton(imageName: "pin", imageDescription: String.localized("pin"))
-    }()
-
     private lazy var moreButton: UIButton = {
-        return createUIButton(imageName: "ellipsis.circle", imageDescription: String.localized("pin"))
+        return createUIButton(imageName: "ellipsis.circle", imageDescription: String.localized("menu_more_options"))
     }()
 
     public override init(frame: CGRect) {
@@ -104,10 +90,6 @@ class ChatListEditingBar: UIView {
             mainContentView.constraintAlignBottomTo(self, paddingBottom: Utils.getSafeBottomLayoutInset())
         ])
 
-        let pinBtnGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(pinButtonPressed))
-        pinBtnGestureRecognizer.numberOfTapsRequired = 1
-        pinButton.addGestureRecognizer(pinBtnGestureRecognizer)
-
         let deleteBtnGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(deleteButtonPressed))
         deleteBtnGestureRecognizer.numberOfTapsRequired = 1
         deleteButton.addGestureRecognizer(deleteBtnGestureRecognizer)
@@ -117,10 +99,6 @@ class ChatListEditingBar: UIView {
         archiveButton.addGestureRecognizer(archiveBtnGestureRecognizer)
 
         moreButton.addTarget(self, action: #selector(ChatListEditingBar.onMorePressed), for: .touchUpInside)
-    }
-
-    @objc func pinButtonPressed() {
-        delegate?.onPinButtonPressed()
     }
 
     @objc func deleteButtonPressed() {

--- a/deltachat-ios/View/ChatListEditingBar.swift
+++ b/deltachat-ios/View/ChatListEditingBar.swift
@@ -13,8 +13,9 @@ class ChatListEditingBar: UIView {
     var showArchive: Bool? {
         didSet {
             guard let showArchive = showArchive else { return }
+            let imageName = showArchive ? "tray.and.arrow.down" : "tray.and.arrow.up"
             let description = showArchive ? String.localized("archive") : String.localized("unarchive")
-            configureButtonLayout(archiveButton, imageName: nil, imageDescription: description)
+            configureButtonLayout(archiveButton, imageName: imageName, imageDescription: description, showImageAndText: true)
         }
     }
 
@@ -42,7 +43,7 @@ class ChatListEditingBar: UIView {
     }()
 
     private lazy var archiveButton: UIButton = {
-        return createUIButton(imageName: nil, imageDescription: String.localized("archive"))
+        return createUIButton(imageName: "tray.and.arrow.down", imageDescription: String.localized("archive"))
     }()
 
     private lazy var moreButton: UIButton = {
@@ -58,23 +59,28 @@ class ChatListEditingBar: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func createUIButton(imageName: String?, imageDescription: String, tintColor: UIColor = .systemBlue) -> UIButton {
+    private func createUIButton(imageName: String, imageDescription: String, tintColor: UIColor = .systemBlue) -> UIButton {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         configureButtonLayout(button, imageName: imageName, imageDescription: imageDescription, tintColor: tintColor)
         return button
     }
     
-    private func configureButtonLayout(_ button: UIButton, imageName: String?, imageDescription: String, tintColor: UIColor = .systemBlue) {
-        if let imageName, #available(iOS 13.0, *) {
+    private func configureButtonLayout(_ button: UIButton, imageName: String, imageDescription: String, tintColor: UIColor = .systemBlue, showImageAndText: Bool = false) {
+        if #available(iOS 13.0, *) {
             button.setImage(UIImage(systemName: imageName), for: .normal)
             button.tintColor = tintColor
+            if showImageAndText {
+                button.setTitle(imageDescription, for: .normal)
+                button.setTitleColor(tintColor, for: .normal)
+                button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+                button.fixImageAndTitleSpacing()
+            }
             button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         } else {
             button.setTitle(imageDescription, for: .normal)
             button.setTitleColor(tintColor, for: .normal)
             button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
-            button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         }
         button.accessibilityLabel = imageDescription
     }


### PR DESCRIPTION
pin/mute are arguably rarely used multi-select actions, move them to '...'
this puts more focus on archive/delete/markread, which are also the options directly present in other messengers.
    
also, that makes wrong taps less probable :)
    
one could also argue that pin/mute is not needed at all for multi-select, however, as the functionality is there, let's leave that for now.

moreover, this PR shows the titles of the "archive"  esp. here the icon is not that clear, also this is what virtually all other iOS apps are doing in similar situations:

<img width=320 src=https://github.com/user-attachments/assets/684118b9-ce40-4cda-8a4f-641bb75731fd>



<details>
<summary>thoughts and older tries</summary>

tried a cleaner layout, will see how it looks when settings  image for archive back:

<img width=320 src=https://github.com/user-attachments/assets/dc15cbdc-af16-4fe6-a9d1-05e3b4b86f3e>

the follow is somehow uneven, also text for "delete" is not needed. and having image+text for comparable action bars is somehow rare on iOS, maybe to make it more an action button as "cancel" or "mark read" atop ... tries at at  recoded at https://github.com/deltachat/deltachat-ios/compare/r10s/consolidate-multi-select-actions-first-try?expand=1

<img width=320 src=https://github.com/user-attachments/assets/ad632f39-3821-4233-a8af-be819caad1a3>
<img width=320 src=https://github.com/user-attachments/assets/53880ebd-c77a-4756-b4dc-e1d21a857f80>
</details>

