### PR TITLE
add hint about release notes to RELEASE, slight rewordings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 - Saved messages are marked by a little star (#2527)
 - In the "Saved Messages" chat, messages are shown in context and have an option to go to the original (#2527)
 - New group consistency algorithm (#2564)
-- The app now requires less storage deduplicating newly received/sent files (#2564)
+- The app now requires less storage by deduplicating newly received/sent files (#2564)
 - Show 'unconnected' and 'updating' states in profile switcher (#2553)
+- Access recently used apps from app-picker ("Attach / Apps") (#2530)
 - Add 'Paste from Clipboard' to onboarding QR code scanners (#2559)
 - Detect Stickers when dropped, pasted or picked from Gallery (#2535)
 - Modernize menus (#2545, #2558)
@@ -23,7 +24,6 @@
 - Fix rare issue where some messages are not synced between multiple devices (#2564)
 - Fix: do not allow private replies info-messages resulting in invalid chat (#2571)
 - minimum system version is iOS 14 now (all iOS 13 devices can upgrade to iOS 14) (#2459)
-- Access recently used apps from app-picker ("Attach / Apps") (#2530)
 - Update translations and local help (#2561, #2564)
 - Update core to 1.155.2 (#2564, #2570)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,7 +55,7 @@ in Xcode:
 
 on https://appstoreconnect.apple.com :
 
-7. for an **Open Testflight** release, open "My Apps / Delta Chat / TestFlight / iOS"
+7. First, always create **Open Testflight**, at "My Apps / Delta Chat / TestFlight / iOS"
    a) status becomes "Ready to Submit" automatically after some minutes
    b) select "open-testing-group" on the left, select "Builds" tab
    c) click "+" and select the version made "Ready to submit" above
@@ -64,7 +64,8 @@ on https://appstoreconnect.apple.com :
 
    OR
 
-8. for a **Regular release**, open "My Apps/Delta Chat iOS/iOS App+ (first item)"
+8. If the Testflight did not show problems, about a day later,
+   for a **Regular release**, open "My Apps/Delta Chat iOS/iOS App+ (first item)"
    a) enter the version number (without leading "v")
    b) fill out "what's new", use CHANGELOG.md as a template, add the line:
       "These features will roll out over the coming days. Thanks for using Delta Chat!"
@@ -82,5 +83,7 @@ on https://appstoreconnect.apple.com :
 in both cases, make sure, the provided test-email-address is working.
 finally, back on command line:
 
-9. commit changes from 1.-5. add add a tag:
-   $ git tag v1.2.3; git push --tags
+9. a) commit changes from 1.-5. add add a tag:
+      $ git tag v1.2.3; git push --tags
+   b) to give our github followers a nice update,
+      create a release with notes insipred by device message and CHANGELOG.


### PR DESCRIPTION
this PR adds a hint about why a github release should be created to RELEASE.mb