### PR TITLE
open media view unconditionally

### DIFF
--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -473,7 +473,7 @@ class ProfileViewController: UITableViewController {
     }
 
     private func showMedia() {
-        if chatId != 0 && dcContext.getAllMediaCount(chatId: chatId) > 0 {
+        if chatId != 0 {
             navigationController?.pushViewController(AllMediaViewController(dcContext: dcContext, chatId: chatId), animated: true)
         }
     }


### PR DESCRIPTION
if it can be opened from upper right icon in chat, it should also be openable from profile.

there may be eg. locations, so it also makes sense from that point of view (though we will reconsider that part at some point)

#skip-changelog as minor