### PR TITLE
improve layout of 'no contact found' message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - "Message Info" is moved to messages' context menu at "More Options / ..." (#2510)
 - Allow cancelling profile edits, force a name when editing profile (#2506)
 - Fix scrolling issue when cancelling a screen (#2504)
+- Fix layout of 'No contacts found' message (#2517)
 
 
 ## v1.50.4

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -33,6 +33,7 @@ class NewChatViewController: UITableViewController {
         label.isHidden = true
         label.backgroundColor = nil
         label.textColor = DcColors.defaultTextColor
+        label.paddingBottom = 64
         return label
     }()
 

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -31,6 +31,8 @@ class NewChatViewController: UITableViewController {
     private lazy var emptySearchStateLabel: EmptyStateLabel = {
         let label = EmptyStateLabel()
         label.isHidden = true
+        label.backgroundColor = nil
+        label.textColor = DcColors.defaultTextColor
         return label
     }()
 


### PR DESCRIPTION
this PR improves the bit weird layout of the message "No results found for FOO" when searching for contacts and nothing is found

closes #2478

this is how it looks now, nothing special (see #2478 for "before"):



<img width=320 src=https://github.com/user-attachments/assets/533b1571-b0dd-4097-92ec-96dd6828fa83> &nbsp; &nbsp; <img width=320 src=https://github.com/user-attachments/assets/00ba43b8-90f5-4038-83d8-57e4fb2d4b97>
