### PR TITLE
move state icons to title

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -104,16 +104,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         return UIBarButtonItem(customView: LocationStreamingIndicator())
     }()
 
-    private lazy var muteItem: UIBarButtonItem = {
-        let imageView = UIImageView()
-        imageView.tintColor = DcColors.middleGray
-        imageView.image = UIImage(systemName: "speaker.slash.fill")?.withRenderingMode(.alwaysTemplate)
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.heightAnchor.constraint(equalToConstant: 20).isActive = true
-        imageView.widthAnchor.constraint(equalToConstant: 20).isActive = true
-        return UIBarButtonItem(customView: imageView)
-    }()
-
     private lazy var ephemeralMessageItem: UIBarButtonItem = {
         let imageView = UIImageView()
         imageView.tintColor = DcColors.middleGray
@@ -895,7 +885,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 subtitle = nil
             }
             
-            titleView.updateTitleView(title: dcChat.name, subtitle: subtitle, isVerified: dcChat.isProtected)
+            titleView.updateTitleView(title: dcChat.name, subtitle: subtitle, isVerified: dcChat.isProtected, isMuted: dcChat.isMuted)
             titleView.layoutIfNeeded()
             navigationItem.titleView = titleView
             self.navigationItem.setLeftBarButton(nil, animated: true)
@@ -918,9 +908,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
             if dcChat.isSendingLocations {
                 rightBarButtonItems.append(locationStreamingItem)
-            }
-            if dcChat.isMuted {
-                rightBarButtonItems.append(muteItem)
             }
             
             if dcContext.getChatEphemeralTimer(chatId: dcChat.id) > 0 {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -100,10 +100,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         UITapGestureRecognizer(target: self, action: #selector(chatProfilePressed))
     }()
 
-    private var locationStreamingItem: UIBarButtonItem = {
-        return UIBarButtonItem(customView: LocationStreamingIndicator())
-    }()
-
     private lazy var initialsBadge: InitialsBadge = {
         let badge: InitialsBadge
         badge = InitialsBadge(size: 37, accessibilityLabel: String.localized("menu_view_profile"))
@@ -874,8 +870,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             } else {
                 subtitle = nil
             }
-            
-            titleView.updateTitleView(title: dcChat.name, subtitle: subtitle, isVerified: dcChat.isProtected, isMuted: dcChat.isMuted, isEphemeral: dcContext.getChatEphemeralTimer(chatId: dcChat.id) > 0)
+
+            titleView.updateTitleView(title: dcChat.name, subtitle: subtitle, isVerified: dcChat.isProtected, isMuted: dcChat.isMuted,
+                                      isEphemeral: dcContext.getChatEphemeralTimer(chatId: dcChat.id) > 0, isSendingLocations: dcChat.isSendingLocations)
             titleView.layoutIfNeeded()
             navigationItem.titleView = titleView
             self.navigationItem.setLeftBarButton(nil, animated: true)
@@ -894,10 +891,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             } else {
                 let button = UIBarButtonItem(image: UIImage(systemName: "magnifyingglass"), style: .plain, target: self, action: #selector(searchPressed))
                 rightBarButtonItems.append(button)
-            }
-
-            if dcChat.isSendingLocations {
-                rightBarButtonItems.append(locationStreamingItem)
             }
             
             navigationItem.rightBarButtonItems = rightBarButtonItems

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -104,16 +104,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         return UIBarButtonItem(customView: LocationStreamingIndicator())
     }()
 
-    private lazy var ephemeralMessageItem: UIBarButtonItem = {
-        let imageView = UIImageView()
-        imageView.tintColor = DcColors.middleGray
-        imageView.image = UIImage(systemName: "stopwatch")?.withRenderingMode(.alwaysTemplate)
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.heightAnchor.constraint(equalToConstant: 20).isActive = true
-        imageView.widthAnchor.constraint(equalToConstant: 20).isActive = true
-        return UIBarButtonItem(customView: imageView)
-    }()
-
     private lazy var initialsBadge: InitialsBadge = {
         let badge: InitialsBadge
         badge = InitialsBadge(size: 37, accessibilityLabel: String.localized("menu_view_profile"))
@@ -885,7 +875,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 subtitle = nil
             }
             
