### PR TITLE
QuickLook swipe down and less message motion when coming back from GiveBackMyFirstResponder

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2629,9 +2629,15 @@ extension ChatViewController: QLPreviewControllerDelegate {
             previewControllerTargetSnapshot = snapshot
             return snapshot
         } else if let msgId = item.messageId, let row = messageIds.firstIndex(of: msgId) {
-            if let cell = tableView.cellForRow(at: IndexPath(row: row, section: 0)) as? BaseMessageCell,
+            previewControllerTargetHiddenOriginal?.layer.opacity = 1
+            previewControllerTargetSnapshot?.removeFromSuperview()
+            // Scroll to the message that will be dismissed
+            let indexPath = IndexPath(row: row, section: 0)
+            if tableView.indexPathsForVisibleRows?.contains(indexPath) == false {
+                tableView.scrollToRow(at: indexPath, at: .none, animated: false)
+            }
+            if let cell = tableView.cellForRow(at: indexPath) as? BaseMessageCell,
                let snapshot = cell.messageBackgroundContainer.snapshotView(afterScreenUpdates: false) {
-                previewControllerTargetHiddenOriginal?.layer.opacity = 1
                 if cell is ImageTextCell { // hide cell while transitioning
                     cell.layer.opacity = 0
                 }
@@ -2639,7 +2645,6 @@ extension ChatViewController: QLPreviewControllerDelegate {
                 snapshot.clipsToBounds = true
                 snapshot.frame = cell.messageBackgroundContainer.globalFrame
                 tableView.superview?.addSubview(snapshot)
-                previewControllerTargetSnapshot?.removeFromSuperview()
                 previewControllerTargetSnapshot = snapshot
                 previewControllerTargetHiddenOriginal = cell
                 return snapshot

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2022,7 +2022,14 @@ extension ChatViewController {
         let index = msgIds.firstIndex(of: message.id) ?? 0
         let previewController = PreviewController(dcContext: dcContext, type: .multi(msgIds: msgIds, index: index))
         previewController.delegate = self
-        present(previewController, animated: true)
+        if #available(iOS 18, *) {
+            // Pushing instead of presenting on iOS 18 makes sure it shows navigation
+            // and toolbar by default. On iOS 18 this still enables the swipe down to dismiss
+            // gesture and it still animates using previewController(_:transitionViewFor:)
+            navigationController?.pushViewController(previewController, animated: true)
+        } else {
+            present(previewController, animated: true)
+        }
     }
 
     private func didTapAsm(msg: DcMsg, orgText: String) {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2637,7 +2637,7 @@ extension ChatViewController: QLPreviewControllerDelegate {
                 tableView.scrollToRow(at: indexPath, at: .none, animated: false)
             }
             if let cell = tableView.cellForRow(at: indexPath) as? BaseMessageCell,
-               let snapshot = cell.messageBackgroundContainer.snapshotView(afterScreenUpdates: false) {
+               let snapshot = cell.messageBackgroundContainer.snapshotView(afterScreenUpdates: true) {
                 if cell is ImageTextCell { // hide cell while transitioning
                     cell.layer.opacity = 0
                 }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2641,9 +2641,8 @@ extension ChatViewController: QLPreviewControllerDelegate {
                 if cell is ImageTextCell { // hide cell while transitioning
                     cell.layer.opacity = 0
                 }
-                snapshot.layer.opacity = 0
                 snapshot.clipsToBounds = true
-                snapshot.frame = cell.messageBackgroundContainer.globalFrame
+                snapshot.frame = cell.convert(cell.messageBackgroundContainer.frame, to: tableView.superview)
                 tableView.superview?.addSubview(snapshot)
                 previewControllerTargetSnapshot = snapshot
                 previewControllerTargetHiddenOriginal = cell

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -222,7 +222,7 @@ extension FilesViewController {
         guard let index = fileMessageIds.firstIndex(of: msgId) else {
             return
         }
-        let previewController = PreviewController(dcContext: dcContext, type: .multi(fileMessageIds, index))
+        let previewController = PreviewController(dcContext: dcContext, type: .multi(msgIds: fileMessageIds, index: index))
         navigationController?.pushViewController(previewController, animated: true)
     }
 

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -199,7 +199,7 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let previewController = PreviewController(dcContext: dcContext, type: .multi(mediaMessageIds, indexPath.row))
+        let previewController = PreviewController(dcContext: dcContext, type: .multi(msgIds: mediaMessageIds, index: indexPath.row))
         previewController.delegate = self
         navigationController?.pushViewController(previewController, animated: true)
 

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -5,7 +5,7 @@ import DcCore
 class PreviewController: QLPreviewController {
     enum PreviewType {
         case single(URL)
-        case multi([Int], Int) // msgIds, index
+        case multi(msgIds: [Int], index: Int)
     }
 
     let previewType: PreviewType
@@ -49,7 +49,7 @@ extension PreviewController: QLPreviewControllerDataSource {
             return PreviewItem(url: url, title: self.customTitle)
         case .multi(let msgIds, _):
             let msg = dcContext.getMessage(id: msgIds[index])
-            return PreviewItem(url: msg.fileURL, title: self.customTitle)
+            return PreviewItem(url: msg.fileURL, title: self.customTitle, messageId: msg.id)
         }
     }
 }
@@ -58,9 +58,11 @@ extension PreviewController: QLPreviewControllerDataSource {
 class PreviewItem: NSObject, QLPreviewItem {
     var previewItemURL: URL?
     var previewItemTitle: String?
+    var messageId: Int?
 
-    init(url: URL?, title: String?) {
+    init(url: URL?, title: String?, messageId: Int? = nil) {
         self.previewItemURL = url
         self.previewItemTitle = title ?? ""
+        self.messageId = messageId
     }
 }

--- a/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
+++ b/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
@@ -1,4 +1,5 @@
 import UIKit
+import QuickLook
 
 /// https://gist.github.com/Amzd/223979ef5a06d98ef17d2d78dbd96e22
 extension UIViewController {
@@ -27,6 +28,14 @@ extension UIViewController {
             documentPicker.returnFirstRespondersOnDismiss()
         }
         present(documentPicker as UIViewController, animated: animated, completion: completion)
+    }
+
+    /// QLPreviewController causes issues when dismissed using the swipe gesture if there was a first responder active when it was presented.
+    /// Issues range from freezing the previous first responder to crashing the app.
+    public func present(_ previewController: QLPreviewController, animated: Bool, completion: (() -> Void)? = nil) {
+        // QLPreviewController can not be used as child because it would not do its custom transitions
+        let vc = GiveBackMyFirstResponder.asChild(of: previewController)
+        present(vc, animated: animated, completion: completion)
     }
 
     /// In iOS 16 and below and iOS 18 the UIImagePickerController does not give back the first responder when search was used.

--- a/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
+++ b/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
@@ -34,8 +34,8 @@ extension UIViewController {
     /// Issues range from freezing the previous first responder to crashing the app.
     public func present(_ previewController: QLPreviewController, animated: Bool, completion: (() -> Void)? = nil) {
         // QLPreviewController can not be used as child because it would not do its custom transitions
-        let vc = GiveBackMyFirstResponder.asChild(of: previewController)
-        present(vc, animated: animated, completion: completion)
+        previewController.returnFirstRespondersOnDismiss()
+        present(previewController as UIViewController, animated: animated, completion: completion)
     }
 
     /// In iOS 16 and below and iOS 18 the UIImagePickerController does not give back the first responder when search was used.


### PR DESCRIPTION
This PR makes the image preview (quicklook) able to be dismissed by swiping down, instead of the default popGestureRecognizer. This is an improvement because A; the popGesture is only enabled when the navigation bars are shown, B; it interferes with swiping to previous image, and C; the animation feels good.

For this to look good I had to reduce the motion on messages when presenting/dismissing view controllers some more. Now after a view is dismissed the scroll updating is delayed by 0.5s which means that first; the ChatViewController can become firstResponder (bringing up the accessory) and then; the text field can become firstResponder (bringing up the keyboard) without the chat scrolling.

### Quick Look Dismiss (This change is only pre-iOS 18)
| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/9b17775b-093d-4084-aee8-727470d1e5d7"> | <video src="https://github.com/user-attachments/assets/5c697a64-c92d-4774-84b7-0e0679e9554e"> |


### Reduced motion (This change is everywhere)
| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/dfbad789-8e7a-45db-afb9-8d5d7c621445"> | <video src="https://github.com/user-attachments/assets/8ef75b86-d39e-45a4-82f2-4b88b4172fa8"> |
