### PR TITLE
Scan Proxy-QR-codes (#2400)

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -260,7 +260,7 @@ extension InstantOnboardingViewController: MediaPickerDelegate {
 
 // MARK: - QrCodeReaderDelegate
 extension InstantOnboardingViewController: QrCodeReaderDelegate {
-    func handleQrCode(_ viewController: UIViewController, qrCode: String) {
+    func handleQrCode(_ qrCode: String) {
         // update with new code
         let parsedQrCode = dcContext.checkQR(qrCode: qrCode)
         if parsedQrCode.state == DC_QR_LOGIN || parsedQrCode.state == DC_QR_ACCOUNT,

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -260,14 +260,14 @@ extension InstantOnboardingViewController: MediaPickerDelegate {
 
 // MARK: - QrCodeReaderDelegate
 extension InstantOnboardingViewController: QrCodeReaderDelegate {
-    func handleQrCode(_ code: String) {
+    func handleQrCode(_ viewController: UIViewController, qrCode: String) {
         // update with new code
-        let parsedQrCode = dcContext.checkQR(qrCode: code)
+        let parsedQrCode = dcContext.checkQR(qrCode: qrCode)
         if parsedQrCode.state == DC_QR_LOGIN || parsedQrCode.state == DC_QR_ACCOUNT,
            let host = parsedQrCode.text1,
            let url = URL(string: "https://\(host)") {
             self.providerHostURL = url
-            self.qrCodeData = code
+            self.qrCodeData = qrCode
 
             contentView?.updateContent(with: host)
             dismissQRReader()

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -77,7 +77,7 @@ class WelcomeViewController: UIViewController {
             navigationItem.leftBarButtonItem = cancelButton
         }
         if let accountCode {
-            handleQrCode(self, qrCode: accountCode)
+            handleQrCode(accountCode)
         }
     }
 
@@ -227,7 +227,7 @@ class WelcomeViewController: UIViewController {
 
 // MARK: - QrCodeReaderDelegate
 extension WelcomeViewController: QrCodeReaderDelegate {
-    func handleQrCode(_ viewController: UIViewController, qrCode: String) {
+    func handleQrCode(_ qrCode: String) {
         let lot = dcContext.checkQR(qrCode: qrCode)
         if lot.state == DC_QR_BACKUP || lot.state == DC_QR_BACKUP2 {
             confirmSetupNewDevice(qrCode: qrCode)

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -77,7 +77,7 @@ class WelcomeViewController: UIViewController {
             navigationItem.leftBarButtonItem = cancelButton
         }
         if let accountCode {
-            handleQrCode(accountCode)
+            handleQrCode(self, qrCode: accountCode)
         }
     }
 
@@ -227,10 +227,10 @@ class WelcomeViewController: UIViewController {
 
 // MARK: - QrCodeReaderDelegate
 extension WelcomeViewController: QrCodeReaderDelegate {
-    func handleQrCode(_ code: String) {
-        let lot = dcContext.checkQR(qrCode: code)
+    func handleQrCode(_ viewController: UIViewController, qrCode: String) {
+        let lot = dcContext.checkQR(qrCode: qrCode)
         if lot.state == DC_QR_BACKUP || lot.state == DC_QR_BACKUP2 {
-             confirmSetupNewDevice(qrCode: code)
+            confirmSetupNewDevice(qrCode: qrCode)
         } else {
             qrErrorAlert()
         }

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -220,7 +220,7 @@ extension QrCodeReaderController: AVCaptureMetadataOutputObjectsDelegate {
             if supportedCodeTypes.contains(metadataObj.type) {
                 if metadataObj.stringValue != nil {
                     self.captureSession.stopRunning()
-                    self.delegate?.handleQrCode(metadataObj.stringValue!)
+                    self.delegate?.handleQrCode(self, qrCode: metadataObj.stringValue!)
                 }
             }
         }

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -220,7 +220,7 @@ extension QrCodeReaderController: AVCaptureMetadataOutputObjectsDelegate {
             if supportedCodeTypes.contains(metadataObj.type) {
                 if metadataObj.stringValue != nil {
                     self.captureSession.stopRunning()
-                    self.delegate?.handleQrCode(self, qrCode: metadataObj.stringValue!)
+                    self.delegate?.handleQrCode(metadataObj.stringValue!)
                 }
             }
         }

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -156,7 +156,7 @@ class QrPageController: UIPageViewController {
     }
 
     @objc func pasteFromClipboard(_ action: UIAlertAction) {
-        handleQrCode(UIPasteboard.general.string ?? "")
+        handleQrCode(self, qrCode: UIPasteboard.general.string ?? "")
     }
 
     // MARK: - update
@@ -208,9 +208,8 @@ extension QrPageController: UIPageViewControllerDataSource, UIPageViewController
 
 // MARK: - QRCodeDelegate
 extension QrPageController: QrCodeReaderDelegate {
-
-    func handleQrCode(_ code: String) {
+    func handleQrCode(_ viewController: UIViewController, qrCode: String) {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-        appDelegate.appCoordinator.coordinate(qrCode: code, from: self)
+        appDelegate.appCoordinator.coordinate(qrCode: qrCode, from: self)
     }
 }

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -156,7 +156,7 @@ class QrPageController: UIPageViewController {
     }
 
     @objc func pasteFromClipboard(_ action: UIAlertAction) {
-        handleQrCode(self, qrCode: UIPasteboard.general.string ?? "")
+        handleQrCode(UIPasteboard.general.string ?? "")
     }
 
     // MARK: - update
@@ -208,7 +208,7 @@ extension QrPageController: UIPageViewControllerDataSource, UIPageViewController
 
 // MARK: - QRCodeDelegate
 extension QrPageController: QrCodeReaderDelegate {
-    func handleQrCode(_ viewController: UIViewController, qrCode: String) {
+    func handleQrCode(_ qrCode: String) {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         appDelegate.appCoordinator.coordinate(qrCode: qrCode, from: self)
     }

--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -166,6 +166,9 @@ class ProxySettingsViewController: UITableViewController {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
 
+            let proxies = dcContext.getProxies()
+            self.proxies = proxies
+            self.selectedProxy = proxies.first
             self.tableView.reloadData()
         }
     }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -383,7 +383,8 @@ class AppCoordinator: NSObject {
                 _ = dcContext.setConfigFromQR(qrCode: code)
             }))
             viewController.present(alert, animated: true)
-
+        case DC_QR_PROXY:
+            handleProxySelection(on: viewController, dcContext: dcContext, proxyURL: code)
         default:
             var msg = String.localizedStringWithFormat(String.localized("qrscan_contains_text"), code)
             if state == DC_QR_ERROR {

--- a/deltachat-ios/Helper/Protocols.swift
+++ b/deltachat-ios/Helper/Protocols.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 protocol QrCodeReaderDelegate: AnyObject {
-    func handleQrCode(_ viewController: UIViewController, qrCode: String)
+    func handleQrCode(_ qrCode: String)
 }
 
 protocol ContactListDelegate: AnyObject {

--- a/deltachat-ios/Helper/Protocols.swift
+++ b/deltachat-ios/Helper/Protocols.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 protocol QrCodeReaderDelegate: AnyObject {
-    func handleQrCode(_ code: String)
+    func handleQrCode(_ viewController: UIViewController, qrCode: String)
 }
 
 protocol ContactListDelegate: AnyObject {


### PR DESCRIPTION
- QR-Reader learned a new trick: It can scan Proxy-QR-codes now.
- It's pretty simple: You scan a Proxy-QR-code with the QR-code-reader and you see this alter:

![Screenshot 2024-11-18 at 15 14 03](https://github.com/user-attachments/assets/06e146ca-4058-4f16-b54f-c19517864943)

- Fixes #2400 