### PR TITLE
easier accessible apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Access "Apps and Media" by an dedicated icon in chat's upper left corner
+- "Recent Apps and Media" are available from the settings
 - Speed up opening profiles
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Access "Apps and Media" by an dedicated icon in chat's upper left corner
-- "Recent Apps and Media" are available from the settings
+- Access "Apps & Media" by an dedicated icon in chat's upper left corner
+- "Recent Apps & Media" are available from the settings
 - Speed up opening profiles
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Access "Apps & Media" by an dedicated icon in chat's upper left corner
-- "Recent Apps & Media" are available from the settings
+- Access "Apps & Media" by an dedicated icon in chat's upper right corner
+- "All Apps & Media" are available from the settings
 - Speed up opening profiles
 
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -100,18 +100,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         UITapGestureRecognizer(target: self, action: #selector(chatProfilePressed))
     }()
 
-    private lazy var initialsBadge: InitialsBadge = {
-        let badge: InitialsBadge
-        badge = InitialsBadge(size: 37, accessibilityLabel: String.localized("menu_view_profile"))
-        badge.setLabelFont(UIFont.systemFont(ofSize: 14))
-        badge.accessibilityTraits = .button
-        return badge
-    }()
-
-    private lazy var badgeItem: UIBarButtonItem = {
-        return UIBarButtonItem(customView: initialsBadge)
-    }()
-
     private lazy var cancelButton: UIBarButtonItem = {
         return UIBarButtonItem.init(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel, target: self, action: #selector(onCancelPressed))
     }()
@@ -484,8 +472,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         coordinator.animate(
-            alongsideTransition: { [weak self] _ in
-                self?.navigationItem.setRightBarButton(self?.badgeItem, animated: true)
+            alongsideTransition: { _ in
             },
             completion: { [weak self] _ in
                 guard let self else { return }
@@ -879,15 +866,13 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
             if !dcChat.isSelfTalk {
                 if let image = dcChat.profileImage {
-                    initialsBadge.setImage(image)
+                    titleView.initialsBadge.setImage(image)
                 } else {
-                    initialsBadge.setName(dcChat.name)
-                    initialsBadge.setColor(dcChat.color)
+                    titleView.initialsBadge.setName(dcChat.name)
+                    titleView.initialsBadge.setColor(dcChat.color)
                 }
                 let recentlySeen = DcUtils.showRecentlySeen(context: dcContext, chat: dcChat)
-                initialsBadge.setRecentlySeen(recentlySeen)
-
-                rightBarButtonItems.append(badgeItem)
+                titleView.initialsBadge.setRecentlySeen(recentlySeen)
             } else {
                 let button = UIBarButtonItem(image: UIImage(systemName: "magnifyingglass"), style: .plain, target: self, action: #selector(searchPressed))
                 rightBarButtonItems.append(button)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -882,7 +882,11 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 }
                 let recentlySeen = DcUtils.showRecentlySeen(context: dcContext, chat: dcChat)
                 initialsBadge.setRecentlySeen(recentlySeen)
+
                 rightBarButtonItems.append(badgeItem)
+
+                let button = UIBarButtonItem(image: UIImage(systemName: "square.grid.2x2"), style: .plain, target: self, action: #selector(appsAndMediaPressed))
+                rightBarButtonItems.append(button)
             } else {
                 let button = UIBarButtonItem(image: UIImage(systemName: "magnifyingglass"), style: .plain, target: self, action: #selector(searchPressed))
                 rightBarButtonItems.append(button)
@@ -1174,6 +1178,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         DispatchQueue.main.async { [weak self] in
             self?.searchController.isActive = true
         }
+    }
+
+    @objc private func appsAndMediaPressed() {
+        navigationController?.pushViewController(AllMediaViewController(dcContext: dcContext, chatId: chatId), animated: true)
     }
 
     private func clipperButtonMenu() -> UIMenu {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -854,7 +854,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             } else if dcChat.isDeviceTalk {
                 subtitle = String.localized("device_talk_subtitle")
             } else if dcChat.isSelfTalk {
-                subtitle = String.localized("chat_self_talk_subtitle")
+                subtitle = nil
             } else if chatContactIds.count >= 1 {
                 let dcContact = dcContext.getContact(id: chatContactIds[0])
                 if dcContact.isBot {
@@ -873,6 +873,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             self.navigationItem.setLeftBarButton(nil, animated: true)
             
             var rightBarButtonItems = [UIBarButtonItem]()
+
+            let button = UIBarButtonItem(image: UIImage(systemName: "square.grid.2x2"), style: .plain, target: self, action: #selector(appsAndMediaPressed))
+            rightBarButtonItems.append(button)
+
             if !dcChat.isSelfTalk {
                 if let image = dcChat.profileImage {
                     initialsBadge.setImage(image)
@@ -884,9 +888,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 initialsBadge.setRecentlySeen(recentlySeen)
 
                 rightBarButtonItems.append(badgeItem)
-
-                let button = UIBarButtonItem(image: UIImage(systemName: "square.grid.2x2"), style: .plain, target: self, action: #selector(appsAndMediaPressed))
-                rightBarButtonItems.append(button)
             } else {
                 let button = UIBarButtonItem(image: UIImage(systemName: "magnifyingglass"), style: .plain, target: self, action: #selector(searchPressed))
                 rightBarButtonItems.append(button)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -470,22 +470,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         }
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        coordinator.animate(
-            alongsideTransition: { _ in
-            },
-            completion: { [weak self] _ in
-                guard let self else { return }
-                self.updateTitle()
-                DispatchQueue.main.async {
-                    self.reloadData()
-                }
-            }
-        )
-        super.viewWillTransition(to: size, with: coordinator)
-    }
-
-
     @objc func applicationDidBecomeActive(_ notification: NSNotification) {
         if navigationController?.visibleViewController == self {
             handleUserVisibility(isVisible: true)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -862,6 +862,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             var rightBarButtonItems = [UIBarButtonItem]()
 
             let button = UIBarButtonItem(image: UIImage(systemName: "square.grid.2x2"), style: .plain, target: self, action: #selector(appsAndMediaPressed))
+            button.accessibilityLabel = String.localized("apps_and_media")
             rightBarButtonItems.append(button)
 
             if !dcChat.isSelfTalk {

--- a/deltachat-ios/Controller/AllMediaViewController.swift
+++ b/deltachat-ios/Controller/AllMediaViewController.swift
@@ -48,6 +48,7 @@ class AllMediaViewController: UIPageViewController {
         self.dcContext = dcContext
         self.chatId = chatId
         super.init(transitionStyle: .scroll, navigationOrientation: .horizontal, options: [:])
+        hidesBottomBarWhenPushed = true
     }
 
     required init?(coder: NSCoder) {

--- a/deltachat-ios/Controller/AllMediaViewController.swift
+++ b/deltachat-ios/Controller/AllMediaViewController.swift
@@ -16,16 +16,16 @@ class AllMediaViewController: UIPageViewController {
 
     private var pages: [Page] = [
         Page(
+            headerTitle: String.localized("webxdc_apps"),
+            type1: DC_MSG_WEBXDC, type2: 0, type3: 0
+        ),
+        Page(
             headerTitle: String.localized("gallery"),
             type1: DC_MSG_IMAGE, type2: DC_MSG_GIF, type3: DC_MSG_VIDEO
         ),
         Page(
             headerTitle: String.localized("files"),
             type1: DC_MSG_FILE, type2: 0, type3: 0
-        ),
-        Page(
-            headerTitle: String.localized("webxdc_apps"),
-            type1: DC_MSG_WEBXDC, type2: 0, type3: 0
         ),
         Page(
             headerTitle: String.localized("audio"),
@@ -48,12 +48,6 @@ class AllMediaViewController: UIPageViewController {
         self.dcContext = dcContext
         self.chatId = chatId
         super.init(transitionStyle: .scroll, navigationOrientation: .horizontal, options: [:])
-
-        // avoid accidental flashing, let it be two taps to get to the image gallery, also for global media
-        if chatId == 0 {
-            let first = pages.removeFirst()
-            pages.append(first)
-        }
     }
 
     required init?(coder: NSCoder) {

--- a/deltachat-ios/Controller/AllMediaViewController.swift
+++ b/deltachat-ios/Controller/AllMediaViewController.swift
@@ -74,7 +74,7 @@ class AllMediaViewController: UIPageViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationItem.rightBarButtonItem = chatId == 0 && UserDefaults.standard.bool(forKey: "location_streaming") ? mapButton : nil
+        navigationItem.rightBarButtonItem = UserDefaults.standard.bool(forKey: "location_streaming") ? mapButton : nil
     }
 
     // MARK: - actions

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -89,7 +89,7 @@ class ProfileViewController: UITableViewController {
 
     private lazy var mediaCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("webxdc_apps") + " & " + String.localized("media")
+        cell.textLabel?.text = String.localized("apps_and_media")
         cell.imageView?.image = UIImage(systemName: "square.grid.2x2")
         cell.accessoryType = .disclosureIndicator
         return cell

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -90,8 +90,8 @@ class ProfileViewController: UITableViewController {
 
     private lazy var mediaCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("media")
-        cell.imageView?.image = UIImage(systemName: "photo.on.rectangle")
+        cell.textLabel?.text = String.localized("webxdc_apps") + " & " + String.localized("media")
+        cell.imageView?.image = UIImage(systemName: "square.grid.2x2")
         cell.accessoryType = .disclosureIndicator
         return cell
     }()

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -15,7 +15,6 @@ class ProfileViewController: UITableViewController {
     enum Options {
         case bio
         case media
-        case locations
         case startChat
     }
 
@@ -92,14 +91,6 @@ class ProfileViewController: UITableViewController {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.textLabel?.text = String.localized("webxdc_apps") + " & " + String.localized("media")
         cell.imageView?.image = UIImage(systemName: "square.grid.2x2")
-        cell.accessoryType = .disclosureIndicator
-        return cell
-    }()
-
-    private lazy var locationsCell: UITableViewCell = {
-        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.textLabel?.text = String.localized("locations")
-        cell.imageView?.image = UIImage(systemName: "map")
         cell.accessoryType = .disclosureIndicator
         return cell
     }()
@@ -264,10 +255,7 @@ class ProfileViewController: UITableViewController {
             actions.append(.addr)
         }
 
-        options.append(.media) // to unconditionally, to have a visual anchor
-        if UserDefaults.standard.bool(forKey: "location_streaming") {
-            options.append(.locations)
-        }
+        options.append(.media) // add unconditionally, to have a visual anchor
 
         memberManagementRows = 0
         if let chat {
@@ -490,12 +478,6 @@ class ProfileViewController: UITableViewController {
         }
     }
 
-    private func showLocations() {
-        if chatId != 0 {
-            navigationController?.pushViewController(MapViewController(dcContext: dcContext, chatId: chatId), animated: true)
-        }
-    }
-
     private func showEphemeralController() {
         navigationController?.pushViewController(EphemeralMessagesViewController(dcContext: dcContext, chatId: chatId), animated: true)
     }
@@ -702,8 +684,6 @@ class ProfileViewController: UITableViewController {
                 return statusCell
             case .media:
                 return mediaCell
-            case .locations:
-                return locationsCell
             case .startChat:
                 return startChatCell
             }
@@ -754,9 +734,6 @@ class ProfileViewController: UITableViewController {
             case .media:
                 tableView.deselectRow(at: indexPath, animated: true)
                 showMedia()
-            case .locations:
-                tableView.deselectRow(at: indexPath, animated: true)
-                showLocations()
             case .startChat:
                 showChat(otherChatId: dcContext.createChatByContactId(contactId: contactId))
             }

--- a/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
+++ b/deltachat-ios/Controller/Settings/ChatsAndMediaViewController.swift
@@ -122,7 +122,7 @@ internal final class ChatsAndMediaViewController: UITableViewController {
     // MARK: - lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = String.localized("pref_chats_and_media")
+        title = String.localized("pref_chats")
         tableView.rowHeight = UITableView.automaticDimension
     }
 

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -45,7 +45,7 @@ internal final class SettingsViewController: UITableViewController {
     private lazy var chatsAndMediaCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.tag = CellTags.chatsAndMedia.rawValue
-        cell.textLabel?.text = String.localized("pref_chats_and_media")
+        cell.textLabel?.text = String.localized("pref_chats")
         cell.imageView?.image = UIImage(systemName: "message")
         cell.accessoryType = .disclosureIndicator
         return cell
@@ -83,7 +83,7 @@ internal final class SettingsViewController: UITableViewController {
     private lazy var allAppsAndMediaCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.tag = CellTags.allAppsAndMedia.rawValue
-        cell.textLabel?.text =  "Recent Apps & Media"
+        cell.textLabel?.text =  String.localized("all_apps_and_media")
         cell.imageView?.image = UIImage(systemName: "square.grid.2x2")
         cell.accessoryType = .disclosureIndicator
         return cell

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -24,6 +24,7 @@ internal final class SettingsViewController: UITableViewController {
         case selectBackground
         case advanced
         case help
+        case allAppsAndMedia
         case connectivity
         case inviteFriends
     }
@@ -79,6 +80,15 @@ internal final class SettingsViewController: UITableViewController {
         return cell
     }()
 
+    private lazy var allAppsAndMediaCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+        cell.tag = CellTags.allAppsAndMedia.rawValue
+        cell.textLabel?.text =  "Recent Apps & Media"
+        cell.imageView?.image = UIImage(systemName: "square.grid.2x2")
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }()
+
     private lazy var inviteFriendsCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.tag = CellTags.inviteFriends.rawValue
@@ -127,13 +137,15 @@ internal final class SettingsViewController: UITableViewController {
         let preferencesSection = SectionConfigs(
             cells: [self.chatsAndMediaCell, self.notificationCell, self.selectBackgroundCell, self.addAnotherDeviceCell, self.connectivityCell, self.advancedCell]
         )
-        let inviteFriendsSection = SectionConfigs(cells: [self.inviteFriendsCell])
+        let listsSection = SectionConfigs(
+            cells: [allAppsAndMediaCell]
+        )
         let helpSection = SectionConfigs(
             footerTitle: appNameAndVersion,
-            cells: [self.helpCell]
+            cells: [inviteFriendsCell, helpCell]
         )
 
-        return [profileSection, preferencesSection, inviteFriendsSection, helpSection]
+        return [profileSection, preferencesSection, listsSection, helpSection]
     }()
 
     init(dcAccounts: DcAccounts) {
@@ -200,6 +212,7 @@ internal final class SettingsViewController: UITableViewController {
         case .addAnotherDevice: showBackupProviderViewController()
         case .notifications: showNotificationsViewController()
         case .advanced: showAdvanced()
+        case .allAppsAndMedia: showAllAppsAndMedia()
         case .help: showHelp()
         case .connectivity: showConnectivity()
         case .selectBackground: selectBackground()
@@ -268,6 +281,10 @@ internal final class SettingsViewController: UITableViewController {
 
     private func showAdvanced() {
         navigationController?.pushViewController(AdvancedViewController(dcAccounts: dcAccounts), animated: true)
+    }
+
+    private func showAllAppsAndMedia() {
+        navigationController?.pushViewController(AllMediaViewController(dcContext: dcContext), animated: true)
     }
 
     private func showHelp() {

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -10,10 +10,9 @@ class AppCoordinator: NSObject {
     private let dcAccounts: DcAccounts
     // the order below is important as well - and there are two enums, here and at
     // AppStateRestorer (this is error prone and could probably be merged)
-    public  let allMediaTab = 0
-    private let qrTab = 1
-    public  let chatsTab = 2
-    private let settingsTab = 3
+    private let qrTab = 0
+    public  let chatsTab = 1
+    private let settingsTab = 2
 
     private let appStateRestorer = AppStateRestorer.shared
 
@@ -26,12 +25,11 @@ class AppCoordinator: NSObject {
     // MARK: - tabbar view handling
     lazy var tabBarController: UITabBarController = {
         let qrNavController = createQrNavigationController()
-        let allMediaNavController = createAllMediaNavigationController()
         let chatsNavController = createChatsNavigationController()
         let settingsNavController = createSettingsNavigationController()
         let tabBarController = UITabBarController()
         tabBarController.delegate = self
-        tabBarController.viewControllers = [allMediaNavController, qrNavController, chatsNavController, settingsNavController]
+        tabBarController.viewControllers = [qrNavController, chatsNavController, settingsNavController]
         tabBarController.tabBar.tintColor = DcColors.primary
         return tabBarController
     }()
@@ -42,14 +40,6 @@ class AppCoordinator: NSObject {
         let qrCodeTabImage: UIImage?
         qrCodeTabImage = UIImage(systemName: "qrcode")
         nav.tabBarItem = UITabBarItem(title: String.localized("qr_code"), image: qrCodeTabImage, tag: qrTab)
-        return nav
-    }
-
-    private func createAllMediaNavigationController() -> UINavigationController {
-        let root = AllMediaViewController(dcContext: dcAccounts.getSelected())
-        let nav = UINavigationController(rootViewController: root)
-        let allMediaTabImage = UIImage(systemName: "photo.on.rectangle")
-        nav.tabBarItem = UITabBarItem(title: String.localized("menu_all_media"), image: allMediaTabImage, tag: allMediaTab)
         return nav
     }
 
@@ -550,8 +540,7 @@ class AppCoordinator: NSObject {
             }
         }
 
-        self.tabBarController.setViewControllers([createAllMediaNavigationController(),
-                                                  createQrNavigationController(),
+        self.tabBarController.setViewControllers([createQrNavigationController(),
                                                   createChatsNavigationController(),
                                                   createSettingsNavigationController()], animated: false)
         presentTabBarController()

--- a/deltachat-ios/Handler/AppStateRestorer.swift
+++ b/deltachat-ios/Handler/AppStateRestorer.swift
@@ -2,15 +2,14 @@ import UIKit
 
 class AppStateRestorer {
 
-    private let lastActiveTabKey = "last_active_tab2"
+    private let lastActiveTabKey = "last_active_tab3"
     private let lastActiveChatId = "last_active_chat_id"
-    private let offsetKey = 10
+    private let offsetKey = 11
 
     // UserDefaults returns 0 by default which conflicts with tab 0 -> therefore we map our tab indexes by adding an offsetKey
 
     private enum Tab: Int {
-        case allMediaTab = 10 // there are two enums, here and at AppCoordinator (this is error prone and could probably be merged)
-        case qrTab = 11
+        case qrTab = 11 // there are two enums, here and at AppCoordinator (this is error prone and could probably be merged)
         case chatTab = 12
         case settingsTab = 13
         case firstLaunch = 0
@@ -19,16 +18,10 @@ class AppStateRestorer {
     static let shared: AppStateRestorer = AppStateRestorer()
 
     func restoreLastActiveTab() -> Int {
-
-        let restoredTab = UserDefaults.standard.integer(forKey: lastActiveTabKey)
-
-        guard let lastTab = Tab(rawValue: restoredTab) else {
-            safe_fatalError("invalid restored tab")
-            return -1
-        }
+        let lastTab = Tab(rawValue: UserDefaults.standard.integer(forKey: lastActiveTabKey)) ?? .firstLaunch
 
         switch lastTab {
-        case .allMediaTab, .qrTab, .chatTab, .settingsTab:
+        case .qrTab, .chatTab, .settingsTab:
             return lastTab.rawValue - offsetKey
         case .firstLaunch:
             return -1

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -115,5 +115,9 @@ class ChatTitleView: UIStackView {
         titleLabel.isEnabled = enabled
         subtitleLabel.isEnabled = enabled
         verifiedView.alpha = enabled ? 1 : 0.4
+        muteView.alpha = enabled ? 1 : 0.4
+        ephemeralView.alpha = enabled ? 1 : 0.4
+        locationView.alpha = enabled ? 1 : 0.4
+        initialsBadge.alpha = enabled ? 1 : 0.4
     }
 }

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -3,6 +3,14 @@ import DcCore
 
 class ChatTitleView: UIStackView {
 
+    lazy var initialsBadge: InitialsBadge = {
+        let badge: InitialsBadge
+        badge = InitialsBadge(size: 37, accessibilityLabel: String.localized("menu_view_profile"))
+        badge.setLabelFont(UIFont.systemFont(ofSize: 14))
+        badge.accessibilityTraits = .button
+        return badge
+    }()
+
     private lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -63,14 +71,23 @@ class ChatTitleView: UIStackView {
         return subtitleLabel
     }()
 
+    private lazy var textsContainer: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleContainer, subtitleLabel])
+        stackView.axis = .vertical
+        stackView.alignment = .leading
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
     init() {
         super.init(frame: .zero)
         
         isAccessibilityElement = true
-        axis = .vertical
+        axis = .horizontal
         alignment = .center
-        addArrangedSubview(titleContainer)
-        addArrangedSubview(subtitleLabel)
+        spacing = 5
+        addArrangedSubview(initialsBadge)
+        addArrangedSubview(textsContainer)
     }
 
     required init(coder: NSCoder) {


### PR DESCRIPTION
this PR adds some small tweaks that make apps far better accessible - without "pinned messages" we do not have atm:

- add the known "app" icon in the upper right corner of a chat
- the icon opens the whole "media gallery", however, default and first tab is now "Apps"

idea is to have the same on android and desktop, on the latter the fist 3 apps can even be shown with its icon directly in the tab bar.

by these changes, on all platforms you'll know in the upper right corner you can access apps quickly, by only one or two taps:

<img width=250 src=https://github.com/user-attachments/assets/48c7febf-9184-4d49-aef1-718ae310e050>
<img width=250 src=https://github.com/user-attachments/assets/fc2925ad-07d9-4fb6-96ad-ff2fe4b4b799>

the media view is opened with the first tab that contains non-zero media.

a little bit unrelated is the move from "All Media" to "Recent Apps & Media" settings entry. this placement may be unfamiliar for ppl not using iOS, however, whatsapp, telegram & co use the place for similar lists. the old placement was always a bit questionable as the dialog is not that important and also requires more taps on other os; the similarity to "apps" and "qr code" icon was the last drop for tuning that down:

<img width=250 src=https://github.com/user-attachments/assets/847a9953-cdf6-41f8-924b-ea01fbfdc93c>

"Chats & Media" is becoming just "Chats" as on whatsapp/signal/etc - less clutter and less confusion with the new "Apps & Media"

~~in a subsequent PR, it may be nice to have the title-bar-avatar left of the title, btw~~ EDIT: did in this PR and also updated screenshots above
