### PR TITLE
align avatar to message bubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - "All Apps & Media" are available from the settings
 - Clearer app lists by removing redundant "App" subtitle
 - Speed up opening profiles
+- Fix: align avatar in groups to message
 
 
 ## v1.58.5

--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -113,8 +113,9 @@ public class BaseMessageCell: UITableViewCell {
         return view
     }()
 
+    let avatarSize = 34.0
     lazy var avatarView: InitialsBadge = {
-        let view = InitialsBadge(size: 28)
+        let view = InitialsBadge(size: avatarSize)
         view.setColor(UIColor.gray)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
@@ -234,9 +235,9 @@ public class BaseMessageCell: UITableViewCell {
 
         contentView.addConstraints([
             avatarView.constraintAlignLeadingTo(contentView, paddingLeading: 2),
-            avatarView.constraintAlignBottomTo(contentView),
-            avatarView.constraintWidthTo(28, priority: .defaultHigh),
-            avatarView.constraintHeightTo(28, priority: .defaultHigh),
+            avatarView.constraintAlignBottomTo(messageBackgroundContainer),
+            avatarView.constraintWidthTo(avatarSize, priority: .defaultHigh),
+            avatarView.constraintHeightTo(avatarSize, priority: .defaultHigh),
             topLabel.constraintAlignTopTo(messageBackgroundContainer, paddingTop: 6),
             topLabel.constraintAlignLeadingTo(messageBackgroundContainer, paddingLeading: 8),
             topLabel.constraintAlignTrailingMaxTo(messageBackgroundContainer, paddingTrailing: 8),


### PR DESCRIPTION
this PR aligns the avatar in groups to the bottom  of the bubbles, not to reactions that may or may not be there.

moreover, the avatar is made slightly bigger

before / after:

<img width=320 src=https://github.com/user-attachments/assets/d6ba26c8-756f-47a8-825e-9a85df8ffcfb> &nbsp; <img width=320 src=https://github.com/user-attachments/assets/dfc69df3-eacc-4921-8ea4-3a0e473da6fc>

/me now getting some rum