### PR TITLE
hack around broken 'Add Second Device' QR code

### DIFF
--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -301,12 +301,21 @@ public class DcContext {
         return nil
     }
 
+    private func fixAddSecondDeviceQR(_ qrCode: String) -> String {
+        if qrCode.hasPrefix("DCBACKUP2:") {
+            return qrCode
+                .replacingOccurrences(of: ",\"info\":{\"relay_url\":", with: ",\"relay_url\":")
+                .replacingOccurrences(of: "]}}", with: "]}")
+        }
+        return qrCode
+    }
+
     public func joinSecurejoin(qrCode: String) -> Int {
         return Int(dc_join_securejoin(contextPointer, qrCode))
     }
 
     public func checkQR(qrCode: String) -> DcLot {
-        return DcLot(dc_check_qr(contextPointer, qrCode))
+        return DcLot(dc_check_qr(contextPointer, fixAddSecondDeviceQR(qrCode)))
     }
 
     public func setConfigFromQR(qrCode: String) -> Bool {
@@ -314,7 +323,7 @@ public class DcContext {
     }
 
     public func receiveBackup(qrCode: String) -> Bool {
-        return dc_receive_backup(contextPointer, qrCode) != 0
+        return dc_receive_backup(contextPointer, fixAddSecondDeviceQR(qrCode)) != 0
     }
 
     public func stopOngoingProcess() {


### PR DESCRIPTION
core 1.155.2 accidentally broke compatibility
to add-second-device QR codes of previous versions;

this is esp. bad as ppl will have different versions for some days at least, weakening overall UX, esp. of first-time-users
that may come to delta because of praised, seamless multidevice ... :)

this PR is a little experiment, if it is really only the minor JSON change, or sth deeer.

seems, these two repacements fix the issue,
allowing us to release much mess stressful,
while users being happy.

if we think, this is fine,
we should do that better in core, however.

the hack can be removed 3 releases later or so.

see https://github.com/deltachat/deltachat-core-rust/issues/6518 for more details and for snippets how the QR code looks and what this hack is doing

cc @link2xt 