### PR TITLE
faster opening of profile and connectivity

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1160,9 +1160,12 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             return
         }
         titleView.setEnabled(false) // immedidate feedback
-        DispatchQueue.main.async { // opening controller in next loop allows the system to render the immedidate feedback
-            self.showChatDetail(chatId: self.chatId)
-            self.titleView.setEnabled(true)
+        CATransaction.flush()
+
+        self.showChatDetail(chatId: self.chatId)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.titleView.setEnabled(true) // /immedidate feedback
         }
     }
 

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -294,8 +294,11 @@ class ChatListViewController: UITableViewController {
     @objc
     public func onNavigationTitleTapped() {
         titleView.isEnabled = false // immedidate feedback
-        DispatchQueue.main.async { // opening controller in next loop allows the system to render the immedidate feedback
-            self.navigationController?.pushViewController(ConnectivityViewController(dcContext: self.dcContext), animated: true)
+        CATransaction.flush()
+
+        self.navigationController?.pushViewController(ConnectivityViewController(dcContext: self.dcContext), animated: true)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { // /immedidate feedback
             self.titleView.isEnabled = true
         }
     }


### PR DESCRIPTION
before, to get some immediate visual feedback,
we disabled the title and then pushed the view controller on the next main loop. this was kind of okay when profile opening took a lot of time.

meanwhile, profile opening is much faster,
so that this additional look becomes the bottleneck.

this PR changes to push the view controller immediately (as usual elsewhere) - for immediate feedback, CATransaction.flush() is used.

same for the connectivity,
where the same pattern was used.

#skip-changelog as entry was already done with #2718