### PR TITLE
remove email-address unconditionally from title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Don't show message-input when forwarding (#2435)
 - Long-tap links for copying to clipboard (#2445)
+- Hide address in titles: protect against over-the-shoulder-attacks, improve screenshot privacy, clear UX (#2447)
 
 
 ## v1.50.3

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -904,8 +904,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 let dcContact = dcContext.getContact(id: chatContactIds[0])
                 if dcContact.isBot {
                     subtitle = String.localized("bot")
-                } else if dcChat.isProtected == false {
-                    subtitle = dcContact.email
                 } else {
                     subtitle = nil
                 }


### PR DESCRIPTION
_this was discussed in-person with various ppl  on the last physical gathering :)_

the email-address was removed for guaranteed-e2ee chats quite a while ago (https://github.com/deltachat/deltachat-android/pull/2916) reason was, among others, that these addresses are often chatmail and therefore random. (despite expecting otherwise, that was fine for most users).

this PR removes the email-adress unconditionally:

- having the email-address sometimes shown and sometimes not is confusing, and easily looks like a bug. this has become worse with the added vcard-support (before, there were rare non-guaranteed chats in chatmail) - resulting in more random addresses being shown

- _always_ protect against over-the-shoulder attacks

- better privacy in screenshots sent around without thinking much before (cmp. https://github.com/deltachat/deltachat-ios/pull/2329)

- wrt impersonation attacks: the pure email address in the subtitle did never protect against impersonation, one could always get sth. trustworthy looking there, it is better to check the profile with additional information (eg. other chats) if in doubt

- general cleaner, uncluttered layout

- pave the way of the upcoming multi-addresses

drawback is that sometimes one more tap is needed to access the email-address - however, as it is _always_ one tap away now, this can also go easily to the finger memory.

counterpart of https://github.com/deltachat/deltachat-android/pull/3507