### PR TITLE
improve title bar's tap feedback

### DIFF
--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -71,5 +71,6 @@ class ChatTitleView: UIStackView {
     func setEnabled(_ enabled: Bool) {
         titleLabel.isEnabled = enabled
         subtitleLabel.isEnabled = enabled
+        verifiedView.alpha = enabled ? 1 : 0.4
     }
 }


### PR DESCRIPTION
when the title bar is tapped,
the alpha changes for a second, to give feedback.

however, that was missed out for the "green checkmark" icon, which looked a bit unpolished.

#skip-changelog as it is a super minor change, no need to think about that as a user