### PR TITLE
use modern UIMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Detect Stickers when dropped, pasted or picked from Gallery (#2535)
+- Modernize menus (#2543)
 - Fix: In 'View Log', hide keyboard when scrolling down (#2541)
 - Fix: Experimental location sharing now ends at the specified interval even if you don't move (#2537)
 - minimum system version is iOS 14 now (all iOS 13 devices can upgrade to iOS 14) (#2459)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1246,22 +1246,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         present(alert, animated: true, completion: nil)
     }
 
-    private func showMoreMenu() {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
-        if canResend() {
-            alert.addAction(UIAlertAction(title: String.localized("resend"), style: .default, handler: onResendActionPressed(_:)))
-        }
-        if canShare() {
-            alert.addAction(UIAlertAction(title: String.localized("menu_share"), style: .default, handler: onShareActionPressed(_:)))
-        }
-        if canInfo() {
-            alert.addAction(UIAlertAction(title: String.localized("info"), style: .default, handler: onInfoActionPressed(_:)))
-        }
-        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
-        present(alert, animated: true, completion: nil)
-    }
-
-    private func onResendActionPressed(_ action: UIAlertAction) {
+    private func onResendActionPressed() {
         if let rows = tableView.indexPathsForSelectedRows {
             let selectedMsgIds = rows.compactMap { messageIds[$0.row] }
             dcContext.resendMessages(msgIds: selectedMsgIds)
@@ -1269,7 +1254,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         }
     }
 
-    private func onShareActionPressed(_ action: UIAlertAction) {
+    private func onShareActionPressed() {
         if let rows = tableView.indexPathsForSelectedRows {
             let selectedMsgIds = rows.compactMap { messageIds[$0.row] }
             if let msgId = selectedMsgIds.first {
@@ -1279,7 +1264,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         }
     }
 
-    private func onInfoActionPressed(_ action: UIAlertAction) {
+    private func onInfoActionPressed() {
         if let rows = tableView.indexPathsForSelectedRows, let firstRow = rows.first {
             info(at: firstRow)
         }
@@ -2430,8 +2415,24 @@ extension ChatViewController: ChatEditingDelegate {
         }
     }
 
-    func onMorePressed() {
-        showMoreMenu()
+    func onMorePressed() -> UIMenu {
+        var actions = [UIMenuElement]()
+        if canResend() {
+            actions.append(UIAction(title: String.localized("resend"), image: UIImage(systemName: "paperplane")) { [weak self] _ in
+                self?.onResendActionPressed()
+            })
+        }
+        if canShare() {
+            actions.append(UIAction(title: String.localized("menu_share"), image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
+                self?.onShareActionPressed()
+            })
+        }
+        if canInfo() {
+            actions.append(UIAction(title: String.localized("info"), image: UIImage(systemName: "info.circle")) { [weak self] _ in
+                self?.onInfoActionPressed()
+            })
+        }
+        return UIMenu(children: actions)
     }
 
     func onForwardPressed() {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1229,7 +1229,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 }
                 actions.append(action("contact", "person.crop.circle", showContactList))
 
-                completion([UIMenu(options: .displayInline, children: actions)])
+                completion(actions)
             })
         ])
     }

--- a/deltachat-ios/Chat/Views/ChatEditingBar.swift
+++ b/deltachat-ios/Chat/Views/ChatEditingBar.swift
@@ -6,7 +6,7 @@ public protocol ChatEditingDelegate: AnyObject {
     func onForwardPressed()
     func onCancelPressed()
     func onCopyPressed()
-    func onMorePressed()
+    func onMorePressed() -> UIMenu
 }
 
 public class ChatEditingBar: UIView {
@@ -110,17 +110,19 @@ public class ChatEditingBar: UIView {
         ])
 
         copyButton.addTarget(self, action: #selector(ChatEditingBar.onCopyPressed), for: .touchUpInside)
-        moreButton.addTarget(self, action: #selector(ChatEditingBar.onMorePressed), for: .touchUpInside)
         forwardButton.addTarget(self, action: #selector(ChatEditingBar.onForwardPressed), for: .touchUpInside)
         deleteButton.addTarget(self, action: #selector(ChatEditingBar.onDeletePressed), for: .touchUpInside)
+
+        moreButton.showsMenuAsPrimaryAction = true
+        moreButton.menu = UIMenu() // otherwise .menuActionTriggered is not triggered
+        moreButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            moreButton.menu = delegate?.onMorePressed()
+        }, for: .menuActionTriggered)
     }
 
     @objc func onCopyPressed() {
         delegate?.onCopyPressed()
-    }
-
-    @objc func onMorePressed() {
-        delegate?.onMorePressed()
     }
 
     @objc func onForwardPressed() {

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -21,15 +21,12 @@ class InstantOnboardingViewController: UIViewController {
     private var qrCodeData: String?
     private lazy var menuButton: UIBarButtonItem = {
         let image = UIImage(systemName: "ellipsis.circle")
-        let menuButton = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(InstantOnboardingViewController.showMenu(_:)))
-        menuButton.tintColor = DcColors.primary
-        return menuButton
+        return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
 
     private lazy var proxyShieldButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: UIImage(systemName: "checkmark.shield"), style: .plain, target: self, action: #selector(InstantOnboardingViewController.showProxySettings(_:)))
-        button.tintColor = DcColors.primary
-        return button
+        let image = UIImage(systemName: "checkmark.shield")
+        return UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(showProxySettings))
     }()
 
     var progressAlertHandler: ProgressAlertHandler?
@@ -221,22 +218,16 @@ class InstantOnboardingViewController: UIViewController {
         present(alertController, animated: true)
     }
 
-    @objc private func showMenu(_ sender: Any) {
-        let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
-
-        let showProxySettings = UIAlertAction(title: String.localized("proxy_settings"), style: .default) { [weak self] _ in
-            self?.showProxySettings(sender)
-        }
-
-        let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel)
-
-        sheet.addAction(showProxySettings)
-        sheet.addAction(cancelAction)
-
-        present(sheet, animated: true)
+    private func moreButtonMenu() -> UIMenu {
+        let actions = [
+            UIAction(title: String.localized("proxy_use_proxy"), image: UIImage(systemName: "shield")) { [weak self] _ in
+                self?.showProxySettings()
+            },
+        ]
+        return UIMenu(children: actions)
     }
 
-    @objc private func showProxySettings(_ sender: Any) {
+    @objc private func showProxySettings() {
         let proxySettingsController = ProxySettingsViewController(dcContext: dcContext, dcAccounts: dcAccounts)
         navigationController?.pushViewController(proxySettingsController, animated: true)
     }

--- a/deltachat-ios/Controller/FullMessageViewController.swift
+++ b/deltachat-ios/Controller/FullMessageViewController.swift
@@ -5,7 +5,12 @@ import DcCore
 class FullMessageViewController: WebViewViewController {
 
     var loadButton: UIBarButtonItem {
+        // to not encourages people to get used to tap the load button
+        // just to see whether the message they get will change, this is a very generic icon.
+        // (best would be if we know before if an HTML message contains images and thelike,
+        // but we don't and this is probably also not worth  the effort. so we used the second best approach :)
         let image = UIImage(systemName: "ellipsis.circle")
+
         let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(showLoadOptions))
         button.accessibilityLabel = String.localized("load_remote_content")
         return button

--- a/deltachat-ios/Controller/HelpViewController.swift
+++ b/deltachat-ios/Controller/HelpViewController.swift
@@ -18,7 +18,7 @@ class HelpViewController: WebViewViewController {
 
     private lazy var moreButton: UIBarButtonItem = {
         let image = UIImage(systemName: "ellipsis.circle")
-        return UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(moreButtonPressed))
+        return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
 
     override func viewDidLoad() {
@@ -66,29 +66,29 @@ class HelpViewController: WebViewViewController {
         }
     }
 
-    @objc private func moreButtonPressed() {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .safeActionSheet)
-        alert.addAction(UIAlertAction(title: String.localized("global_menu_help_learn_desktop"), style: .default, handler: { _ in
-            if let url = URL(string: "https://delta.chat") {
-                UIApplication.shared.open(url)
-            }
-        }))
-        alert.addAction(UIAlertAction(title: String.localized("privacy_policy"), style: .default, handler: { _ in
-            if let url = URL(string: "https://delta.chat/gdpr") {
-                UIApplication.shared.open(url)
-            }
-        }))
-        alert.addAction(UIAlertAction(title: String.localized("global_menu_help_contribute_desktop"), style: .default, handler: { _ in
-            if let url = URL(string: "https://github.com/deltachat/deltachat-ios") {
-                UIApplication.shared.open(url)
-            }
-        }))
-        alert.addAction(UIAlertAction(title: String.localized("global_menu_help_report_desktop"), style: .default, handler: { _ in
-            if let url = URL(string: "https://github.com/deltachat/deltachat-ios/issues") {
-                UIApplication.shared.open(url)
-            }
-        }))
-        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
-        self.present(alert, animated: true, completion: nil)
+    private func moreButtonMenu() -> UIMenu {
+        let actions = [
+            UIAction(title: String.localized("delta_chat_homepage"), image: UIImage(systemName: "globe")) { _ in
+                if let url = URL(string: "https://delta.chat") {
+                    UIApplication.shared.open(url)
+                }
+            },
+            UIAction(title: String.localized("privacy_policy"), image: UIImage(systemName: "hand.raised")) { _ in
+                if let url = URL(string: "https://delta.chat/gdpr") {
+                    UIApplication.shared.open(url)
+                }
+            },
+            UIAction(title: String.localized("contribute"), image: UIImage(systemName: "wrench.and.screwdriver")) { _ in
+                if let url = URL(string: "https://delta.chat/contribute") {
+                    UIApplication.shared.open(url)
+                }
+            },
+            UIAction(title: String.localized("global_menu_help_report_desktop"), image: UIImage(systemName: "ant")) { _ in
+                if let url = URL(string: "https://github.com/deltachat/deltachat-ios/issues") {
+                    UIApplication.shared.open(url)
+                }
+            },
+        ]
+        return UIMenu(children: actions)
     }
 }

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -21,7 +21,7 @@ class QrCodeReaderController: UIViewController {
 
     private lazy var moreButton: UIBarButtonItem = {
         let image = UIImage(systemName: "ellipsis.circle")
-        return UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(moreButtonPressed))
+        return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
 
     private lazy var infoLabel: UILabel = {
@@ -196,13 +196,13 @@ class QrCodeReaderController: UIViewController {
         captureSession.stopRunning()
     }
 
-    @objc private func moreButtonPressed() {
-        let alert = UIAlertController(title: title, message: nil, preferredStyle: .safeActionSheet)
-        alert.addAction(UIAlertAction(title: String.localized("troubleshooting"), style: .default, handler: { _ in
-            self.navigationController?.pushViewController(HelpViewController(dcContext: DcAccounts.shared.getSelected(), fragment: "#multiclient"), animated: true)
-        }))
-        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
-        self.present(alert, animated: true, completion: nil)
+    private func moreButtonMenu() -> UIMenu {
+        let actions = [
+            UIAction(title: String.localized("troubleshooting"), image: UIImage(systemName: "questionmark.circle")) { [weak self] _ in
+                self?.navigationController?.pushViewController(HelpViewController(dcContext: DcAccounts.shared.getSelected(), fragment: "#multiclient"), animated: true)
+            },
+        ]
+        return UIMenu(children: actions)
     }
 }
 

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -451,9 +451,6 @@ class WebxdcViewController: WebViewViewController {
                     appDelegate.appCoordinator.showChat(chatId: message.chatId, msgId: message.id, animated: true, clearViewControllerStack: true)
                 }
             })
-            actions.append(UIAction(title: String.localized("menu_share"), image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
-                self?.shareWebxdc()
-            })
             if sourceCodeUrl != nil {
                 actions.append(UIMenu(options: [.displayInline],
                     children: [
@@ -485,10 +482,6 @@ class WebxdcViewController: WebViewViewController {
            let url = URL(string: sourceCodeUrl) {
             UIApplication.shared.open(url)
         }
-    }
-
-    private func shareWebxdc() {
-        Utils.share(message: dcContext.getMessage(id: messageId), parentViewController: self, sourceItem: navigationItem.rightBarButtonItem)
     }
 }
 

--- a/deltachat-ios/View/ChatListEditingBar.swift
+++ b/deltachat-ios/View/ChatListEditingBar.swift
@@ -3,7 +3,7 @@ import UIKit
 public protocol ChatListEditingBarDelegate: AnyObject {
     func onDeleteButtonPressed()
     func onArchiveButtonPressed()
-    func onMorePressed()
+    func onMorePressed() -> UIMenu
 }
 
 class ChatListEditingBar: UIView {
@@ -94,7 +94,13 @@ class ChatListEditingBar: UIView {
         archiveBtnGestureRecognizer.numberOfTapsRequired = 1
         archiveButton.addGestureRecognizer(archiveBtnGestureRecognizer)
 
-        moreButton.addTarget(self, action: #selector(ChatListEditingBar.onMorePressed), for: .touchUpInside)
+        moreButton.showsMenuAsPrimaryAction = true
+        moreButton.menu = UIMenu() // otherwise .menuActionTriggered is not triggered
+        moreButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            moreButton.menu = delegate?.onMorePressed()
+        }, for: .menuActionTriggered)
+
     }
 
     @objc func deleteButtonPressed() {
@@ -103,9 +109,5 @@ class ChatListEditingBar: UIView {
 
     @objc func archiveButtonPressed() {
         delegate?.onArchiveButtonPressed()
-    }
-
-    @objc func onMorePressed() {
-        delegate?.onMorePressed()
     }
 }

--- a/deltachat-ios/View/ChatListEditingBar.swift
+++ b/deltachat-ios/View/ChatListEditingBar.swift
@@ -100,7 +100,6 @@ class ChatListEditingBar: UIView {
             guard let self else { return }
             moreButton.menu = delegate?.onMorePressed()
         }, for: .menuActionTriggered)
-
     }
 
     @objc func deleteButtonPressed() {


### PR DESCRIPTION
this PR replaces ~~some~~ all of the old "actionSheet" menus with the more modern ones available since iOS 13/14.

it is all pretty much straight-forward. greater refactorings, renamings are not done, to keep the changed lines small.

see commit messages for more details, this is what it looks like:

<img width="300" src=https://github.com/user-attachments/assets/ab804cb5-2748-450f-a7ac-69342a0ac777><br><br>

<img width="300" src=https://github.com/user-attachments/assets/ac5c6c9a-5b1a-4f10-a6dc-26c8ffb1a25a><br><br>

<img width="300" src=https://github.com/user-attachments/assets/e458f8c3-5390-4076-893f-0abedfa69b2c><br><br>

<img width="300" src=https://github.com/user-attachments/assets/06d036c6-64d6-4f26-a8a4-389ee2546adb><br><br>

<img width=300 src=https://github.com/user-attachments/assets/a8ae5da5-c7f9-415c-bf93-c2a0dc7605d1><br><br>

<img width=300 src=https://github.com/user-attachments/assets/caac8c7d-f5d0-4b02-8bec-67c9e4e7b191><br><br>

<img width=300 src=https://github.com/user-attachments/assets/570514b5-d1d7-4deb-9f60-53a68ff8f440><br><br>

<img width=300 src=https://github.com/user-attachments/assets/9d05be4e-ce29-497f-b3a6-ed12907ab672><br><br>

<img width=300 src=https://github.com/user-attachments/assets/f4f19998-b3e6-4ebe-b046-7c82dcdc1ac2><br><br>