### PR TITLE
hide avatar in multi-select mode

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -885,6 +885,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             let cnt = tableView.indexPathsForSelectedRows?.count ?? 0
             navigationItem.title = String.localized(stringID: "n_selected", parameter: cnt)
             self.navigationItem.setLeftBarButton(cancelButton, animated: true)
+            self.navigationItem.setRightBarButton(nil, animated: true)
         } else {
             let subtitle: String?
             let chatContactIds = dcChat.getContactIds(dcContext)
@@ -910,36 +911,36 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             } else {
                 subtitle = nil
             }
-
+            
             titleView.updateTitleView(title: dcChat.name, subtitle: subtitle, isVerified: dcChat.isProtected)
             titleView.layoutIfNeeded()
             navigationItem.titleView = titleView
             self.navigationItem.setLeftBarButton(nil, animated: true)
+            
+            if let image = dcChat.profileImage {
+                initialsBadge.setImage(image)
+            } else {
+                initialsBadge.setName(dcChat.name)
+                initialsBadge.setColor(dcChat.color)
+            }
+            
+            let recentlySeen = DcUtils.showRecentlySeen(context: dcContext, chat: dcChat)
+            initialsBadge.setRecentlySeen(recentlySeen)
+            
+            var rightBarButtonItems = [badgeItem]
+            if dcChat.isSendingLocations {
+                rightBarButtonItems.append(locationStreamingItem)
+            }
+            if dcChat.isMuted {
+                rightBarButtonItems.append(muteItem)
+            }
+            
+            if dcContext.getChatEphemeralTimer(chatId: dcChat.id) > 0 {
+                rightBarButtonItems.append(ephemeralMessageItem)
+            }
+            
+            navigationItem.rightBarButtonItems = rightBarButtonItems
         }
-
-        if let image = dcChat.profileImage {
-            initialsBadge.setImage(image)
-        } else {
-            initialsBadge.setName(dcChat.name)
-            initialsBadge.setColor(dcChat.color)
-        }
-
-        let recentlySeen = DcUtils.showRecentlySeen(context: dcContext, chat: dcChat)
-        initialsBadge.setRecentlySeen(recentlySeen)
-
-        var rightBarButtonItems = [badgeItem]
-        if dcChat.isSendingLocations {
-            rightBarButtonItems.append(locationStreamingItem)
-        }
-        if dcChat.isMuted {
-            rightBarButtonItems.append(muteItem)
-        }
-
-        if dcContext.getChatEphemeralTimer(chatId: dcChat.id) > 0 {
-            rightBarButtonItems.append(ephemeralMessageItem)
-        }
-
-        navigationItem.rightBarButtonItems = rightBarButtonItems
     }
 
     private var refreshMessagesAfterEditing = false


### PR DESCRIPTION
_for review, best hide whitespace_

this PR hides the chat's avatar in multi-select-mode

- in normal mode, the avatar is tappable, but, to stay focused, on purpose, this is not possible in multi-select-mode. however, it is confusing if same controls act differently

- title-text is also changed - so better change the whole title bar, not half

- it declutters UI during multi-select, there are enough other things to take care about, the cancel button gets for visiblity that way

- things as location, mute, online state are not important when focusing on multi-select

- user started the action from given chat, the avatar does not add much context

- roughtly, this is also what other iOS apps are doing, tuning other things down in multi-select mode

this was true all the time, but with the [new two-finger pan gesture](https://github.com/deltachat/deltachat-ios/pull/2349), it is even easier to use the multi-select mode, so that little flaw became more visible

this is how it looks like now - just clean :)

<img width=310 src=https://github.com/user-attachments/assets/6160c0dc-4668-4b5a-9596-14170f2eebc6>

