### PR TITLE
modern buttons & button icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improve "All media empty" and "Block contact" wordings (#2580)
+- Unify buttons and icons (#2584)
 - Fix: Allow to share contacts that do not have a chat (#2583)
 
 

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -19,6 +19,7 @@ class AccountSwitchViewController: UITableViewController {
     private lazy var addAccountCell: ActionCell = {
         let cell = ActionCell()
         cell.actionTitle = String.localized("add_account")
+        cell.imageView?.image = UIImage(systemName: "plus")
         return cell
     }()
 

--- a/deltachat-ios/Controller/AddGroupMembersViewController.swift
+++ b/deltachat-ios/Controller/AddGroupMembersViewController.swift
@@ -24,7 +24,7 @@ class AddGroupMembersViewController: GroupMembersViewController {
     private lazy var newContactCell: ActionCell = {
         let cell = ActionCell()
         cell.actionColor = UIColor.systemBlue
-        cell.imageView?.image = UIImage(systemName: "pencil")
+        cell.imageView?.image = UIImage(systemName: "highlighter")
         cell.actionTitle = String.localized("menu_new_classic_contact")
         return cell
     }()

--- a/deltachat-ios/Controller/AddGroupMembersViewController.swift
+++ b/deltachat-ios/Controller/AddGroupMembersViewController.swift
@@ -24,6 +24,7 @@ class AddGroupMembersViewController: GroupMembersViewController {
     private lazy var newContactCell: ActionCell = {
         let cell = ActionCell()
         cell.actionColor = UIColor.systemBlue
+        cell.imageView?.image = UIImage(systemName: "pencil")
         cell.actionTitle = String.localized("menu_new_classic_contact")
         return cell
     }()

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -95,7 +95,8 @@ class ContactDetailViewController: UITableViewController {
 
     private lazy var clearChatCell: ActionCell = {
         let cell = ActionCell()
-        cell.imageView?.image = UIImage(systemName: "line.diagonal")
+        let image = if #available(iOS 16.0, *) { "eraser" } else { "rectangle.portrait" }
+        cell.imageView?.image = UIImage(systemName: image)
         cell.actionTitle = String.localized("clear_chat")
         cell.actionColor = UIColor.systemRed
         return cell

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -226,16 +226,13 @@ class ContactDetailViewController: UITableViewController {
                 return locationsCell
             case .ephemeralMessages:
                 return ephemeralMessagesCell
-            }
-        case .statusArea:
-            return statusCell
-        case .startChatButtons:
-            switch viewModel.startChatButtonFor(row: row) {
             case .startChat:
                 return startChatCell
             case .shareContact:
                 return shareContactCell
             }
+        case .statusArea:
+            return statusCell
         case .chatActions:
             switch viewModel.chatActionFor(row: row) {
             case .archiveChat:
@@ -268,8 +265,6 @@ class ContactDetailViewController: UITableViewController {
             handleChatOption(indexPath: indexPath)
         case .statusArea:
             break
-        case .startChatButtons:
-            handleStartChatButton(indexPath: indexPath)
         case .chatActions:
             handleChatAction(indexPath: indexPath)
         case .sharedChats:
@@ -429,12 +424,6 @@ class ContactDetailViewController: UITableViewController {
             showLocations()
         case .ephemeralMessages:
             showEphemeralMessagesController()
-        }
-    }
-
-    private func handleStartChatButton(indexPath: IndexPath) {
-        let startChatButton = viewModel.startChatButtonFor(row: indexPath.row)
-        switch startChatButton {
         case .startChat:
             tableView.deselectRow(at: indexPath, animated: false)
             let contactId = viewModel.contactId

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -49,12 +49,8 @@ class ContactDetailViewController: UITableViewController {
         }
 
         let isOnHomescreen = chatIdsOnHomescreen.contains(viewModel.chatId)
-        if isOnHomescreen {
-            cell.actionTitle = String.localized("remove_from_widget")
-        } else {
-            cell.actionTitle = String.localized("add_to_widget")
-        }
-        cell.actionColor = UIColor.systemBlue
+        cell.imageView?.image = UIImage(systemName: isOnHomescreen ? "minus.square" : "plus.square")
+        cell.actionTitle = String.localized(isOnHomescreen ? "remove_from_widget" : "add_to_widget")
         return cell
     }()
 
@@ -75,27 +71,29 @@ class ContactDetailViewController: UITableViewController {
 
     private lazy var showEncrInfoCell: ActionCell = {
         let cell = ActionCell()
+        cell.imageView?.image = UIImage(systemName: "info.circle")
         cell.actionTitle = String.localized("encryption_info_title_desktop")
-        cell.actionColor = UIColor.systemBlue
         return cell
     }()
 
     private lazy var blockContactCell: ActionCell = {
         let cell = ActionCell()
+        cell.imageView?.image = UIImage(systemName: "nosign")
         cell.actionTitle = viewModel.contact.isBlocked ? String.localized("menu_unblock_contact") : String.localized("menu_block_contact")
-        cell.actionColor = viewModel.contact.isBlocked ? UIColor.systemBlue : UIColor.systemRed
+        cell.actionColor = UIColor.systemRed
         return cell
     }()
 
     private lazy var archiveChatCell: ActionCell = {
         let cell = ActionCell()
+        cell.imageView?.image = UIImage(systemName: viewModel.chatIsArchived ? "tray.and.arrow.up" : "tray.and.arrow.down")
         cell.actionTitle = viewModel.chatIsArchived ? String.localized("menu_unarchive_chat") :  String.localized("menu_archive_chat")
-        cell.actionColor = UIColor.systemBlue
         return cell
     }()
 
     private lazy var clearChatCell: ActionCell = {
         let cell = ActionCell()
+        cell.imageView?.image = UIImage(systemName: "line.diagonal")
         cell.actionTitle = String.localized("clear_chat")
         cell.actionColor = UIColor.systemRed
         return cell
@@ -103,6 +101,7 @@ class ContactDetailViewController: UITableViewController {
 
     private lazy var deleteChatCell: ActionCell = {
         let cell = ActionCell()
+        cell.imageView?.image = UIImage(systemName: "trash")
         cell.actionTitle = String.localized("menu_delete_chat")
         cell.actionColor = UIColor.systemRed
         return cell
@@ -436,6 +435,7 @@ class ContactDetailViewController: UITableViewController {
         if archived {
             self.navigationController?.popToRootViewController(animated: false)
         } else {
+            archiveChatCell.imageView?.image = UIImage(systemName: "tray.and.arrow.down")
             archiveChatCell.actionTitle = String.localized("menu_archive_chat")
         }
     }
@@ -459,16 +459,12 @@ class ContactDetailViewController: UITableViewController {
         guard #available(iOS 17, *) else { return }
 
         let onHomescreen = viewModel.toggleChatInHomescreenWidget()
-        if onHomescreen {
-            homescreenWidgetCell.actionTitle = String.localized("remove_from_widget")
-        } else {
-            homescreenWidgetCell.actionTitle =  String.localized("add_to_widget")
-        }
+        homescreenWidgetCell.imageView?.image = UIImage(systemName: onHomescreen ? "minus.square" : "plus.square")
+        homescreenWidgetCell.actionTitle = String.localized(onHomescreen ? "remove_from_widget" : "add_to_widget")
     }
 
     private func updateBlockContactCell() {
         blockContactCell.actionTitle = viewModel.contact.isBlocked ? String.localized("menu_unblock_contact") : String.localized("menu_block_contact")
-        blockContactCell.actionColor = viewModel.contact.isBlocked ? UIColor.systemBlue : UIColor.systemRed
     }
 
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -225,13 +225,16 @@ class ContactDetailViewController: UITableViewController {
                 return locationsCell
             case .ephemeralMessages:
                 return ephemeralMessagesCell
+            }
+        case .statusArea:
+            return statusCell
+        case .startChatButtons:
+            switch viewModel.startChatButtonFor(row: row) {
             case .startChat:
                 return startChatCell
             case .shareContact:
                 return shareContactCell
             }
-        case .statusArea:
-            return statusCell
         case .chatActions:
             switch viewModel.chatActionFor(row: row) {
             case .archiveChat:
@@ -264,6 +267,8 @@ class ContactDetailViewController: UITableViewController {
             handleChatOption(indexPath: indexPath)
         case .statusArea:
             break
+        case .startChatButtons:
+            handleStartChatButton(indexPath: indexPath)
         case .chatActions:
             handleChatAction(indexPath: indexPath)
         case .sharedChats:
@@ -423,6 +428,12 @@ class ContactDetailViewController: UITableViewController {
             showLocations()
         case .ephemeralMessages:
             showEphemeralMessagesController()
+        }
+    }
+
+    private func handleStartChatButton(indexPath: IndexPath) {
+        let startChatButton = viewModel.startChatButtonFor(row: indexPath.row)
+        switch startChatButton {
         case .startChat:
             tableView.deselectRow(at: indexPath, animated: false)
             let contactId = viewModel.contactId

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -22,10 +22,11 @@ class ContactDetailViewController: UITableViewController {
     }()
 
 
-    private lazy var startChatCell: ActionCell = {
-        let cell = ActionCell()
-        cell.actionColor = UIColor.systemBlue
-        cell.actionTitle = String.localized("send_message")
+    private lazy var startChatCell: UITableViewCell = {
+        let cell = UITableViewCell()
+        cell.imageView?.image = UIImage(systemName: "paperplane")
+        cell.textLabel?.text = String.localized("send_message")
+        cell.textLabel?.textColor = UIColor.systemBlue
         return cell
     }()
 
@@ -54,10 +55,11 @@ class ContactDetailViewController: UITableViewController {
         return cell
     }()
 
-    private lazy var shareContactCell: ActionCell = {
-        let cell = ActionCell()
-        cell.actionTitle = String.localized("menu_share")
-        cell.actionColor = UIColor.systemBlue
+    private lazy var shareContactCell: UITableViewCell = {
+        let cell = UITableViewCell()
+        cell.imageView?.image = UIImage(systemName: "square.and.arrow.up")
+        cell.textLabel?.text = String.localized("menu_share")
+        cell.textLabel?.textColor = UIColor.systemBlue
         return cell
     }()
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -22,11 +22,10 @@ class ContactDetailViewController: UITableViewController {
     }()
 
 
-    private lazy var startChatCell: UITableViewCell = {
-        let cell = UITableViewCell()
+    private lazy var startChatCell: ActionCell = {
+        let cell = ActionCell()
         cell.imageView?.image = UIImage(systemName: "paperplane")
-        cell.textLabel?.text = String.localized("send_message")
-        cell.textLabel?.textColor = UIColor.systemBlue
+        cell.actionTitle = String.localized("send_message")
         return cell
     }()
 
@@ -55,11 +54,10 @@ class ContactDetailViewController: UITableViewController {
         return cell
     }()
 
-    private lazy var shareContactCell: UITableViewCell = {
-        let cell = UITableViewCell()
+    private lazy var shareContactCell: ActionCell = {
+        let cell = ActionCell()
         cell.imageView?.image = UIImage(systemName: "square.and.arrow.up")
-        cell.textLabel?.text = String.localized("menu_share")
-        cell.textLabel?.textColor = UIColor.systemBlue
+        cell.actionTitle = String.localized("menu_share")
         return cell
     }()
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -369,7 +369,7 @@ class ContactDetailViewController: UITableViewController {
     @objc private func shareContact() {
         guard let vcardData = viewModel.context.makeVCard(contactIds: [viewModel.contactId]) else { return }
 
-        RelayHelper.shared.setForwardVCard(dialogTitle: String.localized("forward_to"), vcardData: vcardData)
+        RelayHelper.shared.setForwardVCard(vcardData: vcardData)
         navigationController?.popToRootViewController(animated: true)
     }
 

--- a/deltachat-ios/Controller/EphemeralMessagesViewController.swift
+++ b/deltachat-ios/Controller/EphemeralMessagesViewController.swift
@@ -103,7 +103,10 @@ class EphemeralMessagesViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return String.localized("ephemeral_messages_hint")
+        if !dcContext.getChat(chatId: chatId).isSelfTalk { // the hint refers to "all member of the chat", this is weird for "Saved Messages"
+            return String.localized("ephemeral_messages_hint")
+        }
+        return nil
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -547,7 +547,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 }
                 if row == membersRowAddMembers {
                     actionCell.actionTitle = String.localized(chat.isBroadcast ? "add_recipients" : "group_add_members")
-                    actionCell.imageView?.image = UIImage(systemName: "person.badge.plus")
+                    actionCell.imageView?.image = UIImage(systemName: "plus")
                     actionCell.actionColor = UIColor.systemBlue
                 } else if row == membersRowQrInvite {
                     actionCell.actionTitle = String.localized("qrshow_join_group_title")

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -87,13 +87,14 @@ class GroupChatDetailViewController: UIViewController {
 
     private lazy var archiveChatCell: ActionCell = {
         let cell = ActionCell()
+        cell.imageView?.image = UIImage(systemName: chat.isArchived ? "tray.and.arrow.up" : "tray.and.arrow.down")
         cell.actionTitle = chat.isArchived ? String.localized("menu_unarchive_chat") :  String.localized("menu_archive_chat")
-        cell.actionColor = UIColor.systemBlue
         return cell
     }()
 
     private lazy var cloneChatCell: ActionCell = {
         let cell = ActionCell()
+        cell.imageView?.image = UIImage(systemName: "square.on.square")
         cell.actionTitle = String.localized("clone_chat")
         cell.actionColor = UIColor.systemBlue
         return cell
@@ -101,6 +102,7 @@ class GroupChatDetailViewController: UIViewController {
 
     private lazy var leaveGroupCell: ActionCell = {
         let cell = ActionCell()
+        cell.imageView?.image = UIImage(systemName: "xmark")
         cell.actionTitle = String.localized("menu_leave_group")
         cell.actionColor = UIColor.systemRed
         return cell
@@ -115,6 +117,7 @@ class GroupChatDetailViewController: UIViewController {
 
     private lazy var clearChatCell: ActionCell = {
         let cell = ActionCell()
+        cell.imageView?.image = UIImage(systemName: "line.diagonal")
         cell.actionTitle = String.localized("clear_chat")
         cell.actionColor = UIColor.systemRed
         return cell
@@ -122,6 +125,7 @@ class GroupChatDetailViewController: UIViewController {
 
     private lazy var deleteChatCell: ActionCell = {
         let cell = ActionCell()
+        cell.imageView?.image = UIImage(systemName: "trash")
         cell.actionTitle = String.localized("menu_delete_chat")
         cell.actionColor = UIColor.systemRed
         return cell
@@ -163,12 +167,8 @@ class GroupChatDetailViewController: UIViewController {
         }
 
         let isOnHomescreen = chatIdsOnHomescreen.contains(chatId)
-        if isOnHomescreen {
-            cell.actionTitle = String.localized("remove_from_widget")
-        } else {
-            cell.actionTitle = String.localized("add_to_widget")
-        }
-        cell.actionColor = UIColor.systemBlue
+        cell.imageView?.image = UIImage(systemName: isOnHomescreen ? "minus.square" : "plus.square")
+        cell.actionTitle = String.localized(isOnHomescreen ? "remove_from_widget" : "add_to_widget")
         return cell
     }()
 
@@ -369,11 +369,8 @@ class GroupChatDetailViewController: UIViewController {
             onHomescreen = true
         }
 
-        if onHomescreen {
-            homescreenWidgetCell.actionTitle = String.localized("remove_from_widget")
-        } else {
-            homescreenWidgetCell.actionTitle =  String.localized("add_to_widget")
-        }
+        homescreenWidgetCell.imageView?.image = UIImage(systemName: onHomescreen ? "minus.square" : "plus.square")
+        homescreenWidgetCell.actionTitle = String.localized(onHomescreen ? "remove_from_widget" : "add_to_widget")
     }
 
     @objc func editButtonPressed() {
@@ -402,6 +399,7 @@ class GroupChatDetailViewController: UIViewController {
         }
         dcContext.archiveChat(chatId: chat.id, archive: !archivedBefore)
         if archivedBefore {
+            archiveChatCell.imageView?.image = UIImage(systemName: "tray.and.arrow.down")
             archiveChatCell.actionTitle = String.localized("menu_archive_chat")
         } else {
             self.navigationController?.popToRootViewController(animated: false)
@@ -549,9 +547,11 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 }
                 if row == membersRowAddMembers {
                     actionCell.actionTitle = String.localized(chat.isBroadcast ? "add_recipients" : "group_add_members")
+                    actionCell.imageView?.image = UIImage(systemName: "plus")
                     actionCell.actionColor = UIColor.systemBlue
                 } else if row == membersRowQrInvite {
                     actionCell.actionTitle = String.localized("qrshow_join_group_title")
+                    actionCell.imageView?.image = UIImage(systemName: "qrcode")
                     actionCell.actionColor = UIColor.systemBlue
                 }
                 return actionCell

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -102,7 +102,7 @@ class GroupChatDetailViewController: UIViewController {
 
     private lazy var leaveGroupCell: ActionCell = {
         let cell = ActionCell()
-        cell.imageView?.image = UIImage(systemName: "xmark")
+        cell.imageView?.image = UIImage(systemName: "signpost.right")
         cell.actionTitle = String.localized("menu_leave_group")
         cell.actionColor = UIColor.systemRed
         return cell

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -547,7 +547,7 @@ extension GroupChatDetailViewController: UITableViewDelegate, UITableViewDataSou
                 }
                 if row == membersRowAddMembers {
                     actionCell.actionTitle = String.localized(chat.isBroadcast ? "add_recipients" : "group_add_members")
-                    actionCell.imageView?.image = UIImage(systemName: "plus")
+                    actionCell.imageView?.image = UIImage(systemName: "person.badge.plus")
                     actionCell.actionColor = UIColor.systemBlue
                 } else if row == membersRowQrInvite {
                     actionCell.actionTitle = String.localized("qrshow_join_group_title")

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -117,7 +117,8 @@ class GroupChatDetailViewController: UIViewController {
 
     private lazy var clearChatCell: ActionCell = {
         let cell = ActionCell()
-        cell.imageView?.image = UIImage(systemName: "line.diagonal")
+        let image = if #available(iOS 16.0, *) { "eraser" } else { "rectangle.portrait" }
+        cell.imageView?.image = UIImage(systemName: image)
         cell.actionTitle = String.localized("clear_chat")
         cell.actionColor = UIColor.systemRed
         return cell

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -94,7 +94,8 @@ class GroupChatDetailViewController: UIViewController {
 
     private lazy var cloneChatCell: ActionCell = {
         let cell = ActionCell()
-        cell.imageView?.image = UIImage(systemName: "square.on.square")
+        let image = if #available(iOS 15.0, *) { "rectangle.portrait.on.rectangle.portrait" } else { "square.on.square" }
+        cell.imageView?.image = UIImage(systemName: image)
         cell.actionTitle = String.localized("clone_chat")
         cell.actionColor = UIColor.systemBlue
         return cell
@@ -102,7 +103,8 @@ class GroupChatDetailViewController: UIViewController {
 
     private lazy var leaveGroupCell: ActionCell = {
         let cell = ActionCell()
-        cell.imageView?.image = UIImage(systemName: "signpost.right")
+        let image = if #available(iOS 15.0, *) { "rectangle.portrait.and.arrow.right" } else { "arrow.right.square" }
+        cell.imageView?.image = UIImage(systemName: image)
         cell.actionTitle = String.localized("menu_leave_group")
         cell.actionColor = UIColor.systemRed
         return cell

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -180,6 +180,13 @@ class NewChatViewController: UITableViewController {
         }
     }
 
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        if section == sectionContacts {
+            return String.localized("chat_with")
+        }
+        return nil
+    }
+
     override func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
         let row = indexPath.row
         let section = indexPath.section

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -150,16 +150,17 @@ class NewChatViewController: UITableViewController {
 
             switch newOptions[row] {
             case .scanQRCode:
-                actionCell.imageView?.image = UIImage(systemName: "plus")
+                actionCell.imageView?.image = UIImage(systemName: "qrcode")
                 actionCell.actionTitle = String.localized("menu_new_contact")
             case .newGroup:
-                actionCell.imageView?.image = UIImage(systemName: "plus")
+                actionCell.imageView?.image = UIImage(systemName: "person.2")
                 actionCell.actionTitle = String.localized("menu_new_group")
             case .newBroadcastList:
-                actionCell.imageView?.image = UIImage(systemName: "plus")
+                let image = if #available(iOS 17, *) { "horn" } else { "speaker.wave.3" }
+                actionCell.imageView?.image = UIImage(systemName: image)
                 actionCell.actionTitle = String.localized("new_broadcast_list")
             case .newContact:
-                actionCell.imageView?.image = UIImage(systemName: "pencil")
+                actionCell.imageView?.image = UIImage(systemName: "highlighter")
                 actionCell.actionTitle = String.localized("menu_new_classic_contact")
             }
 

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -153,11 +153,10 @@ class NewChatViewController: UITableViewController {
                 actionCell.imageView?.image = UIImage(systemName: "qrcode")
                 actionCell.actionTitle = String.localized("menu_new_contact")
             case .newGroup:
-                actionCell.imageView?.image = UIImage(systemName: "person.2")
+                actionCell.imageView?.image = UIImage(systemName: "plus")
                 actionCell.actionTitle = String.localized("menu_new_group")
             case .newBroadcastList:
-                let image = if #available(iOS 17, *) { "horn" } else { "speaker.wave.3" }
-                actionCell.imageView?.image = UIImage(systemName: image)
+                actionCell.imageView?.image = UIImage(systemName: "plus")
                 actionCell.actionTitle = String.localized("new_broadcast_list")
             case .newContact:
                 actionCell.imageView?.image = UIImage(systemName: "highlighter")

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -148,6 +148,7 @@ class NewChatViewController: UITableViewController {
         if section == sectionNew {
             guard let actionCell = tableView.dequeueReusableCell(withIdentifier: ActionCell.reuseIdentifier, for: indexPath) as? ActionCell else { fatalError("No Action Cell") }
 
+            actionCell.imageView?.image = UIImage(systemName: "plus")
             switch newOptions[row] {
             case .scanQRCode:
                 actionCell.actionTitle = String.localized("menu_new_contact")
@@ -163,6 +164,7 @@ class NewChatViewController: UITableViewController {
         } else if section == sectionInviteFriends {
             guard let actionCell = tableView.dequeueReusableCell(withIdentifier: ActionCell.reuseIdentifier, for: indexPath) as? ActionCell else { fatalError("No Action Cell") }
 
+            actionCell.imageView?.image = UIImage(systemName: "heart")
             actionCell.actionTitle = String.localized("invite_friends")
             return actionCell
 

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -148,15 +148,18 @@ class NewChatViewController: UITableViewController {
         if section == sectionNew {
             guard let actionCell = tableView.dequeueReusableCell(withIdentifier: ActionCell.reuseIdentifier, for: indexPath) as? ActionCell else { fatalError("No Action Cell") }
 
-            actionCell.imageView?.image = UIImage(systemName: "plus")
             switch newOptions[row] {
             case .scanQRCode:
+                actionCell.imageView?.image = UIImage(systemName: "plus")
                 actionCell.actionTitle = String.localized("menu_new_contact")
             case .newGroup:
+                actionCell.imageView?.image = UIImage(systemName: "plus")
                 actionCell.actionTitle = String.localized("menu_new_group")
             case .newBroadcastList:
+                actionCell.imageView?.image = UIImage(systemName: "plus")
                 actionCell.actionTitle = String.localized("new_broadcast_list")
             case .newContact:
+                actionCell.imageView?.image = UIImage(systemName: "pencil")
                 actionCell.actionTitle = String.localized("menu_new_classic_contact")
             }
 

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -161,6 +161,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
         case .invite:
             guard let actionCell = tableView.dequeueReusableCell(withIdentifier: ActionCell.reuseIdentifier, for: indexPath) as? ActionCell else { fatalError("No ActionCell") }
             if inviteRows[row] == .addMembers {
+                actionCell.imageView?.image = UIImage(systemName: "person.badge.plus")
                 actionCell.actionTitle = String.localized(createBroadcast ? "add_recipients" : "group_add_members")
                 actionCell.actionColor = UIColor.systemBlue
                 actionCell.isUserInteractionEnabled = true

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -161,7 +161,7 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
         case .invite:
             guard let actionCell = tableView.dequeueReusableCell(withIdentifier: ActionCell.reuseIdentifier, for: indexPath) as? ActionCell else { fatalError("No ActionCell") }
             if inviteRows[row] == .addMembers {
-                actionCell.imageView?.image = UIImage(systemName: "person.badge.plus")
+                actionCell.imageView?.image = UIImage(systemName: "plus")
                 actionCell.actionTitle = String.localized(createBroadcast ? "add_recipients" : "group_add_members")
                 actionCell.actionColor = UIColor.systemBlue
                 actionCell.isUserInteractionEnabled = true

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -116,7 +116,7 @@ class QrPageController: UIPageViewController {
             self?.pasteFromClipboard()
         })
         if dcContext.isChatmail == false {
-            actions.append(UIAction(title: String.localized("menu_new_classic_contact"), image: UIImage(systemName: "pencil")) { [weak self] _ in
+            actions.append(UIAction(title: String.localized("menu_new_classic_contact"), image: UIImage(systemName: "highlighter")) { [weak self] _ in
                 guard let self else { return }
                 self.navigationController?.pushViewController(NewContactController(dcContext: self.dcContext), animated: true)
             })

--- a/deltachat-ios/Controller/Settings/NotificationsViewController.swift
+++ b/deltachat-ios/Controller/Settings/NotificationsViewController.swift
@@ -50,11 +50,10 @@ internal final class NotificationsViewController: UITableViewController {
         })
     }()
 
-    private lazy var systemSettingsCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+    private lazy var systemSettingsCell: ActionCell = {
+        let cell = ActionCell()
         cell.tag = CellTags.systemSettings.rawValue
         cell.textLabel?.text = String.localized("system_settings")
-        cell.accessoryType = .disclosureIndicator
         return cell
     }()
 

--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -40,6 +40,7 @@ class ProxySettingsViewController: UITableViewController {
 
         addProxyCell = ActionCell()
         addProxyCell.actionTitle = String.localized("proxy_add")
+        addProxyCell.imageView?.image = UIImage(systemName: "plus")
         toggleProxyCell = SwitchCell(textLabel: String.localized("proxy_use_proxy"), on: dcContext.isProxyEnabled)
 
         super.init(style: .insetGrouped)

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -31,8 +31,9 @@ class RelayHelper {
 
     // forwarding messages
 
-    func setForwardVCard(dialogTitle: String, vcardData: Data) {
-        self.dialogTitle = dialogTitle
+    func setForwardVCard(vcardData: Data) {
+        finishRelaying()
+        self.dialogTitle = String.localized("chat_share_with_title")
         self.forwardVCardData = vcardData
     }
 

--- a/deltachat-ios/View/ActionCell.swift
+++ b/deltachat-ios/View/ActionCell.swift
@@ -15,6 +15,9 @@ class ActionCell: UITableViewCell {
     var actionColor: UIColor? {
         didSet {
             textLabel?.textColor = actionColor ?? UIColor.systemBlue
+            if let imageView {
+                imageView.tintColor = actionColor ?? UIColor.systemBlue
+            }
         }
     }
 

--- a/deltachat-ios/View/ActionCell.swift
+++ b/deltachat-ios/View/ActionCell.swift
@@ -8,45 +8,22 @@ class ActionCell: UITableViewCell {
 
     var actionTitle: String? {
         didSet {
-            actionLabel.text = actionTitle
+            textLabel?.text = actionTitle
         }
     }
 
     var actionColor: UIColor? {
         didSet {
-            actionLabel.textColor = actionColor ?? UIColor.systemBlue
+            textLabel?.textColor = actionColor ?? UIColor.systemBlue
         }
     }
 
-    private lazy var actionLabel: UILabel = {
-        let label = UILabel()
-        label.text = actionTitle
-        label.textColor = UIColor.systemBlue
-        label.font = .preferredFont(forTextStyle: .body)
-        label.adjustsFontForContentSizeCategory = true
-        label.textAlignment = .center
-        label.numberOfLines = 0
-        return label
-    }()
-
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupSubviews()
+        textLabel?.textColor = UIColor.systemBlue
     }
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    private func setupSubviews() {
-        contentView.addSubview(actionLabel)
-        actionLabel.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addConstraints([
-            actionLabel.constraintAlignLeadingTo(contentView, paddingLeading: 12),
-            actionLabel.constraintAlignTrailingTo(contentView, paddingTrailing: 12),
-            actionLabel.constraintAlignTopTo(contentView, paddingTop: 12),
-            actionLabel.constraintAlignBottomTo(contentView, paddingBottom: 12)
-
-        ])
     }
 }

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -8,6 +8,7 @@ class ContactDetailViewModel {
     enum ProfileSections {
         case chatOptions
         case statusArea
+        case startChatButtons
         case sharedChats
         case chatActions
     }
@@ -17,8 +18,11 @@ class ContactDetailViewModel {
         case allMedia
         case locations
         case ephemeralMessages
-        case shareContact
+    }
+
+    enum StartChatButton {
         case startChat
+        case shareContact
     }
 
     enum ChatAction {
@@ -47,6 +51,7 @@ class ContactDetailViewModel {
     private var sections: [ProfileSections] = []
     private var chatActions: [ChatAction] = []
     private var chatOptions: [ChatOption] = []
+    private var startChatButtons: [StartChatButton] = []
 
     init(dcContext: DcContext, contactId: Int) {
         self.context = dcContext
@@ -74,12 +79,17 @@ class ContactDetailViewModel {
             sections.append(.statusArea)
         }
 
+        if !isSavedMessages && !isDeviceTalk {
+            sections.append(.startChatButtons)
+        }
+
         if sharedChats.length > 0 && !isSavedMessages && !isDeviceTalk {
             sections.append(.sharedChats)
         }
         sections.append(.chatActions)
 
         chatOptions = []
+        startChatButtons = []
         if dcContact.getVerifierId() != 0 {
             chatOptions.append(.verifiedBy)
         }
@@ -93,11 +103,11 @@ class ContactDetailViewModel {
         if chatExists {
             if !isDeviceTalk {
                 chatOptions.append(.ephemeralMessages)
-                chatOptions.append(.startChat)
+                startChatButtons.append(.startChat)
             }
 
             if isSavedMessages == false && isDeviceTalk == false {
-                chatOptions.append(.shareContact)
+                startChatButtons.append(.shareContact)
             }
 
             chatActions = [.archiveChat]
@@ -111,8 +121,8 @@ class ContactDetailViewModel {
             chatActions.append(.clearChat)
             chatActions.append(.deleteChat)
         } else {
-            chatOptions.append(.startChat)
-            chatOptions.append(.shareContact)
+            startChatButtons.append(.startChat)
+            startChatButtons.append(.shareContact)
             chatActions = [.showEncrInfo, .blockContact]
         }
 
@@ -129,6 +139,10 @@ class ContactDetailViewModel {
 
     func chatOptionFor(row: Int) -> ContactDetailViewModel.ChatOption {
         return chatOptions[row]
+    }
+
+    func startChatButtonFor(row: Int) -> ContactDetailViewModel.StartChatButton {
+        return startChatButtons[row]
     }
 
     var chatIsArchived: Bool {
@@ -155,6 +169,7 @@ class ContactDetailViewModel {
         switch sections[section] {
         case .chatOptions: return chatOptions.count
         case .statusArea: return 1
+        case .startChatButtons: return startChatButtons.count
         case .sharedChats: return sharedChats.length
         case .chatActions: return chatActions.count
         }
@@ -191,7 +206,7 @@ class ContactDetailViewModel {
         switch sections[section] {
         case .statusArea: return (isSavedMessages || isDeviceTalk) ? nil : String.localized("pref_default_status_label")
         case .sharedChats: return String.localized("profile_shared_chats")
-        case .chatOptions, .chatActions: return nil
+        case .chatOptions, .startChatButtons, .chatActions: return nil
         }
     }
 
@@ -205,7 +220,7 @@ class ContactDetailViewModel {
             } else {
                 return String.localizedStringWithFormat(String.localized("last_seen_at"), DateUtils.getExtendedAbsTimeSpanString(timeStamp: Double(lastSeen)))
             }
-        case .statusArea, .sharedChats, .chatActions: return nil
+        case .statusArea, .startChatButtons, .sharedChats, .chatActions: return nil
         }
     }
 

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -8,7 +8,6 @@ class ContactDetailViewModel {
     enum ProfileSections {
         case chatOptions
         case statusArea
-        case startChatButtons
         case sharedChats
         case chatActions
     }
@@ -18,11 +17,8 @@ class ContactDetailViewModel {
         case allMedia
         case locations
         case ephemeralMessages
-    }
-
-    enum StartChatButton {
-        case startChat
         case shareContact
+        case startChat
     }
 
     enum ChatAction {
@@ -51,7 +47,6 @@ class ContactDetailViewModel {
     private var sections: [ProfileSections] = []
     private var chatActions: [ChatAction] = []
     private var chatOptions: [ChatOption] = []
-    private var startChatButtons: [StartChatButton] = []
 
     init(dcContext: DcContext, contactId: Int) {
         self.context = dcContext
@@ -79,17 +74,12 @@ class ContactDetailViewModel {
             sections.append(.statusArea)
         }
 
-        if !isSavedMessages && !isDeviceTalk {
-            sections.append(.startChatButtons)
-        }
-
         if sharedChats.length > 0 && !isSavedMessages && !isDeviceTalk {
             sections.append(.sharedChats)
         }
         sections.append(.chatActions)
 
         chatOptions = []
-        startChatButtons = []
         if dcContact.getVerifierId() != 0 {
             chatOptions.append(.verifiedBy)
         }
@@ -103,11 +93,11 @@ class ContactDetailViewModel {
         if chatExists {
             if !isDeviceTalk {
                 chatOptions.append(.ephemeralMessages)
-                startChatButtons.append(.startChat)
+                chatOptions.append(.startChat)
             }
 
             if isSavedMessages == false && isDeviceTalk == false {
-                startChatButtons.append(.shareContact)
+                chatOptions.append(.shareContact)
             }
 
             chatActions = [.archiveChat]
@@ -121,8 +111,8 @@ class ContactDetailViewModel {
             chatActions.append(.clearChat)
             chatActions.append(.deleteChat)
         } else {
-            startChatButtons.append(.startChat)
-            startChatButtons.append(.shareContact)
+            chatOptions.append(.startChat)
+            chatOptions.append(.shareContact)
             chatActions = [.showEncrInfo, .blockContact]
         }
 
@@ -139,10 +129,6 @@ class ContactDetailViewModel {
 
     func chatOptionFor(row: Int) -> ContactDetailViewModel.ChatOption {
         return chatOptions[row]
-    }
-
-    func startChatButtonFor(row: Int) -> ContactDetailViewModel.StartChatButton {
-        return startChatButtons[row]
     }
 
     var chatIsArchived: Bool {
@@ -169,7 +155,6 @@ class ContactDetailViewModel {
         switch sections[section] {
         case .chatOptions: return chatOptions.count
         case .statusArea: return 1
-        case .startChatButtons: return startChatButtons.count
         case .sharedChats: return sharedChats.length
         case .chatActions: return chatActions.count
         }
@@ -206,7 +191,7 @@ class ContactDetailViewModel {
         switch sections[section] {
         case .statusArea: return (isSavedMessages || isDeviceTalk) ? nil : String.localized("pref_default_status_label")
         case .sharedChats: return String.localized("profile_shared_chats")
-        case .chatOptions, .startChatButtons, .chatActions: return nil
+        case .chatOptions, .chatActions: return nil
         }
     }
 
@@ -220,7 +205,7 @@ class ContactDetailViewModel {
             } else {
                 return String.localizedStringWithFormat(String.localized("last_seen_at"), DateUtils.getExtendedAbsTimeSpanString(timeStamp: Double(lastSeen)))
             }
-        case .statusArea, .startChatButtons, .sharedChats, .chatActions: return nil
+        case .statusArea, .sharedChats, .chatActions: return nil
         }
     }
 

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -93,10 +93,10 @@ class ContactDetailViewModel {
         if chatExists {
             if !isDeviceTalk {
                 chatOptions.append(.ephemeralMessages)
-                chatOptions.append(.startChat)
             }
 
-            if isSavedMessages == false && isDeviceTalk == false {
+            if !isSavedMessages && !isDeviceTalk {
+                chatOptions.append(.startChat)
                 chatOptions.append(.shareContact)
             }
 


### PR DESCRIPTION
this PR modernises the buttons used in profiles, settings etc. this is another step much easier possible after dropping ios12

- menus meanwhile also have icons: for better recognition, it makes sense that same functions show up similar (affects eg. "share" or "add to widget" but also "delete")

- esp. the "QR code" icon at "New Contact" is a win; this was figured out on android to make quite some difference in ux

- left-align buttons as meanwhile usual in virtually all comparable apps and screens

for the other icons, we stay conservative and do not add too many things, eg. "add" is a simply plus sign at most places - for adding profiles, groups, members, proxies

some impressions of affected screens:

<img width=320 src=https://github.com/user-attachments/assets/4afac75d-2267-4a45-94cf-23f1ea6c8a0d><br>

<img width=320 src=https://github.com/user-attachments/assets/c0872295-1283-4b3a-8aed-707379b88e67><br>

<img width=320 src=https://github.com/user-attachments/assets/13f09d7e-fd7d-4e18-8f54-57c21f262f02><br>

<img width=320 src=https://github.com/user-attachments/assets/ffdca22d-3255-4375-8a8a-b72255092984><br>

<img width=320 src=https://github.com/user-attachments/assets/cb7d0bbf-e4f3-4d46-a202-3d69d7576ef6><br>






