### PR TITLE
add "Paste" to onboarding QR code scanners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Show 'unconnected' and 'updating' states in account switcher (#2553)
+- Add 'Paste from Clipboard' to onboarding QR code scanners (#2559)
 - Detect Stickers when dropped, pasted or picked from Gallery (#2535)
 - Modernize menus (#2545, #2558)
 - Fix: In 'View Log', hide keyboard when scrolling down (#2541)

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -73,9 +73,7 @@ class QrCodeReaderController: UIViewController {
             })
         }
 
-        if showTroubleshooting {
-            navigationItem.rightBarButtonItem = moreButton
-        }
+        navigationItem.rightBarButtonItem = moreButton
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -197,11 +195,15 @@ class QrCodeReaderController: UIViewController {
     }
 
     private func moreButtonMenu() -> UIMenu {
-        let actions = [
-            UIAction(title: String.localized("troubleshooting"), image: UIImage(systemName: "questionmark.circle")) { [weak self] _ in
+        var actions = [UIMenuElement]()
+        actions.append(UIAction(title: String.localized("paste_from_clipboard"), image: UIImage(systemName: "doc.on.clipboard")) { [weak self] _ in
+            self?.delegate?.handleQrCode(UIPasteboard.general.string ?? "")
+        })
+        if showTroubleshooting {
+            actions.append(UIAction(title: String.localized("troubleshooting"), image: UIImage(systemName: "questionmark.circle")) { [weak self] _ in
                 self?.navigationController?.pushViewController(HelpViewController(dcContext: DcAccounts.shared.getSelected(), fragment: "#multiclient"), animated: true)
-            },
-        ]
+            })
+        }
         return UIMenu(children: actions)
     }
 }


### PR DESCRIPTION
this PR adds the function "Paste From Clipboard" to the two onboarding QR code scanner ("Add as Second Device" and "Scan Invitation Code")

<img width=320 src=https://github.com/user-attachments/assets/3ce4ef2e-27d2-46e1-8da8-a75fe1699834>

<img width=320 src=https://github.com/user-attachments/assets/922fb398-8f5f-4123-945a-62ef5a78639d>

closes https://github.com/deltachat/deltachat-ios/issues/2552
