### PR TITLE
Fix stickers dropped pasted and picked from gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - More modern attach menu (#2522)
 - Attach mini apps using the App-picker from the attach menu (#2450)
 - Show the apps-tab unconditionally (#2526)
+- Detect Stickers when dropped, pasted or picked from Gallery (#2535)
 - Append dropped URLs to text field instead of attaching as file (#2523)
 - Drag images from a chat and drop it to another chat or even to another app (use a second finger for navigating!) (#2509)
 - Paste .webp images via drag'n'drop (#2507)

--- a/DcCore/DcCore/Extensions/UIImage+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UIImage+Extensions.swift
@@ -50,8 +50,44 @@ public extension UIImage {
     }
 
     func isTransparent() -> Bool {
-      guard let alpha: CGImageAlphaInfo = self.cgImage?.alphaInfo else { return false }
-      return alpha == .first || alpha == .last || alpha == .premultipliedFirst || alpha == .premultipliedLast
+        guard let alpha: CGImageAlphaInfo = self.cgImage?.alphaInfo else { return false }
+        return alpha == .first || alpha == .last || alpha == .premultipliedFirst || alpha == .premultipliedLast
     }
 
+    var hasStickerLikeProperties: Bool {
+        let preiOS18StickerSize = CGSize(width: 140, height: 140)
+        let iOS18StickerSize = CGSize(width: 160, height: 160)
+        if size.equalTo(preiOS18StickerSize) || size.equalTo(iOS18StickerSize) {
+            return true
+        }
+
+        if !self.isTransparent() {
+            return false
+        }
+        guard let cgImage = self.cgImage,
+              let data = cgImage.dataProvider?.data as Data?,
+              let dataPtr = data.withUnsafeBytes({ $0.bindMemory(to: UInt8.self).baseAddress }),
+              !data.isEmpty else {
+            return false // Unable to get the CGImage or image data
+        }
+
+        let width = cgImage.width
+        let height = cgImage.height
+        let bytesPerRow = cgImage.bytesPerRow
+
+        // Check the alpha values of the pixels at the corners
+        let topLeftIndex = 0
+        let topRightIndex = max(0, width - 1)
+        let bottomLeftIndex = max(0, bytesPerRow * (height - 1))
+        let bottomRightIndex = max(0, bytesPerRow * (height - 1) + width - 1)
+
+        if dataPtr[topLeftIndex] < 255,
+           dataPtr[topRightIndex] < 255,
+           dataPtr[bottomLeftIndex] < 255,
+           dataPtr[min(data.count - 1, bottomRightIndex)] < 255 {
+            return true
+        }
+
+        return false
+    }
 }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1696,6 +1696,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func sendSticker(_ image: UIImage) {
         DispatchQueue.global().async { [weak self] in
+            // TODO: Remove this when core is fixed https://github.com/deltachat/deltachat-core-rust/issues/6447
+            let image = image.scaleDownImage(toMax: 300) ?? image
+
             guard let self, let path = ImageFormat.saveImage(image: image, directory: .cachesDirectory) else { return }
 
             if self.draft.draftMsg != nil {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1666,6 +1666,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     private func stageImage(_ image: UIImage) {
         DispatchQueue.global().async { [weak self] in
             guard let self else { return }
+            guard !image.hasStickerLikeProperties else {
+                return self.sendSticker(image)
+            }
             if let pathInCachesDir = ImageFormat.saveImage(image: image, directory: .cachesDirectory) {
                 DispatchQueue.main.async {
                     if pathInCachesDir.suffix(4).contains(".gif") {
@@ -2637,16 +2640,7 @@ extension ChatViewController: AudioControllerDelegate {
 // MARK: - ChatInputTextViewPasteDelegate
 extension ChatViewController: ChatInputTextViewPasteDelegate {
     func onImagePasted(image: UIImage) {
-
-        let preiOS18StickerSize = CGSize(width: 140, height: 140)
-        let iOS18StickerSize = CGSize(width: 160, height: 160)
-        let isSticker = image.size.equalTo(preiOS18StickerSize) || image.size.equalTo(iOS18StickerSize)
-
-        if isSticker {
-            sendSticker(image)
-        } else {
-            stageImage(image)
-        }
+        stageImage(image)
     }
 }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1696,7 +1696,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func sendSticker(_ image: UIImage) {
         DispatchQueue.global().async { [weak self] in
-            // TODO: Remove this when core is fixed https://github.com/deltachat/deltachat-core-rust/issues/6447
+            // stickers may be huge when drag'n'dropped from photo-recognition, scale down to a reasonable size
             let image = image.scaleDownImage(toMax: 300) ?? image
 
             guard let self, let path = ImageFormat.saveImage(image: image, directory: .cachesDirectory) else { return }

--- a/deltachat-ios/Helper/ChatDropInteraction.swift
+++ b/deltachat-ios/Helper/ChatDropInteraction.swift
@@ -69,12 +69,12 @@ public class ChatDropInteraction {
                 self.delegate?.onImageDragAndDropped(image: image)
             }
         } else if droppedItem.itemProvider.canLoadObject(ofClass: UIImage.self) {
-            droppedItem.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] imageItem, error in
+            droppedItem.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] imageItem, _ in
                 guard let image = imageItem as? UIImage else { return }
                 self?.delegate?.onImageDragAndDropped(image: image)
             }
         } else {
-            // Some images (eg webP) can't be loaded into UIImage by UIDropSession so we fall back on SD.
+            // Some images (like webP) can't be loaded into UIImage by UIDropSession so we fall back on SD.
             // See `UIImage.readableTypeIdentifiersForItemProvider` for ones that can.
             droppedItem.itemProvider.loadDataRepresentation(forTypeIdentifier: kUTTypeImage as String) { [weak self] data, _ in
                 guard let self, let image = UIImage.sd_image(with: data) else { return }

--- a/deltachat-ios/Helper/ChatDropInteraction.swift
+++ b/deltachat-ios/Helper/ChatDropInteraction.swift
@@ -64,7 +64,7 @@ public class ChatDropInteraction {
         // If webP is provided and eg JPEG (or another type that is supported by loadObject),
         // always pick webP because it might have transparancy unlike JPEG.
         if #available(iOS 14, *), droppedItem.itemProvider.hasItemConformingToTypeIdentifier(UTType.webP.identifier) {
-            droppedItem.itemProvider.loadDataRepresentation(forTypeIdentifier: kUTTypeImage as String) { [weak self] webPData, _ in
+            droppedItem.itemProvider.loadDataRepresentation(forTypeIdentifier: UTType.webP.identifier) { [weak self] webPData, _ in
                 guard let self, let image = UIImage.sd_image(withWebPData: webPData) else { return }
                 self.delegate?.onImageDragAndDropped(image: image)
             }


### PR DESCRIPTION
This uses the transparency logic from #2258 and sends image as sticker when they come from anywhere, not just pasted.

Also prioritize webP data in dropped items to prevent transparency loss when webP and JPEG are provided by drag and drop.

That PR mentioned dropping was unreliable which I think happened because sometimes the drop provides a webP which was not supported at all previously.

It also mentioned a sometimes black background which was either the system providing both JPEG and webP and Delta Chat choosing JPEG which does not have transparency OR the dropped image was too big core resized it and lost transparency (https://github.com/deltachat/deltachat-core-rust/issues/6447).