### PR TITLE
group photo-based actions together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Show 'unconnected' and 'updating' states in account switcher (#2553)
 - Detect Stickers when dropped, pasted or picked from Gallery (#2535)
-- Modernize menus (#2543)
+- Modernize menus (#2545, #2558)
 - Fix: In 'View Log', hide keyboard when scrolling down (#2541)
 - Fix: Experimental location sharing now ends at the specified interval even if you don't move (#2537)
 - Fix crash on account deletion (#2554)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1212,9 +1212,11 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                     UIAction(title: String.localized(localized), image: UIImage(systemName: systemImage), attributes: attributes, handler: { _ in handler() })
                 }
 
-                actions.append(action("camera", "camera", showCameraViewController))
-                let galleryImage = if #available(iOS 16, *) { "photo.stack" } else { "photo" }
-                actions.append(action("gallery", galleryImage, showPhotoVideoLibrary))
+                actions.append(UIMenu(options: [.displayInline], children: [
+                    action("camera", "camera", showCameraViewController),
+                    action("gallery", "photo.on.rectangle", showPhotoVideoLibrary)
+                ]))
+
                 actions.append(action("files", "folder", self.showDocumentLibrary))
                 actions.append(action("webxdc_apps", "square.grid.2x2", showAppPicker))
                 actions.append(action("voice_message", "mic", showVoiceMessageRecorder))


### PR DESCRIPTION
as a rule of thumb, 6+ items in a menu is too much for the eye to catch. so, group 'camera' and 'gallery',
which are also the most often used actions.

<img width=320 src=https://github.com/user-attachments/assets/eb1fb083-2986-4d49-9cf2-082295e899e1>

successor of #2543