### PR TITLE
Fix no notification and 30 sec stale app when NSE crashed in background from running out of memory

### DIFF
--- a/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
@@ -27,19 +27,20 @@ public extension UserDefaults {
 
         if until > Date().addingTimeInterval(30) {
             // user changed their system clock so we reset nse fetching date
-            setNseFetching(until: Date().addingTimeInterval(30))
+            setNseFetching(for: 30)
         }
 
         return until > Date()
     }
 
-    /// Set the time until which the Notification Service Extension could be fetching. Call with nil or Date() when NSE fetching is done.
-    ///
-    /// Note: Do not call with date further than 30 seconds into the future. NSE fetching should not take more than 30 seconds.
-    static func setNseFetching(until: Date?) {
-        precondition(until == nil || until! <= Date().addingTimeInterval(30),
-                     "Don't set NSE fetching for more than 30 seconds")
-        shared?.set(until?.timeIntervalSince1970, forKey: nseFetchingKey)
+    /// Set the amount of seconds for which the Notification Service Extension could be fetching. Call setNseFetchingDone when done.
+    static func setNseFetching(for seconds: Double) {
+        assert(0...30 ~= seconds, "Don't set NSE fetching for more than 30 seconds")
+        shared?.set(Date().timeIntervalSince1970 + seconds, forKey: nseFetchingKey)
+    }
+
+    static func setNseFetchingDone() {
+        shared?.set(nil, forKey: nseFetchingKey)
     }
 
     static func pushToDebugArray(_ value: String) {

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -28,7 +28,6 @@ class NotificationService: UNNotificationServiceExtension {
         let memoryPressureSource = DispatchSource.makeMemoryPressureSource(eventMask: .critical)
         memoryPressureSource.setEventHandler {
             // Order of importance because we might crash very soon
-            // TODO: Could notify with "received message too big to decrypt in background"
             contentHandler(bestAttemptContent)
             exitedDueToCriticalMemory = true
             UserDefaults.pushToDebugArray("ERR5")

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -30,6 +30,7 @@ class NotificationService: UNNotificationServiceExtension {
             // Order of importance because we might crash very soon
             contentHandler(bestAttemptContent)
             exitedDueToCriticalMemory = true
+            UserDefaults.setNseFetching(for: 3)
             UserDefaults.pushToDebugArray("ERR5")
         }
         memoryPressureSource.activate()

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -14,7 +14,7 @@ class NotificationService: UNNotificationServiceExtension {
             contentHandler(silenceNotification())
             return
         }
-        UserDefaults.setNseFetching(until: Date().addingTimeInterval(26))
+        UserDefaults.setNseFetching(for: 26)
 
         // as we're mixing in notifications from accounts without PUSH and we cannot add multiple notifications,
         // it is best to move everything to the same thread - and set just no threadIdentifier
@@ -36,13 +36,13 @@ class NotificationService: UNNotificationServiceExtension {
 
         guard dcAccounts.backgroundFetch(timeout: 25) && !exitedDueToCriticalMemory else {
             UserDefaults.pushToDebugArray("ERR3")
-            UserDefaults.setNseFetching(until: nil)
+            UserDefaults.setNseFetchingDone()
             if !exitedDueToCriticalMemory {
                 contentHandler(bestAttemptContent)
             }
             return
         }
-        UserDefaults.setNseFetching(until: nil)
+        UserDefaults.setNseFetchingDone()
 
         var messageCount = 0
         var reactionCount = 0
@@ -147,7 +147,7 @@ class NotificationService: UNNotificationServiceExtension {
         // For Delta Chat, it is just fine to do nothing - assume eg. bad network or mail servers not reachable,
         // then a "You have new messages" is the best that can be done.
         UserDefaults.pushToDebugArray("ERR4")
-        UserDefaults.setNseFetching(until: nil)
+        UserDefaults.setNseFetchingDone()
     }
 
     private func silenceNotification() -> UNMutableNotificationContent {

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -30,7 +30,6 @@ class NotificationService: UNNotificationServiceExtension {
             // Order of importance because we might crash very soon
             // TODO: Could notify with "received message too big to decrypt in background"
             contentHandler(bestAttemptContent)
-            UserDefaults.setNseFetching(until: Date().addingTimeInterval(3))
             exitedDueToCriticalMemory = true
             UserDefaults.pushToDebugArray("ERR5")
         }

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -63,19 +63,15 @@ public class DcAccounts {
         if UserDefaults.nseFetching {
             // Wait for NSE-fetch to terminate before starting main-IO (both keep state unsynced, running at the same time would mess things up).
             // The other way round, NSE is not started when main-IO is running.
-            let start = CFAbsoluteTimeGetCurrent()
             NotificationCenter.default.post(name: Event.connectivityChanged, object: nil) // additional events needed as state changed outside mainapp
             startOrReschedule()
             func startOrReschedule() {
                 if UserDefaults.mainIoRunning {
                     logger.info("➡️ wait for NSE to terminate")
-                    if UserDefaults.nseFetching && (CFAbsoluteTimeGetCurrent() - start) < 30.0 { // NSE runs max 25 seconds
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                            startOrReschedule()
-                        }
+                    if UserDefaults.nseFetching {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: startOrReschedule)
                     } else {
                         dc_accounts_start_io(accountsPointer)
-                        UserDefaults.setNseFetching(false) // reset as NSE may have terminated unexpectedly. this also terminate other startIo() waiting loops
                         NotificationCenter.default.post(name: Event.messagesChanged, object: nil, userInfo: ["message_id": Int(0), "chat_id": Int(0)])
                     }
                 }


### PR DESCRIPTION
When receiving a notification for a message over ~5mb, the background fetch crashes because the Notification Service Extension is not allowed over 24mb of memory by the system. (and 12mb on older iOS)

This crash means no notification and on launch the app stays stale for 30 seconds because nseFetching user default was not set to false. 

This PR fixes both by just sending the best attempt notification when memory is critical which is just "You received messages" and refactoring nseFetching to never return true for more than 30 seconds since it was set. Now the app is only stale for 26 seconds after the crashed NSE launched, instead of 30 sec after app launch.

To test I send an 8mb GIF (attached) after force terminating the app to make sure it's not still running in background.
 
![livekindly-vexquisitstudiohq](https://github.com/user-attachments/assets/986ea261-bcef-4686-875b-59f56d053665)
