### PR TITLE
remove legacy smtp_certificate_checks

### DIFF
--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -714,7 +714,6 @@ public class DcContext {
             }
         }
         set {
-            setConfig("smtp_certificate_checks", "\(newValue)")
             setConfig("imap_certificate_checks", "\(newValue)")
         }
     }


### PR DESCRIPTION
setting imap_certificate_checks is sufficient meanwhile, smtp_certificate_checks will be removed soon

closes https://github.com/deltachat/deltachat-ios/issues/2669 , thanks @Hocuri for the reminder!

#skip-changelog as this is not  a user-visible change