### PR TITLE
keep message in edit on app switches 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - More characters in notification before truncating
 - Fix: separate multiple notifications coming in at the same time
 - Fix: tapping a notification when app was terminated now opens the notifications context
+- Fix: keep message in edit on app switches
 
 ## v1.58.1
 2025-04

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1071,10 +1071,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         }
     }
 
-    @objc private func saveDraft() {
-        draft.save(context: dcContext)
-    }
-
     private func configureMessageInputBar() {
         messageInputBar.delegate = self
         messageInputBar.inputTextView.tintColor = DcColors.primary

--- a/deltachat-ios/Chat/DraftModel.swift
+++ b/deltachat-ios/Chat/DraftModel.swift
@@ -65,7 +65,6 @@ public class DraftModel {
 
     public func save(context: DcContext) {
         if sendEditRequestFor != nil {
-            clear()
             return
         }
 

--- a/deltachat-ios/Chat/DraftModel.swift
+++ b/deltachat-ios/Chat/DraftModel.swift
@@ -44,6 +44,7 @@ public class DraftModel {
     }
 
     public func setAttachment(viewType: Int32?, path: String?, mimetype: String? = nil) {
+        sendEditRequestFor = nil
         let quoteMsg = draftMsg?.quoteMessage
         draftMsg = dcContext.newMessage(viewType: viewType ?? DC_MSG_TEXT)
         draftMsg?.quoteMessage = quoteMsg
@@ -52,6 +53,7 @@ public class DraftModel {
     }
 
     public func clearAttachment() {
+        sendEditRequestFor = nil
         let quoteMsg = draftMsg?.quoteMessage
         if text != nil || quoteMsg != nil {
             draftMsg = dcContext.newMessage(viewType: DC_MSG_TEXT)


### PR DESCRIPTION
on app switches draft.save() is called,
which accidentally also cleared the "edit state"
(the "edit state" is short-living and tracked in memory only
and not restored)

the code is a bit of a mess, this PR only fixes the issue at hand,
but does not attempt to make the code more readable and logic
(might be not so easy anyways, this draft handling is _always_ more complicated than expected) -
but at least some dead code is removed and the changes are very short :)

closes #2674 