### PR TITLE
Reduced motion on chat messages

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -276,11 +276,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 }
             }
         }
-        keyboardManager?.on(event: .willHide) { [tableView = tableView!, inputAccessoryView] notification in
-            UIView.animate(withDuration: notification.timeInterval, delay: 0, options: notification.animationOptions) {
-                tableView.contentInset.top = max(inputAccessoryView?.frame.height ?? 0, tableView.safeAreaInsets.bottom)
-            }
-        }
 
         if !dcContext.isConfigured() {
             // TODO: display message about nothing being configured


### PR DESCRIPTION
Reduce the amount of motion the chat messages receive.

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/6479febf-a87b-43a0-9c75-d01fcaab32c7"> | <video src="https://github.com/user-attachments/assets/191deacd-24b0-43a7-a3f8-12df9d6d27fc"> |
| <video src="https://github.com/user-attachments/assets/cc63c97f-84b8-4bdd-bc0d-586f3564c403"> | <video src="https://github.com/user-attachments/assets/7e81fa9b-7c73-47c6-8c93-3786602c3f0d"> |

This is possible because willShow is always called, even if keyboard hides, because the system will show the accessory. 