### PR TITLE
cleanup voice message UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- Improve voice message UI
+
+
 ## v1.58.4
 2025-05
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1416,7 +1416,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
         if #available(iOS 15.0, *), let sheet = navigationController.sheetPresentationController {
             sheet.detents = [.large()]
-            sheet.preferredCornerRadius = 20
         }
 
         present(navigationController, animated: true)
@@ -1430,7 +1429,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         if #available(iOS 15.0, *) {
             if let sheet = navigationController.sheetPresentationController {
                 sheet.detents = [.large(), .medium()]
-                sheet.preferredCornerRadius = 20
             }
         }
 
@@ -1858,7 +1856,6 @@ extension ChatViewController {
                 if #available(iOS 15.0, *) {
                     if let sheet = navigationController.sheetPresentationController {
                         sheet.detents = [.medium(), .large()]
-                        sheet.preferredCornerRadius = 20
                     }
                 }
                 present(navigationController, animated: true)
@@ -2294,7 +2291,6 @@ extension ChatViewController: BaseMessageCellDelegate {
         if #available(iOS 15.0, *) {
             if let sheet = navigationController.sheetPresentationController {
                 sheet.detents = [.medium()]
-                sheet.preferredCornerRadius = 20
             }
         }
 

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -76,8 +76,18 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         return UIBarButtonItem(image: UIImage(systemName: "mic"), style: .plain, target: self, action: #selector(continueRecording))
     }()
 
