### PR TITLE
hide 'show classic email' for chatmail, move down otherwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Hide superfluous "Show Classic E-mails" advanced setting for chatmail
 - Update translations and local help
 
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -206,7 +206,7 @@ internal final class AdvancedViewController: UITableViewController {
         let viewLogSection = SectionConfigs(
             headerTitle: nil,
             footerTitle: String.localized("enable_realtime_explain"),
-            cells: [viewLogCell, showEmailsCell, realtimeChannelsCell])
+            cells: [viewLogCell, realtimeChannelsCell])
         let experimentalSection = SectionConfigs(
             headerTitle: String.localized("pref_experimental_features"),
             footerTitle: nil,
@@ -234,7 +234,7 @@ internal final class AdvancedViewController: UITableViewController {
             let serverSection = SectionConfigs(
                 headerTitle: String.localized("pref_server"),
                 footerTitle: String.localized("pref_only_fetch_mvbox_explain"),
-                cells: [accountSettingsCell, sentboxWatchCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell, proxySettingsCell])
+                cells: [accountSettingsCell, proxySettingsCell, showEmailsCell, sentboxWatchCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell])
             return [viewLogSection, experimentalSection, appAccessSection, encryptionSection, serverSection]
         }
     }()


### PR DESCRIPTION
the option is not really needed for chatmail

counterpart of https://github.com/deltachat/deltachat-android/pull/3708