### PR TITLE
Allow interactive dismissal of VCs that need custom first responder handling

### DIFF
--- a/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
+++ b/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Combine
 
 /// https://gist.github.com/Amzd/223979ef5a06d98ef17d2d78dbd96e22
 extension UIViewController {

--- a/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
+++ b/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
@@ -26,21 +26,18 @@ extension UIViewController {
         // give back the first responder when search was used
         if #available(iOS 16, *) {
             documentPicker.returnFirstRespondersOnDismiss()
-            present(documentPicker as UIViewController, animated: animated, completion: completion)
-        } else {
-            present(documentPicker as UIViewController, animated: animated, completion: completion)
         }
+        present(documentPicker as UIViewController, animated: animated, completion: completion)
     }
 
     /// In iOS 16 and below and iOS 18 the UIImagePickerController does not give back the first responder when search was used.
     /// This function fixes that by making the previous first responder, first responder again when the image picker is dismissed.
     public func present(_ imagePicker: UIImagePickerController, animated: Bool, completion: (() -> Void)? = nil) {
-        if #available(iOS 17, *) {
-            if #unavailable(iOS 18) {
-                return present(imagePicker as UIViewController, animated: animated, completion: completion)
-            }
+        if #unavailable(iOS 17) { // pre iOS 17
+            imagePicker.returnFirstRespondersOnDismiss()
+        } else if #available(iOS 18, *) { // iOS 18 and up
+            imagePicker.returnFirstRespondersOnDismiss()
         }
-        imagePicker.returnFirstRespondersOnDismiss()
         present(imagePicker as UIViewController, animated: animated, completion: completion)
     }
 }
@@ -57,6 +54,7 @@ extension UIViewController {
 
     fileprivate var lastResponders: [UIResponder] {
         get { objc_getAssociatedObject(self, &lastRespondersKey) as? [UIResponder] ?? [] }
+        /// Filter for self because that could create a reference cycle
         set { objc_setAssociatedObject(self, &lastRespondersKey, newValue.filter { $0 !== self }, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)}
     }
 


### PR DESCRIPTION
Some View Controllers don't give back the first responder correctly (eg when you use the search bar in UIImagePickerController). To combat this we previously wrapped those in a custom view controller that just gave back the responders manually. That sadly had the side effect of disabling interactive dismissal (swipe down to dismiss).

This PR fixes the interactive dismiss by doing away with the custom view controller wrapper and instead swizzling the methods. 

Swizzling is a bit controversial but it is used by Firebase which is in many apps, and the associated objects usage is already in our app because SDWebImage uses it too.