### PR TITLE
truncate too long text in generated images

### DIFF
--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -62,10 +62,18 @@ struct Utils {
     static func makeImageWithText(image: UIImage?, text: String) -> UIImage? {
         guard let image = image?.withTintColor(UIColor.white) else { return nil }
 
+        let maxLen = 11
+        let shortText: String
+        if text.count > maxLen {
+            shortText = text.substring(0, maxLen - 1).trimmingCharacters(in: .whitespacesAndNewlines) + "…"
+        } else {
+            shortText = text
+        }
+
         let spacing: CGFloat = 4
         let textAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 14), .foregroundColor: UIColor.white]
 
-        let textSize = text.size(withAttributes: textAttributes)
+        let textSize = shortText.size(withAttributes: textAttributes)
         let width = max(image.size.width, textSize.width)
         let height = image.size.height + spacing + textSize.height
 
@@ -75,7 +83,7 @@ struct Utils {
             image.draw(at: imageOrigin)
 
             let textOrigin = CGPoint(x: (renderer.format.bounds.width - textSize.width) / 2, y: image.size.height + spacing)
-            text.draw(at: textOrigin, withAttributes: textAttributes)
+            shortText.draw(at: textOrigin, withAttributes: textAttributes)
         }
     }
 


### PR DESCRIPTION
using too long text really looks bad as apple scales down the images so that it fits - but everything will become unreadable.

still, translators should be cautious to use short text, we warned about that already here and there,
but we can probly iterate.

successor of #2351, #2354, #2355

before / after:

<img width=320  src=https://github.com/user-attachments/assets/2fdb56f0-385e-48c5-8085-2062e3af9bc5>
<img width=320 src=https://github.com/user-attachments/assets/16c14597-a54a-4963-9074-f90c232f6d73>


