### PR TITLE
Prevent automatic limited access alert

### DIFF
--- a/deltachat-ios/Info.plist
+++ b/deltachat-ios/Info.plist
@@ -74,6 +74,8 @@
 	<string>Delta Chat wants to save images to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Delta Chat will let you choose which photos from your library to send.</string>
+	<key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
+	<true/>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>


### PR DESCRIPTION
When sending an image from your gallery the first time each run the system can ask if you want to give the app access to more photos (see image). Delta Chat doesn't need access to photos so this popup is useless. This PR disables the automatic popup as per the docs: 

> Add the PHPhotoLibraryPreventAutomaticLimitedAccessAlert key with a Boolean value of true to your app’s Info.plist file to prevent the system from automatically presenting the limited library selection prompt.
https://developer.apple.com/documentation/photos/phauthorizationstatus/limited

We can still ask permission manually in the future with `PHPhotoLibrary.presentLimitedLibraryPicker(from:)` even with this plist entry.

![IMG_3213](https://github.com/user-attachments/assets/42ce7a68-9dcc-4418-8703-7c578b29c999)

How to test:
before: Force Quit > Send image from Gallery > receive popup
after: Force Quit > Send image from Gallery > no popup
