### PR TITLE
use 'bookmark' symbol for 'saved messages', tweak forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Improve "message menu": many options are now faster accessible (#2586)
+- When forwarding to "Saved Messages", if possible, save the message including context (#2587)
 - Copy scanned QR code text to clipboard (#2582)
 - Improve "All media empty" and "Block contact" wordings (#2580)
 - Unify buttons and icons (#2584)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1917,7 +1917,7 @@ extension ChatViewController {
                     UIAction.menuAction(localizationKey: "forward", systemImageName: "arrowshape.turn.up.forward", indexPath: indexPath, action: forward)
                 )
 
-                if !dcChat.isSelfTalk && !message.isMarkerOrInfo { // info-messages out of context are confusing, see #2567
+                if !dcChat.isSelfTalk && message.canSave {
                     if message.savedMessageId != 0 {
                         children.append(
                             UIAction.menuAction(localizationKey: "unsave", systemImageName: "bookmark.slash", indexPath: indexPath, action: toggleSave)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -957,16 +957,12 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         self.reloadData()
     }
 
-    private func isMarkerOrInfo(_ message: DcMsg) -> Bool {
-        return message.id == DC_MSG_ID_MARKER1 || message.id == DC_MSG_ID_DAYMARKER || message.isInfo || message.type == DC_MSG_VIDEOCHAT_INVITATION
-    }
-
     private func canReply(to message: DcMsg) -> Bool {
-        return !isMarkerOrInfo(message) && dcChat.canSend
+        return !message.isMarkerOrInfo && dcChat.canSend
     }
 
     private func canReplyPrivately(to message: DcMsg) -> Bool {
-        return !isMarkerOrInfo(message) && dcChat.isGroup && !message.isFromCurrentSender
+        return !message.isMarkerOrInfo && dcChat.isGroup && !message.isFromCurrentSender
     }
 
     /// Verifies if the last message cell is fully visible
@@ -1921,7 +1917,7 @@ extension ChatViewController {
                     UIAction.menuAction(localizationKey: "forward", systemImageName: "arrowshape.turn.up.forward", indexPath: indexPath, action: forward)
                 )
 
-                if !dcChat.isSelfTalk && !isMarkerOrInfo(message) { // info-messages out of context are confusing, see #2567
+                if !dcChat.isSelfTalk && !message.isMarkerOrInfo { // info-messages out of context are confusing, see #2567
                     if message.savedMessageId != 0 {
                         children.append(
                             UIAction.menuAction(localizationKey: "unsave", systemImageName: "bookmark.slash", indexPath: indexPath, action: toggleSave)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1930,11 +1930,11 @@ extension ChatViewController {
                 if !isMarkerOrInfo(message) { // info-messages out of context results in confusion, see https://github.com/deltachat/deltachat-ios/issues/2567
                     if dcChat.isSelfTalk || message.savedMessageId != 0 {
                         children.append(
-                            UIAction.menuAction(localizationKey: "unsave", systemImageName: "star.slash", indexPath: indexPath, action: toggleSave)
+                            UIAction.menuAction(localizationKey: "unsave", systemImageName: "bookmark.slash", indexPath: indexPath, action: toggleSave)
                         )
                     } else {
                         children.append(
-                            UIAction.menuAction(localizationKey: "save_desktop", systemImageName: "star", indexPath: indexPath, action: toggleSave)
+                            UIAction.menuAction(localizationKey: "save_desktop", systemImageName: "bookmark", indexPath: indexPath, action: toggleSave)
                         )
                     }
                 }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1679,13 +1679,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func toggleSave(at indexPath: IndexPath) {
         let message = dcContext.getMessage(id: messageIds[indexPath.row])
-        if dcChat.isSelfTalk {
-            if message.originalMessageId != 0 {
-                dcContext.deleteMessage(msgId: message.id)
-            } else {
-                askToDeleteMessage(id: message.id)
-            }
-        } else if message.savedMessageId != 0 {
+        if message.savedMessageId != 0 {
             dcContext.deleteMessage(msgId: message.savedMessageId)
         } else {
             dcContext.saveMessages(with: [messageIds[indexPath.row]])
@@ -1927,8 +1921,8 @@ extension ChatViewController {
                     UIAction.menuAction(localizationKey: "forward", systemImageName: "arrowshape.turn.up.forward", indexPath: indexPath, action: forward)
                 )
 
-                if !isMarkerOrInfo(message) { // info-messages out of context results in confusion, see https://github.com/deltachat/deltachat-ios/issues/2567
-                    if dcChat.isSelfTalk || message.savedMessageId != 0 {
+                if !dcChat.isSelfTalk && !isMarkerOrInfo(message) { // info-messages out of context are confusing, see #2567
+                    if message.savedMessageId != 0 {
                         children.append(
                             UIAction.menuAction(localizationKey: "unsave", systemImageName: "bookmark.slash", indexPath: indexPath, action: toggleSave)
                         )

--- a/deltachat-ios/Chat/Views/StatusView.swift
+++ b/deltachat-ios/Chat/Views/StatusView.swift
@@ -8,6 +8,7 @@ public class StatusView: UIView {
     private let padlockView: UIImageView
     private let locationView: UIImageView
     private let stateView: UIImageView
+    private let savedView: UIImageView
 
     override init(frame: CGRect) {
 
@@ -21,8 +22,10 @@ public class StatusView: UIView {
         locationView.translatesAutoresizingMaskIntoConstraints = false
         stateView = UIImageView()
         stateView.translatesAutoresizingMaskIntoConstraints = false
+        savedView = UIImageView()
+        savedView.translatesAutoresizingMaskIntoConstraints = false
 
-        contentStackView = UIStackView(arrangedSubviews: [dateLabel, padlockView, locationView, stateView])
+        contentStackView = UIStackView(arrangedSubviews: [savedView, padlockView, dateLabel, locationView, stateView])
         contentStackView.alignment = .center
         contentStackView.spacing = 0
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
@@ -54,6 +57,9 @@ public class StatusView: UIView {
 
             stateView.widthAnchor.constraint(equalToConstant: 20),
             stateView.heightAnchor.constraint(equalToConstant: 20),
+
+            savedView.widthAnchor.constraint(equalToConstant: 6),
+            savedView.heightAnchor.constraint(equalToConstant: 11),
         ]
 
         NSLayoutConstraint.activate(constraints)
@@ -64,16 +70,13 @@ public class StatusView: UIView {
         dateLabel.text = nil
         padlockView.isHidden = true
         locationView.isHidden = true
+        savedView.isHidden = true
         stateView.isHidden = true
     }
 
     public func update(message: DcMsg, tintColor: UIColor) {
         dateLabel.text = message.formattedSentDate()
         dateLabel.textColor = tintColor
-
-        if message.savedMessageId != 0 || message.originalMessageId != 0 {
-            dateLabel.text = "★ " + (dateLabel.text ?? "")
-        }
 
         if message.showPadlock() {
             padlockView.image = UIImage(named: "ic_lock")?.maskWithColor(color: tintColor)
@@ -87,6 +90,13 @@ public class StatusView: UIView {
             locationView.isHidden = false
         } else {
             locationView.isHidden = true
+        }
+
+        if message.savedMessageId != 0 || message.originalMessageId != 0 {
+            savedView.image = UIImage(systemName: "bookmark.fill")?.maskWithColor(color: tintColor)
+            savedView.isHidden = false
+        } else {
+            savedView.isHidden = true
         }
 
         let state: Int

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -460,10 +460,6 @@ public class DcContext {
         dc_resend_msgs(contextPointer, msgIds.compactMap { UInt32($0) }, Int32(msgIds.count))
     }
 
-    public func forwardMessage(with msgId: Int, to chat: Int) {
-        dc_forward_msgs(contextPointer, [UInt32(msgId)], 1, UInt32(chat))
-    }
-
     public func forwardMessages(with msgIds: [Int], to chat: Int) {
         dc_forward_msgs(contextPointer, msgIds.compactMap { UInt32($0) }, Int32(msgIds.count), UInt32(chat))
     }

--- a/deltachat-ios/DC/DcMsg.swift
+++ b/deltachat-ios/DC/DcMsg.swift
@@ -52,6 +52,10 @@ public class DcMsg {
         return id == DC_MSG_ID_MARKER1 || id == DC_MSG_ID_DAYMARKER || isInfo || type == DC_MSG_VIDEOCHAT_INVITATION
     }
 
+    public var canSave: Bool {
+        return !isMarkerOrInfo // info-messages out of context are confusing, see #2567
+    }
+
     public var originalMessageId: Int {
         return Int(dc_msg_get_original_msg_id(messagePointer))
     }

--- a/deltachat-ios/DC/DcMsg.swift
+++ b/deltachat-ios/DC/DcMsg.swift
@@ -48,6 +48,10 @@ public class DcMsg {
         return Int(dc_msg_get_from_id(messagePointer))
     }
 
+    public var isMarkerOrInfo: Bool {
+        return id == DC_MSG_ID_MARKER1 || id == DC_MSG_ID_DAYMARKER || isInfo || type == DC_MSG_VIDEOCHAT_INVITATION
+    }
+
     public var originalMessageId: Int {
         return Int(dc_msg_get_original_msg_id(messagePointer))
     }

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -64,8 +64,12 @@ class RelayHelper {
     }
 
     func forwardIdsAndFinishRelaying(to chat: Int) {
-        if let messageIds = self.forwardIds {
-            RelayHelper.dcContext?.forwardMessages(with: messageIds, to: chat)
+        if let messageIds = self.forwardIds, let dcContext = RelayHelper.dcContext {
+            if dcContext.getChat(chatId: chat).isSelfTalk {
+                dcContext.saveMessages(with: messageIds)
+            } else {
+                dcContext.forwardMessages(with: messageIds, to: chat)
+            }
         }
         finishRelaying()
     }

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -63,12 +63,19 @@ class RelayHelper {
         return forwardIds != nil || forwardText != nil || forwardFileData != nil || forwardVCardData != nil
     }
 
-    func forwardIdsAndFinishRelaying(to chat: Int) {
+    func forwardIdsAndFinishRelaying(to chatId: Int) {
         if let messageIds = self.forwardIds, let dcContext = RelayHelper.dcContext {
-            if dcContext.getChat(chatId: chat).isSelfTalk {
-                dcContext.saveMessages(with: messageIds)
+            if dcContext.getChat(chatId: chatId).isSelfTalk {
+                for id in messageIds {
+                    let curr = dcContext.getMessage(id: id)
+                    if curr.canSave && curr.savedMessageId == 0 && curr.chatId != chatId {
+                        dcContext.saveMessages(with: [curr.id])
+                    } else {
+                        dcContext.forwardMessages(with: [curr.id], to: chatId)
+                    }
+                }
             } else {
-                dcContext.forwardMessages(with: messageIds, to: chat)
+                dcContext.forwardMessages(with: messageIds, to: chatId)
             }
         }
         finishRelaying()


### PR DESCRIPTION
after some discussion with @adbenitez , the bookmark symbol is better for 'save' than a star:

- we're using that already for the save messages (even though there is a star on the bookmark ...)
- by that, it underlines that "save" is really only a shortcut for "forward to -> saved messages"
- 'bookmark' does not mix with an reaction so easily
- it also seems more often used for 'save' in comparable apps (eg. here on github for notifications, also on combination with "save"

moreover, this PR tweaks forwarding, so that forwarding to 'saved messages', if possible, saves the message instead if of forwarding it


<img width=320 src=https://github.com/user-attachments/assets/d3797660-a644-43a2-b371-10e31a7ac08a><br><br>
<img width=320 src=https://github.com/user-attachments/assets/1d8c4bf3-69f6-4d0e-8b72-3dff27052227>

the lock icon could also be sharper, but that is another PR then :)