### PR TITLE
tweak share proxy layout

### DIFF
--- a/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
@@ -34,6 +34,7 @@ class ShareProxyViewController: UIViewController {
         explanationLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
         explanationLabel.text = String.localized("proxy_share_explain")
         explanationLabel.numberOfLines = 0
+        explanationLabel.textAlignment = .center
 
         contentStackView = UIStackView(arrangedSubviews: [qrContentView, explanationLabel, shareLinkButton, UIView()])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false

--- a/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
@@ -33,6 +33,7 @@ class ShareProxyViewController: UIViewController {
         explanationLabel.translatesAutoresizingMaskIntoConstraints = false
         explanationLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
         explanationLabel.text = String.localized("proxy_share_explain")
+        explanationLabel.numberOfLines = 0
 
         contentStackView = UIStackView(arrangedSubviews: [qrContentView, explanationLabel, shareLinkButton, UIView()])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
@@ -49,7 +50,6 @@ class ShareProxyViewController: UIViewController {
         view.backgroundColor = .secondarySystemBackground
 
         shareLinkButton.addTarget(self, action: #selector(ShareProxyViewController.shareInviteLink(_:)), for: .touchUpInside)
-        shareLinkButton.setTitleColor(DcColors.primary, for: .normal)
 
         let svg = dcContext.createQRSVG(for: proxyUrlString)
         qrContentView.image = getQrImage(svg: svg)

--- a/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
@@ -24,6 +24,8 @@ class ShareProxyViewController: UIViewController {
         qrContentView = UIImageView()
         qrContentView.contentMode = .scaleAspectFit
         qrContentView.translatesAutoresizingMaskIntoConstraints = false
+        qrContentView.setContentHuggingPriority(.defaultLow, for: .vertical)
+        qrContentView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
 
         shareLinkButton = UIButton(type: .system)
         shareLinkButton.setTitle(String.localized("proxy_share_link"), for: .normal)
@@ -36,7 +38,7 @@ class ShareProxyViewController: UIViewController {
         explanationLabel.numberOfLines = 0
         explanationLabel.textAlignment = .center
 
-        contentStackView = UIStackView(arrangedSubviews: [qrContentView, explanationLabel, shareLinkButton, UIView()])
+        contentStackView = UIStackView(arrangedSubviews: [qrContentView, explanationLabel, shareLinkButton])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .vertical
         contentStackView.alignment = .center
@@ -65,22 +67,14 @@ class ShareProxyViewController: UIViewController {
     required init?(coder: NSCoder) { fatalError() }
 
     private func setupConstraints() {
-
-        let qrImageRatio: CGFloat
-        if let image = qrContentView.image {
-            qrImageRatio = image.size.height / image.size.width
-        } else {
-            qrImageRatio = 1
-        }
-
         verticalCenterConstraint = contentStackView.centerYAnchor.constraint(equalTo: contentScrollView.centerYAnchor)
         contentTopAnchor = contentStackView.topAnchor.constraint(equalTo: contentScrollView.topAnchor, constant: 16)
         contentBottomAnchor = contentScrollView.bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor, constant: 16)
 
         let constraints = [
-            qrContentView.widthAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.75),
+            qrContentView.widthAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.65),
             qrContentView.widthAnchor.constraint(lessThanOrEqualToConstant: 260),
-            qrContentView.heightAnchor.constraint(equalTo: qrContentView.widthAnchor, multiplier: qrImageRatio),
+            qrContentView.heightAnchor.constraint(equalTo: qrContentView.widthAnchor),
 
             contentScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             contentScrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),


### PR DESCRIPTION
this works on screens i tested, however, i still do not have an easy way to say "i have three views, let the first consume all additional space" - so on this case, let the qr code consume everything while staying square, cc @Amzd maybe you have a better idea :)

for the other points of https://github.com/deltachat/deltachat-ios/issues/2659  - they are good enough now:
- seems the font size is default, might appear a little smaller as the system adapts. that's fine
- the left/right is also fine, it is now wrapped, so usually the border is no longer touched on long strings, only small or even no padding is good enough