### PR TITLE
calculate media count in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- Speed up opening profiles
+
+
 ## v1.58.5
 2025-05
 

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -232,9 +232,7 @@ class ProfileViewController: UITableViewController {
         guard let ui = notification.userInfo, let changedChatId = ui["chat_id"] as? Int else { return }
 
         if changedChatId == chatId {
-            DispatchQueue.main.async { [weak self] in
-                self?.updateMediaCellValues()
-            }
+            updateMediaCellValues()
         }
 
         if sharedChatIdsContain(chatId: changedChatId) {
@@ -401,7 +399,13 @@ class ProfileViewController: UITableViewController {
     }
 
     private func updateMediaCellValues() {
-        mediaCell.detailTextLabel?.text = chatId == 0 ? String.localized("none") : dcContext.getAllMediaCountString(chatId: chatId)
+        DispatchQueue.global().async { [weak self] in
+            guard let self else { return }
+            let label = chatId == 0 ? String.localized("none") : dcContext.getAllMediaCountString(chatId: chatId)
+            DispatchQueue.main.async { [weak self] in
+                self?.mediaCell.detailTextLabel?.text = label
+            }
+        }
     }
 
     private func updateMembers() {


### PR DESCRIPTION
calculation is usually fast,
however, potentially it can take a moment.
as the profile is opened often,
it makes sense to schedule that to background,
also, as nothing is dependent on that state