### PR TITLE
better visible 'saved' state in menu

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1920,7 +1920,7 @@ extension ChatViewController {
                 if !dcChat.isSelfTalk && message.canSave {
                     if message.savedMessageId != 0 {
                         children.append(
-                            UIAction.menuAction(localizationKey: "unsave", systemImageName: "bookmark.slash", indexPath: indexPath, action: toggleSave)
+                            UIAction.menuAction(localizationKey: "unsave", systemImageName: "bookmark.slash.fill", indexPath: indexPath, action: toggleSave)
                         )
                     } else {
                         children.append(


### PR DESCRIPTION
inspired from mastodon:
- unfilled = unsaved, filled = saved
- the filled variant is used in the bubbles as well, so it makes sense to slash that out

this is nitpicky, no one will really care ;)

main noticable advantage is,
that save and unsave icon are better distinguishable.

i tried same for pin and other states,
but there the effect is much less, as less often used and anyways more visible by eg. reordering, may even look like a bug to use different icons.