### PR TITLE
webp support for pasting images

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		30FDB71F24D8170E0066C48D /* TextMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FDB71E24D8170E0066C48D /* TextMessageCell.swift */; };
 		30FDB72124D838240066C48D /* BaseMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FDB72024D838240066C48D /* BaseMessageCell.swift */; };
 		5F153E9A2CC38BAA00871ABE /* GiveBackMyFirstResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F153E992CC38BAA00871ABE /* GiveBackMyFirstResponder.swift */; };
+		5F4945AB2D315E7000DCD50A /* UIPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */; };
 		5F785F6E2CB9344F003FFFB9 /* ReusableCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */; };
 		7070FB9B2101ECBB000DC258 /* NewGroupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7070FB9A2101ECBB000DC258 /* NewGroupController.swift */; };
 		7092474120B3869500AF8799 /* ContactDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7092474020B3869500AF8799 /* ContactDetailViewController.swift */; };
@@ -460,6 +461,7 @@
 		30FDB72024D838240066C48D /* BaseMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseMessageCell.swift; sourceTree = "<group>"; };
 		5299B7A064591DDEE0678CD6 /* Pods-DcShare.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DcShare.debug.xcconfig"; path = "Target Support Files/Pods-DcShare/Pods-DcShare.debug.xcconfig"; sourceTree = "<group>"; };
 		5F153E992CC38BAA00871ABE /* GiveBackMyFirstResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiveBackMyFirstResponder.swift; sourceTree = "<group>"; };
+		5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPasteboard.swift; sourceTree = "<group>"; };
 		5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableCellProtocol.swift; sourceTree = "<group>"; };
 		7070FB9A2101ECBB000DC258 /* NewGroupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGroupController.swift; sourceTree = "<group>"; };
 		7092474020B3869500AF8799 /* ContactDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDetailViewController.swift; sourceTree = "<group>"; };
@@ -767,6 +769,7 @@
 				D85DF9772C4A96CB00A01408 /* UserDefaults+Extensions.swift */,
 				D8083ACF2D14384F005DCB7D /* UserDefaults+Widgets.swift */,
 				D82AD24C2D27E47A009D6026 /* UIApplication+Orientation.swift */,
+				5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1647,6 +1650,7 @@
 				304219D92440734A00516852 /* DcMsg+Extension.swift in Sources */,
 				AE52EA19229EB53C00C586C9 /* ContactDetailHeader.swift in Sources */,
 				78E45E4421D3F14A00D4B15E /* UIImage+Extension.swift in Sources */,
+				5F4945AB2D315E7000DCD50A /* UIPasteboard.swift in Sources */,
 				3080A022277DE09900E74565 /* InputTextView.swift in Sources */,
 				30734326249A280B00BF9AD1 /* MediaQualityViewController.swift in Sources */,
 				3080A01C277DDB8A00E74565 /* InputBarAccessoryViewDelegate.swift in Sources */,

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputTextView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputTextView.swift
@@ -232,7 +232,7 @@ open class InputTextView: UITextView {
     
     open override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         
-        if action == NSSelectorFromString("paste:") && UIPasteboard.general.hasImages {
+        if action == NSSelectorFromString("paste:") && UIPasteboard.general.hasImagesExtended {
             return isImagePasteEnabled
         }
         return super.canPerformAction(action, withSender: sender)
@@ -240,7 +240,7 @@ open class InputTextView: UITextView {
     
     open override func paste(_ sender: Any?) {
         
-        guard isImagePasteEnabled, let image = UIPasteboard.general.image else {
+        guard isImagePasteEnabled, let image = UIPasteboard.general.imageExtended else {
             return super.paste(sender)
         }
         for plugin in inputBarAccessoryView?.inputPlugins ?? [] {

--- a/deltachat-ios/Chat/Views/ChatInputTextView.swift
+++ b/deltachat-ios/Chat/Views/ChatInputTextView.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 import MobileCoreServices
-import UniformTypeIdentifiers
 
 public class ChatInputTextView: InputTextView {
 
@@ -16,14 +15,14 @@ public class ChatInputTextView: InputTextView {
 
     // MARK: - Image Paste Support
     open override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        if action == NSSelectorFromString("paste:") && UIPasteboard.general.hasImages {
+        if action == NSSelectorFromString("paste:") && UIPasteboard.general.hasImagesExtended {
             return true
         }
         return super.canPerformAction(action, withSender: sender)
     }
 
     open override func paste(_ sender: Any?) {
-        guard let image = UIPasteboard.general.image else {
+        guard let image = UIPasteboard.general.imageExtended else {
             return super.paste(sender)
         }
         imagePasteDelegate?.onImagePasted(image: image)

--- a/deltachat-ios/Extensions/UIPasteboard.swift
+++ b/deltachat-ios/Extensions/UIPasteboard.swift
@@ -1,0 +1,17 @@
+import SDWebImage
+import UIKit
+import UniformTypeIdentifiers
+
+extension UIPasteboard {
+    /// Also returns true for webp (on iOS 14+)
+    public var hasImagesExtended: Bool {
+        guard #available(iOS 14.0, *) else { return hasImages }
+        return hasImages || types.contains(UTType.webP.identifier)
+    }
+
+    /// Also returns webp image (on iOS 14+)
+    public var imageExtended: UIImage? {
+        guard #available(iOS 14.0, *) else { return image }
+        return image ?? UIImage.sd_image(withWebPData: data(forPasteboardType: UTType.webP.identifier))
+    }
+}


### PR DESCRIPTION
Previously you could not paste webp images which could be really confusing:

- Saved an image from Safari to Photos
- In Photos long press it and "Copy Photo"
- Try to paste in Delta Chat
- No "Paste" shows up

At no point will the user have seen it is a webp image and pasting it was not supported, and they might have thought DeltaChat did not support pasting images at all (I did for a while).

I added it in a way that we can add more image types that are not directly supported when we find them.