### PR TITLE
show preview of bio on the settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 - Protect metadata: encrypt message's sent date
 - Do not fail to send messages in groups if some encryption keys are missing
 - Synchronize contact name changes across devices
-- Improve UX by hiding address in primary settings screen; passing it around without e2ee information won't work
+- Hide address in primary settings screen, so it cannot be passed around without e2ee info
+- Show self bio summary in primary settings screen
 - Fix: make vcards compatible to Proton Mail again
 - Fix: enncrypt broadcast list and make them work again with chatmail
 - Fix changing group names that was not working in some situations

--- a/deltachat-ios/ViewModel/ContactCellViewModel.swift
+++ b/deltachat-ios/ViewModel/ContactCellViewModel.swift
@@ -82,7 +82,12 @@ class ProfileViewModel: AvatarCellViewModel {
         self.dcContext = context
         contact = context.getContact(id: Int(DC_CONTACT_ID_SELF))
         title = context.displayname ?? String.localized("pref_your_name")
-        subtitle = ""
+
+        if let bio = context.selfstatus {
+            subtitle = bio.replacingOccurrences(of: "\\r\\n|\\n", with: " ", options: .regularExpression)
+        } else {
+            subtitle = String.localized("pref_default_status_label")
+        }
     }
 }
 


### PR DESCRIPTION
this PR adds a preview of the bio to the place [freed up](https://github.com/deltachat/deltachat-ios/pull/2664) by the email address. if not bio is set, the text "Bio" is shown.

idea is that the profile becomes more weight by multi-transport, therefore it is good to let  ppl know already from the setting page that sth like a bio exist (forcing it on onboarding, however, is too much). one set, it is more visible, so that it might be update more often etc.

many other messengers show the profile summary at the same place.

<img width=320 src=https://github.com/user-attachments/assets/eaf1ebbb-4675-49d0-aa28-62c0f1304bf9>

thanks @adbenitez for the hint at https://github.com/deltachat/deltachat-android/pull/3730#issuecomment-2797112301