### PR TITLE
Show chat-list for invalid deeplinks (#2464)

### DIFF
--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -217,7 +217,12 @@ class AppCoordinator: NSObject {
             }
         }
 
-        showChat(chatId: chatId, animated: false, clearViewControllerStack: true)
+        let chat = dcAccounts.getSelected().getChat(chatId: chatId)
+        if chat.isValid {
+            showChat(chatId: chatId, animated: false, clearViewControllerStack: true)
+        } else {
+            showChats()
+        }
         return true
     }
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -183,11 +183,13 @@ class AppCoordinator: NSObject {
 
         let dcContext = dcAccounts.getSelected()
         let dcMsg = dcContext.getMessage(id: messageId)
-        if dcMsg.type == DC_MSG_WEBXDC {
+        if dcMsg.isValid, dcMsg.type == DC_MSG_WEBXDC {
             showChat(chatId: chatId, msgId: messageId, openHighlightedMsg: true, animated: false, clearViewControllerStack: true)
             return true
+        } else {
+            showChats()
+            return false
         }
-        return false
     }
 
     private func handleOpenChatDeeplink(url: URL) -> Bool {

--- a/deltachat-ios/DC/DcMsg.swift
+++ b/deltachat-ios/DC/DcMsg.swift
@@ -31,6 +31,10 @@ public class DcMsg {
         return dc_msg_is_forwarded(messagePointer) != 0
     }
 
+    public var isValid: Bool {
+        return messagePointer != nil
+    }
+
     public var messageId: String {
         return "\(id)"
     }


### PR DESCRIPTION
In case of an invalid chat/message, we show the chatlist. Closes #2464.