### PR TITLE
Fixed share extension taking twice the memory per image it needed to

### DIFF
--- a/DcShare/Helper/ShareAttachment.swift
+++ b/DcShare/Helper/ShareAttachment.swift
@@ -101,23 +101,8 @@ class ShareAttachment {
     }
 
     private func createImageMsg(_ item: NSItemProvider) {
-        item.loadItem(forTypeIdentifier: kUTTypeImage as String, options: nil) { data, error in
-            var result: UIImage?
-            switch data {
-            case let image as UIImage:
-                result = image
-            case let data as Data:
-                result = ImageFormat.loadImageFrom(data: data)
-            case let url as URL:
-                if let nsurl = NSURL(string: url.absoluteString) {
-                    // scaleDownImage() uses less memory than core and avoids exhausing the 120 mb memory restriction of extensions (see #1330)
-                    result = ImageFormat.scaleDownImage(nsurl, toMax: 1280)
-                }
-            default:
-                self.error = "Unexpected data: \(type(of: data))"
-            }
-            if let result = result,
-               let path = ImageFormat.saveImage(image: result, directory: .cachesDirectory) {
+        item.loadImage { image, error in
+            if let image, let path = ImageFormat.saveImage(image: image, directory: .cachesDirectory) {
                 _ = self.addDcMsg(path: path, viewType: DC_MSG_IMAGE)
                 self.delegate?.onAttachmentChanged()
                 if self.imageThumbnail == nil {
@@ -125,7 +110,7 @@ class ShareAttachment {
                     self.delegate?.onThumbnailChanged()
                 }
             }
-            if let error = error {
+            if let error {
                 self.error = error.localizedDescription
             }
         }

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -131,6 +131,8 @@
 		5F153E9A2CC38BAA00871ABE /* GiveBackMyFirstResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F153E992CC38BAA00871ABE /* GiveBackMyFirstResponder.swift */; };
 		5F4945AB2D315E7000DCD50A /* UIPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */; };
 		5F785F6E2CB9344F003FFFB9 /* ReusableCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */; };
+		5FFAA5442D56673A00B1D54F /* NSItemProvider+loadImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FFAA5432D56673A00B1D54F /* NSItemProvider+loadImage.swift */; };
+		5FFAA5452D56679C00B1D54F /* NSItemProvider+loadImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FFAA5432D56673A00B1D54F /* NSItemProvider+loadImage.swift */; };
 		7070FB9B2101ECBB000DC258 /* NewGroupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7070FB9A2101ECBB000DC258 /* NewGroupController.swift */; };
 		7092474120B3869500AF8799 /* ContactDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7092474020B3869500AF8799 /* ContactDetailViewController.swift */; };
 		70B8882E2091B8550074812E /* ContactCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B8882D2091B8550074812E /* ContactCell.swift */; };
@@ -464,6 +466,7 @@
 		5F153E992CC38BAA00871ABE /* GiveBackMyFirstResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiveBackMyFirstResponder.swift; sourceTree = "<group>"; };
 		5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPasteboard.swift; sourceTree = "<group>"; };
 		5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableCellProtocol.swift; sourceTree = "<group>"; };
+		5FFAA5432D56673A00B1D54F /* NSItemProvider+loadImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSItemProvider+loadImage.swift"; sourceTree = "<group>"; };
 		7070FB9A2101ECBB000DC258 /* NewGroupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGroupController.swift; sourceTree = "<group>"; };
 		7092474020B3869500AF8799 /* ContactDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDetailViewController.swift; sourceTree = "<group>"; };
 		70B8882D2091B8550074812E /* ContactCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCell.swift; sourceTree = "<group>"; };
@@ -762,6 +765,7 @@
 				AEE56D7F225504DB007DC082 /* Extensions.swift */,
 				D84738D12BBC1C2C00ECD52B /* UIAction+Extension.swift */,
 				78E45E4321D3F14A00D4B15E /* UIImage+Extension.swift */,
+				5FFAA5432D56673A00B1D54F /* NSItemProvider+loadImage.swift */,
 				305961832346125000C80F33 /* UIEdgeInsets+Extensions.swift */,
 				305961862346125000C80F33 /* NSAttributedString+Extensions.swift */,
 				305961882346125000C80F33 /* CGRect+Extensions.swift */,
@@ -1616,6 +1620,7 @@
 				3057027F24C5B2F800D84EFC /* ChatListViewModel.swift in Sources */,
 				302589FF2452FA280086C1CD /* ShareAttachment.swift in Sources */,
 				3057029F24C6445000D84EFC /* EmptyStateLabel.swift in Sources */,
+				5FFAA5452D56679C00B1D54F /* NSItemProvider+loadImage.swift in Sources */,
 				305702A224C6455400D84EFC /* TypeAlias.swift in Sources */,
 				308850A0282A914F00204623 /* DcMsg+Extension.swift in Sources */,
 				30238D0028A557E800EF14AC /* FileHelper.swift in Sources */,
@@ -1669,6 +1674,7 @@
 				3080A022277DE09900E74565 /* InputTextView.swift in Sources */,
 				30734326249A280B00BF9AD1 /* MediaQualityViewController.swift in Sources */,
 				3080A01C277DDB8A00E74565 /* InputBarAccessoryViewDelegate.swift in Sources */,
