### PR TITLE
preserve filenames on sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 2025-02
 
 - Tweak menu order (#2604)
+- Fix: Preserve filenames on sharing (#2605)
 
 
 ## v1.54.0

--- a/deltachat-ios/Helper/FileHelper.swift
+++ b/deltachat-ios/Helper/FileHelper.swift
@@ -87,4 +87,17 @@ public class FileHelper {
             print("err: \(error.localizedDescription)")
         }
     }
+
+    static func copyIfPossible(src: URL, dest: URL) -> URL {
+        do {
+            if FileManager.default.fileExists(atPath: dest.path) {
+                try FileManager.default.removeItem(at: dest)
+            }
+            try FileManager.default.copyItem(at: src, to: dest)
+            return dest
+        } catch {
+            logger.error("cannot copy \(src) to \(dest)")
+            return src
+        }
+    }
 }

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -94,17 +94,26 @@ struct Utils {
     }
 
     public static func share(message: DcMsg, parentViewController: UIViewController, sourceView: UIView? = nil, sourceItem: UIBarButtonItem? = nil) {
-        guard let fileURL = message.fileURL else { return }
+        guard let scrambledURL = message.fileURL else { return }
+
+        let shareURL: URL
+        if let filename = message.filename {
+            let cleanURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+            shareURL = FileHelper.copyIfPossible(src: scrambledURL, dest: cleanURL)
+        } else {
+            shareURL = scrambledURL
+        }
+
         let objectsToShare: [Any]
         if message.type == DC_MSG_WEBXDC {
             let dict = message.getWebxdcInfoDict()
             let previewImage = message.getWebxdcPreviewImage()
-            let previewText = dict["name"] as? String ?? fileURL.lastPathComponent
+            let previewText = dict["name"] as? String ?? shareURL.lastPathComponent
             objectsToShare = [WebxdcItemSource(title: previewText,
                                                previewImage: previewImage,
-                                               url: fileURL)]
+                                               url: shareURL)]
         } else {
-            objectsToShare = [fileURL]
+            objectsToShare = [shareURL]
         }
 
         let activityVC = UIActivityViewController(activityItems: objectsToShare, applicationActivities: nil)


### PR DESCRIPTION
this PR copies files to share, to give the original file name to other apps.

closes https://github.com/deltachat/deltachat-ios/issues/2524

# before

this is the baseline:

<img width=250 src=https://github.com/user-attachments/assets/db50ced1-dab4-44bf-beda-9438e2235a39>
<img width=250 src=https://github.com/user-attachments/assets/1a0c406d-935c-495d-a7ff-815b78aa18ef>
<img width=250 src=https://github.com/user-attachments/assets/e190cca2-11de-4794-900a-1985375997a6>

# after

the filename is `test.pdf` - the extension is hidden by iOS, and shown as the type:

<img width=250 src=https://github.com/user-attachments/assets/0c06ed78-3958-4759-823d-d460f98b6243>
<img width=250 src=https://github.com/user-attachments/assets/75f263e3-5a09-4d48-b9c0-cd3a537c1f23>
<img width=250 src=https://github.com/user-attachments/assets/4787636c-cb22-4fe4-81e6-30758d77b219>

# other tests

i tested also to set metadata instead of copying, this was fine in the "share preview", however, the final app again gets the wrong filename, see details below.

<details>

<img width=250 src=https://github.com/user-attachments/assets/02babe8e-06b8-414b-8d0e-7621eb577f55>
<img width=250 src=https://github.com/user-attachments/assets/27c7717e-a87b-43fb-899b-77d24cd9a06d>
<img width=250 src=https://github.com/user-attachments/assets/7f3cc61f-fd13-401a-a845-abb4a49ccb65>

</details>

i tried that using all of `activityViewControllerPlaceholderItem`, `LPLinkMetadata.originalURL`, `LPLinkMetadata.title`, `QLPreviewItem.title` - none of them worked for me.

the gallery, however, still contains the scrambled names, copying them would require to copy all images on each swipe, that seems over the too. also, when sharing images, the name is barely anywhere displayed on the destination apps - and even the unscrambled name often looks scrambles.

still, user can share from delta chat and not from gallery to get the correct names. if ppl complain at scale, we can iterate :)