### PR TITLE
widget wordings

### DIFF
--- a/DcWidget/DcWidget.swift
+++ b/DcWidget/DcWidget.swift
@@ -7,7 +7,7 @@ struct DcShortcutWidgetView: View {
 
     var body: some View {
         if entry.shortcuts.isEmpty {
-            Text(String.localized("ios_widget_apps_description"))
+            Text(String.localized("shortcuts_widget_description"))
         } else {
             let rows = [GridItem(.fixed(56)), GridItem(.fixed(56))]
             LazyHGrid(rows: rows) {
@@ -79,8 +79,8 @@ struct DcWidget: Widget {
             }
         }
         .supportedFamilies([.systemSmall, .systemMedium])
-        .configurationDisplayName(String.localized("ios_widget_apps_title"))
-        .description(String.localized("ios_widget_apps_description"))
+        .configurationDisplayName(String.localized("shortcuts_widget_title"))
+        .description(String.localized("shortcuts_widget_description"))
     }
 }
 

--- a/DcWidget/DcWidget.swift
+++ b/DcWidget/DcWidget.swift
@@ -7,7 +7,7 @@ struct DcShortcutWidgetView: View {
 
     var body: some View {
         if entry.shortcuts.isEmpty {
-            Text(String.localized("ios_widget_no_apps"))
+            Text(String.localized("ios_widget_apps_description"))
         } else {
             let rows = [GridItem(.fixed(56)), GridItem(.fixed(56))]
             LazyHGrid(rows: rows) {

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -1053,12 +1053,12 @@ extension ChatListViewController: ChatListEditingBarDelegate {
             let chatPresentInHomescreenWidget = allHomescreenChatsIds.contains(chatId)
             let action: UIAlertAction
             if chatPresentInHomescreenWidget {
-                action = UIAlertAction(title: String.localized("ios_remove_from_home_screen"), style: .default) { [weak self] _ in
+                action = UIAlertAction(title: String.localized("remove_from_widget"), style: .default) { [weak self] _ in
                     guard let self else { return }
                     userDefaults.removeChatFromHomescreenWidget(accountId: self.dcContext.id, chatId: chatId)
                 }
             } else {
-                action = UIAlertAction(title: String.localized("ios_add_to_home_screen"), style: .default) { [weak self] _ in
+                action = UIAlertAction(title: String.localized("add_to_widget"), style: .default) { [weak self] _ in
                     guard let self else { return }
 
                     userDefaults.addChatToHomescreenWidget(accountId: self.dcContext.id, chatId: chatId)

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -50,9 +50,9 @@ class ContactDetailViewController: UITableViewController {
 
         let isOnHomescreen = chatIdsOnHomescreen.contains(viewModel.chatId)
         if isOnHomescreen {
-            cell.actionTitle = String.localized("ios_remove_from_home_screen")
+            cell.actionTitle = String.localized("remove_from_widget")
         } else {
-            cell.actionTitle = String.localized("ios_add_to_home_screen")
+            cell.actionTitle = String.localized("add_to_widget")
         }
         cell.actionColor = UIColor.systemBlue
         return cell
@@ -462,9 +462,9 @@ class ContactDetailViewController: UITableViewController {
 
         let onHomescreen = viewModel.toggleChatInHomescreenWidget()
         if onHomescreen {
-            homescreenWidgetCell.actionTitle = String.localized("ios_remove_from_home_screen")
+            homescreenWidgetCell.actionTitle = String.localized("remove_from_widget")
         } else {
-            homescreenWidgetCell.actionTitle =  String.localized("ios_add_to_home_screen")
+            homescreenWidgetCell.actionTitle =  String.localized("add_to_widget")
         }
     }
 

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -211,7 +211,7 @@ extension FilesViewController: UITableViewDelegate, UITableViewDataSource {
                     if isOnHomescreen {
                         children.append(
                             UIAction.menuAction(
-                                localizationKey: "ios_remove_from_home_screen",
+                                localizationKey: "remove_from_widget",
                                 systemImageName: "rectangle.on.rectangle.slash",
                                 indexPath: indexPath,
                                 action: { _ in
@@ -221,7 +221,7 @@ extension FilesViewController: UITableViewDelegate, UITableViewDataSource {
                     } else {
                         children.append(
                             UIAction.menuAction(
-                                localizationKey: "ios_add_to_home_screen",
+                                localizationKey: "add_to_widget",
                                 systemImageName: "plus.rectangle.on.rectangle",
                                 indexPath: indexPath,
                                 action: { _ in

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -164,9 +164,9 @@ class GroupChatDetailViewController: UIViewController {
 
         let isOnHomescreen = chatIdsOnHomescreen.contains(chatId)
         if isOnHomescreen {
-            cell.actionTitle = String.localized("ios_remove_from_home_screen")
+            cell.actionTitle = String.localized("remove_from_widget")
         } else {
-            cell.actionTitle = String.localized("ios_add_to_home_screen")
+            cell.actionTitle = String.localized("add_to_widget")
         }
         cell.actionColor = UIColor.systemBlue
         return cell
@@ -362,9 +362,9 @@ class GroupChatDetailViewController: UIViewController {
         }
 
         if onHomescreen {
-            homescreenWidgetCell.actionTitle = String.localized("ios_remove_from_home_screen")
+            homescreenWidgetCell.actionTitle = String.localized("remove_from_widget")
         } else {
-            homescreenWidgetCell.actionTitle =  String.localized("ios_add_to_home_screen")
+            homescreenWidgetCell.actionTitle =  String.localized("add_to_widget")
         }
     }
 

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -446,13 +446,13 @@ class WebxdcViewController: WebViewViewController {
             
             let homescreenAction: UIAlertAction
             if isOnHomescreen {
-                homescreenAction = UIAlertAction(title: String.localized("ios_remove_from_home_screen"), style: .default) { [weak self] _ in
+                homescreenAction = UIAlertAction(title: String.localized("remove_from_widget"), style: .default) { [weak self] _ in
                     guard let self else { return }
                     
                     userDefaults.removeWebxdcFromHomescreen(accountId: accountId, messageId: messageId)
                 }
             } else {
-                homescreenAction = UIAlertAction(title: String.localized("ios_add_to_home_screen"), style: .default) { [weak self] _ in
+                homescreenAction = UIAlertAction(title: String.localized("add_to_widget"), style: .default) { [weak self] _ in
                     guard let self else { return }
                     
                     userDefaults.addWebxdcToHomescreenWidget(accountId: accountId, messageId: messageId)

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -1065,7 +1065,7 @@
 "backup_successful_explain_ios" = "You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.";
 "location_denied" = "Location access denied";
 "location_denied_explain_ios" = "In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".";
-"ios_widget_apps_title" = "Shortcuts";
-"ios_widget_apps_description" = "Use Delta Chat's \"Add To Widget\" to add items";
+"shortcuts_widget_title" = "Shortcuts";
+"shortcuts_widget_description" = "Use Delta Chat's \"Add To Widget\" to add items";
 "remove_from_widget" = "Remove from Widget";
 "add_to_widget" = "Add to Widget";

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -1067,5 +1067,5 @@
 "location_denied_explain_ios" = "In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".";
 "ios_widget_apps_title" = "Shortcuts";
 "ios_widget_apps_description" = "Use Delta Chat's \"Add To Widget\" to add items";
-"ios_remove_from_home_screen" = "Remove from Widget";
-"ios_add_to_home_screen" = "Add to Widget";
+"remove_from_widget" = "Remove from Widget";
+"add_to_widget" = "Add to Widget";

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -1065,11 +1065,7 @@
 "backup_successful_explain_ios" = "You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.";
 "location_denied" = "Location access denied";
 "location_denied_explain_ios" = "In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".";
-"widget_no_apps" = "In-Chat Utilities or Games will be shown here";
-"widget_most_recent_apps_title" = "Shortcuts";
-"widget_most_recent_apps_description" = "Shows the most recent In-Chat Utilities and Games";
-"ios_widget_no_apps" = "In-Chat Utilities or Games will be shown here";
 "ios_widget_apps_title" = "Shortcuts";
-"ios_widget_apps_description" = "Shortcuts to In-Chat Utilities and Games";
-"ios_remove_from_home_screen" = "Remove from Homescreen";
-"ios_add_to_home_screen" = "Add to Homescreen";
+"ios_widget_apps_description" = "Use Delta Chat's \"Add To Widget\" to add items";
+"ios_remove_from_home_screen" = "Remove from Widget";
+"ios_add_to_home_screen" = "Add to Widget";

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -8,7 +8,7 @@
     <string name="location_denied">Location access denied</string>
     <string name="location_denied_explain_ios">In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".</string>
     <string name="shortcuts_widget_title">Shortcuts</string>
-    <string name="shortcuts_widget_description">Use Delta Chat's \"Add To Widget\" to add items</string>
+    <string name="shortcuts_widget_description">Use Delta Chat's \"Add to Widget\" to add items</string>
     <string name="remove_from_widget">Remove from Widget</string>
     <string name="add_to_widget">Add to Widget</string>
 </resources>

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -7,9 +7,6 @@
     <string name="backup_successful_explain_ios">You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.</string>
     <string name="location_denied">Location access denied</string>
     <string name="location_denied_explain_ios">In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".</string>
-    <string name="widget_no_apps">In-Chat Utilities or Games will be shown here</string>
-    <string name="widget_most_recent_apps_title">Shortcuts</string>
-    <string name="widget_most_recent_apps_description">Shows the most recent In-Chat Utilities and Games</string>
     <string name="ios_widget_no_apps">In-Chat Utilities or Games will be shown here</string>
     <string name="ios_widget_apps_title">Shortcuts</string>
     <string name="ios_widget_apps_description">Shortcuts to In-Chat Utilities and Games</string>

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -9,6 +9,6 @@
     <string name="location_denied_explain_ios">In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".</string>
     <string name="ios_widget_apps_title">Shortcuts</string>
     <string name="ios_widget_apps_description">Use Delta Chat's \"Add To Widget\" to add items</string>
-    <string name="ios_remove_from_home_screen">Remove from Widget</string>
-    <string name="ios_add_to_home_screen">Add to Widget</string>
+    <string name="remove_from_widget">Remove from Widget</string>
+    <string name="add_to_widget">Add to Widget</string>
 </resources>

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -7,8 +7,8 @@
     <string name="backup_successful_explain_ios">You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.</string>
     <string name="location_denied">Location access denied</string>
     <string name="location_denied_explain_ios">In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".</string>
-    <string name="ios_widget_apps_title">Shortcuts</string>
-    <string name="ios_widget_apps_description">Use Delta Chat's \"Add To Widget\" to add items</string>
+    <string name="shortcuts_widget_title">Shortcuts</string>
+    <string name="shortcuts_widget_description">Use Delta Chat's \"Add To Widget\" to add items</string>
     <string name="remove_from_widget">Remove from Widget</string>
     <string name="add_to_widget">Add to Widget</string>
 </resources>

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -7,9 +7,8 @@
     <string name="backup_successful_explain_ios">You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.</string>
     <string name="location_denied">Location access denied</string>
     <string name="location_denied_explain_ios">In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".</string>
-    <string name="ios_widget_no_apps">In-Chat Utilities or Games will be shown here</string>
     <string name="ios_widget_apps_title">Shortcuts</string>
-    <string name="ios_widget_apps_description">Shortcuts to In-Chat Utilities and Games</string>
-    <string name="ios_remove_from_home_screen">Remove from Homescreen</string>
-    <string name="ios_add_to_home_screen">Add to Homescreen</string>
+    <string name="ios_widget_apps_description">Use Delta Chat's \"Add To Widget\" to add items</string>
+    <string name="ios_remove_from_home_screen">Remove from Widget</string>
+    <string name="ios_add_to_home_screen">Add to Widget</string>
 </resources>


### PR DESCRIPTION
this PR changes the wording for the widgets from "Add to Home screen" to "Add to Widget", same for "remove".

moreover, the description is changed to be more actionable, and, as a side effect, does not need to mention apps:

<img width=250 src=https://github.com/user-attachments/assets/b1c9d7fb-11df-40e2-baee-b9df5b4ca235>
<img width=250 src=https://github.com/user-attachments/assets/7be10d16-63db-48c9-afc3-ff85a122954e>
<br><br><br>

this is how the buttons look like now:

<img width=250 src=https://github.com/user-attachments/assets/03a048c3-12f8-48d7-9509-dd38bb0c00e6>
<img width=250 src=https://github.com/user-attachments/assets/2c244549-7938-4b73-a429-8d965ad8cecb>
<br><br><br>

and finally, if all chats and apps are removed, the widget shows the following hint - looks a but handwavy, but usually, the user does not see the hint here at all as the widget comes prefilled with the chats "Saved Messages" and "Device Messages":

<img width=250 src=https://github.com/user-attachments/assets/d6ac8f86-31b9-434c-a378-37a3552c420a>
<br><br><br>

targets #2439 , once this is merged, we can add the new strings to android to make them translatable and finally close #2439