### PR TITLE
make 'delete chat' directly available

### DIFF
--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -341,7 +341,7 @@ class ProfileViewController: UITableViewController {
                 }
                 let image = if #available(iOS 16.0, *) { "eraser" } else { "rectangle.portrait" }
                 moreOptions.append(action("clear_chat", image, attributes: [.destructive], showClearConfirmationAlert))
-                moreOptions.append(action("menu_delete_chat", "trash", attributes: [.destructive], showDeleteConfirmationAlert))
+                actions.append(action("menu_delete_chat", "trash", attributes: [.destructive], showDeleteConfirmationAlert))
             }
 
             actions.append(contentsOf: [


### PR DESCRIPTION
this is an opinionated minor,
however, having that red 'delete' here as well as on other places, is good for consistency.
also, 'delete' is the most common of the 'red actions' and 'more' is directly below.