### PR TITLE
Show initial and color if no image is set (#2468)

### DIFF
--- a/DcWidget/DcWidget.swift
+++ b/DcWidget/DcWidget.swift
@@ -47,11 +47,15 @@ struct ChatShortcutView: View {
     var body: some View {
         Link(destination: chat.url) {
             if let image = chat.image {
-                // Use Circle as mask
                 Image(uiImage: image)
                     .fullColor()
-            } else {
-                Color(.systemBackground)
+            } else if let colorImage = UIImage(color: chat.color) {
+                ZStack {
+                    Image(uiImage: colorImage)
+                    Text(chat.title.first?.uppercased() ?? "🫶")
+                        .foregroundStyle(.white)
+                        .font(.system(size: 34))
+                }
             }
         }
         .frame(width: 56, height: 56)

--- a/DcWidget/WidgetProvider.swift
+++ b/DcWidget/WidgetProvider.swift
@@ -18,10 +18,10 @@ struct Provider: TimelineProvider {
             .app(AppShortcut(accountId: 0, chatId: 0, messageId: 0, image: UIImage(named: "checklist"), title: "checklist")),
             .app(AppShortcut(accountId: 0, chatId: 1, messageId: 1, image: UIImage(named: "hello"), title: "hello")),
             .app(AppShortcut(accountId: 0, chatId: 2, messageId: 2, image: UIImage(named: "packabunchas"), title: "packabunchas")),
-            .chat(ChatShortcut(accountId: 0, chatId: 3, title: "Messages to self", image: UIImage(named: "saved-messages"))),
+            .chat(ChatShortcut(accountId: 0, chatId: 3, title: "Messages to self", image: UIImage(named: "saved-messages"), color: .green)),
             .app(AppShortcut(accountId: 0, chatId: 4, messageId: 4, image: UIImage(named: "pixel"), title: "pixel")),
             .app(AppShortcut(accountId: 0, chatId: 5, messageId: 5, image: UIImage(named: "webxdc"), title: "webxdc")),
-            .chat(ChatShortcut(accountId: 0, chatId: 6, title: "Broadcast", image: UIImage(named: "broadcast"))),
+            .chat(ChatShortcut(accountId: 0, chatId: 6, title: "Broadcast", image: UIImage(named: "broadcast"), color: .red)),
         ]
 
         return UsedWebxdcEntry(date: Date(), shortcuts: Array(shortcuts.prefix(limit)))
@@ -74,12 +74,14 @@ struct Provider: TimelineProvider {
                     let chat = dcContext.getChat(chatId: chatId)
                     let title = chat.name
                     let image = chat.profileImage
+                    let color = chat.color
 
                     return .chat(ChatShortcut(
                         accountId: entry.accountId,
                         chatId: chatId,
                         title: title,
-                        image: image
+                        image: image,
+                        color: color
                     ))
                 }
             }
@@ -120,6 +122,7 @@ struct ChatShortcut: Identifiable, Hashable {
     let chatId: Int
     let title: String
     let image: UIImage?
+    let color: UIColor
 
     var url: URL {
         var urlComponents = URLComponents()

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		D8083AD02D14384F005DCB7D /* UserDefaults+Widgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8083ACF2D14384F005DCB7D /* UserDefaults+Widgets.swift */; };
 		D8083AD12D143868005DCB7D /* UserDefaults+Widgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8083ACF2D14384F005DCB7D /* UserDefaults+Widgets.swift */; };
 		D80F62792B59D1CC00877059 /* DefaultReactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F62782B59D1CC00877059 /* DefaultReactions.swift */; };
+		D82AD20F2D26B087009D6026 /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E45E4321D3F14A00D4B15E /* UIImage+Extension.swift */; };
 		D84738D22BBC1C2C00ECD52B /* LegacyMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84738D12BBC1C2C00ECD52B /* LegacyMenuItem.swift */; };
 		D84AED242B55E8EB00D753F6 /* ReactionsOverviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84AED232B55E8EB00D753F6 /* ReactionsOverviewViewController.swift */; };
 		D84AED272B566C0700D753F6 /* ReactionsOverviewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84AED262B566C0700D753F6 /* ReactionsOverviewTableViewCell.swift */; };
@@ -1829,6 +1830,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D89C45732D0B0166005B1491 /* WidgetEntry.swift in Sources */,
+				D82AD20F2D26B087009D6026 /* UIImage+Extension.swift in Sources */,
 				D8083AD12D143868005DCB7D /* UserDefaults+Widgets.swift in Sources */,
 				D8C7B6982CF87F5E003A6AD1 /* DcMsg+Extension.swift in Sources */,
 			);

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -437,12 +437,12 @@ class ContactCell: UITableViewCell {
             }
             avatar.setRecentlySeen(false)
             setStatusIndicators(unreadCount: 0,
-            status: 0,
-            visibility: 0,
-            isLocationStreaming: false,
-            isContactRequest: false,
-            isArchiveLink: false,
-            isVerified: false)
+                                status: 0,
+                                visibility: 0,
+                                isLocationStreaming: false,
+                                isContactRequest: false,
+                                isArchiveLink: false,
+                                isVerified: false)
         }
 
         accessibilityLabel = (titleLabel.text != nil ? ((titleLabel.text ?? "")+"\n") : "")


### PR DESCRIPTION
I thought that the initial/background-color-thing was created in Core but then I learned: That's the app's responsibility. This PR makes the Chat-shortcut show the initial and the background-color if no image is set:

![2468](https://github.com/user-attachments/assets/b56aa683-11e7-4f0f-ba8e-599d0302a8dc)

Closes #2468
Will collide with #2467 