### PR TITLE
Fix for location sharing not ending unless you move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Detect Stickers when dropped, pasted or picked from Gallery (#2535)
 - Fix: In 'View Log', hide keyboard when scrolling down (#2541)
+- Fix: Experimental location sharing now ends at the specified interval even if you don't move (#2537)
 
 
 ## v1.50.5


### PR DESCRIPTION
Encountered this at CCC, even while moving around ~10 meters, maybe because it was inside a building.

- Start Location streaming for 5 mins
- Wait 5 mins then stop moving
- Previously location sharing would stay on, draining battery.