### PR TITLE
save multiple messages in one go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Save multiple selected messages in one go
 - Improve voice message UI
 - Fix bitrate for "worse" outgoing media quality
 


### PR DESCRIPTION
this PR allows to save/unsave multiple selected messages from the "multiple select menu".

- if a single selected message cannot be saved, neither "Save" nor "Unsave" is available

- if a single selected message is not saved, the available option is "Save".

- only if all selected messages are saved, the available option is "Unsave"

<img width=280 src=https://github.com/user-attachments/assets/dbc3a542-0802-4efb-9e65-be4abfbe4766>

for ordering, cmp https://support.delta.chat/t/saved-messages-appear-out-of-order/3779/2