### PR TITLE
add a warning when scanning a too new backup QR code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Tweak menu order (#2604)
 - Save space by Deduplicating files on sending (#2612)
 - Accessibility: voice over reads a reaction summary for messages (#2608)
+- detect incompatible profiles from newer app version when importing them
 - Prepare the app for receiving edited messages (#6550)
 - Prepare the app for receiving message deletion requests (#6550)
 - Fix: Hide read-only chats on forwarding and sort list accordingly (#2436)

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -230,10 +230,12 @@ class WelcomeViewController: UIViewController {
 extension WelcomeViewController: QrCodeReaderDelegate {
     func handleQrCode(_ qrCode: String) {
         let lot = dcContext.checkQR(qrCode: qrCode)
-        if lot.state == DC_QR_BACKUP || lot.state == DC_QR_BACKUP2 {
+        if lot.state == DC_QR_BACKUP2 {
             confirmSetupNewDevice(qrCode: qrCode)
+        } else if lot.state == DC_QR_BACKUP_TOO_NEW {
+            qrErrorAlert(title: String.localized("multidevice_receiver_needs_update"))
         } else {
-            qrErrorAlert()
+            qrErrorAlert(title: String.localized("qraccount_qr_code_cannot_be_used"), message: dcContext.lastErrorString)
         }
     }
 
@@ -282,9 +284,8 @@ extension WelcomeViewController: QrCodeReaderDelegate {
         }
     }
 
-    private func qrErrorAlert() {
-        let title = String.localized("qraccount_qr_code_cannot_be_used")
-        let alert = UIAlertController(title: title, message: dcContext.lastErrorString, preferredStyle: .alert)
+    private func qrErrorAlert(title: String, message: String? = nil) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let okAction = UIAlertAction(
             title: String.localized("ok"),
             style: .default,

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -377,11 +377,16 @@ class AppCoordinator: NSObject {
             }))
             viewController.present(alert, animated: true, completion: nil)
 
-        case DC_QR_BACKUP, DC_QR_BACKUP2:
+        case DC_QR_BACKUP2:
             // alert is shown in WelcomeViewController
             guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
             _ = dcAccounts.add()
             appDelegate.reloadDcContext(accountCode: code)
+
+        case DC_QR_BACKUP_TOO_NEW:
+            let alert = UIAlertController(title: String.localized("multidevice_receiver_needs_update"), message: nil, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: nil))
+            viewController.present(alert, animated: true)
 
         case DC_QR_WEBRTC_INSTANCE:
             guard let domain = qrParsed.text1 else { return }
@@ -498,7 +503,7 @@ class AppCoordinator: NSObject {
 
         if let accountCode {
             let qr = dcAccounts.getSelected().checkQR(qrCode: accountCode)
-            if qr.state == DC_QR_BACKUP || qr.state == DC_QR_BACKUP2 {
+            if qr.state == DC_QR_BACKUP2 || qr.state == DC_QR_BACKUP_TOO_NEW {
                 viewControllers = [WelcomeViewController(dcAccounts: dcAccounts, accountCode: accountCode)]
             } else {
                 viewControllers = [


### PR DESCRIPTION
this PR shows a warning if the user scans a backup QR code from a too new Delta Chat version.

the user has to update their device first.

counterpart of https://github.com/deltachat/deltachat-android/pull/3629 and https://github.com/deltachat/deltachat-desktop/issues/4709

<img width=320 src=https://github.com/user-attachments/assets/bece4e12-7ca1-4d45-a346-c064a3908ce0>
