### PR TITLE
contact profile: hide unavailable media/location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Copy scanned QR code text to clipboard (#2582)
 - Improve "All media empty" and "Block contact" wordings (#2580)
 - Unify buttons and icons (#2584)
+- Hide unneeded buttons in contact profiles (#2589)
 - Fix: Allow to share contacts that do not have a chat (#2583)
 
 

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -119,10 +119,6 @@ class ContactDetailViewController: UITableViewController {
         cell.textLabel?.text = String.localized("media")
         cell.imageView?.image = UIImage(systemName: "photo.on.rectangle")
         cell.accessoryType = .disclosureIndicator
-        if viewModel.chatId == 0 {
-            cell.isUserInteractionEnabled = false
-            cell.textLabel?.isEnabled = false
-        }
         return cell
     }()
 
@@ -131,10 +127,6 @@ class ContactDetailViewController: UITableViewController {
         cell.textLabel?.text = String.localized("locations")
         cell.imageView?.image = UIImage(systemName: "map")
         cell.accessoryType = .disclosureIndicator
-        if viewModel.chatId == 0 {
-            cell.isUserInteractionEnabled = false
-            cell.textLabel?.isEnabled = false
-        }
         return cell
     }()
 

--- a/deltachat-ios/ViewModel/ContactDetailViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactDetailViewModel.swift
@@ -83,14 +83,15 @@ class ContactDetailViewModel {
         if dcContact.getVerifierId() != 0 {
             chatOptions.append(.verifiedBy)
         }
-        chatOptions.append(.allMedia)
-        if UserDefaults.standard.bool(forKey: "location_streaming") {
-            chatOptions.append(.locations)
-        }
 
         var chatActions: [ChatAction]
         let chatExists = chatId != 0
         if chatExists {
+            chatOptions.append(.allMedia)
+            if UserDefaults.standard.bool(forKey: "location_streaming") {
+                chatOptions.append(.locations)
+            }
+
             if !isDeviceTalk {
                 chatOptions.append(.ephemeralMessages)
             }


### PR DESCRIPTION
if there is no chat with a contact,
in the contact's profile,
hide the superfluous media and location options -
similar to eg. shared chats and buttons as clear/delete chat.

this unclutters the profile,
puting things as "send message" more into focus.
and it looks better,
there are otherwise a bit too many grey tones in the upper area :)

cmp https://github.com/deltachat/deltachat-ios/pull/708

before / after:

<img width=300 src=https://github.com/user-attachments/assets/76e58f24-bf33-4e05-adf4-5e91d4ccb618> &nbsp; &nbsp; <img width=300 src=https://github.com/user-attachments/assets/3b8787f9-a9f6-4e2e-976e-369e4980ae3f>
