### PR TITLE
use a dedicated selection background in chatlist

### DIFF
--- a/DcCore/DcCore/Helper/DcColors.swift
+++ b/DcCore/DcCore/Helper/DcColors.swift
@@ -38,6 +38,7 @@ public struct DcColors {
     public static let systemMessageBackgroundColor = UIColor.init(hexString: "65444444")
     public static let systemMessageFontColor = UIColor.white
     public static let deaddropBackground = UIColor.themeColor(light: UIColor.init(hexString: "f2f2f6"), dark: UIColor.init(hexString: "1a1a1c"))
+    public static let selectBackground = UIColor.themeColor(light: UIColor.init(hexString: "d2d2d6"), dark: UIColor.init(hexString: "3a3a3c"))
     public static let accountSwitchBackgroundColor = UIColor.themeColor(light: UIColor.init(hexString: "65CCCCCC"), dark: UIColor.init(hexString: "65444444"))
 
     public static let myReactionLabel = UIColor.themeColor(light: UIColor(named: "Colors/MyReactionLabel")!)

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -218,6 +218,7 @@ class ContactCell: UITableViewCell {
     private func setupSubviews() {
         let margin: CGFloat = 10
         selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = DcColors.selectBackground
         isAccessibilityElement = true
 
         avatar.translatesAutoresizingMaskIntoConstraints = false
@@ -352,15 +353,6 @@ class ContactCell: UITableViewCell {
     func setColor(_ color: UIColor) {
         avatar.setColor(color)
     }
-
-    public override func setSelected(_ selected: Bool, animated: Bool) {
-         super.setSelected(selected, animated: animated)
-         if selected {
-             selectedBackgroundView?.backgroundColor = DcColors.selectBackground
-         } else {
-             selectedBackgroundView?.backgroundColor = .clear
-         }
-     }
 
     // use this update-method to update cell in cellForRowAt whenever it is possible - other set-methods will be set private in progress
     func updateCell(cellViewModel: AvatarCellViewModel) {

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -217,6 +217,7 @@ class ContactCell: UITableViewCell {
 
     private func setupSubviews() {
         let margin: CGFloat = 10
+        selectedBackgroundView = UIView()
         isAccessibilityElement = true
 
         avatar.translatesAutoresizingMaskIntoConstraints = false
@@ -351,6 +352,15 @@ class ContactCell: UITableViewCell {
     func setColor(_ color: UIColor) {
         avatar.setColor(color)
     }
+
+    public override func setSelected(_ selected: Bool, animated: Bool) {
+         super.setSelected(selected, animated: animated)
+         if selected {
+             selectedBackgroundView?.backgroundColor = DcColors.selectBackground
+         } else {
+             selectedBackgroundView?.backgroundColor = .clear
+         }
+     }
 
     // use this update-method to update cell in cellForRowAt whenever it is possible - other set-methods will be set private in progress
     func updateCell(cellViewModel: AvatarCellViewModel) {


### PR DESCRIPTION
this fixed the random background bug from https://github.com/deltachat/deltachat-ios/issues/2364

i also took the chance to make the selection a little more obvious, closer to what other apps are doing:

<img width=300 src=https://github.com/user-attachments/assets/17ccf9a3-e81c-477d-a9c9-31ad1358fd66> &nbsp; &nbsp; <img width=300 src=https://github.com/user-attachments/assets/f5453b99-8eaf-4ac2-abc0-68b582bd2201>



closes #2364

i found the fix by checking what we're doing in the message list :)

cc @Amzd does this make sense to you?