### PR TITLE
change order of profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - "Message Info" is moved to messages' context menu at "More Options / ..." (#2510)
 - To easier differ between multiple profiles, set a "Private Tag" (long tap profile switcher) (#2511)
 - In profile switcher's context menu, you have quick access to "Mute Notifications" for a profile (#2511)
+- Sort profiles to top in profile switcher, see context menu (#2519)
 - Allow cancelling profile edits, force a name when editing profile (#2506)
 - Fix scrolling issue when cancelling a screen (#2504)
 - Fix layout of 'No contacts found' message (#2517)

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -9,7 +9,7 @@ class AccountSwitchViewController: UITableViewController {
     private let addSection = 1
 
     private lazy var accountIds: [Int] = {
-        return dcAccounts.getAll()
+        return dcAccounts.getAllSorted()
     }()
 
     private lazy var cancelButton: UIBarButtonItem = {
@@ -99,6 +99,7 @@ class AccountSwitchViewController: UITableViewController {
                 let children: [UIMenuElement] = [
                     UIAction.menuAction(localizationKey: muteTitle, systemImageName: muteImage, indexPath: indexPath, action: { self.toggleMute(at: $0) }),
                     UIAction.menuAction(localizationKey: "profile_tag", systemImageName: "tag", indexPath: indexPath, action: { self.setProfileTag(at: $0) }),
+                    UIAction.menuAction(localizationKey: "move_to_top", systemImageName: "arrow.up", indexPath: indexPath, action: { self.moveToTop(at: $0) }),
                     UIMenu(
                         options: [.displayInline],
                         children: [
@@ -132,6 +133,13 @@ class AccountSwitchViewController: UITableViewController {
         })
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
         present(alert, animated: true)
+    }
+
+    func moveToTop(at indexPath: IndexPath) {
+        let accountId = accountIds[indexPath.row]
+        dcAccounts.moveToTop(id: accountId)
+        accountIds = dcAccounts.getAllSorted()
+        tableView.reloadData()
     }
 
     func selectAccount(previousAccountId: Int, accountId: Int, cell: UITableViewCell) {

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -45,6 +45,23 @@ public class DcAccounts {
         return DcUtils.copyAndFreeArray(inputArray: cAccounts)
     }
 
+    public func getAllSorted() -> [Int] {
+        return getAll().sorted { a, b in
+            // no need to check for equality as sorted() is guaranteed to be stable;
+            // meaning it preserves the relative order of elements that compare as equal here
+            let orderA = get(id: a).getConfigInt("ui.ios.account_order"), orderB = get(id: b).getConfigInt("ui.ios.account_order")
+            return orderA > orderB
+        }
+    }
+
+    public func moveToTop(id: Int) {
+        var maxOrder = 0
+        getAll().forEach {
+            maxOrder = max(maxOrder, get(id: $0).getConfigInt("ui.ios.account_order"))
+        }
+        get(id: id).setConfigInt("ui.ios.account_order", maxOrder + 1)
+    }
+
     public func getSelected() -> DcContext {
         let cPtr = dc_accounts_get_selected_account(accountsPointer)
         return DcContext(contextPointer: cPtr)

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -1064,3 +1064,4 @@
 "backup_successful_explain_ios" = "You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.";
 "location_denied" = "Location access denied";
 "location_denied_explain_ios" = "In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".";
+"move_to_top" = "Move to Top";

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -7,4 +7,5 @@
     <string name="backup_successful_explain_ios">You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.</string>
     <string name="location_denied">Location access denied</string>
     <string name="location_denied_explain_ios">In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".</string>
+	<string name="move_to_top">Move to Top</string>
 </resources>


### PR DESCRIPTION
_seems iOS is the first UI that allows profile reordering :)_

this PR adds a "Move to Top" to the new profiles context menu, picking up the idea we had with @adbenitez for android but that never was implemented :)

most ppl only have few accounts, so that 10-sth-line approach should be perfectly fine then - and if you have more accounts, you will figure out how to use it :)

<img  width=320 src=https://github.com/user-attachments/assets/a806c8f9-8d2d-488d-9519-98c2f1776ebd>

a drag-to-order would be nice as well, but that is out of scope for me currently :)

for storage, a `ui.*` is used, i was first thinking about adding sth to core, however, it seems even better if that part is independent. otoh, it seems good if order is preserved within UI on export/import or so

merges into #2511