### PR TITLE
attach original images and files directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Select and send multiple images at the same time
 - Recode videos to reasonable quality and size
+- Attach images and videos as original files
 - Support pasted GIFs
 - Group notifications in Notification Center by chat
 - More characters in notification before truncating

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2401,7 +2401,16 @@ extension ChatViewController: MediaPickerDelegate {
                 if let typeIdentifier = itemProvider.registeredTypeIdentifiers.first {
                     itemProvider.loadFileRepresentation(forTypeIdentifier: typeIdentifier, completionHandler: { [weak self] url, error in
                         if let url {
-                            self?.stageDocument(url: url as NSURL)
+                            do {
+                                let copyURL = FileManager.default.temporaryDirectory.appendingPathComponent(url.lastPathComponent)
+                                if FileManager.default.fileExists(atPath: copyURL.path) {
+                                    try FileManager.default.removeItem(at: copyURL)
+                                }
+                                try FileManager.default.copyItem(at: url, to: copyURL) // create a copy as the file is too short-living otherwise
+                                self?.stageDocument(url: copyURL as NSURL)
+                            } catch {
+                                self?.logAndAlert(error: error.localizedDescription)
+                            }
                         } else if let error {
                             self?.logAndAlert(error: error.localizedDescription)
                         }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1184,7 +1184,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             action("gallery", "photo.on.rectangle", showPhotoVideoLibrary)
         ]))
 
-        actions.append(action("files", "folder", self.showDocumentLibrary))
+        actions.append(action("files", "folder", showFilesLibrary))
         actions.append(action("webxdc_apps", "square.grid.2x2", showAppPicker))
         actions.append(action("voice_message", "mic", showVoiceMessageRecorder))
         if let config = dcContext.getConfig("webrtc_instance"), !config.isEmpty {
@@ -1331,8 +1331,8 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         }
     }
 
