### PR TITLE
dismiss voice recording by cancel button only

### DIFF
--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -90,6 +90,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         self.navigationController?.isToolbarHidden = false
         self.navigationController?.toolbar.isTranslucent = true
         self.navigationController?.navigationBar.isTranslucent = true
+        self.navigationController?.isModalInPresentation = true
 
         self.navigationItem.leftBarButtonItem = cancelButton
         self.navigationItem.rightBarButtonItem = doneButton


### PR DESCRIPTION
tap outside or swipe down is easily done accidentally

#skip-changelog, this is a part of #2707