### PR TITLE
fix proxies added doubles sometimes

### DIFF
--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -89,10 +89,9 @@ class ProxySettingsViewController: UITableViewController {
 
             let parsedProxy = self.dcContext.checkQR(qrCode: proxyURL)
             if parsedProxy.state == DC_QR_PROXY, self.dcContext.setConfigFromQR(qrCode: proxyURL) {
-                self.proxies.insert(proxyURL, at: self.proxies.startIndex)
-                self.selectedProxy = proxyURL
-                self.dcContext.setProxies(proxyURLs: self.proxies)
                 self.dcAccounts.restartIO()
+                self.proxies = dcContext.getProxies()
+                self.selectedProxy = proxies.first
 
                 DispatchQueue.main.async {
                     self.toggleProxyCell.uiSwitch.isEnabled = (self.proxies.isEmpty == false)


### PR DESCRIPTION
this PR fixes the duplicated proxy entries mentioned at  https://github.com/deltachat/deltachat-ios/pull/2388#pullrequestreview-2432766803 - we first thought it is a core-bug, but eventually was not.

_this was a hard to find bug ... i hope i could explain it correctly :)_

core normalizes proxy-url
when calling `set_config_from_qr(URL_ORG)`.

by calling `set_config(URL_ORG)` instead of `URL_NORM=get_config()` after adding, we discarded the normalisation.

selecting later by `set_config_from_qr(URL_ORG)` finally results in `URL_ORG` as well as `URL_NORM` being added to the list.

one could argue,
that normalisation should also take place at `set_config()`, however, this is not the case.

it also seems more resilient to refresh the list on adding, so that really the state and the URLs used on core are shown.