### PR TITLE
Tapping a notification when app is terminated now opens context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Group notifications in Notification Center by chat
 - More characters in notification before truncating
 - Fix: separate multiple notifications coming in at the same time
+- Fix: tapping a notification when app was terminated now opens the notifications context
 
 ## v1.58.1
 2025-04

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -56,6 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.info("➡️ didFinishLaunchingWithOptions")
         UserDefaults.standard.populateDefaultEmojis()
         UserDefaults.setMainIoRunning()
+        UNUserNotificationCenter.current().delegate = self
 
         let webPCoder = SDImageWebPCoder.shared
         SDImageCodersManager.shared.addCoder(webPCoder)
@@ -351,7 +352,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             guard let self else { return }
 
             self.notifyToken = nil
-            UNUserNotificationCenter.current().delegate = self
             UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
                 DispatchQueue.main.async {
                     if !granted || error != nil {


### PR DESCRIPTION
Previously we did not set the UNUserNotificationCenter delegate synchronously in `application(_:didFinishLaunchingWithOptions:)` which meant that if the app was not already running, a tapped notification did not call `AppDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)` (because AppDelegate was not yet the ununc delegate) which meant it did not navigate to the chat.

This is specifically mentioned in a comment on `UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)
`
> The delegate must be set before the application returns from application:didFinishLaunchingWithOptions:

<img width="826" alt="image" src="https://github.com/user-attachments/assets/781e4689-dd11-4822-a0f9-055e472f6e3f" />

This was **not** a regression from #2534 therefore I added changelog
