### PR TITLE
do not fade background for swipe-to-reply

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -747,12 +747,11 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             action.image = UIImage(systemName: "arrowshape.turn.up.left.fill")?
                 .sd_tintedImage(with: DcColors.defaultInverseColor)?
                 .sd_flippedImage(withHorizontal: false, vertical: true)
-            action.backgroundColor = DcColors.chatBackgroundColor.withAlphaComponent(0.25)
         } else {
             action.image = UIImage(named: "ic_reply_black")?
                 .sd_flippedImage(withHorizontal: false, vertical: true)
-            action.backgroundColor = .systemBlue
         }
+        action.backgroundColor = .systemGray.withAlphaComponent(0.0) // nil or .clear do not result in transparence
         action.accessibilityLabel = String.localized("notify_reply_button")
         let configuration = UISwipeActionsConfiguration(actions: [action])
 


### PR DESCRIPTION
this PR cleans up the style of the reply icon when using "swipe to reply"

instead, of using two different transparency tones, just show the clear reply icon as on android, but also as done by most other messenger apps. note, that, although possible, the button is rarely "hit", usually it is used as "full swipe".

the existing .25 tranparency also led to some sort of bug, as the system adds another view for the "overscroll", resulting in different transparency levels, that looked a bit off. tbh, maybe that changed on iOS side somehow and was cleaner at some point.
<br />

_before - note the two different shades nearby the reply button, one could read that as a bug:_
<img width=320 src=https://github.com/user-attachments/assets/98cc45cc-0138-4b5b-932c-7731b2665be0>
<br />

_after - clean and unexcited, no questions, just boring standard:_
<img width=320 src=https://github.com/user-attachments/assets/52c2ce7c-dee5-4fad-ab87-43b5cb430254>

