### PR TITLE
more modern settings pages

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
@@ -280,7 +280,7 @@ class AccountSetupController: UITableViewController {
         self.imapSecurityValue = AccountSetupSecurityValue(initValue: dcContext.getConfigInt("mail_security"))
         self.smtpSecurityValue = AccountSetupSecurityValue(initValue: dcContext.getConfigInt("send_security"))
 
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         hidesBottomBarWhenPushed = true
     }
 

--- a/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
+++ b/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
@@ -25,7 +25,7 @@ class CertificateCheckController: UITableViewController {
         for (index, value) in options.enumerated() where currentValue == value {
             selectedIndex = index
         }
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         self.title = sectionTitle
     }
 

--- a/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
+++ b/deltachat-ios/Controller/AccountSetup/SecuritySettingsController.swift
@@ -21,7 +21,7 @@ class SecuritySettingsController: UITableViewController {
 
     init(initValue: Int, title: String) {
         selectedIndex = options.firstIndex(of: Int32(initValue)) ?? 0
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         self.title = title
     }
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -146,7 +146,7 @@ class ContactDetailViewController: UITableViewController {
 
     init(dcContext: DcContext, contactId: Int) {
         self.viewModel = ContactDetailViewModel(dcContext: dcContext, contactId: contactId)
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
 
         NotificationCenter.default.addObserver(self, selector: #selector(ContactDetailViewController.handleContactsChanged(_:)), name: Event.contactsChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(ContactDetailViewController.handleIncomingMessage(_:)), name: Event.incomingMessage, object: nil)

--- a/deltachat-ios/Controller/EditContactController.swift
+++ b/deltachat-ios/Controller/EditContactController.swift
@@ -13,7 +13,7 @@ class EditContactController: UITableViewController {
         dcContact = dcContext.getContact(id: contactIdForUpdate)
         authNameOrAddr = dcContact.authName.isEmpty ? dcContact.email : dcContact.authName
         cells = [nameCell]
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
 
         nameCell.textFieldDelegate = self
         nameCell.textField.text = dcContact.editedName

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -51,7 +51,7 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
         } else {
             self.editRows = [.name, .avatar]
         }
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         self.avatarSelectionCell.hintLabel.text = String.localized(useGroupWording ? "group_avatar" : "image")
         self.avatarSelectionCell.onAvatarTapped = onAvatarTapped
         title = String.localized(useGroupWording ? "menu_edit_group" : "global_menu_edit_desktop")

--- a/deltachat-ios/Controller/EphemeralMessagesViewController.swift
+++ b/deltachat-ios/Controller/EphemeralMessagesViewController.swift
@@ -31,7 +31,7 @@ class EphemeralMessagesViewController: UITableViewController {
     init(dcContext: DcContext, chatId: Int) {
         self.dcContext = dcContext
         self.chatId = chatId
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
 
         // select option close to the timespan (that may no be available as an option eg. in case option have changed)
         self.currentIndex = 0

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -57,7 +57,7 @@ class GroupChatDetailViewController: UIViewController {
     }()
 
     lazy var tableView: UITableView = {
-        let table = UITableView(frame: .zero, style: .grouped)
+        let table = UITableView(frame: .zero, style: .insetGrouped)
         table.register(ActionCell.self, forCellReuseIdentifier: ActionCell.reuseIdentifier)
         table.register(ContactCell.self, forCellReuseIdentifier: ContactCell.reuseIdentifier)
         table.delegate = self

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -77,7 +77,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
             templateChat = nil
         }
         self.groupContactIds = Array(contactIdsForGroup)
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
     }
 
     required init?(coder _: NSCoder) {

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -273,7 +273,7 @@ internal final class AdvancedViewController: UITableViewController {
     init(dcAccounts: DcAccounts) {
         self.dcContext = dcAccounts.getSelected()
         self.dcAccounts = dcAccounts
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         hidesBottomBarWhenPushed = true
     }
 

--- a/deltachat-ios/Controller/Settings/AutodelOptionsViewController.swift
+++ b/deltachat-ios/Controller/Settings/AutodelOptionsViewController.swift
@@ -70,7 +70,7 @@ class AutodelOptionsViewController: UITableViewController {
         self.dcContext = dcContext
         self.fromServer = fromServer
         self.currVal = dcContext.getConfigInt(fromServer ? "delete_server_after" :  "delete_device_after")
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         self.title = String.localized("delete_old_messages")
         hidesBottomBarWhenPushed = true
     }

--- a/deltachat-ios/Controller/Settings/AutodelOverviewViewController.swift
+++ b/deltachat-ios/Controller/Settings/AutodelOverviewViewController.swift
@@ -45,7 +45,7 @@ class AutodelOverviewViewController: UITableViewController {
 
     init(dcContext: DcContext) {
         self.dcContext = dcContext
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         self.title = String.localized("delete_old_messages")
         hidesBottomBarWhenPushed = true
     }

--- a/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
+++ b/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
@@ -111,7 +111,7 @@ internal final class ChatsAndMediaViewController: UITableViewController {
     init(dcAccounts: DcAccounts) {
         self.dcContext = dcAccounts.getSelected()
         self.dcAccounts = dcAccounts
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         hidesBottomBarWhenPushed = true
     }
 

--- a/deltachat-ios/Controller/Settings/DownloadOnDemandViewController.swift
+++ b/deltachat-ios/Controller/Settings/DownloadOnDemandViewController.swift
@@ -17,7 +17,7 @@ class DownloadOnDemandViewController: UITableViewController {
     init(dcContext: DcContext) {
         self.dcContext = dcContext
         self.options = [0, 163840, 655360, 5242880, 26214400]
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         self.title = String.localized("auto_download_messages")
         hidesBottomBarWhenPushed = true
     }

--- a/deltachat-ios/Controller/Settings/EmailOptionsViewController.swift
+++ b/deltachat-ios/Controller/Settings/EmailOptionsViewController.swift
@@ -17,7 +17,7 @@ class EmailOptionsViewController: UITableViewController {
     init(dcContext: DcContext) {
         self.dcContext = dcContext
         self.options = [Int(DC_SHOW_EMAILS_OFF), Int(DC_SHOW_EMAILS_ACCEPTED_CONTACTS), Int(DC_SHOW_EMAILS_ALL)]
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         self.title = String.localized("pref_show_emails")
         hidesBottomBarWhenPushed = true
     }

--- a/deltachat-ios/Controller/Settings/MediaQualityViewController.swift
+++ b/deltachat-ios/Controller/Settings/MediaQualityViewController.swift
@@ -17,7 +17,7 @@ class MediaQualityViewController: UITableViewController {
     init(dcContext: DcContext) {
         self.dcContext = dcContext
         self.options = [Int(DC_MEDIA_QUALITY_BALANCED), Int(DC_MEDIA_QUALITY_WORSE)]
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         self.title = String.localized("pref_outgoing_media_quality")
         hidesBottomBarWhenPushed = true
     }

--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -42,7 +42,7 @@ class ProxySettingsViewController: UITableViewController {
         addProxyCell.actionTitle = String.localized("proxy_add")
         toggleProxyCell = SwitchCell(textLabel: String.localized("proxy_use_proxy"), on: dcContext.isProxyEnabled)
 
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
 
         tableView.register(SwitchCell.self, forCellReuseIdentifier: SwitchCell.reuseIdentifier)
         tableView.register(ActionCell.self, forCellReuseIdentifier: ActionCell.reuseIdentifier)

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -49,7 +49,7 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     init(dcAccounts: DcAccounts) {
         self.dcAccounts = dcAccounts
         self.dcContext = dcAccounts.getSelected()
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         hidesBottomBarWhenPushed = true
     }
 

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -161,7 +161,7 @@ internal final class SettingsViewController: UITableViewController {
     init(dcAccounts: DcAccounts) {
         self.dcContext = dcAccounts.getSelected()
         self.dcAccounts = dcAccounts
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
 
         // set connectivity changed observer before we acutally init `connectivityCell.detailTextLabel` in `updateCells()`,
         // otherwise, we may miss events and the label is not correct.

--- a/deltachat-ios/Controller/Settings/VideoChatInstanceViewController.swift
+++ b/deltachat-ios/Controller/Settings/VideoChatInstanceViewController.swift
@@ -62,7 +62,7 @@ class VideoChatInstanceViewController: UITableViewController {
 
     init(dcContext: DcContext) {
         self.dcContext = dcContext
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         self.updateSelected(selectedCustom: false)
         self.title = String.localized("videochat_instance")
         hidesBottomBarWhenPushed = true

--- a/deltachat-ios/View/ContactDetailHeader.swift
+++ b/deltachat-ios/View/ContactDetailHeader.swift
@@ -129,7 +129,8 @@ class ContactDetailHeader: UIView {
     }
 
     private func setupSubviews() {
-        let margin: CGFloat = 10
+        let lrMargin: CGFloat = 16
+        let spacing: CGFloat = 10
         let horizontalStackView = UIStackView(arrangedSubviews: [searchButton, muteButton])
 
         addSubview(avatar)
@@ -142,22 +143,22 @@ class ContactDetailHeader: UIView {
         addConstraints([
             avatar.constraintWidthTo(badgeSize),
             avatar.constraintHeightTo(badgeSize),
-            avatar.constraintAlignLeadingTo(self, paddingLeading: badgeSize / 4),
+            avatar.constraintAlignLeadingTo(self, paddingLeading: lrMargin),
             avatar.constraintCenterYTo(self),
             greenCheckmark.constraintHeightTo(titleLabel.font.pointSize * 0.9),
             greenCheckmark.widthAnchor.constraint(equalTo: greenCheckmark.heightAnchor),
         ])
 
-        labelsContainer.leadingAnchor.constraint(equalTo: avatar.trailingAnchor, constant: margin).isActive = true
+        labelsContainer.leadingAnchor.constraint(equalTo: avatar.trailingAnchor, constant: spacing).isActive = true
         labelsContainer.centerYAnchor.constraint(equalTo: avatar.centerYAnchor).isActive = true
-        labelsContainer.trailingAnchor.constraint(equalTo: horizontalStackView.leadingAnchor, constant: -margin).isActive = true
+        labelsContainer.trailingAnchor.constraint(equalTo: horizontalStackView.leadingAnchor, constant: -spacing).isActive = true
 
         horizontalStackView.axis = .horizontal
         horizontalStackView.distribution = .fillEqually
         horizontalStackView.alignment = .center
-        horizontalStackView.constraintAlignTrailingToAnchor(trailingAnchor, paddingTrailing: margin).isActive = true
+        horizontalStackView.constraintAlignTrailingToAnchor(trailingAnchor, paddingTrailing: lrMargin).isActive = true
         horizontalStackView.constraintCenterYTo(self).isActive = true
-        horizontalStackView.spacing = margin
+        horizontalStackView.spacing = spacing
     }
 
     func updateDetails(title: String?, subtitle: String?) {


### PR DESCRIPTION
this PR uses `.insetGroup` as added for iOS 13 for typical settings controllers.

this is better in sync with other apps and the system. moreover, buttons are now better recognized as such. "pure" lists as the chatlist or the contactlists stay as `.grouped` (as there is not so much to group, more or less the whole view controller are the same group there)

some examples:

<img width=320 src=https://github.com/user-attachments/assets/8b09673f-d882-4605-b92f-b478b131005b> &nbsp; <img width=320 src=https://github.com/user-attachments/assets/197dbe73-ade8-4915-a016-9621e880da2d>

