### PR TITLE
create widget-IDs unique when using different profiles

### DIFF
--- a/DcWidget/WidgetProvider.swift
+++ b/DcWidget/WidgetProvider.swift
@@ -115,7 +115,7 @@ enum Shortcut: Identifiable {
 }
 
 struct ChatShortcut: Identifiable, Hashable {
-    var id: String { "chat-\(chatId)" }
+    var id: String { "chat-\(accountId)-\(chatId)" }
 
     let accountId: Int
     let chatId: Int
@@ -137,7 +137,7 @@ struct ChatShortcut: Identifiable, Hashable {
 }
 
 struct AppShortcut: Identifiable, Hashable {
-    var id: String { "app-\(messageId)" }
+    var id: String { "app-\(accountId)-\(messageId)" }
 
     let accountId: Int
     let chatId: Int


### PR DESCRIPTION
i am not deep in these widget details, at a first glance, the ID is created by us and used by the system only - and it needs to be unique. this would be fulfilled by adding accountId.

i tested with existing shortcuts - they keep working.

this PR makes it possible to add multiple "saved messages" shortcuts from different profiles - in practise https://github.com/deltachat/deltachat-ios/issues/2647 was probably not the only bug, the approach would have failed wheneven two messages or chats have the same id across profiles - "saved messages" was just a case where this is virtually always the case.

i also have some weird bug from time to time that renders widget as "white" boxes - maybe that is relate to this fix somehow,  i will keep an eye on that (i cannot reproduce that part)

fixes https://github.com/deltachat/deltachat-ios/issues/2647