### PR TITLE
add a warning when pulling translations to feature branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,8 +140,7 @@ you may leave a note in the PR about the desired merge strategy.
 ## Translations
 
 Translations are done via [Transifex](https://explore.transifex.com/delta-chat/),
-you can log in there with your E-Mail Address or with a Github or Google handle.
-You find two projects there:
+you find two projects there:
 - "Delta Chat App" contains the strings used in the app's UI
 - "Delta Chat Website" contains the offline help from "Settings / Help"
   as well as the pages used on <https://delta.chat>
@@ -156,6 +155,21 @@ do a PR to [`strings.xml`](https://github.com/deltachat/deltachat-android/blob/m
 or to [`help.md`](https://github.com/deltachat/deltachat-pages/blob/master/en/help.md).
 Again, please do not mix adding things and refactorings, esp. for `help.md`,
 this would require retranslations and should be considered carefully.
+
+
+### Prototyping Translations
+
+Sometimes, strings are not yet available in the translations.
+Or adding them there is too much overhead, eg. it is not clear how the final wording will be.
+
+In these cases, to use use the normal translations functions code-wise,
+in your feature branch,
+add these strings to `./deltachat-ios/en.lproj` and `./scripts/untranslated.xml`.
+
+The latter is need to avoid `en.lproj` being overwritten on next translation update (see [RELEASE.md](./RELEASE.md)).
+
+Translations updates must not be done in feature branches as that makes review harder
+and easily result in merge conflicts.
 
 
 ## Other Ways To Contribute

--- a/scripts/tx-pull-translations.sh
+++ b/scripts/tx-pull-translations.sh
@@ -41,3 +41,15 @@ for (( i=0; i<${#IOS_TRANSLATIONS[@]}; i++ )) {
 rm -rf $TMP_ANDROID_TRANSLATIONS
 
 cd ..
+
+
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ ! "$branch" == *"update-transl"* ]]; then
+    echo
+    echo " ☝️ It seems you're on a normal feature branch."
+    echo "   For conflict-free merging, do not commit non-english translations here."
+    git status --short "*.strings*"
+    echo "   (non-english translations go to explicit update-translation branches)"
+    echo
+fi

--- a/scripts/tx-pull-translations.sh
+++ b/scripts/tx-pull-translations.sh
@@ -42,14 +42,3 @@ rm -rf $TMP_ANDROID_TRANSLATIONS
 
 cd ..
 
-
-
-branch=$(git rev-parse --abbrev-ref HEAD)
-if [[ ! "$branch" == *"update-transl"* ]]; then
-    echo
-    echo " ☝️ It seems you're on a normal feature branch."
-    echo "   For conflict-free merging, do not commit non-english translations here."
-    git status --short "*.strings*"
-    echo "   (non-english translations go to explicit update-translation branches)"
-    echo
-fi

--- a/scripts/tx-pull-translations.sh
+++ b/scripts/tx-pull-translations.sh
@@ -4,17 +4,10 @@
 # Credits to Daniel Cohen Gindi.
 
 
-# ----Main-----
 
 cd scripts
 
 TMP_ANDROID_TRANSLATIONS=tmpAndroidTranslations
-
-if [[ -z `which node` ]] 
-then
-    echo "ERROR: You need to have node installed. Exiting."
-    exit 
-fi
 
 if [[ -z `which tx` ]] 
 then


### PR DESCRIPTION
pulling translations to feature branches clutter diff and make review harder and easily result in merge conflicts.

it should usually not be done