### PR TITLE
show context menu on long-tapping proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Drag images from a chat and drop it to another chat or even to another app (use a second finger for navigating!) (#2509)
 - Paste .webp images via drag'n'drop (#2507)
 - Add "Copy Image" to messages' conext menu
+- Long-tap a proxy to share or delete (#2521)
 - "Message Info" is moved to messages' context menu at "More Options / ..." (#2510)
 - Allow cancelling profile edits, force a name when editing profile (#2506)
 - Fix scrolling issue when cancelling a screen (#2504)

--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -297,7 +297,6 @@ extension ProxySettingsViewController {
             }
         }
         shareAction.backgroundColor = .systemGreen
-        shareAction.accessibilityLabel = String.localized("proxy_share_link")
         shareAction.image = Utils.makeImageWithText(image: UIImage(systemName: "square.and.arrow.up"), text: String.localized("menu_share"))
 
         let configuration = UISwipeActionsConfiguration(actions: [shareAction])
@@ -338,7 +337,7 @@ extension ProxySettingsViewController {
             actionProvider: { [weak self] _ in
                 guard let self else { return nil }
                 let children: [UIMenuElement] = [
-                    UIAction.menuAction(localizationKey: "proxy_share_link", systemImageName: "square.and.arrow.up", indexPath: indexPath, action: { self.shareProxy(at: $0) }),
+                    UIAction.menuAction(localizationKey: "menu_share", systemImageName: "square.and.arrow.up", indexPath: indexPath, action: { self.shareProxy(at: $0) }),
                     UIMenu(
                         options: [.displayInline],
                         children: [

--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -272,8 +272,7 @@ extension ProxySettingsViewController {
             }
         } else {
             if indexPath.section == ProxySettingsSection.enableProxies.rawValue {
-                toggleProxyCell.uiSwitch.isOn.toggle()
-                toggleProxyCell.didToggleSwitch(toggleProxyCell.uiSwitch)
+                // enabling/disabling requires using the switch, as usual internally and also by the system and most other apps
             } else if indexPath.section == ProxySettingsSection.proxies.rawValue {
                 selectProxy(at: indexPath)
             } else /*if indexPath.section == ProxySettingsSection.add.rawValue*/ {

--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -328,4 +328,26 @@ extension ProxySettingsViewController {
 
         return configuration
     }
+
+    override func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        guard indexPath.section == ProxySettingsSection.proxies.rawValue else { return nil }
+
+        return UIContextMenuConfiguration(
+            identifier: nil,
+            previewProvider: nil,
+            actionProvider: { [weak self] _ in
+                guard let self else { return nil }
+                let children: [UIMenuElement] = [
+                    UIAction.menuAction(localizationKey: "proxy_share_link", systemImageName: "square.and.arrow.up", indexPath: indexPath, action: { self.shareProxy(at: $0) }),
+                    UIMenu(
+                        options: [.displayInline],
+                        children: [
+                            UIAction.menuAction(localizationKey: "delete", attributes: [.destructive], systemImageName: "trash", indexPath: indexPath, action: { self.deleteProxy(at: $0) })
+                        ]
+                    )
+                ]
+                return UIMenu(children: children)
+            }
+        )
+    }
 }

--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -329,7 +329,10 @@ extension ProxySettingsViewController {
     }
 
     override func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-        guard indexPath.section == ProxySettingsSection.proxies.rawValue else { return nil }
+        guard
+            proxies.isEmpty == false,
+            indexPath.section == ProxySettingsSection.proxies.rawValue
+        else { return nil }
 
         return UIContextMenuConfiguration(
             identifier: nil,


### PR DESCRIPTION
this PR shows a context menu with the options 'Share' and 'Delete' when a proxy item is long-tapped.

historicaly, swiping a row left/right
are the default way where ppl expect actions,
esp. as context menus only were added on iOS 13.

however, it happend to me regulary, that i try to long tap - and i have seen that also by others that are using the app, seems long-tap is quite arrived on iOS,
so, let's just support both ways
(as we stop supporting iOS 12, these menus are much more accessible for devs :)

<img width=320 src=https://github.com/user-attachments/assets/b1f6cf1d-1330-4e83-a01c-335d17f2572e>

moreover, this PR streamlines the behaviour of the switch, and avoids accidental long tapping the row and avoids wrong expectations when using switches elsewhere (in contrast to Android, on iOS it is more usual to let the user use the concrete switch, not the whole row)