### PR TITLE
force a name on editing profile

### DIFF
--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -11,6 +11,14 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
 
     private let dcContext: DcContext
 
+    lazy var doneButton: UIBarButtonItem = {
+        return UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonPressed))
+    }()
+
+    lazy var cancelButton: UIBarButtonItem = {
+        return UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed))
+    }()
+
     private lazy var mediaPicker: MediaPicker? = {
         let mediaPicker = MediaPicker(dcContext: dcContext, navigationController: navigationController)
         mediaPicker.delegate = self
@@ -31,7 +39,7 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     private var deleteAvatar: Bool = false
 
     private lazy var nameCell: TextFieldCell = {
-        let cell = TextFieldCell(description: String.localized("pref_your_name"), placeholder: String.localized("pref_your_name"))
+        let cell = TextFieldCell(description: String.localized("pref_your_name"), placeholder: String.localized("please_enter_name"))
         cell.setText(text: dcContext.displayname)
         cell.textFieldDelegate = self
         cell.textField.returnKeyType = .default
@@ -51,6 +59,13 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
         self.dcContext = dcAccounts.getSelected()
         super.init(style: .insetGrouped)
         hidesBottomBarWhenPushed = true
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(SelfProfileViewController.textDidChangeNotification(notification:)),
+            name: UITextField.textDidChangeNotification,
+            object: nameCell.textField
+        )
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -64,8 +79,13 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
             self?.onAvatarTapped()
         }
         tableView.rowHeight = UITableView.automaticDimension
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonPressed))
-        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed))
+        navigationItem.rightBarButtonItem = doneButton
+        navigationItem.leftBarButtonItem = cancelButton
+        validateFields()
+    }
+
+    func validateFields() {
+        doneButton.isEnabled = !(nameCell.textField.text?.isEmpty ?? true)
     }
 
     // MARK: - Table view data source
@@ -87,6 +107,11 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
 
     override func tableView(_: UITableView, titleForFooterInSection section: Int) -> String? {
         return sections[section].footerTitle
+    }
+
+    // MARK: - Notifications
+    @objc func textDidChangeNotification(notification: Notification) {
+        validateFields()
     }
 
     // MARK: - actions

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -27,7 +27,8 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     private lazy var avatarSelectionCell: AvatarSelectionCell = {
         return AvatarSelectionCell(image: dcContext.getSelfAvatarImage())
     }()
-    private var avatarChanged: (UIImage?)?
+    private var changeAvatar: UIImage?
+    private var deleteAvatar: Bool = false
 
     private lazy var nameCell: TextFieldCell = {
         let cell = TextFieldCell(description: String.localized("pref_your_name"), placeholder: String.localized("pref_your_name"))
@@ -96,12 +97,10 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     @objc func doneButtonPressed() {
         dcContext.selfstatus = statusCell.getText()
         dcContext.displayname = nameCell.getText()
-        if let avatarChanged {
-            if let newAvatar = avatarChanged {
-                AvatarHelper.saveSelfAvatarImage(dcContext: dcContext, image: newAvatar)
-            } else {
-                dcContext.selfavatar = nil
-            }
+        if let changeAvatar {
+            AvatarHelper.saveSelfAvatarImage(dcContext: dcContext, image: changeAvatar)
+        } else if deleteAvatar {
+            dcContext.selfavatar = nil
         }
         navigationController?.popViewController(animated: true)
     }
@@ -115,8 +114,9 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     }
 
     private func deleteProfileIconPressed(_ action: UIAlertAction) {
-        avatarChanged = (nil)
-        self.avatarSelectionCell.setAvatar(image: nil)
+        changeAvatar = nil
+        deleteAvatar = true
+        avatarSelectionCell.setAvatar(image: nil)
     }
 
     private func onAvatarTapped() {
@@ -132,10 +132,10 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     }
 
     func onImageSelected(image: UIImage) {
-        avatarChanged = (image)
-        self.avatarSelectionCell.setAvatar(image: image)
+        changeAvatar = image
+        deleteAvatar = false
+        avatarSelectionCell.setAvatar(image: image)
     }
-
 }
 
 

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -27,6 +27,7 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     private lazy var avatarSelectionCell: AvatarSelectionCell = {
         return AvatarSelectionCell(image: dcContext.getSelfAvatarImage())
     }()
