### PR TITLE
larger member count in profiles

### DIFF
--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -44,7 +44,7 @@ class ProfileViewController: UITableViewController {
     // MARK: - subviews
 
     private lazy var headerCell: ProfileHeader = {
-        let header = ProfileHeader()
+        let header = ProfileHeader(hasSubtitle: isGroup || isBroadcast)
         header.onAvatarTap = showEnlargedAvatar
         header.setRecentlySeen(contact?.wasSeenRecently ?? false)
         return header
@@ -169,7 +169,7 @@ class ProfileViewController: UITableViewController {
             title = String.localized("profile")
         }
 
-        headerCell.frame = CGRect(0, 0, tableView.frame.width, ProfileHeader.headerHeight)
+        headerCell.frame = CGRect(0, 0, tableView.frame.width, headerCell.headerHeight)
         tableView.tableHeaderView = headerCell
     }
 
@@ -191,7 +191,7 @@ class ProfileViewController: UITableViewController {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            headerCell.frame = CGRect(0, 0, tableView.frame.width, ProfileHeader.headerHeight)
+            headerCell.frame = CGRect(0, 0, tableView.frame.width, headerCell.headerHeight)
         }
     }
     
@@ -376,7 +376,13 @@ class ProfileViewController: UITableViewController {
 
     private func updateHeader() {
         if let chat {
-            headerCell.updateDetails(title: chat.name)
+            let subtitle: String? = if isGroup || isBroadcast {
+                String.localizedStringWithFormat(String.localized(isBroadcast ? "n_recipients" : "n_members"), chat.getContactIds(dcContext).count)
+            } else {
+                nil
+            }
+
+            headerCell.updateDetails(title: chat.name, subtitle: subtitle)
             if let img = chat.profileImage {
                 headerCell.setImage(img)
             } else {

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -790,10 +790,7 @@ class ProfileViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        if sections[section] == .members {
-            guard let chat else { return nil }
-            return String.localizedStringWithFormat(String.localized(isBroadcast ? "n_recipients" : "n_members"), chat.getContactIds(dcContext).count)
-        } else if sections[section] == .sharedChats {
+        if sections[section] == .sharedChats {
             return String.localized("profile_shared_chats")
         }
         return nil

--- a/deltachat-ios/View/ProfileHeader.swift
+++ b/deltachat-ios/View/ProfileHeader.swift
@@ -5,7 +5,7 @@ class ProfileHeader: UIStackView {
 
     var onAvatarTap: VoidFunction?
 
-    public static let headerHeight: CGFloat = 240
+    public var headerHeight: CGFloat = 240
 
     private lazy var avatar: InitialsBadge = {
         let badge = InitialsBadge(size: 160)
@@ -51,7 +51,16 @@ class ProfileHeader: UIStackView {
         return stackView
     }()
 
-    init() {
+    private lazy var subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.lineBreakMode = .byTruncatingTail
+        label.textColor = DcColors.defaultTextColor
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    init(hasSubtitle: Bool) {
         super.init(frame: .zero)
         backgroundColor = .clear
         axis = .vertical
@@ -61,6 +70,12 @@ class ProfileHeader: UIStackView {
         addArrangedSubview(UIView()) // spacer
         addArrangedSubview(avatar)
         addArrangedSubview(titleLabelContainer)
+        if hasSubtitle {
+            addArrangedSubview(subtitleLabel)
+            headerHeight = 240 + 32
+        } else {
+            headerHeight = 240
+        }
         addArrangedSubview(UIView()) // spacer
 
         addConstraints([
@@ -73,8 +88,9 @@ class ProfileHeader: UIStackView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func updateDetails(title: String?) {
+    func updateDetails(title: String, subtitle: String? = nil) {
         titleLabel.text = title
+        subtitleLabel.text = subtitle
     }
 
     func setImage(_ image: UIImage) {

--- a/deltachat-ios/View/ProfileHeader.swift
+++ b/deltachat-ios/View/ProfileHeader.swift
@@ -65,9 +65,14 @@ class ProfileHeader: UIStackView {
         backgroundColor = .clear
         axis = .vertical
         alignment = .center
-        spacing = 12
 
-        addArrangedSubview(UIView()) // spacer
+
+        let spacerTop = UIView()
+        let spacerBottom = UIView()
+        spacerTop.translatesAutoresizingMaskIntoConstraints = false
+        spacerBottom.translatesAutoresizingMaskIntoConstraints = false
+
+        addArrangedSubview(spacerTop)
         addArrangedSubview(avatar)
         addArrangedSubview(titleLabelContainer)
         if hasSubtitle {
@@ -76,9 +81,10 @@ class ProfileHeader: UIStackView {
         } else {
             headerHeight = 240
         }
-        addArrangedSubview(UIView()) // spacer
+        addArrangedSubview(spacerBottom)
 
         addConstraints([
+            spacerTop.heightAnchor.constraint(equalTo: spacerBottom.heightAnchor),
             greenCheckmark.constraintHeightTo(titleLabel.font.pointSize * 0.8),
             greenCheckmark.widthAnchor.constraint(equalTo: greenCheckmark.heightAnchor),
         ])


### PR DESCRIPTION
this makes it implicitly clearer,
that a profile belongs to a group.

it also picks up the UI element of subtitle=memberCount known of the titles.

<img width=320 src=https://github.com/user-attachments/assets/81ad853a-0472-4514-b8e3-a6f4feeaf036>


#skip-changelog covered by CHANGELOG entry of #2690 already