### PR TITLE
fix off-by-one error in location streaming

### DIFF
--- a/deltachat-ios/Helper/LocationManager.swift
+++ b/deltachat-ios/Helper/LocationManager.swift
@@ -120,7 +120,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     func disableLocationStreamingInAllChats() {
         if dcContext.isSendingLocationsToChat(chatId: 0) {
             let dcChatlist = dcContext.getChatlist(flags: 0, queryString: nil, queryId: 0)
-            for i in 0...dcChatlist.length {
+            for i in 0..<dcChatlist.length {
                 let chatId = dcChatlist.getChatId(index: i)
                 if dcContext.isSendingLocationsToChat(chatId: chatId) {
                     dcContext.sendLocationsToChat(chatId: chatId, seconds: 0)


### PR DESCRIPTION
chatlist.length is an invalid index, as usual.

i did not test nor checked the impact, just came over that while checking how a swift for look is used :)

#skip-changelog