### PR TITLE
end chatlist's editing mode on widget action

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -1056,12 +1056,13 @@ extension ChatListViewController: ChatListEditingBarDelegate {
                 action = UIAlertAction(title: String.localized("ios_remove_from_home_screen"), style: .default) { [weak self] _ in
                     guard let self else { return }
                     userDefaults.removeChatFromHomescreenWidget(accountId: self.dcContext.id, chatId: chatId)
+                    setLongTapEditing(false)
                 }
             } else {
                 action = UIAlertAction(title: String.localized("ios_add_to_home_screen"), style: .default) { [weak self] _ in
                     guard let self else { return }
-
                     userDefaults.addChatToHomescreenWidget(accountId: self.dcContext.id, chatId: chatId)
+                    setLongTapEditing(false)
                 }
             }
             alert.addAction(action)


### PR DESCRIPTION
similar to mute, pin, etc.,
it seems expected that the editing mode is ended once 'Add to Widget' or 'Remove from Widget' is tapped in the chatlist.

this also gives visual feedback,
that is missing without.