### PR TITLE
disable blank issue template as it gets much more into focus by recent github changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Feature requests
     url: https://support.delta.chat/c/features/6


### PR DESCRIPTION


creating "blank" issues should be a real exception, we really want the track for bugs are agreed enhancements only.

before, the main options were BUG REPORT, FEATURE REQUEST, SUPPORT QUESTION - with a very much tuned down "blank" issue at the bottom.

with the upcoming change, the main options will be BUG REPORT, BLANK ISSUE, FEATURE REQUEST, SUPPORT QUESTION - with "blank" issue even more exposed than FEATURE REQUEST or SUPPORT QUESTION.

this PR disables the blank issue therefore,
if really needed one can create a BUG report and remove the corresponding tag (in fact, that was always what i was doing,
i did not notice "blank" before :)

the following images show the change _without_ this PR:

<img width="984" alt="Screenshot 2025-01-16 at 23 31 50" src="https://github.com/user-attachments/assets/3634e773-8698-4e91-bb67-04b6a33de7d7" />
<img width="882" alt="Screenshot 2025-01-16 at 23 29 07" src="https://github.com/user-attachments/assets/9f6891ab-a8a8-4b32-bbcf-0f619eef1dcc" />
