### PR TITLE
prefer .alert over .actionSheet for unexpected popups as warnings

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2301,7 +2301,7 @@ extension ChatViewController: BaseMessageCellDelegate {
             // prefer previewError over QLPreviewController.canPreview().
             // (the latter returns `true` for .webm - which is not wrong as _something_ is shown, even if the video cannot be played)
             if previewError && message.type == DC_MSG_VIDEO {
-                let alert = UIAlertController(title: "To play this video, share to apps as VLC on the following page.", message: nil, preferredStyle: .safeActionSheet)
+                let alert = UIAlertController(title: "To play this video, share to apps as VLC on the following page.", message: nil, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .default, handler: { _ in
                     self.showMediaGalleryFor(message: message)
                 }))
@@ -2597,7 +2597,7 @@ extension ChatViewController: AudioControllerDelegate {
     func onAudioPlayFailed() {
         let alert = UIAlertController(title: String.localized("error"),
                                       message: String.localized("cannot_play_audio_file"),
-                                      preferredStyle: .safeActionSheet)
+                                      preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: nil))
         self.present(alert, animated: true, completion: nil)
     }

--- a/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
+++ b/deltachat-ios/Controller/AccountSetup/AccountSetupController.swift
@@ -436,8 +436,8 @@ class AccountSetupController: UITableViewController {
            let oldAddress = dcContext.getConfig("configured_addr"),
            oldAddress != emailAddress {
             let msg = String.localizedStringWithFormat(String.localized("aeap_explanation"), oldAddress, emailAddress)
-            let alert = UIAlertController(title: msg, message: nil, preferredStyle: .safeActionSheet)
-            alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .default, handler: { _ in
+            let alert = UIAlertController(title: msg, message: nil, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .destructive, handler: { _ in
                 loginButtonPressedContinue()
             }))
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -119,7 +119,7 @@ internal final class AdvancedViewController: UITableViewController {
                 if cell.isOn {
                     let alert = UIAlertController(title: String.localized("pref_only_fetch_mvbox_title"),
                         message: String.localized("pref_imap_folder_warn_disable_defaults"),
-                        preferredStyle: .safeActionSheet)
+                        preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .destructive, handler: { _ in
                         self.dcContext.setConfigBool("only_fetch_mvbox", true)
                     }))


### PR DESCRIPTION
see apple guidelines, this was a bit off here and there. still, there are cornercases :)


#skip-changelog as no normal changelog reader will know about the difference