### PR TITLE
show correct location streaming state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Unify buttons and icons (#2584)
 - Hide unneeded buttons in contact profiles (#2589, #2590)
 - Fix: Allow to share contacts that do not have a chat (#2583)
+- Fix: update attach menu when location streaming is enabled/disabled (#2598)
 
 
 ## v1.52.2

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1157,24 +1157,27 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         messageInputBar.padding = UIEdgeInsets(top: 6, left: 6, bottom: 6, right: 12)
         messageInputBar.shouldManageSendButtonEnabledState = false
 
-        let leftItems = [
-            InputBarButtonItem()
-                .configure {
-                    $0.spacing = .fixed(0)
-                    let clipperIcon = UIImage(named: "ic_attach_file_36pt")?.withRenderingMode(.alwaysTemplate)
-                    $0.image = clipperIcon
-                    $0.tintColor = DcColors.primary
-                    $0.setSize(CGSize(width: 40, height: 40), animated: false)
-                    $0.accessibilityLabel = String.localized("menu_add_attachment")
-                    $0.accessibilityTraits = .button
-                    $0.showsMenuAsPrimaryAction = true
-                    $0.menu = clipperButtonMenu()
-                }.onSelected {
-                    $0.tintColor = UIColor.themeColor(light: .lightGray, dark: .darkGray)
-                }.onDeselected {
-                    $0.tintColor = DcColors.primary
-                }
-        ]
+        let attachButton = InputBarButtonItem()
+            .configure {
+                $0.spacing = .fixed(0)
+                let clipperIcon = UIImage(named: "ic_attach_file_36pt")?.withRenderingMode(.alwaysTemplate)
+                $0.image = clipperIcon
+                $0.tintColor = DcColors.primary
+                $0.setSize(CGSize(width: 40, height: 40), animated: false)
+                $0.accessibilityLabel = String.localized("menu_add_attachment")
+                $0.accessibilityTraits = .button
+            }.onSelected {
+                $0.tintColor = UIColor.themeColor(light: .lightGray, dark: .darkGray)
+            }.onDeselected {
+                $0.tintColor = DcColors.primary
+            }
+        attachButton.showsMenuAsPrimaryAction = true
+        attachButton.menu = UIMenu() // otherwise .menuActionTriggered is not triggered
+        attachButton.addAction(UIAction { [weak self] _ in
+            attachButton.menu = self?.clipperButtonMenu()
+        }, for: .menuActionTriggered)
+
+        let leftItems = [attachButton]
 
         messageInputBar.setStackViewItems(leftItems, forStack: .left, animated: false)
 


### PR DESCRIPTION
> _easier to review by hiding whitespace_

this PR creates the attach menu on every opening, not only on the first (deferred opening was considered useful at https://github.com/deltachat/deltachat-ios/pull/2543 , but seems anyways needed now)

this fixes the changed state not be shown immediately in the attach menu.

closes #2597 

<img width=240 src=https://github.com/user-attachments/assets/7136e4a1-f6f1-4671-b211-c4a98d615c30>
