### PR TITLE
hide "ephemeral" icon reliably in edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Make search in "Saved Messages" available in title bar (it was available in profile before)
 - Fix names of explicitly attached files (#2628)
+- Fix hiding of "disappearing messages" icon in edit mode
 - Update translations
 
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -870,7 +870,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             let cnt = tableView.indexPathsForSelectedRows?.count ?? 0
             navigationItem.title = String.localized(stringID: "n_selected", parameter: cnt)
             self.navigationItem.setLeftBarButton(cancelButton, animated: true)
-            self.navigationItem.setRightBarButton(nil, animated: true)
+            navigationItem.rightBarButtonItems = nil
         } else {
             let subtitle: String?
             let chatContactIds = dcChat.getContactIds(dcContext)


### PR DESCRIPTION
setRightBarButton(nil) does not remove all buttons set by rightBarButtonItems; concretely, this was the ephemeral icon that was visible sometimes in edit mode