### PR TITLE
tweak proxy icons

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -45,7 +45,7 @@ class ChatListViewController: UITableViewController {
         let button: UIBarButtonItem
 
         if #available(iOS 13, *) {
-            button = UIBarButtonItem(image: UIImage(systemName: "shield"), style: .plain, target: self, action: #selector(ChatListViewController.showProxySettings))
+            button = UIBarButtonItem(image: UIImage(systemName: "checkmark.shield"), style: .plain, target: self, action: #selector(ChatListViewController.showProxySettings))
         } else {
             button = UIBarButtonItem(title: String.localized("proxy_settings"), style: .plain, target: self, action: #selector(ChatListViewController.showProxySettings))
         }
@@ -729,9 +729,9 @@ class ChatListViewController: UITableViewController {
         guard #available(iOS 13, *) else { return }
 
         if dcContext.isProxyEnabled {
-            proxyShieldButton.image = UIImage(systemName: "shield")
+            proxyShieldButton.image = UIImage(systemName: "checkmark.shield")
         } else {
-            proxyShieldButton.image = UIImage(systemName: "shield.slash")
+            proxyShieldButton.image = UIImage(systemName: "shield")
         }
     }
 


### PR DESCRIPTION
this changes the proxy icon above the chatlist
to checked-shield (ON) and emtpy-shield (OFF)

- the striked-shield for OFF is confusing, as at other places, the strike through is used to show an action, so what would happen when the button is pressed (mute). analoguely, the strike-shield, one could think, the button removes the proxy.

- the checked-shield is better in that regard: while still showing state, it is still true that the action is to check another proxy

- empty-shield as a button also works better, action is to show the proxy list

- it simply looks better when a proxy is ON

state vs. action on buttons is tricky :)

moreover, the change is analogue to Telegram-iOS,
and also to deltachat-android, at least for the empty-shield :)

on / off:

<img width=320 src=https://github.com/user-attachments/assets/52496423-4c71-47ef-8a5b-2486da12c23c> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; <img width=320 src=https://github.com/user-attachments/assets/8cbc9657-f0a4-443d-b059-87dbc690342e>

