### PR TITLE
Hide proxy-shield in multi-select

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -773,7 +773,7 @@ class ChatListViewController: UITableViewController {
             titleView.text = String.localized("chat_archived_label")
             if !handleMultiSelectionTitle() {
                 navigationItem.setLeftBarButton(nil, animated: true)
-                navigationItem.setRightBarButton(markReadButton, animated: true)
+                navigationItem.setRightBarButtonItems([markReadButton], animated: true)
             }
             updateMarkReadButton()
         } else {
@@ -783,7 +783,7 @@ class ChatListViewController: UITableViewController {
                 updateAccountButton()
 
                 if dcContext.getProxies().isEmpty {
-                    navigationItem.setRightBarButton(newButton, animated: true)
+                    navigationItem.setRightBarButtonItems([newButton], animated: true)
                 } else {
                     updateProxyButton()
                     navigationItem.setRightBarButtonItems([newButton, proxyShieldButton], animated: true)
@@ -806,7 +806,7 @@ class ChatListViewController: UITableViewController {
         let cnt = tableView.indexPathsForSelectedRows?.count ?? 0
         titleView.text = String.localized(stringID: "n_selected", parameter: cnt)
         navigationItem.setLeftBarButton(cancelButton, animated: true)
-        navigationItem.setRightBarButton(markReadButton, animated: true)
+        navigationItem.setRightBarButtonItems([markReadButton], animated: true)
         updateMarkReadButton()
         return true
     }


### PR DESCRIPTION
`setRightBarButton` seems to do something differently than `setBarButonItems`. I fixed it in the other places as well. And as a proof, please enjoy this screenshot:

![Screenshot 2024-11-18 at 08 57 34](https://github.com/user-attachments/assets/aec6a962-9d31-484d-874d-d8c7630c2ce4)

Fixes #2401 (I didn't include a changelog-entry as this is a fix to an unreleased thing)