### PR TITLE
allow to open http-proxy-links in browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- offer to open http-links detected as proxy also in the browser (#6237)
+
+
 ## v1.48.4
 
 - fix: show forward-icon on iOS 15 and older

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -219,6 +219,13 @@ class AppCoordinator: NSObject {
 
         selectAlert.addAction(cancelAction)
         selectAlert.addAction(selectAction)
+        if proxyURL.starts(with: "http") {
+            selectAlert.addAction(UIAlertAction(title: String.localized("open"), style: .default) { _ in
+                if let url = URL(string: proxyURL) {
+                    UIApplication.shared.open(url)
+                }
+            })
+        }
 
         viewController.present(selectAlert, animated: true)
     }


### PR DESCRIPTION
http-proxies are identified by having a port number; this is not the case for most http-pages.

however, if the guessing can be wrong,
always offer to open the browser alternatively

counterpart of https://github.com/deltachat/deltachat-android/pull/3435 feature proposal at: https://support.delta.chat/t/in-the-new-android-client-it-is-not-possible-to-click-to-open-urls-with-port-numbers/3327