### PR TITLE
allow to share contacts without chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improve "All media empty" and "Block contact" wordings (#2580)
+- Fix: Allow to share contacts that do not have a chat (#2583)
 
 
 ## v1.52.2

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -112,6 +112,7 @@ class ContactDetailViewModel {
             chatActions.append(.deleteChat)
         } else {
             chatOptions.append(.startChat)
+            chatOptions.append(.shareContact)
             chatActions = [.showEncrInfo, .blockContact]
         }
 


### PR DESCRIPTION
this PR allows to share contacts that do not have a chat (yet).
sharing contacts one has a chat with was always possible.

closes https://github.com/deltachat/deltachat-ios/issues/2581

<img width=320 src=https://github.com/user-attachments/assets/9b656aa4-1dc5-46a7-82e8-ab18317810f1>

