### PR TITLE
hide tab bar when proxy controller is pushed

### DIFF
--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -48,6 +48,7 @@ class ProxySettingsViewController: UITableViewController {
         tableView.register(SwitchCell.self, forCellReuseIdentifier: SwitchCell.reuseIdentifier)
         tableView.register(ActionCell.self, forCellReuseIdentifier: ActionCell.reuseIdentifier)
         tableView.register(ProxyTableViewCell.self, forCellReuseIdentifier: ProxyTableViewCell.reuseIdentifier)
+        hidesBottomBarWhenPushed = true
 
         toggleProxyCell.uiSwitch.isEnabled = (proxies.isEmpty == false)
         toggleProxyCell.action = { [weak self] cell in


### PR DESCRIPTION
this makes navigation clearer,
avoids situations where ppl are lost,
and is consistent with the app otherwise.

#skip-changelog as this is a minor, even hard to explain :)
