### PR TITLE
bureaucracy: PRs should have a CHANGELOG entry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,9 @@ Otherwise fork the repository and create a branch in your fork.
 Please add a meaningful description to your PR
 so that reviewers get an idea about what the modifications are supposed to do.
 
-A meaningful PR title is helpful for [updating `CHANGELOG.md` on releases](./RELEASE.md)
-(CHANGELOG.md is updated manually
-to only add things that are at least roughly understandable by the end user)
+If the PR is about end-user-related enhancements or fixes,
+add an understandable, not too technical,
+line atop of [`CHANGELOG.md`](./CHANGELOG.md) under the title `## Unreleased`
 
 If the changes affect the user interface,
 screenshots are very helpful,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@ then, create a "bump-to-VERSION" PR:
    a) add title `## v1.2.3` or `## v1.2.3 Testflight`  
    b) redact lines from `## Unreleased` there  
    c) add core version to end of changelog entry as `- update to core 1.2.3` or `- using core 1.2.3`  
-   c) encorperate <https://github.com/deltachat/deltachat-core-rust/blob/main/CHANGELOG.md>
+   c) incorporate <https://github.com/deltachat/deltachat-core-rust/blob/main/CHANGELOG.md>
       and redact too technical terms, so that the end user can understand it
 
    in case previous entries of the changelog refer to not officially released versions,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,18 +20,15 @@ the "update-core-and-stuff-DATE" PR can be merged without review
 
 then, create a "bump-to-VERSION" PR:
 
-3. a) update CHANGELOG.md
-      from <https://github.com/deltachat/deltachat-core-rust/blob/main/CHANGELOG.md>
-      and <https://github.com/deltachat/deltachat-ios/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc>.
-      do not just copy and avoid technical terms.
-      the changelog is for the end user and shall show impacts form that angle.
-      for consistency, use existing formatting style.
-   b) update changelog date as `YYYY-MM`
-   c) add used core version to end of changelog entry
-      as `update to core 1.2.3` or `using core 1.2.3`
+3. update CHANGELOG.md:  
+   a) add title `## v1.2.3` or `## v1.2.3 Testflight`  
+   b) redact lines from `## Unreleased` there  
+   c) add core version to end of changelog entry as `- update to core 1.2.3` or `- using core 1.2.3`  
+   c) encorperate <https://github.com/deltachat/deltachat-core-rust/blob/main/CHANGELOG.md>
+      and redact too technical terms, so that the end user can understand it
 
-   in case previous entries of the changelog refer to betas or to not officially released versions,
-   the entries can be summarized.
+   in case previous entries of the changelog refer to not officially released versions,
+   the entries should be summarized.
    this makes it easier for the end user to follow changes by showing major changes atop.
 
 4. on major changes, add a device message to `ChatListController::viewDidLoad()`


### PR DESCRIPTION
this PR updates some guidelines, to the discussed idea of adding CHANGELOG entries sooner.

background is that the "list of recent" PR is unreliable and things easily get overseen. same for creating milestones ~~for that, which was also not working in practise.~~

the CHANGELOG approach has the advantage of having the incentive of easier releases at the end :)

it is known, there are tools forcing CHANGELOG entries, however, we decided to try without first and see how it goes


nb: that this "compliance" or "bureaucracy" PR actually removes lines is also a good sign :)