+    lazy var playButton: UIBarButtonItem = {
+        return UIBarButtonItem(image: UIImage(systemName: "play"), style: .plain, target: self, action: #selector(playRecording))
+    }()
+
+    lazy var spaceItem = {
+        let item = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
+        item.width = 24
+        return item
+    }()
+
     lazy var flexItem = {
-        return UIBarButtonItem.init(barButtonSystemItem: UIBarButtonItem.SystemItem.flexibleSpace, target: nil, action: nil)
+        return UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
     }()
     
     init(dcContext: DcContext) {
@@ -208,10 +218,14 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         audioRecorder?.record()
     }
 
+    @objc func playRecording() {
+        // TODO
+    }
+
     @objc func pauseRecording() {
         isRecordingPaused = true
         audioRecorder?.pause()
-        self.setToolbarItems([continueRecordingButton, flexItem], animated: true)
+        self.setToolbarItems([continueRecordingButton, spaceItem, playButton, flexItem], animated: true)
     }
 
     @objc func cancelAction() {

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -29,6 +29,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
 
     var recordingFilePath: String = ""
     var audioRecorder: AVAudioRecorder?
+    var audioPlayer: AVAudioPlayer?
 
     var isFirstUsage: Bool = true
 
@@ -94,7 +95,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
             AVEncoderBitRateKey: 32000,
             AVNumberOfChannelsKey: 1
         ] as [String: Any]
-        return try? AVAudioRecorder.init(url: URL(fileURLWithPath: recordingFilePath), settings: recordSettings)
+        return try? AVAudioRecorder(url: URL(fileURLWithPath: recordingFilePath), settings: recordSettings)
     }
 
     init(dcContext: DcContext) {
@@ -222,7 +223,10 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func playRecording() {
-        // TODO
+        audioRecorder = nil // release file
+        audioPlayer = try? AVAudioPlayer(contentsOf: URL(fileURLWithPath: recordingFilePath))
+        audioPlayer?.prepareToPlay()
+        audioPlayer?.play()
     }
 
     @objc func pauseRecording() {

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -85,10 +85,6 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         item.width = 24
         return item
     }()
-
-    lazy var flexItem = {
-        return UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-    }()
     
     init(dcContext: DcContext) {
         bitrate = dcContext.getConfigInt("media_quality") == 1 ? bitrateWorse : bitrateBalanced
@@ -193,7 +189,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func startRecording() {
-        self.setToolbarItems([pauseButton, flexItem], animated: true)
+        self.setToolbarItems([pauseButton], animated: true)
         doneButton.isEnabled = true
         if FileManager.default.fileExists(atPath: recordingFilePath) {
             _ = try? FileManager.default.removeItem(atPath: recordingFilePath)
@@ -213,7 +209,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func continueRecording() {
-        self.setToolbarItems([pauseButton, flexItem], animated: true)
+        self.setToolbarItems([pauseButton], animated: true)
         isRecordingPaused = false
         audioRecorder?.record()
     }
@@ -225,7 +221,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     @objc func pauseRecording() {
         isRecordingPaused = true
         audioRecorder?.pause()
-        self.setToolbarItems([continueRecordingButton, spaceItem, playButton, flexItem], animated: true)
+        self.setToolbarItems([continueRecordingButton, spaceItem, playButton], animated: true)
     }
 
     @objc func cancelAction() {
@@ -249,7 +245,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
 
     func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
         if flag {
-            self.setToolbarItems([startRecordingButton, flexItem], animated: true)
+            self.setToolbarItems([startRecordingButton], animated: true)
             if let oldSessionCategory = oldSessionCategory {
                _ = try? AVAudioSession.sharedInstance().setCategory(oldSessionCategory)
                UIApplication.shared.isIdleTimerDisabled = wasIdleTimerDisabled
@@ -274,7 +270,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
 
                     if self.isFirstUsage {
                         if !granted {
-                            self.setToolbarItems([self.startRecordingButton, self.flexItem], animated: true)
+                            self.setToolbarItems([self.startRecordingButton], animated: true)
                             self.startRecordingButton.isEnabled = false
                         } else {
                             self.pauseButton.isEnabled = granted

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -57,44 +57,23 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }()
 
     lazy var cancelButton: UIBarButtonItem = {
-        let button = UIBarButtonItem.init(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel,
-                                          target: self,
-                                          action: #selector(cancelAction))
-        return button
+        return UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelAction))
     }()
 
     lazy var doneButton: UIBarButtonItem = {
-        let button = UIBarButtonItem.init(title: String.localized("menu_send"),
-                                          style: UIBarButtonItem.Style.done,
-                                          target: self,
-                                          action: #selector(doneAction))
-        return button
+        return UIBarButtonItem(title: String.localized("menu_send"), style: .done, target: self, action: #selector(doneAction))
     }()
 
     lazy var pauseButton: UIBarButtonItem = {
-        let button = UIBarButtonItem.init(barButtonSystemItem: UIBarButtonItem.SystemItem.pause,
-                                          target: self,
-                                          action: #selector(pauseRecordingButtonAction))
-        button.tintColor = UIColor.themeColor(light: .darkGray, dark: .lightGray)
-        return button
+        return UIBarButtonItem(image: UIImage(systemName: "pause"), style: .plain, target: self, action: #selector(pauseRecordingButtonAction))
     }()
 
     lazy var startRecordingButton: UIBarButtonItem = {
-        let button =  UIBarButtonItem.init(image: UIImage(systemName: "mic"),
-                                           style: UIBarButtonItem.Style.plain,
-                                           target: self,
-                                           action: #selector(recordingButtonAction))
-        button.tintColor = UIColor.themeColor(light: .darkGray, dark: .lightGray)
-        return button
+        return UIBarButtonItem(image: UIImage(systemName: "mic"), style: .plain, target: self, action: #selector(recordingButtonAction))
     }()
 
     lazy var continueRecordingButton: UIBarButtonItem = {
-        let button = UIBarButtonItem.init(image: UIImage(systemName: "mic"),
-                                          style: UIBarButtonItem.Style.plain,
-                                          target: self,
-                                          action: #selector(continueRecordingButtonAction))
-        button.tintColor = UIColor.themeColor(light: .darkGray, dark: .lightGray)
-        return button
+        return UIBarButtonItem(image: UIImage(systemName: "mic"), style: .plain, target: self, action: #selector(continueRecordingButtonAction))
     }()
 
     lazy var flexItem = {

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -30,9 +30,6 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     var recordingFilePath: String = ""
     var audioRecorder: AVAudioRecorder?
 
-    var normalTintColor: UIColor = UIColor.systemBlue
-    var highlightedTintColor = UIColor.systemRed
-
     var isFirstUsage: Bool = true
 
     lazy var waveFormView: SCSiriWaveformView = {
@@ -131,11 +128,6 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         waveFormView.fill(view: view)
         noRecordingPermissionView.fill(view: view, paddingLeading: 10, paddingTrailing: 10)
 
-        self.navigationController?.toolbar.tintColor = normalTintColor
-        self.navigationController?.navigationBar.tintColor = normalTintColor
-        self.navigationController?.navigationBar.isTranslucent = true
-        self.navigationController?.toolbar.isTranslucent = true
-
         let recordSettings = [AVFormatIDKey: kAudioFormatMPEG4AAC,
                               AVSampleRateKey: 44100.0,
                               AVEncoderBitRateKey: 32000,
@@ -196,17 +188,16 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func updateMeters() {
-        if let audioRecorder = audioRecorder {
-            if audioRecorder.isRecording || isRecordingPaused {
-                audioRecorder.updateMeters()
-                let normalizedValue: Float = pow(10, audioRecorder.averagePower(forChannel: 0) / 20)
-                waveFormView.waveColor = highlightedTintColor
-                waveFormView.update(withLevel: CGFloat(normalizedValue))
-                self.navigationItem.title = String.timeStringForInterval(audioRecorder.currentTime)
-            } else {
-                waveFormView.waveColor = normalTintColor
-                waveFormView.update(withLevel: 0)
-            }
+        guard let audioRecorder else { return }
+        if isRecordingPaused {
+            waveFormView.waveColor = UIColor.systemGray2
+            waveFormView.update(withLevel: 0)
+        } else {
+            audioRecorder.updateMeters()
+            let normalizedValue: Float = pow(10, audioRecorder.averagePower(forChannel: 0) / 20)
+            waveFormView.waveColor = UIColor.systemRed
+            waveFormView.update(withLevel: CGFloat(normalizedValue))
+            self.navigationItem.title = String.timeStringForInterval(audioRecorder.currentTime)
         }
     }
 

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -74,14 +74,6 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         return button
     }()
 
-    lazy var cancelRecordingButton: UIBarButtonItem = {
-        let button = UIBarButtonItem.init(barButtonSystemItem: UIBarButtonItem.SystemItem.trash,
-                                                 target: self,
-                                                 action: #selector(cancelRecordingAction))
-        button.tintColor = UIColor.themeColor(light: .darkGray, dark: .lightGray)
-        return button
-    }()
-
     lazy var pauseButton: UIBarButtonItem = {
         let button = UIBarButtonItem.init(barButtonSystemItem: UIBarButtonItem.SystemItem.pause,
                                           target: self,
@@ -129,7 +121,6 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         self.navigationController?.toolbar.isTranslucent = true
         self.navigationController?.navigationBar.isTranslucent = true
 
-        self.navigationItem.title = String.localized("voice_message")
         self.navigationItem.leftBarButtonItem = cancelButton
         self.navigationItem.rightBarButtonItem = doneButton
 
@@ -220,8 +211,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func recordingButtonAction() {
-        self.setToolbarItems([flexItem, cancelRecordingButton, flexItem, pauseButton, flexItem], animated: true)
-        cancelRecordingButton.isEnabled = true
+        self.setToolbarItems([pauseButton, flexItem], animated: true)
         doneButton.isEnabled = true
         if FileManager.default.fileExists(atPath: recordingFilePath) {
             _ = try? FileManager.default.removeItem(atPath: recordingFilePath)
@@ -241,7 +231,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func continueRecordingButtonAction() {
-        self.setToolbarItems([flexItem, cancelRecordingButton, flexItem, pauseButton, flexItem], animated: true)
+        self.setToolbarItems([pauseButton, flexItem], animated: true)
         isRecordingPaused = false
         audioRecorder?.record()
     }
@@ -249,20 +239,12 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     @objc func pauseRecordingButtonAction() {
         isRecordingPaused = true
         audioRecorder?.pause()
-        self.setToolbarItems([flexItem, cancelRecordingButton, flexItem, continueRecordingButton, flexItem], animated: true)
-    }
-
-    @objc func cancelRecordingAction() {
-        isRecordingPaused = false
-        cancelRecordingButton.isEnabled = false
-        doneButton.isEnabled = false
-        audioRecorder?.stop()
-        _ = try? FileManager.default.removeItem(atPath: recordingFilePath)
-        self.navigationItem.title = String.localized("voice_message")
+        self.setToolbarItems([continueRecordingButton, flexItem], animated: true)
     }
 
     @objc func cancelAction() {
-        cancelRecordingAction()
+        audioRecorder?.stop()
+        _ = try? FileManager.default.removeItem(atPath: recordingFilePath)
         dismiss(animated: true, completion: nil)
     }
 
@@ -281,7 +263,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
 
     func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
         if flag {
-            self.setToolbarItems([flexItem, cancelRecordingButton, flexItem, startRecordingButton, flexItem], animated: true)
+            self.setToolbarItems([startRecordingButton, flexItem], animated: true)
             if let oldSessionCategory = oldSessionCategory {
                _ = try? AVAudioSession.sharedInstance().setCategory(oldSessionCategory)
                UIApplication.shared.isIdleTimerDisabled = wasIdleTimerDisabled
@@ -306,7 +288,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
 
                     if self.isFirstUsage {
                         if !granted {
-                            self.setToolbarItems([self.flexItem, self.startRecordingButton, self.flexItem], animated: true)
+                            self.setToolbarItems([self.startRecordingButton, self.flexItem], animated: true)
                             self.startRecordingButton.isEnabled = false
                         } else {
                             self.pauseButton.isEnabled = granted

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -169,11 +169,13 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     @objc func updateMeters() {
         guard let audioRecorder else { return }
         if isRecordingPaused {
+            waveFormView.idleAmplitude = 0
             waveFormView.waveColor = UIColor.systemGray2
             waveFormView.update(withLevel: 0)
         } else {
             audioRecorder.updateMeters()
             let normalizedValue: Float = pow(10, audioRecorder.averagePower(forChannel: 0) / 20)
+            waveFormView.idleAmplitude = 0.01
             waveFormView.waveColor = UIColor.systemRed
             waveFormView.update(withLevel: CGFloat(normalizedValue))
             self.navigationItem.title = String.timeStringForInterval(audioRecorder.currentTime)

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -86,7 +86,17 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         item.width = 24
         return item
     }()
-    
+
+    private func createAudioRecorder() -> AVAudioRecorder? {
+        let recordSettings = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: 44100.0,
+            AVEncoderBitRateKey: 32000,
+            AVNumberOfChannelsKey: 1
+        ] as [String: Any]
+        return try? AVAudioRecorder.init(url: URL(fileURLWithPath: recordingFilePath), settings: recordSettings)
+    }
+
     init(dcContext: DcContext) {
         bitrate = dcContext.getConfigInt("media_quality") == 1 ? bitrateWorse : bitrateBalanced
         super.init(nibName: nil, bundle: nil)
@@ -114,13 +124,9 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         waveFormView.fill(view: view)
         noRecordingPermissionView.fill(view: view, paddingLeading: 10, paddingTrailing: 10)
 
-        let recordSettings = [AVFormatIDKey: kAudioFormatMPEG4AAC,
-                              AVSampleRateKey: 44100.0,
-                              AVEncoderBitRateKey: 32000,
-                              AVNumberOfChannelsKey: 1] as [String: Any]
         let globallyUniqueString = ProcessInfo.processInfo.globallyUniqueString
         recordingFilePath = NSTemporaryDirectory().appending(globallyUniqueString).appending(".m4a")
-        audioRecorder = try? AVAudioRecorder.init(url: URL(fileURLWithPath: recordingFilePath), settings: recordSettings)
+        audioRecorder = createAudioRecorder()
         audioRecorder?.delegate = self
         audioRecorder?.isMeteringEnabled = true
     }

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -34,7 +34,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
 
     lazy var waveFormView: SCSiriWaveformView = {
         let view = SCSiriWaveformView()
-        view.alpha = 0.0
+        view.isHidden = true
         view.waveColor = .clear
         view.backgroundColor = .clear
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -45,13 +45,14 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
 
     lazy var noRecordingPermissionView: UILabel = {
         let view = UILabel()
+        view.isHidden = true
         view.font = .preferredFont(forTextStyle: .body)
         view.adjustsFontForContentSizeCategory = true
         view.textColor = DcColors.defaultTextColor
         view.lineBreakMode = .byWordWrapping
         view.numberOfLines = 0
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.text = String.localized("perm_required_title") + "\n\n" + String.localized("perm_explain_access_to_mic_denied")
+        view.text = String.localized("perm_required_title") + " - " + String.localized("perm_explain_access_to_mic_denied")
         view.textAlignment = .center
         return view
     }()
@@ -264,8 +265,8 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         audioSession.requestRecordPermission({ granted in
             DispatchQueue.main.async { [weak self] in
                 if let self {
-                    self.noRecordingPermissionView.alpha = granted ? 0.0 : 1.0
-                    self.waveFormView.alpha = granted ? 1.0 : 0.0
+                    self.noRecordingPermissionView.isHidden = granted
+                    self.waveFormView.isHidden = !granted
                     self.doneButton.isEnabled = granted
 
                     if self.isFirstUsage {

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -65,15 +65,15 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }()
 
     lazy var pauseButton: UIBarButtonItem = {
-        return UIBarButtonItem(image: UIImage(systemName: "pause"), style: .plain, target: self, action: #selector(pauseRecordingButtonAction))
+        return UIBarButtonItem(image: UIImage(systemName: "pause"), style: .plain, target: self, action: #selector(pauseRecording))
     }()
 
     lazy var startRecordingButton: UIBarButtonItem = {
-        return UIBarButtonItem(image: UIImage(systemName: "mic"), style: .plain, target: self, action: #selector(recordingButtonAction))
+        return UIBarButtonItem(image: UIImage(systemName: "mic"), style: .plain, target: self, action: #selector(startRecording))
     }()
 
     lazy var continueRecordingButton: UIBarButtonItem = {
-        return UIBarButtonItem(image: UIImage(systemName: "mic"), style: .plain, target: self, action: #selector(continueRecordingButtonAction))
+        return UIBarButtonItem(image: UIImage(systemName: "mic"), style: .plain, target: self, action: #selector(continueRecording))
     }()
 
     lazy var flexItem = {
@@ -182,7 +182,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         }
     }
 
-    @objc func recordingButtonAction() {
+    @objc func startRecording() {
         self.setToolbarItems([pauseButton, flexItem], animated: true)
         doneButton.isEnabled = true
         if FileManager.default.fileExists(atPath: recordingFilePath) {
@@ -202,13 +202,13 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         }
     }
 
-    @objc func continueRecordingButtonAction() {
+    @objc func continueRecording() {
         self.setToolbarItems([pauseButton, flexItem], animated: true)
         isRecordingPaused = false
         audioRecorder?.record()
     }
 
-    @objc func pauseRecordingButtonAction() {
+    @objc func pauseRecording() {
         isRecordingPaused = true
         audioRecorder?.pause()
         self.setToolbarItems([continueRecordingButton, flexItem], animated: true)
@@ -264,7 +264,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
                             self.startRecordingButton.isEnabled = false
                         } else {
                             self.pauseButton.isEnabled = granted
-                            self.recordingButtonAction()
+                            self.startRecording()
                         }
 
                         self.isFirstUsage = false

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -724,7 +724,6 @@ class ChatListViewController: UITableViewController {
         if #available(iOS 15.0, *) {
             if let sheet = accountSwitchNavigationController.sheetPresentationController {
                 sheet.detents = [.medium(), .large()]
-                sheet.preferredCornerRadius = 20
             }
         } else {
             accountSwitchTransitioningDelegate = PartialScreenModalTransitioningDelegate(from: self, to: accountSwitchNavigationController)

--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -163,7 +163,6 @@ class ProxySettingsViewController: UITableViewController {
         let navigationController = UINavigationController(rootViewController: shareProxyViewController)
         if #available(iOS 15.0, *), let sheet = navigationController.sheetPresentationController {
             sheet.detents = [.medium()]
-            sheet.preferredCornerRadius = 20
 
             present(navigationController, animated: true)
         } else {

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -70,7 +70,6 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
                 } else {
                     sheet.detents = [.medium()]
                 }
-                sheet.preferredCornerRadius = 20
             }
         } else {
             if let shownViewController = navigationController?.visibleViewController {

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -62,7 +62,14 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
 
         if #available(iOS 15.0, *) {
             if let sheet = audioRecorderNavController.sheetPresentationController {
-                sheet.detents = [.medium()]
+                if #available(iOS 16.0, *) {
+                    let customDetent = UISheetPresentationController.Detent.custom(identifier: .init("thirtyPercent")) { context in
+                        return context.maximumDetentValue * 0.3
+                    }
+                    sheet.detents = [customDetent]
+                } else {
+                    sheet.detents = [.medium()]
+                }
                 sheet.preferredCornerRadius = 20
             }
         } else {


### PR DESCRIPTION

- removed questionable UX of trashcan vs cancel button - if one wants to start again, better cancel and it record again
- _really still_ wavefrom on pausing
- clearer pausing functionality (no confusion with trash or other buttons)
- the recorder uses a smaller part of the screen
- no flashing of an error message on slower devices if there is no error
- some code cleanup

apart from that, there are no logic changed in recorder handling

<img width=320 src=https://github.com/user-attachments/assets/c177135e-f34d-417b-bd98-f8b09a9c6e69>

i also tried to have a "playback" button, however, that is a bit tricky UI wise as well as implementation wise (you cannot play a file that is currently recorded, you have to finalize it, resume again - or use contatenate multiple records later - anyway, we did not had that before, and if we want to, staging voice messages as on desktop seems better - also other audio files would benefit from that)