-    private func showDocumentLibrary() {
-        mediaPicker?.showDocumentLibrary()
+    private func showFilesLibrary() {
+        mediaPicker?.showFilesLibrary()
     }
 
     private func showVoiceMessageRecorder() {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2337,7 +2337,7 @@ extension ChatViewController: MediaPickerDelegate {
         stageImage(image)
     }
 
-    func onMediaSelected(mediaPicker: MediaPicker, itemProviders: [NSItemProvider]) {
+    func onMediaSelected(mediaPicker: MediaPicker, itemProviders: [NSItemProvider], sendAsFile: Bool) {
         if itemProviders.count > 1 {
 
             // send multiple selected item in one go directly

--- a/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/WelcomeViewController.swift
@@ -167,7 +167,7 @@ class WelcomeViewController: UIViewController {
         if dcContext.isConfigured() {
             return
         }
-        mediaPicker?.showDocumentLibrary(selectFolder: true)
+        mediaPicker?.showDocumentLibrary(selectBackupArchives: true)
     }
 
     private func importBackup(at filepath: String) {

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -93,7 +93,7 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
         if selectBackupArchives {
             documentPicker = .init(forOpeningContentTypes: [UTType.archive], asCopy: false)
         } else {
-            documentPicker = .init(forOpeningContentTypes: [UTType.pdf, .text, .rtf, .spreadsheet, .vCard, .zip, .image, .data], asCopy: true)
+            documentPicker = .init(forOpeningContentTypes: [.pdf, .text, .rtf, .spreadsheet, .vCard, .zip, .image, .data], asCopy: true)
         }
         documentPicker.delegate = self
         documentPicker.allowsMultipleSelection = false

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -77,11 +77,11 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
     }
 
     func showFilesLibrary() {
-        let alert = UIAlertController(title: nil, message: "Send original files and uncompressed images", preferredStyle: .safeActionSheet)
-        alert.addAction(UIAlertAction(title: "Choose from Files", style: .default) { [weak self] _ in
+        let alert = UIAlertController(title: nil, message: String.localized("files_attach_hint"), preferredStyle: .safeActionSheet)
+        alert.addAction(UIAlertAction(title: String.localized("choose_from_files"), style: .default) { [weak self] _ in
             self?.showDocumentLibrary()
         })
-        alert.addAction(UIAlertAction(title: "Choose from Gallery", style: .default) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: String.localized("choose_from_gallery"), style: .default) { [weak self] _ in
             self?.showGallery(sendAsFile: true)
         })
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -75,6 +75,19 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
         navigationController?.present(audioRecorderNavController, animated: true)
     }
 
+    func showFilesLibrary() {
+        let alert = UIAlertController(title: "Send original documents and uncompressed images",
+                                      message: "This may need lots of storage and traffic.", preferredStyle: .safeActionSheet)
+        alert.addAction(UIAlertAction(title: "Choose from Documents", style: .default) { [weak self] _ in
+            self?.showDocumentLibrary()
+        })
+        alert.addAction(UIAlertAction(title: "Choose from Gallery", style: .default) { [weak self] _ in
+            self?.showGallery()
+        })
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
+        navigationController?.present(alert, animated: true)
+    }
+
     func showDocumentLibrary(selectBackupArchives: Bool = false) {
         let documentPicker: UIDocumentPickerViewController
         if selectBackupArchives {

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -77,9 +77,8 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
     }
 
     func showFilesLibrary() {
-        let alert = UIAlertController(title: "Send original documents and uncompressed images",
-                                      message: "This may need lots of storage and traffic.", preferredStyle: .safeActionSheet)
-        alert.addAction(UIAlertAction(title: "Choose from Documents", style: .default) { [weak self] _ in
+        let alert = UIAlertController(title: nil, message: "Send original files and uncompressed images", preferredStyle: .safeActionSheet)
+        alert.addAction(UIAlertAction(title: "Choose from Files", style: .default) { [weak self] _ in
             self?.showDocumentLibrary()
         })
         alert.addAction(UIAlertAction(title: "Choose from Gallery", style: .default) { [weak self] _ in
@@ -110,7 +109,9 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
         if !allowCropping {
             var configuration = PHPickerConfiguration(photoLibrary: .shared())
             configuration.filter = nil
-            configuration.selectionLimit = 0
+            // as raw files are 10~100 times larger and full inboxes are bad,
+            // sending raw files should be explicitly selected - also that shows size in staging area and makes difference clear
+            configuration.selectionLimit = sendAsFile ? 1 : 0
             configuration.preferredAssetRepresentationMode = .compatible
             let imagePicker = PHPickerViewController(configuration: configuration)
             imagePicker.delegate = self

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -75,13 +75,12 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
         navigationController?.present(audioRecorderNavController, animated: true)
     }
 
-    func showDocumentLibrary(selectFolder: Bool = false) {
+    func showDocumentLibrary(selectBackupArchives: Bool = false) {
         let documentPicker: UIDocumentPickerViewController
-        if selectFolder {
+        if selectBackupArchives {
             documentPicker = .init(forOpeningContentTypes: [UTType.archive], asCopy: false)
         } else {
-            let types = [UTType.pdf, .text, .rtf, .spreadsheet, .vCard, .zip, .image, .data]
-            documentPicker = .init(forOpeningContentTypes: types, asCopy: true)
+            documentPicker = .init(forOpeningContentTypes: [UTType.pdf, .text, .rtf, .spreadsheet, .vCard, .zip, .image, .data], asCopy: true)
         }
         documentPicker.delegate = self
         documentPicker.allowsMultipleSelection = false

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -131,6 +131,7 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
     }
 
     func showCamera(allowCropping: Bool = false, supportedMediaTypes: CameraMediaTypes = .allAvailable) {
+        self.sendAsFile = false
         if UIImagePickerController.isSourceTypeAvailable(.camera) {
             let imagePickerController = UIImagePickerController()
             imagePickerController.sourceType = .camera


### PR DESCRIPTION
this PR shows a little dialog before the file selector, allowing to choose from gallery as well. this is also what WhatsApp and Telegram are doing meanwhile - as we were working anyway in that area, that seemed to be an easy improvement (before, you had to go to system gallery, and save a file to the "Files App" before you could attach it)

<img width=280 src=https://github.com/user-attachments/assets/2038e175-694a-4021-82a9-3b7de21c3088>

closes https://github.com/deltachat/deltachat-ios/issues/1840