### PR TITLE
add mute option for 8 hour

### DIFF
--- a/deltachat-ios/Helper/Constants.swift
+++ b/deltachat-ios/Helper/Constants.swift
@@ -25,6 +25,7 @@ struct Time {
     static let oneHour = 60 * 60
     static let twoHours = 2 * 60 * 60
     static let sixHours = 6 * 60 * 60
+    static let eightHours = 8 * 60 * 60
     static let oneDay = 24 * 60 * 60
     static let oneWeek = 7 * 24 * 60 * 60
     static let fiveWeeks = 5 * 7 * 24 * 60 * 60

--- a/deltachat-ios/Helper/MuteDialog.swift
+++ b/deltachat-ios/Helper/MuteDialog.swift
@@ -5,7 +5,7 @@ struct MuteDialog {
         let forever = -1
         let options: [(name: String, duration: Int)] = [
             ("mute_for_one_hour", Time.oneHour),
-            ("mute_for_two_hours", Time.twoHours),
+            ("mute_for_eight_hours", Time.eightHours),
             ("mute_for_one_day", Time.oneDay),
             ("mute_for_seven_days", Time.oneWeek),
             ("mute_forever", forever),


### PR DESCRIPTION
counterpart of https://github.com/deltachat/deltachat-android/pull/3678

cmp https://support.delta.chat/t/mute-group-chat-notifications-for-8-hours/3624/6