### PR TITLE
fix attach-contact's cancel button position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Allow cancelling profile edits, force a name when editing profile (#2506)
 - Fix scrolling issue when cancelling a screen (#2504)
 - Fix layout of 'No contacts found' message (#2517)
+- Fix position of 'Attach Contact's 'Cancel' button (#2532)
 - Don't hide the Apps-tab anymore (#2526)
 - Use the new App-picker to share apps (#2450)
 

--- a/deltachat-ios/Chat/Send Contact/SendContactViewController.swift
+++ b/deltachat-ios/Chat/Send Contact/SendContactViewController.swift
@@ -47,7 +47,7 @@ class SendContactViewController: UIViewController {
         setupConstraints()
 
         let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(SendContactViewController.cancel(_:)))
-        navigationItem.rightBarButtonItem = cancelButton
+        navigationItem.leftBarButtonItem = cancelButton
 
         searchController.searchResultsUpdater = self
         navigationItem.searchController = searchController


### PR DESCRIPTION
a single 'Cancel' button is usually left of a view controller according to human interface guidelines (this issue became more obvious as 'Contact' is now the fist item in the attach menu)

