### PR TITLE
show connectivity problems also account switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Show 'unconnected' and 'updating' states in account switcher (#2553)
 - Detect Stickers when dropped, pasted or picked from Gallery (#2535)
 - Fix: In 'View Log', hide keyboard when scrolling down (#2541)
 - Fix: Experimental location sharing now ends at the specified interval even if you don't move (#2537)

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -176,11 +176,8 @@ public class DcEventHandler {
             ])
 
         case DC_EVENT_CONNECTIVITY_CHANGED:
-            if accountId != dcAccounts.getSelected().id {
-                return
-            }
             logger.info("📡[\(accountId)] connectivity changed")
-            NotificationCenter.default.post(name: Event.connectivityChanged, object: nil)
+            NotificationCenter.default.post(name: Event.connectivityChanged, object: nil, userInfo: ["account_id": Int(accountId)])
 
         case DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE:
             if let sem = dcAccounts.fetchSemaphore {

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -131,6 +131,8 @@ class InstantOnboardingViewController: UIViewController {
     }
 
     @objc func connectivityChanged(_ notification: Notification) {
+        guard dcContext.id == notification.userInfo?["account_id"] as? Int else { return }
+
         DispatchQueue.main.async { [weak self] in
             self?.updateMenuButtons()
         }

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -341,8 +341,16 @@ class AccountCell: UITableViewCell {
             accountName.accessibilityLabel = title
         }
 
+        let connectivityString = DcUtils.getConnectivityString(dcContext: dcContext, connectedString: "")
         if let label = dcContext.getConfig("private_tag") {
-            tagLabel.text = label
+            tagLabel.text = if !connectivityString.isEmpty {
+                connectivityString + " · " + label
+            } else {
+                label
+            }
+            tagLabel.isHidden = false
+        } else if !connectivityString.isEmpty {
+            tagLabel.text = connectivityString
             tagLabel.isHidden = false
         } else {
             tagLabel.isHidden = true

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -26,6 +26,7 @@ class AccountSwitchViewController: UITableViewController {
         self.dcAccounts = dcAccounts
         super.init(style: .insetGrouped)
         setupSubviews()
+        NotificationCenter.default.addObserver(self, selector: #selector(handleConnectivityChanged), name: Event.connectivityChanged, object: nil)
     }
 
     required init?(coder: NSCoder) {
@@ -225,6 +226,12 @@ class AccountSwitchViewController: UITableViewController {
 
     @objc private func cancelAction() {
         dismiss(animated: true)
+    }
+
+    @objc private func handleConnectivityChanged(_ notification: Notification) {
+        DispatchQueue.main.async { [weak self] in
+            self?.tableView.reloadData()
+        }
     }
 }
 

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -196,6 +196,8 @@ class ChatListViewController: UITableViewController {
     // MARK: - Notifications
 
     @objc private func handleConnectivityChanged(_ notification: Notification) {
+        guard dcContext.id == notification.userInfo?["account_id"] as? Int else { return }
+
         DispatchQueue.main.async { [weak self] in
             self?.updateTitle()
         }

--- a/deltachat-ios/Controller/ConnectivityViewController.swift
+++ b/deltachat-ios/Controller/ConnectivityViewController.swift
@@ -158,6 +158,8 @@ class ConnectivityViewController: WebViewViewController {
     }
 
     @objc private func handleConnectivityChanged(_ notification: Notification) {
+        guard dcContext.id == notification.userInfo?["account_id"] as? Int else { return }
+
         loadHtml()
     }
 

--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -172,6 +172,8 @@ class ProxySettingsViewController: UITableViewController {
     // MARK: - Notifications
 
     @objc private func handleConnectivityChanged(_ notification: Notification) {
+        guard dcContext.id == notification.userInfo?["account_id"] as? Int else { return }
+
         DispatchQueue.main.async { [weak self] in
             self?.tableView.reloadData()
         }

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -218,6 +218,8 @@ internal final class SettingsViewController: UITableViewController {
     // MARK: - Notifications
 
     @objc private func handleConnectivityChanged(_ notification: Notification) {
+        guard dcContext.id == notification.userInfo?["account_id"] as? Int else { return }
+
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
 

--- a/deltachat-ios/DC/DcAccount.swift
+++ b/deltachat-ios/DC/DcAccount.swift
@@ -77,9 +77,13 @@ public class DcAccounts {
 
     public func startIo() {
         if UserDefaults.nseFetching {
+            // Let UI display "Updating..." (additional events needed that state is not managed by core)
+            getAll().forEach {
+                NotificationCenter.default.post(name: Event.connectivityChanged, object: nil, userInfo: ["account_id": $0])
+            }
+
             // Wait for NSE-fetch to terminate before starting main-IO (both keep state unsynced, running at the same time would mess things up).
             // The other way round, NSE is not started when main-IO is running.
-            NotificationCenter.default.post(name: Event.connectivityChanged, object: nil) // additional events needed as state changed outside mainapp
             startOrReschedule()
             func startOrReschedule() {
                 if UserDefaults.mainIoRunning {


### PR DESCRIPTION
unless the state is "connected", this PR adds the connectivity string to the new subtitle in the account  switcher.

this results in having the strings "Not Connected", "Updating" etc. there - just the same strings as in the app title when unconnected.

i was thinking in adding some colored dots as in arcane chat, however, we are (a) not using them in the main title (b) that would need additional explanations where a "Not Connected" is self explaining and (c) the current one is easier :)

main point was to have sth, and also get the changed event in; we can always iterate :)

this is how it looks like if everyrhing is disconnected:

<img width=320 src=https://github.com/user-attachments/assets/990d3fb0-09b4-46f2-83ec-a8c1b763ad9b>


when connection is fine, the switcher looks exactly as always