### PR TITLE
do not write deprecated DC_CERTCK_ACCEPT_INVALID_CERTIFICATES

### DIFF
--- a/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
+++ b/deltachat-ios/Controller/AccountSetup/CertificateCheckController.swift
@@ -7,7 +7,7 @@ protocol CertificateCheckDelegate: AnyObject {
 
 class CertificateCheckController: UITableViewController {
 
-    private let options = [Int(DC_CERTCK_AUTO), Int(DC_CERTCK_STRICT), Int(DC_CERTCK_ACCEPT_INVALID_CERTIFICATES)]
+    private let options = [Int(DC_CERTCK_AUTO), Int(DC_CERTCK_STRICT), Int(DC_CERTCK_ACCEPT_INVALID)]
     private var currentValue: Int
     private var selectedIndex: Int?
     weak var delegate: CertificateCheckDelegate?
@@ -79,7 +79,7 @@ class CertificateCheckController: UITableViewController {
                 return String.localized("automatic")
             case Int(DC_CERTCK_STRICT):
                 return String.localized("strict")
-            case Int(DC_CERTCK_ACCEPT_INVALID_CERTIFICATES):
+            case Int(DC_CERTCK_ACCEPT_INVALID):
                 return String.localized("accept_invalid_certificates")
             default:
                 return "Undefined"

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -701,10 +701,13 @@ public class DcContext {
 
     public var certificateChecks: Int {
         get {
-            if let str = getConfig("imap_certificate_checks") {
-                return Int(str) ?? 0
-            } else {
-                return 0
+            switch Int32(getConfigInt("imap_certificate_checks")) {
+            case DC_CERTCK_ACCEPT_INVALID, DC_CERTCK_ACCEPT_INVALID_CERTIFICATES:
+                return Int(DC_CERTCK_ACCEPT_INVALID)
+            case DC_CERTCK_STRICT:
+                return Int(DC_CERTCK_STRICT)
+            default:
+                return Int(DC_CERTCK_AUTO)
             }
         }
         set {


### PR DESCRIPTION
the meaning of the values unfortunately went through some changes and confusion, that now result in some mess. i tried to do the changes really on point here, and not introduce another layer of possible conversion bugs by adding eg.  an additional swift enum (that area is anyway subject to change with the upcoming multi-transport using json instead of "config")

compare https://github.com/deltachat/deltachat-core-rust/pull/6176

closes #2384 