### PR TITLE
Fix for scrolling issue and keyboard resign when starting an interactivePopGesture but canceling it.

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -311,6 +311,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         emptyStateView.addCenteredTo(parentView: backgroundContainer, evadeKeyboard: true)
     }
 
+    var isInitialViewWillAppear = true
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         // this will be removed in viewWillDisappear
@@ -349,7 +350,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
         messageInputBar.scrollDownButton.isHidden = true
 
-        if isMovingToParent { // being pushed
+        if isInitialViewWillAppear {
             becomeFirstResponder()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 self.tableView.contentInset.top = max(self.inputAccessoryView?.frame.height ?? 0, self.tableView.safeAreaInsets.bottom)
@@ -361,6 +362,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 }
             }
         }
+        isInitialViewWillAppear = false
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
Previously when canceling interactive pop gesture it would scroll back to bottom (or to new messages indicator) and dismiss the keyboard. There is still some lag that happens when you cancel but that is due to recalculation of the navbar title (which might not be needed but I don't know the edge cases).

| Before | After | 
| --- | --- | 
| <video src="https://github.com/user-attachments/assets/167d2f05-bae7-4d52-847e-102aa034193f"> | <video src="https://github.com/user-attachments/assets/f3ad2f00-6586-4729-b8de-537ddcd77862"> |