-            titleView.updateTitleView(title: dcChat.name, subtitle: subtitle, isVerified: dcChat.isProtected, isMuted: dcChat.isMuted)
+            titleView.updateTitleView(title: dcChat.name, subtitle: subtitle, isVerified: dcChat.isProtected, isMuted: dcChat.isMuted, isEphemeral: dcContext.getChatEphemeralTimer(chatId: dcChat.id) > 0)
             titleView.layoutIfNeeded()
             navigationItem.titleView = titleView
             self.navigationItem.setLeftBarButton(nil, animated: true)
@@ -908,10 +898,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
             if dcChat.isSendingLocations {
                 rightBarButtonItems.append(locationStreamingItem)
-            }
-            
-            if dcContext.getChatEphemeralTimer(chatId: dcChat.id) > 0 {
-                rightBarButtonItems.append(ephemeralMessageItem)
             }
             
             navigationItem.rightBarButtonItems = rightBarButtonItems

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -32,8 +32,18 @@ class ChatTitleView: UIStackView {
         return imageView
     }()
 
+    private lazy var ephemeralView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.tintColor = DcColors.middleGray
+        imageView.image = UIImage(systemName: "stopwatch")?.withRenderingMode(.alwaysTemplate)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.widthAnchor.constraint(equalToConstant: 16).isActive = true
+        imageView.heightAnchor.constraint(equalToConstant: 16).isActive = true
+        return imageView
+    }()
+
     private lazy var titleContainer: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, verifiedView, muteView])
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, verifiedView, muteView, ephemeralView])
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.spacing = 3
@@ -63,11 +73,12 @@ class ChatTitleView: UIStackView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func updateTitleView(title: String, subtitle: String?, isVerified: Bool, isMuted: Bool) {
+    func updateTitleView(title: String, subtitle: String?, isVerified: Bool, isMuted: Bool, isEphemeral: Bool) {
         titleLabel.text = title
         titleLabel.textColor = DcColors.defaultTextColor
         verifiedView.isHidden = !isVerified
         muteView.isHidden = !isMuted
+        ephemeralView.isHidden = !isEphemeral
 
         if let subtitle {
             subtitleLabel.text = subtitle

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -42,8 +42,12 @@ class ChatTitleView: UIStackView {
         return imageView
     }()
 
+    private lazy var locationView: UIImageView = {
+        return LocationStreamingIndicator(height: 16)
+    }()
+
     private lazy var titleContainer: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, verifiedView, muteView, ephemeralView])
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, verifiedView, muteView, ephemeralView, locationView])
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.spacing = 3
@@ -73,12 +77,13 @@ class ChatTitleView: UIStackView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func updateTitleView(title: String, subtitle: String?, isVerified: Bool, isMuted: Bool, isEphemeral: Bool) {
+    func updateTitleView(title: String, subtitle: String?, isVerified: Bool, isMuted: Bool, isEphemeral: Bool, isSendingLocations: Bool) {
         titleLabel.text = title
         titleLabel.textColor = DcColors.defaultTextColor
         verifiedView.isHidden = !isVerified
         muteView.isHidden = !isMuted
         ephemeralView.isHidden = !isEphemeral
+        locationView.isHidden = !isSendingLocations
 
         if let subtitle {
             subtitleLabel.text = subtitle

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -23,8 +23,17 @@ class ChatTitleView: UIStackView {
         return imgView
     }()
 
+    private lazy var muteView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.tintColor = DcColors.middleGray
+        imageView.image = UIImage(systemName: "speaker.slash.fill")?.withRenderingMode(.alwaysTemplate)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.widthAnchor.constraint(equalToConstant: 16).isActive = true
+        return imageView
+    }()
+
     private lazy var titleContainer: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, verifiedView])
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, verifiedView, muteView])
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.spacing = 3
@@ -54,10 +63,11 @@ class ChatTitleView: UIStackView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func updateTitleView(title: String, subtitle: String?, isVerified: Bool) {
+    func updateTitleView(title: String, subtitle: String?, isVerified: Bool, isMuted: Bool) {
         titleLabel.text = title
         titleLabel.textColor = DcColors.defaultTextColor
         verifiedView.isHidden = !isVerified
+        muteView.isHidden = !isMuted
 
         if let subtitle {
             subtitleLabel.text = subtitle


### PR DESCRIPTION
the old place was more reserved for "action buttons"

#skip-changelog as this is a very minor, barely visible change