### PR TITLE
no 'delete on all devices' for device messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 - Edit your messages (#2621, #2611)
 - Delete your messages for everyone (#2621, #2611)
-- Make search in "Saved Messages" available in title bar (it was available in profile before) (#2630, #2633)
+- Search "Saved Messages" from title bar (it was available in profile before) (#2630, #2633)
 - Remove "Manage Keys" and "Import Autocrypt Setup Message" to avoid undefined security behaviour;
   use "Add Second Device" and "Send Autocrypt Setup Message" instead (#2636)
+- Improve deletion confirmation for "Device Messages"
 - Fix names of explicitly attached files (#2628)
 - Fix hiding of "disappearing messages" icon in edit mode
 - Update translations

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1282,7 +1282,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             canDeleteForEveryone = false
         }
 
-        let alert = UIAlertController(title: String.localized(stringID: "ask_delete_messages", parameter: ids.count), message: nil, preferredStyle: .safeActionSheet)
+        let alert = UIAlertController(title: Utils.askDeleteMsgsText(count: ids.count, chat: dcChat), message: nil, preferredStyle: .safeActionSheet)
         alert.addAction(UIAlertAction(title: String.localized(dcChat.isSelfTalk ? "delete" : "delete_for_me"), style: .destructive, handler: { _ in
             self.dcContext.deleteMessages(msgIds: ids)
             deleteInUi(ids: ids)

--- a/deltachat-ios/Controller/ContactDetailViewController.swift
+++ b/deltachat-ios/Controller/ContactDetailViewController.swift
@@ -472,7 +472,7 @@ class ContactDetailViewController: UITableViewController {
         if !msgIds.isEmpty {
             let alert = UIAlertController(
                 title: nil,
-                message: String.localized(stringID: "ask_delete_messages", parameter: msgIds.count),
+                message: Utils.askDeleteMsgsText(count: msgIds.count, chat: viewModel.context.getChat(chatId: viewModel.chatId)),
                 preferredStyle: .safeActionSheet
             )
             alert.addAction(UIAlertAction(title: String.localized("clear_chat"), style: .destructive, handler: { _ in

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -132,7 +132,7 @@ class FilesViewController: UIViewController {
     // MARK: - actions
 
     private func askToDeleteItem(at indexPath: IndexPath) {
-        let title = String.localized(stringID: "ask_delete_messages", parameter: 1)
+        let title = Utils.askDeleteMsgsText(count: 1)
         let alertController =  UIAlertController(title: title, message: nil, preferredStyle: .safeActionSheet)
         let okAction = UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { [weak self] _ in
             self?.deleteItem(at: indexPath)

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -222,7 +222,7 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
     // MARK: - Actions
 
     private func askToDeleteItem(at indexPath: IndexPath) {
-        let title = String.localized(stringID: "ask_delete_messages", parameter: 1)
+        let title = Utils.askDeleteMsgsText(count: 1)
         let alertController =  UIAlertController(title: title, message: nil, preferredStyle: .safeActionSheet)
         let okAction = UIAlertAction(title: String.localized("delete"), style: .destructive, handler: { [weak self] _ in
             self?.deleteItem(at: indexPath)

--- a/deltachat-ios/Controller/GroupChatDetailViewController.swift
+++ b/deltachat-ios/Controller/GroupChatDetailViewController.swift
@@ -716,7 +716,7 @@ extension GroupChatDetailViewController {
         if !msgIds.isEmpty {
             let alert = UIAlertController(
                 title: nil,
-                message: String.localized(stringID: "ask_delete_messages", parameter: msgIds.count),
+                message: Utils.askDeleteMsgsText(count: msgIds.count),
                 preferredStyle: .safeActionSheet
             )
             alert.addAction(UIAlertAction(title: String.localized("clear_chat"), style: .destructive, handler: { _ in

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -56,6 +56,15 @@ struct Utils {
         return window?.safeAreaInsets.bottom ?? 0
     }
 
+    public static func askDeleteMsgsText(count: Int, chat: DcChat? = nil) -> String {
+        let isDeviceTalk = if let chat {
+            chat.isDeviceTalk
+        } else {
+            false
+        }
+        return String.localized(stringID: isDeviceTalk ? "ask_delete_messages_simple" : "ask_delete_messages", parameter: count)
+    }
+
     // Puts text below the given image and returns as a new image.
     // The result is ready to be used with `UIContextualAction.image` -
     // which shows the title otherwise only for large heightForRowAt (>= 91 in experiments).


### PR DESCRIPTION
do not say "Delete on all your devices"
when deleting a message in the "Device Messages" chat.

while this is a minor,
it is one of the first things the user may see,
better be correct there to not give a false first impression of correctness :)

cmp https://github.com/deltachat/deltachat-android/pull/3677