+				5FFAA5442D56673A00B1D54F /* NSItemProvider+loadImage.swift in Sources */,
 				D89C456D2D0AF6A8005B1491 /* WidgetEntry.swift in Sources */,
 				30FDB70524D1C1000066C48D /* ChatViewController.swift in Sources */,
 				3080A013277DDABA00E74565 /* KeyboardNotification.swift in Sources */,

--- a/deltachat-ios/Controller/NewContactController.swift
+++ b/deltachat-ios/Controller/NewContactController.swift
@@ -5,7 +5,7 @@ class NewContactController: UITableViewController {
 
     let dcContext: DcContext
     var createChatOnSave = true
-    var prefilledSeachResult: String?
+    var prefilledSearchResult: String?
 
     let emailCell = TextFieldCell.makeEmailCell()
     let nameCell = TextFieldCell.makeNameCell()
@@ -34,7 +34,7 @@ class NewContactController: UITableViewController {
     init(dcContext: DcContext, searchResult: String? = nil) {
         self.dcContext = dcContext
         cells = [emailCell, nameCell]
-        prefilledSeachResult = searchResult
+        prefilledSearchResult = searchResult
         super.init(style: .insetGrouped)
         emailCell.textFieldDelegate = self
         nameCell.textFieldDelegate = self
@@ -59,7 +59,7 @@ class NewContactController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        if let searchResult = prefilledSeachResult, searchResult.contains("@") {
+        if let searchResult = prefilledSearchResult, searchResult.contains("@") {
             emailCell.textField.insertText(searchResult)
         }
     }

--- a/deltachat-ios/Extensions/NSItemProvider+loadImage.swift
+++ b/deltachat-ios/Extensions/NSItemProvider+loadImage.swift
@@ -1,0 +1,25 @@
+import UIKit
+import UniformTypeIdentifiers
+
+extension NSItemProvider {
+    /// Load image prefering WebP (to prevent transparency loss) and falling back on `UIImage.sd_image(with:)` using raw data.
+    public func loadImage(completionHandler: @escaping (UIImage?, (any Error)?) -> Void) {
+        // If webP is provided and eg JPEG (or another type that is supported by loadObject),
+        // always pick webP because it might have transparancy unlike JPEG.
+        if hasItemConformingToTypeIdentifier(UTType.webP.identifier) {
+            loadDataRepresentation(forTypeIdentifier: UTType.webP.identifier) { webPData, error in
+                completionHandler(UIImage.sd_image(withWebPData: webPData), error)
+            }
+        } else if canLoadObject(ofClass: UIImage.self) {
+            loadObject(ofClass: UIImage.self) { imageItem, error in
+                completionHandler(imageItem as? UIImage, error)
+            }
+        } else {
+            // Some images (like webP) can't be loaded into UIImage by UIDropSession so we fall back on SD.
+            // See `UIImage.readableTypeIdentifiersForItemProvider` for ones that can.
+            loadDataRepresentation(forTypeIdentifier: UTType.image.identifier) { data, error in
+                completionHandler(UIImage.sd_image(with: data), error)
+            }
+        }
+    }
+}

--- a/deltachat-ios/Helper/ChatDropInteraction.swift
+++ b/deltachat-ios/Helper/ChatDropInteraction.swift
@@ -51,26 +51,9 @@ public class ChatDropInteraction {
 
     private func loadImageObjects(session: UIDropSession) {
         guard let droppedItem = session.items.first else { return }
-
-        // If webP is provided and eg JPEG (or another type that is supported by loadObject),
-        // always pick webP because it might have transparancy unlike JPEG.
-        if #available(iOS 14, *), droppedItem.itemProvider.hasItemConformingToTypeIdentifier(UTType.webP.identifier) {
-            droppedItem.itemProvider.loadDataRepresentation(forTypeIdentifier: UTType.webP.identifier) { [weak self] webPData, _ in
-                guard let self, let image = UIImage.sd_image(withWebPData: webPData) else { return }
-                self.delegate?.onImageDragAndDropped(image: image)
-            }
-        } else if droppedItem.itemProvider.canLoadObject(ofClass: UIImage.self) {
-            droppedItem.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] imageItem, _ in
-                guard let image = imageItem as? UIImage else { return }
-                self?.delegate?.onImageDragAndDropped(image: image)
-            }
-        } else {
-            // Some images (like webP) can't be loaded into UIImage by UIDropSession so we fall back on SD.
-            // See `UIImage.readableTypeIdentifiersForItemProvider` for ones that can.
-            droppedItem.itemProvider.loadDataRepresentation(forTypeIdentifier: kUTTypeImage as String) { [weak self] data, _ in
-                guard let self, let image = UIImage.sd_image(with: data) else { return }
-                self.delegate?.onImageDragAndDropped(image: image)
-            }
+        droppedItem.itemProvider.loadImage { [weak self] image, _ in
+            guard let self, let image else { return }
+            self.delegate?.onImageDragAndDropped(image: image)
         }
     }
 


### PR DESCRIPTION
Avoid `NSItemProvider.loadItem` for images because that does some conversion that causes the image data to be twice the size of images retrieved through `NSItemProvider.loadDataRepresentation`. 

`NSItemProvider.loadDataRepresentation` creates a UIImage of the same footprint that the info in Photos app indicates the image should be.

I changed the share extension to use the same code as drag and drop because they both get NSItemProviders.