### PR TITLE
show edited label in front of date, same as on android and desktop

### DIFF
--- a/deltachat-ios/Chat/Views/StatusView.swift
+++ b/deltachat-ios/Chat/Views/StatusView.swift
@@ -31,7 +31,7 @@ public class StatusView: UIView {
         savedView = UIImageView()
         savedView.translatesAutoresizingMaskIntoConstraints = false
 
-        contentStackView = UIStackView(arrangedSubviews: [savedView, padlockView, dateLabel, editedLabel, locationView, stateView])
+        contentStackView = UIStackView(arrangedSubviews: [savedView, padlockView, editedLabel, dateLabel, locationView, stateView])
         contentStackView.alignment = .center
         contentStackView.spacing = 2
         contentStackView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
#skip-changelog as "edited feature" is not even rolled out