### PR TITLE
Never update the widget automatically, only on changes (#2479)

### DIFF
--- a/DcWidget/WidgetProvider.swift
+++ b/DcWidget/WidgetProvider.swift
@@ -89,9 +89,8 @@ struct Provider: TimelineProvider {
 
         let currentDate = Date()
         let entry = UsedWebxdcEntry(date: currentDate, shortcuts: shortcuts)
-        let nextDate = Calendar.current.date(byAdding: .minute, value: 15, to: currentDate)!
 
-        let timeline = Timeline(entries: [entry], policy: .after(nextDate))
+        let timeline = Timeline(entries: [entry], policy: .never)
         completion(timeline)
     }
 }


### PR DESCRIPTION
We don't need to update the widget automatically anymore as users can configure the widget. Previously, we updated the shortcuts frequently as we showed the most recent apps.

(Hopefully fixes #2479)