### PR TITLE
full-screen display of own avatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Modernise "Close" button in overlay sheets
+- full-screen display of own avatar from "your profile" settings
 - Hide superfluous "Show Classic E-mails" advanced setting for chatmail
 - Update translations and local help
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Modernise "Close" button in overlay sheets
-- full-screen display of own avatar from "your profile" settings
+- Full-screen display of own avatar from "your profile" settings
 - Hide superfluous "Show Classic E-mails" advanced setting for chatmail
 - Update translations and local help
 

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -125,6 +125,14 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
         navigationController?.popViewController(animated: true)
     }
 
+    private func enlargeAvatarPressed(_ action: UIAlertAction) {
+        guard let image = avatarSelectionCell.badge.getImage() else { return }
+        guard let file = try? AvatarHelper.saveAvatarImageToFile(image: image) else { return }
+        let previewController = PreviewController(dcContext: dcContext, type: .single(file))
+        previewController.customTitle = String.localized("pref_profile_photo")
+        navigationController?.pushViewController(previewController, animated: true)
+    }
+
     private func galleryButtonPressed(_ action: UIAlertAction) {
         mediaPicker?.showPhotoGallery()
     }
@@ -141,6 +149,9 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
 
     private func onAvatarTapped() {
         let alert = UIAlertController(title: String.localized("pref_profile_photo"), message: nil, preferredStyle: .safeActionSheet)
+        if avatarSelectionCell.isAvatarSet() {
+            alert.addAction(UIAlertAction(title: String.localized("global_menu_view_desktop"), style: .default, handler: enlargeAvatarPressed(_:)))
+        }
         alert.addAction(PhotoPickerAlertAction(title: String.localized("camera"), style: .default, handler: cameraButtonPressed(_:)))
         alert.addAction(PhotoPickerAlertAction(title: String.localized("gallery"), style: .default, handler: galleryButtonPressed(_:)))
         if avatarSelectionCell.isAvatarSet() {

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -126,9 +126,13 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     }
 
     private func enlargeAvatarPressed(_ action: UIAlertAction) {
+        // temporarily save to file as PreviewController uses QLPreviewItem which does not accept UIImage
         guard let image = avatarSelectionCell.badge.getImage() else { return }
-        guard let file = try? AvatarHelper.saveAvatarImageToFile(image: image) else { return }
-        let previewController = PreviewController(dcContext: dcContext, type: .single(file))
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("preview.png")
+        guard let imageData = image.pngData() else { return }
+        guard let file = try? imageData.write(to: url) else { return }
+
+        let previewController = PreviewController(dcContext: dcContext, type: .single(url))
         previewController.customTitle = String.localized("pref_profile_photo")
         navigationController?.pushViewController(previewController, animated: true)
     }

--- a/deltachat-ios/Helper/AvatarHelper.swift
+++ b/deltachat-ios/Helper/AvatarHelper.swift
@@ -34,7 +34,7 @@ class AvatarHelper {
         }
     }
 
-    private static func saveAvatarImageToFile(image: UIImage) throws -> URL {
+    static func saveAvatarImageToFile(image: UIImage) throws -> URL {
         if let data = image.jpegData(compressionQuality: 1.0) {
             let filemanager = FileManager.default
             let docDir = filemanager.urls(for: .documentDirectory, in: .userDomainMask)[0]

--- a/deltachat-ios/Helper/AvatarHelper.swift
+++ b/deltachat-ios/Helper/AvatarHelper.swift
@@ -34,7 +34,7 @@ class AvatarHelper {
         }
     }
 
-    static func saveAvatarImageToFile(image: UIImage) throws -> URL {
+    private static func saveAvatarImageToFile(image: UIImage) throws -> URL {
         if let data = image.jpegData(compressionQuality: 1.0) {
             let filemanager = FileManager.default
             let docDir = filemanager.urls(for: .documentDirectory, in: .userDomainMask)[0]

--- a/deltachat-ios/View/InitialsBadge.swift
+++ b/deltachat-ios/View/InitialsBadge.swift
@@ -146,7 +146,8 @@ public class InitialsBadge: UIView {
         label.text = nil
         accessibilityLabel = nil
     }
-    
+
+    // render including shape etc.
     public func asImage() -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(bounds.size, isOpaque, 0.0)
         if let context = UIGraphicsGetCurrentContext() {
@@ -156,5 +157,10 @@ public class InitialsBadge: UIView {
             return image
         }
         return nil
+    }
+
+    // return the raw, rectange image
+    public func getImage() -> UIImage? {
+        return imageView.image
     }
 }


### PR DESCRIPTION
this PR picks up a [feature suggestion from the forum](https://support.delta.chat/t/a-few-small-changes-to-make-dc-ios-better/3675) and allows to view one's self avatar enlarged:

<img width=320 src=https://github.com/user-attachments/assets/a8827db9-774d-4f3d-950c-ddf076febe03>

~~was easy enough~~ ~~a little more complicated as expected~~ well, meanwhile we expect there is no "just" :)

cc @Raiden-GH - thanks for the concrete and detailed suggestion