### PR TITLE
hide archive bottom bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: In 'View Log', hide keyboard when scrolling down (#2541)
 - Fix: Experimental location sharing now ends at the specified interval even if you don't move (#2537)
 - Fix crash on account deletion (#2554)
+- Fix hiding of the bottom bar when archive is opened (#2560)
 - minimum system version is iOS 14 now (all iOS 13 devices can upgrade to iOS 14) (#2459)
 
 

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -90,6 +90,7 @@ class ChatListViewController: UITableViewController {
         self.dcAccounts = dcAccounts
         self.isArchive = isArchive
         super.init(style: .plain)
+        hidesBottomBarWhenPushed = isArchive
         DispatchQueue.global(qos: .userInteractive).async { [weak self] in
             guard let self else { return }
             self.viewModel = ChatListViewModel(dcContext: self.dcContext, isArchive: isArchive)


### PR DESCRIPTION
i think, this was the case at some point, but not totally sure. anyways, it should be hidden for a clear navigation experience, this is also what other messengers (whatsapp, telegram, signal at least) are doing.

closes #2556