### PR TITLE
avoid scrolling context menu

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1269,6 +1269,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         if canShare() {
             alert.addAction(UIAlertAction(title: String.localized("menu_share"), style: .default, handler: onShareActionPressed(_:)))
         }
+        if canInfo() {
+            alert.addAction(UIAlertAction(title: String.localized("info"), style: .default, handler: onInfoActionPressed(_:)))
+        }
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
         present(alert, animated: true, completion: nil)
     }
@@ -1288,6 +1291,12 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 Utils.share(message: dcContext.getMessage(id: msgId), parentViewController: self, sourceView: self.view)
                 setEditing(isEditing: false)
             }
+        }
+    }
+
+    private func onInfoActionPressed(_ action: UIAlertAction) {
+        if let rows = tableView.indexPathsForSelectedRows, let firstRow = rows.first {
+            info(at: firstRow)
         }
     }
 
@@ -1970,7 +1979,6 @@ extension ChatViewController {
                 }
 
                 children.append(contentsOf: [
-                    UIAction.menuAction(localizationKey: "info", systemImageName: "info", indexPath: indexPath, action: info),
                     UIMenu(options: [.displayInline], children: [
                         UIAction.menuAction(localizationKey: "menu_more_options", systemImageName: "checkmark.circle", indexPath: indexPath, action: selectMore),
                     ])
@@ -2144,8 +2152,12 @@ extension ChatViewController {
         return false
     }
 
+    private func canInfo() -> Bool {
+        return tableView.indexPathsForSelectedRows?.count == 1
+    }
+
     private func evaluateMoreButton() {
-        editingBar.moreButton.isEnabled = canShare() || canResend()
+        editingBar.moreButton.isEnabled = canShare() || canResend() || canInfo()
     }
 
     func setEditing(isEditing: Bool, selectedAtIndexPath: IndexPath? = nil) {


### PR DESCRIPTION
this PR avoids scrolling context menu as made more probable by adding "Copy Image" at https://github.com/deltachat/deltachat-ios/pull/2508

avoid scrolling is realised by moving 'Info' to the 'More Options / ...' menu - 'info' is currently anyways more a debug view, and it is good to have that a bit more away

this is how the "largest" menu looks on one of the smaller phones (iphone 13 mini):

<img width=300 src=https://github.com/user-attachments/assets/f8565c6c-0194-4be8-b1fa-478f9fdb9ebe> &nbsp; &nbsp; <img width= 300 src=https://github.com/user-attachments/assets/7402175a-3407-42b3-a5fa-ad936e4ea48b>

still, not sure if "Copy Image" is that important, esp. as also available via "Share", however, with this PR menus are not larger than before #2508 -- and we can always resort and iterate