### PR TITLE
Add proxy to onboarding (#2390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - fix: show forward-icon on iOS 15 and older
-- Add an option to use Proxy-servers (#2382)
+- Add an option to use Proxy-servers (#2382, #2390)
 - Show on Chatlist if there are Proxy-servers (#2383)
 - Detect Proxy-servers in Chat-messages (#2389)
 - Share Proxy-servers with your friends, family and allies (#2394)

--- a/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
@@ -23,6 +23,7 @@ class AccountSetupController: UITableViewController {
     private let tagSmtpSecurityCell = 11
     private let tagCertCheckCell = 12
     private let tagViewLogCell = 15
+    private let tagProxyCell = 16
 
     private let tagTextFieldEmail = 100
     private let tagTextFieldPassword = 200
@@ -53,6 +54,7 @@ class AccountSetupController: UITableViewController {
         smtpServerCell,
         smtpPortCell,
         certCheckCell,
+        proxyCell,
         viewLogCell
     ]
     private let editView: Bool
@@ -239,6 +241,14 @@ class AccountSetupController: UITableViewController {
 
     lazy var certValue: Int = dcContext.certificateChecks
 
+    lazy var proxyCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        cell.textLabel?.text = String.localized("proxy_settings")
+        cell.tag = tagProxyCell
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }()
+
     lazy var viewLogCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.textLabel?.text = String.localized("pref_view_log")
@@ -296,6 +306,11 @@ class AccountSetupController: UITableViewController {
         super.viewWillAppear(animated)
         initSelectionCells()
         handleLoginButton()
+        updateCells()
+    }
+
+    private func updateCells() {
+        proxyCell.detailTextLabel?.text = dcContext.isProxyEnabled ? String.localized("on") : nil
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -365,6 +380,8 @@ class AccountSetupController: UITableViewController {
         case tagViewLogCell:
             tableView.deselectRow(at: indexPath, animated: false)
             showLogViewController()
+        case tagProxyCell:
+            showProxySettings()
         default:
             break
         }
@@ -586,6 +603,11 @@ class AccountSetupController: UITableViewController {
     }
 
     // MARK: - coordinator
+
+    private func showProxySettings() {
+        let proxySettingsController = ProxySettingsViewController(dcContext: dcContext, dcAccounts: dcAccounts)
+        navigationController?.pushViewController(proxySettingsController, animated: true)
+    }
 
     private func showLogViewController() {
         let controller = LogViewController(dcContext: dcContext)


### PR DESCRIPTION
- Adds a menu-button to Instant-Onboarding (that turns into a Proxy-Shield, just like on the Chat-list). This menu opens a sheet to add a proxy. The idea is to make it not too obvious. LMK if you prefer an easy, straight-forward navbar-item
- Adds another menu-entry to manual account setup ("Classic Email Login 🥸") to configure a proxy
- Closes #2390 

![2390_1](https://github.com/user-attachments/assets/0b1ea11f-9604-4297-ad2b-368f3164e218)
![2390_2](https://github.com/user-attachments/assets/8225893f-2cbd-47df-bee6-2350bc06371e)

(Please forgive me the German screenshots)
