### PR TITLE
open contact in scope when tapping info messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Modernise "Close" button in overlay sheets
 - Full-screen display of own avatar from "your profile" settings
+- Tapping info messages with contacts open the contact's profile
 - Hide superfluous "Show Classic E-mails" advanced setting for chatmail
 - Add a message with further information when securejoin times out (instead of allowing to send unencrypted)
 - Forwarding messages do not inherit "Edited" state

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -798,7 +798,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         case (_, DC_INFO_INVALID_UNENCRYPTED_MAIL):
             showInvalidUnencryptedDialog()
         default:
-            break
+            if let contactId = message.infoContactId, contactId != DC_CONTACT_ID_SELF {
+                navigationController?.pushViewController(ContactDetailViewController(dcContext: dcContext, contactId: contactId), animated: true)
+            }
         }
     }
 

--- a/deltachat-ios/DC/DcMsg.swift
+++ b/deltachat-ios/DC/DcMsg.swift
@@ -314,6 +314,11 @@ public class DcMsg {
         return dc_msg_get_info_type(messagePointer)
     }
 
+    public var infoContactId: Int? {
+        let id = Int(dc_msg_get_info_contact_id(messagePointer))
+        return id == 0 ? nil : id
+    }
+
     public var hasHtml: Bool {
         return dc_msg_has_html(messagePointer) == 1
     }


### PR DESCRIPTION


if this is the case:

- info messages are much shorter and easier to read as the email addresses are removed

- instead, when tapping the info message, the contact profile in scope is opened, see #6714 for more details

https://github.com/user-attachments/assets/5e97aec4-b69f-4b5e-b2bc-e8773b7e26ae


counterpart of https://github.com/deltachat/deltachat-android/pull/3710 and https://github.com/deltachat/deltachat-desktop/issues/4913