### PR TITLE
when NSE is fetching, do not delay app start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Show on Chatlist if there are Proxy-servers (#2383)
 - Detect Proxy-servers in Chat-messages (#2389)
 - Share Proxy-servers with your friends, family and allies (#2394)
+- fix: no startup delay when processing PUSH notifications in parallel, just show "Updating..." in title bar
 
 ## v1.48.3
 2024-11

--- a/DcCore/DcCore/Helper/DcUtils.swift
+++ b/DcCore/DcCore/Helper/DcUtils.swift
@@ -127,6 +127,8 @@ public struct DcUtils {
             return String.localized("connectivity_updating")
         } else if connectivity >= DC_CONNECTIVITY_CONNECTING {
           return String.localized("connectivity_connecting")
+        } else if UserDefaults.nseFetching {
+          return String.localized("connectivity_updating")
         } else {
           return String.localized("connectivity_not_connected")
         }

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -55,17 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         logger.info("➡️ didFinishLaunchingWithOptions")
         UserDefaults.standard.populateDefaultEmojis()
-
-        // The NSE ("Notification Service Extension") must not run at the same time as the app.
-        // The other way round, the NSE is not started with the app running.
         UserDefaults.setMainIoRunning()
-        var pollSeconds = 0
-        while UserDefaults.nseFetching && pollSeconds < 30 {
-            logger.info("➡️ wait for NSE to terminate")
-            usleep(1_000_000)
-            pollSeconds += 1
-        }
-        UserDefaults.setNseFetching(false) // NSE terminated unexpectedly, do not always wait 30 seconds
 
         let webPCoder = SDImageWebPCoder.shared
         SDImageCodersManager.shared.addCoder(webPCoder)

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -64,6 +64,7 @@ public class DcAccounts {
             // Wait for NSE-fetch to terminate before starting main-IO (both keep state unsynced, running at the same time would mess things up).
             // The other way round, NSE is not started when main-IO is running.
             let start = CFAbsoluteTimeGetCurrent()
+            NotificationCenter.default.post(name: Event.connectivityChanged, object: nil) // additional events needed as state changed outside mainapp
             startOrReschedule()
             func startOrReschedule() {
                 if UserDefaults.mainIoRunning {
@@ -75,6 +76,7 @@ public class DcAccounts {
                     } else {
                         dc_accounts_start_io(accountsPointer)
                         UserDefaults.setNseFetching(false) // reset as NSE may have terminated unexpectedly. this also terminate other startIo() waiting loops
+                        NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: ["message_id": Int(0), "chat_id": Int(0)])
                     }
                 }
             }

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -60,7 +60,25 @@ public class DcAccounts {
     }
 
     public func startIo() {
-        dc_accounts_start_io(accountsPointer)
+        if UserDefaults.nseFetching {
+            // Wait for NSE-fetch to terminate before starting main-IO (both keep state unsynced, running at the same time would mess things up).
+            // The other way round, NSE is not started when main-IO is running.
+            let start = CFAbsoluteTimeGetCurrent()
+            func startOrReschedule() {
+                logger.info("➡️ wait for NSE to terminate")
+                if UserDefaults.nseFetching && CFAbsoluteTimeGetCurrent() - start < 30.0 { // NSE runs max 25 seconds
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                        startOrReschedule()
+                    }
+                } else {
+                    dc_accounts_start_io(accountsPointer)
+                    UserDefaults.setNseFetching(false) // reset as NSE may have terminated unexpectedly. this also terminate other startIo() waiting loops
+                }
+            }
+            startOrReschedule()
+        } else {
+            dc_accounts_start_io(accountsPointer)
+        }
     }
 
     public func stopIo() {


### PR DESCRIPTION
this PR avoids the app being stale on startup for up to 30 seconds in case the NSE ("notification service extension")  is not yet terminated.
EDIT: the system may even terminate the app during that timeframe

instead, the app is started, but startIo() is delayed until the NSE has finished (which takes at max 30 seconds)


### some background: 

the core cannot handle multiple processes fetching concurrently, reason is that some IMAP fetch state (last seen UID?)  is hold in RAM and not synced between processes (cc @link2xt is this still correct?)

Delta Chat iOS has currently up to three processes: main, share-extension, notification-service-extension. 

share extension is fine as nothing is read from IMAP. 

for the  notification-service-extension we do a fetch using `dc_accounts_background_fetch()` - and if the user starts the mainapp in that time (max. 30 seconds), cannot start_io() - before this PR we delayed the app start - and now we delay start_io() only.

this is not great program-wise, but from the view if the user quite okay