### PR TITLE
relative dates in chat date markers

### DIFF
--- a/DcCore/DcCore/Helper/DateUtils.swift
+++ b/DcCore/DcCore/Helper/DateUtils.swift
@@ -23,10 +23,15 @@ public class DateUtils {
         formatter.locale = .current
         return formatter
     }
-    
-    public static func getDateString(date: Date) -> String {
+
+    /// Returns a string representation of the given date.
+    /// - Parameters:
+    ///   - date: The date to be formatted.
+    ///   - relativeToCurrentDate: If true, the string will be relative to the current date. Eg. "Today", "Yesterday", "Tomorrow".
+    public static func getDateString(date: Date, relativeToCurrentDate: Bool = false) -> String {
         let formatter = getLocalDateFormatter()
         formatter.dateStyle = .full
+        formatter.doesRelativeDateFormatting = relativeToCurrentDate
         return formatter.string(from: date)
     }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -575,9 +575,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 if nextMessageId == DC_MSG_ID_MARKER1 && indexPath.row - 2 >= 0 {
                     nextMessageId = messageIds[indexPath.row - 2]
                 }
-
                 let nextMessage = dcContext.getMessage(id: nextMessageId)
-                cell.update(text: DateUtils.getDateString(date: nextMessage.sentDate), weight: .bold)
+                let dateString = DateUtils.getDateString(date: nextMessage.sentDate, relativeToCurrentDate: true)
+                cell.update(text: dateString, weight: .bold)
             } else {
                 cell.update(text: "ErrDaymarker")
             }


### PR DESCRIPTION
show "Today" instead of current date in chat

![image](https://github.com/user-attachments/assets/91504649-b37c-43bc-adc0-03d75e6e78ba)