+    private var avatarChanged: (UIImage?)?
 
     private lazy var nameCell: TextFieldCell = {
         let cell = TextFieldCell(description: String.localized("pref_your_name"), placeholder: String.localized("pref_your_name"))
@@ -95,6 +96,13 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     @objc func doneButtonPressed() {
         dcContext.selfstatus = statusCell.getText()
         dcContext.displayname = nameCell.getText()
+        if let avatarChanged {
+            if let newAvatar = avatarChanged {
+                AvatarHelper.saveSelfAvatarImage(dcContext: dcContext, image: newAvatar)
+            } else {
+                dcContext.selfavatar = nil
+            }
+        }
         navigationController?.popViewController(animated: true)
     }
 
@@ -107,15 +115,15 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     }
 
     private func deleteProfileIconPressed(_ action: UIAlertAction) {
-        dcContext.selfavatar = nil
-        updateAvatarCell()
+        avatarChanged = (nil)
+        self.avatarSelectionCell.setAvatar(image: nil)
     }
 
     private func onAvatarTapped() {
         let alert = UIAlertController(title: String.localized("pref_profile_photo"), message: nil, preferredStyle: .safeActionSheet)
         alert.addAction(PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:)))
         alert.addAction(PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:)))
-        if dcContext.getSelfAvatarImage() != nil {
+        if avatarSelectionCell.isAvatarSet() {
             alert.addAction(UIAlertAction(title: String.localized("delete"), style: .destructive, handler: deleteProfileIconPressed(_:)))
         }
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
@@ -124,12 +132,8 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     }
 
     func onImageSelected(image: UIImage) {
-        AvatarHelper.saveSelfAvatarImage(dcContext: dcContext, image: image)
-        updateAvatarCell()
-    }
-
-    private func updateAvatarCell() {
-        self.avatarSelectionCell.setAvatar(image: dcContext.getSelfAvatarImage())
+        avatarChanged = (image)
+        self.avatarSelectionCell.setAvatar(image: image)
     }
 
 }

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -64,11 +64,8 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
             self?.onAvatarTapped()
         }
         tableView.rowHeight = UITableView.automaticDimension
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        dcContext.selfstatus = statusCell.getText()
-        dcContext.displayname = nameCell.getText()
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonPressed))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed))
     }
 
     // MARK: - Table view data source
@@ -93,6 +90,16 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     }
 
     // MARK: - actions
+    @objc func cancelButtonPressed() {
+        navigationController?.popViewController(animated: true)
+    }
+
+    @objc func doneButtonPressed() {
+        dcContext.selfstatus = statusCell.getText()
+        dcContext.displayname = nameCell.getText()
+        navigationController?.popViewController(animated: true)
+    }
+
     private func galleryButtonPressed(_ action: UIAlertAction) {
         mediaPicker?.showPhotoGallery()
     }

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -10,7 +10,6 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     }
 
     private let dcContext: DcContext
-    private let dcAccounts: DcAccounts
 
     private lazy var mediaPicker: MediaPicker? = {
         let mediaPicker = MediaPicker(dcContext: dcContext, navigationController: navigationController)
@@ -47,7 +46,6 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     }()
 
     init(dcAccounts: DcAccounts) {
-        self.dcAccounts = dcAccounts
         self.dcContext = dcAccounts.getSelected()
         super.init(style: .insetGrouped)
         hidesBottomBarWhenPushed = true

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -62,7 +62,7 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
 
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(SelfProfileViewController.textDidChangeNotification(notification:)),
+            selector: #selector(textDidChangeNotification),
             name: UITextField.textDidChangeNotification,
             object: nameCell.textField
         )

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -60,12 +60,7 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
         super.init(style: .insetGrouped)
         hidesBottomBarWhenPushed = true
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(textDidChangeNotification),
-            name: UITextField.textDidChangeNotification,
-            object: nameCell.textField
-        )
+        NotificationCenter.default.addObserver(self, selector: #selector(textDidChange), name: UITextField.textDidChangeNotification, object: nameCell.textField)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -110,7 +105,7 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     }
 
     // MARK: - Notifications
-    @objc func textDidChangeNotification(notification: Notification) {
+    @objc func textDidChange(notification: Notification) {
         validateFields()
     }
 


### PR DESCRIPTION
this PR adds "Cancel" and "Done" buttons to the edit profile screen, where "Done" is only tappable when actually a name is  entered.

if no name is entered the placeholder shows a hint to enter a name - this should be sufficient as the user was actually deleting the name and sees that "Done" is no longer possible. on entering the screen,  usually, the name is set as we also force a name elsewhere, see issue for reasoning

as a side effect, whole dialog is no easier accessible, one can tap around and try out things, and can always "Cancel" things.

this is also what is known by WhatsApp/Signal/Others

<img width=300 src=https://github.com/user-attachments/assets/e2bff869-29a0-4ee0-ae1a-9d8deaf81829> &nbsp; &nbsp; <img width=300 src=https://github.com/user-attachments/assets/959a715c-2780-4626-acdc-f2b461b8a24f>


closes #2243