### PR TITLE
modernise close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Modernise "Close" button in overlay sheets
 - Hide superfluous "Show Classic E-mails" advanced setting for chatmail
 - Update translations and local help
 

--- a/deltachat-ios/Chat/Apps/AppPickerViewController.swift
+++ b/deltachat-ios/Chat/Apps/AppPickerViewController.swift
@@ -59,7 +59,7 @@ class AppPickerViewController: UIViewController {
         segmentedControl.addTarget(self, action: #selector(AppPickerViewController.segmentedControlValueChanged(_:)), for: .valueChanged)
         navigationItem.titleView = segmentedControl
 
-        let closeButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel, target: self, action: #selector(AppPickerViewController.close(_:)))
+        let closeButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(AppPickerViewController.close(_:)))
         navigationItem.leftBarButtonItem = closeButton
         self.defaultCloseButton = closeButton
 

--- a/deltachat-ios/Chat/Apps/AppPickerViewController.swift
+++ b/deltachat-ios/Chat/Apps/AppPickerViewController.swift
@@ -60,7 +60,7 @@ class AppPickerViewController: UIViewController {
         navigationItem.titleView = segmentedControl
 
         let closeButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(AppPickerViewController.close(_:)))
-        navigationItem.leftBarButtonItem = closeButton
+        navigationItem.rightBarButtonItem = closeButton
         self.defaultCloseButton = closeButton
 
         setupConstraints()
@@ -93,7 +93,7 @@ class AppPickerViewController: UIViewController {
         downloadingView.isHidden = false
         downloadingView.activityIndicator.startAnimating()
         downloadingView.activityIndicator.hidesWhenStopped = true
-        navigationItem.leftBarButtonItem = nil
+        navigationItem.rightBarButtonItem = nil
     }
 
     @objc func hideLoading() {
@@ -101,7 +101,7 @@ class AppPickerViewController: UIViewController {
         navigationItem.titleView = segmentedControl
         downloadingView.isHidden = true
         downloadingView.activityIndicator.stopAnimating()
-        navigationItem.leftBarButtonItem = defaultCloseButton
+        navigationItem.rightBarButtonItem = defaultCloseButton
     }
 
     @objc func segmentedControlValueChanged(_ sender: UISegmentedControl) {

--- a/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
+++ b/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
@@ -34,7 +34,7 @@ class ReactionsOverviewViewController: UIViewController {
 
         title = String.localized("reactions")
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(ReactionsOverviewViewController.dismiss(_:)))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(ReactionsOverviewViewController.dismiss(_:)))
 
     }
     

--- a/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
+++ b/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
@@ -34,7 +34,7 @@ class ReactionsOverviewViewController: UIViewController {
 
         title = String.localized("reactions")
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(ReactionsOverviewViewController.dismiss(_:)))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(ReactionsOverviewViewController.dismiss(_:)))
 
     }
     

--- a/deltachat-ios/Chat/Send Contact/SendContactViewController.swift
+++ b/deltachat-ios/Chat/Send Contact/SendContactViewController.swift
@@ -47,7 +47,7 @@ class SendContactViewController: UIViewController {
         setupConstraints()
 
         let closeButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(SendContactViewController.cancel(_:)))
-        navigationItem.leftBarButtonItem = closeButton
+        navigationItem.rightBarButtonItem = closeButton
 
         searchController.searchResultsUpdater = self
         navigationItem.searchController = searchController

--- a/deltachat-ios/Chat/Send Contact/SendContactViewController.swift
+++ b/deltachat-ios/Chat/Send Contact/SendContactViewController.swift
@@ -46,8 +46,8 @@ class SendContactViewController: UIViewController {
         view.addSubview(tableView)
         setupConstraints()
 
-        let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(SendContactViewController.cancel(_:)))
-        navigationItem.leftBarButtonItem = cancelButton
+        let closeButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(SendContactViewController.cancel(_:)))
+        navigationItem.leftBarButtonItem = closeButton
 
         searchController.searchResultsUpdater = self
         navigationItem.searchController = searchController

--- a/deltachat-ios/Chat/Send Contact/SendContactViewController.swift
+++ b/deltachat-ios/Chat/Send Contact/SendContactViewController.swift
@@ -46,7 +46,7 @@ class SendContactViewController: UIViewController {
         view.addSubview(tableView)
         setupConstraints()
 
-        let closeButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(SendContactViewController.cancel(_:)))
+        let closeButton = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(SendContactViewController.cancel(_:)))
         navigationItem.rightBarButtonItem = closeButton
 
         searchController.searchResultsUpdater = self

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -13,7 +13,7 @@ class AccountSwitchViewController: UITableViewController {
     }()
 
     private lazy var cancelButton: UIBarButtonItem = {
-        return UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(cancelAction))
+        return UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(cancelAction))
     }()
 
     private lazy var addAccountCell: ActionCell = {

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -13,7 +13,7 @@ class AccountSwitchViewController: UITableViewController {
     }()
 
     private lazy var cancelButton: UIBarButtonItem = {
-        return UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelAction))
+        return UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(cancelAction))
     }()
 
     private lazy var addAccountCell: ActionCell = {

--- a/deltachat-ios/Controller/AccountSwitchViewController.swift
+++ b/deltachat-ios/Controller/AccountSwitchViewController.swift
@@ -36,7 +36,7 @@ class AccountSwitchViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.setLeftBarButton(cancelButton, animated: false)
+        navigationItem.setRightBarButton(cancelButton, animated: false)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
@@ -54,7 +54,7 @@ class ShareProxyViewController: UIViewController {
         let svg = dcContext.createQRSVG(for: proxyUrlString)
         qrContentView.image = getQrImage(svg: svg)
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(ShareProxyViewController.done(_:)))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(ShareProxyViewController.done(_:)))
 
         view.addSubview(contentScrollView)
 

--- a/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
@@ -54,7 +54,7 @@ class ShareProxyViewController: UIViewController {
         let svg = dcContext.createQRSVG(for: proxyUrlString)
         qrContentView.image = getQrImage(svg: svg)
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: String.localized("done"), style: .done, target: self, action: #selector(ShareProxyViewController.done(_:)))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.close, target: self, action: #selector(ShareProxyViewController.done(_:)))
 
         view.addSubview(contentScrollView)
 


### PR DESCRIPTION
inspired by @Raiden-GH's [forum suggestion about making more place for the tabs](https://github.com/deltachat/deltachat-ios/pull/2655) by using an "x" icon instead of the "cancel" button, i took the chance to modernise some more sheets.

the "x" icon went to the right however, that feels more natural

btw, this is _easily_ possible only as we [dropped iOS 12](https://github.com/deltachat/deltachat-ios/pull/2539) recently

<img width=250 src=https://github.com/user-attachments/assets/b02157f7-bc31-4e3c-913e-b81c6bdc15f6>
&nbsp;
<img width=250 src=https://github.com/user-attachments/assets/95a39a17-3553-493d-a239-685f2006d78c>
&nbsp;
<img width=250 src=https://github.com/user-attachments/assets/4bac2e7a-db3e-471b-95f2-5fbfdeca41e1>
&nbsp;
<img width=250 src=https://github.com/user-attachments/assets/2e5efadf-c19f-4e7c-bc0e-0573ec7565ac>
&nbsp;
<img width=250 src=https://github.com/user-attachments/assets/642778c9-245d-414a-bff0-d169b3339ffc>

the missing padding and wrapping in the proxy view should be improved btw, see https://github.com/deltachat/deltachat-ios/issues/2659