### PR TITLE
unify initials generation

### DIFF
--- a/DcWidget/DcWidget.swift
+++ b/DcWidget/DcWidget.swift
@@ -52,7 +52,7 @@ struct ChatShortcutView: View {
             } else if let colorImage = UIImage(color: chat.color, size: CGSize(width: 56, height: 56)) {
                 ZStack {
                     Image(uiImage: colorImage)
-                    Text(chat.title.first?.uppercased() ?? "🫶")
+                    Text(DcUtils.getInitials(inputName: chat.title))
                         .foregroundStyle(.white)
                         .font(.system(size: 34))
                 }


### PR DESCRIPTION
let the avatars look the same in case things fail.

this is also better in case we need to adapt things (might be names get prefixed by `~`, see https://github.com/deltachat/deltachat-android/pull/3520)