### PR TITLE
disable two-finger pan gesture during message search, fix 'more'

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1768,6 +1768,16 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         replyPrivatelyToMessage(at: indexPath)
     }
 
+    private func cancelSearch() {
+        if searchController.isActive {
+            searchController.isActive = false
+            configureDraftArea(draft: draft)
+            becomeFirstResponder()
+            navigationItem.searchController = nil
+            reloadData()
+        }
+    }
+
     @objc private func selectMore(_ sender: Any) {
         guard let menuItem = UIMenuController.shared.menuItems?.first as? LegacyMenuItem,
               let indexPath = menuItem.indexPath else { return }
@@ -1776,6 +1786,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }
 
     private func selectMore(at indexPath: IndexPath) {
+        cancelSearch()
         setEditing(isEditing: true, selectedAtIndexPath: indexPath)
         if UIAccessibility.isVoiceOverRunning {
             forceVoiceOverFocussingCell(at: indexPath, postingFinished: nil)
@@ -2614,11 +2625,7 @@ extension ChatViewController: UISearchBarDelegate {
     }
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        searchController.isActive = false
-        configureDraftArea(draft: draft)
-        becomeFirstResponder()
-        navigationItem.searchController = nil
-        reloadData()
+        cancelSearch()
     }
 }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -849,7 +849,8 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }
 
     override func tableView(_ tableView: UITableView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
-        true
+        let canMultiSelect = !searchController.isActive
+        return canMultiSelect
     }
     override func tableView(_ tableView: UITableView, didBeginMultipleSelectionInteractionAt indexPath: IndexPath) {
         setEditing(isEditing: true)


### PR DESCRIPTION
this PR disables two-finger pan gesture in the message list, for the same reasons as https://github.com/deltachat/deltachat-ios/pull/2374 

moreover, the PR ends the search when entering multi-select-mode via the more-menu - this fixes an older bug.

cc @Amzd 