### PR TITLE
move webxdc-realtime out of experimental

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1233,7 +1233,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         alert.addAction(galleryAction)
         alert.addAction(documentAction)
 
-        if dcContext.hasWebxdc(chatId: 0) {
+        if dcContext.hasWebxdc() {
             let webxdcAction = UIAlertAction(title: String.localized("webxdc_apps"), style: .default, handler: webxdcButtonPressed(_:))
             alert.addAction(webxdcAction)
         }

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -201,19 +201,11 @@ internal final class AdvancedViewController: UITableViewController {
 
     lazy var realtimeChannelsCell: SwitchCell = {
         return SwitchCell(
-            textLabel: "Realtime Channels",
+            textLabel: String.localized("enable_realtime"),
             on: dcContext.getConfigBool("webxdc_realtime_enabled"),
-            action: { cell in
-                self.dcContext.setConfigBool("webxdc_realtime_enabled", cell.isOn)
-                if cell.isOn {
-                    let alert = UIAlertController(title: "Thanks for trying out the experimental feature 🧪 \"Realtime Channels\"",
-                        message: "\"Realtime Channels\" allow to create direct connections between devices.\n\n"
-                               + "If you want to quit the experimental feature, you can disable it at \"Settings / Advanced\".",
-                        preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: nil))
-                    self.navigationController?.present(alert, animated: true, completion: nil)
-                }
-        })
+            action: { [weak self] cell in
+                self?.dcContext.setConfigBool("webxdc_realtime_enabled", cell.isOn)
+            })
     }()
 
     private lazy var viewLogCell: UITableViewCell = {
@@ -227,12 +219,12 @@ internal final class AdvancedViewController: UITableViewController {
     private lazy var sections: [SectionConfigs] = {
         let viewLogSection = SectionConfigs(
             headerTitle: nil,
-            footerTitle: nil,
-            cells: [showEmailsCell, viewLogCell])
+            footerTitle: String.localized("enable_realtime_explain"),
+            cells: [viewLogCell, showEmailsCell, realtimeChannelsCell])
         let experimentalSection = SectionConfigs(
             headerTitle: String.localized("pref_experimental_features"),
             footerTitle: nil,
-            cells: [videoChatInstanceCell, broadcastListsCell, locationStreamingCell, realtimeChannelsCell])
+            cells: [videoChatInstanceCell, broadcastListsCell, locationStreamingCell])
 
         if dcContext.isChatmail {
             let encryptionSection = SectionConfigs(

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -217,10 +217,18 @@ internal final class AdvancedViewController: UITableViewController {
     }()
 
     private lazy var sections: [SectionConfigs] = {
-        let viewLogSection = SectionConfigs(
-            headerTitle: nil,
-            footerTitle: String.localized("enable_realtime_explain"),
-            cells: [viewLogCell, showEmailsCell, realtimeChannelsCell])
+        let viewLogSection: SectionConfigs
+        if dcContext.hasWebxdc() {
+            viewLogSection = SectionConfigs(
+                headerTitle: nil,
+                footerTitle: String.localized("enable_realtime_explain"),
+                cells: [viewLogCell, showEmailsCell, realtimeChannelsCell])
+        } else {
+            viewLogSection = SectionConfigs(
+                headerTitle: nil,
+                footerTitle: nil,
+                cells: [viewLogCell, showEmailsCell])
+        }
         let experimentalSection = SectionConfigs(
             headerTitle: String.localized("pref_experimental_features"),
             footerTitle: nil,

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -203,9 +203,9 @@ public class DcContext {
         return messageIds
     }
 
-    public func hasWebxdc(chatId: Int) -> Bool {
+    public func hasWebxdc() -> Bool {
         if !anyWebxdcSeen {
-            anyWebxdcSeen = !getChatMedia(chatId: chatId, messageType: DC_MSG_WEBXDC, messageType2: 0, messageType3: 0).isEmpty
+            anyWebxdcSeen = !getChatMedia(chatId: 0, messageType: DC_MSG_WEBXDC, messageType2: 0, messageType3: 0).isEmpty
         }
         return anyWebxdcSeen
     }


### PR DESCRIPTION
we decided that the option should go out of experimental and become on by default.

this will be done with the next core update, existing settings won't be changed. core PR is at https://github.com/deltachat/deltachat-core-rust/pull/6125

moreover, the strings are about to change as well, see discussion at https://github.com/deltachat/deltachat-android/pull/3398

<img width=320  src=https://github.com/user-attachments/assets/64687091-85e8-4c4d-9162-f855cfb67d34>
