### PR TITLE
remove redundant 'App' subtitle in 'Apps' list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Access "Apps & Media" by an dedicated icon in chat's upper right corner
 - "All Apps & Media" are available from the settings
+- Clearer app lists by removing redundant "App" subtitle
 - Speed up opening profiles
 
 

--- a/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
+++ b/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
@@ -115,7 +115,7 @@ class DocumentGalleryFileCell: UITableViewCell {
         let name = dict["name"] as? String ?? "ErrName" // name should not be empty
 
         title.text = document.isEmpty ? name : "\(document) – \(name)"
-        subtitle.text = summary.isEmpty ? String.localized("webxdc_app") : summary
+        subtitle.text = summary.isEmpty ? nil : summary
     }
 
     private func generateThumbnailFor(url: URL, placeholder: UIImage?) {


### PR DESCRIPTION
this is probably a relict
from times where apps were shown together with 'Files'.

in the chat, the word "App" stays in case there is no summary.

for drafts, it seems a good idea to say sth as "Tap 'Send' to let others use this app" (we got feedback of ppl confused by drafts, i will do a commit for that on android)

<img width=320 src=https://github.com/user-attachments/assets/e93f3891-6158-4599-b952-b129121ccf52>
