### PR TITLE
Show Webxdc-message in chat (#2413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- Show a Webxdc-app in chat (#2413) 
+
 ## v1.50.1
 2024-12
 

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -457,6 +457,17 @@ class WebxdcViewController: WebViewViewController {
         let shareAction = UIAlertAction(title: String.localized("menu_share"), style: .default, handler: shareWebxdc(_:))
         alert.addAction(shareAction)
 
+        let showInChatAction = UIAlertAction(title: String.localized("show_in_chat"), style: .default) { [weak self] _ in
+            guard let self, let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+            let message = dcContext.getMessage(id: self.messageId)
+            let chatId = message.chatId
+
+            DispatchQueue.main.async {
+                appDelegate.appCoordinator.showChat(chatId: chatId, msgId: message.id, animated: true, clearViewControllerStack: true)
+            }
+        }
+        alert.addAction(showInChatAction)
+
         let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil)
         alert.addAction(cancelAction)
         self.present(alert, animated: true, completion: nil)


### PR DESCRIPTION
This PR adds a menu-entry so that users can go from an Webxdc-app to the chat-message that contains the Webxdc-app. It looks like this:

![Simulator Screenshot - iPhone 16 Pro - 2024-12-09 at 11 44 47](https://github.com/user-attachments/assets/41d0354c-6f8a-4246-8b84-b0ba175c3cca)


Closes #2413.