### PR TITLE
even more modern settings pages 

### DIFF
--- a/deltachat-ios/Controller/GroupMembersViewController.swift
+++ b/deltachat-ios/Controller/GroupMembersViewController.swift
@@ -76,7 +76,7 @@ class GroupMembersViewController: UITableViewController {
 
     init(dcContext: DcContext) {
         self.dcContext = dcContext
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         hidesBottomBarWhenPushed = true
     }
 

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -76,7 +76,7 @@ class NewChatViewController: UITableViewController {
         }
         self.newOptions = newOptions
 
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         hidesBottomBarWhenPushed = true
     }
 

--- a/deltachat-ios/Controller/NewContactController.swift
+++ b/deltachat-ios/Controller/NewContactController.swift
@@ -35,7 +35,7 @@ class NewContactController: UITableViewController {
         self.dcContext = dcContext
         cells = [emailCell, nameCell]
         prefilledSeachResult = searchResult
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
         emailCell.textFieldDelegate = self
         nameCell.textFieldDelegate = self
 


### PR DESCRIPTION
use .insetGrouped also for 'new chat',  'add members…' and 'add contact manually'; each of them may have buttons, which look better. also it is much more consistent now. the only .grouped style left is the main chatlist

successor of https://github.com/deltachat/deltachat-ios/pull/2474

targets https://github.com/deltachat/deltachat-ios/issues/2478 

<img width=250 src=https://github.com/user-attachments/assets/00821938-7ba0-4164-8247-10e3365fb2fa>
<img width=250 src=https://github.com/user-attachments/assets/6e678d6a-b849-4a4c-b2c5-ecace679eaef>
<img width=250 src=https://github.com/user-attachments/assets/c0375b2b-381f-488e-9faf-5805200395ab>

