### PR TITLE
Fix: No weird results when searching for space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Clearer app lists by removing redundant "App" subtitle
 - Speed up opening profiles
 - Fix: align avatar in groups to message
+- Fix: return correct results when searching for a space
 
 
 ## v1.58.5

--- a/DcCore/DcCore/Extensions/String+Extensions.swift
+++ b/DcCore/DcCore/Extensions/String+Extensions.swift
@@ -22,10 +22,6 @@ public extension String {
         return resultString
     }
 
-    func containsCharacters() -> Bool {
-        return !trimmingCharacters(in: [" "]).isEmpty
-    }
-
     func containsExact(subSequence: String?) -> [Int] {
         guard let searchText = subSequence else {
             return []

--- a/DcShare/ViewModel/ChatListViewModel.swift
+++ b/DcShare/ViewModel/ChatListViewModel.swift
@@ -18,7 +18,7 @@ class ChatListViewModel: NSObject {
 
     // if searchfield is empty we show default chat list
     private var showSearchResults: Bool {
-        return searchActive && searchText.containsCharacters()
+        return searchActive && !searchText.isEmpty
     }
 
     private var chatList: DcChatlist!
@@ -80,7 +80,7 @@ class ChatListViewModel: NSObject {
         let unreadMessages = dcContext.getUnreadMessages(chatId: chatId)
 
         var chatTitleIndexes: [Int] = []
-        if searchText.containsCharacters() {
+        if !searchText.isEmpty {
             let chatName = chat.name
             chatTitleIndexes = chatName.containsExact(subSequence: searchText)
         }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -176,7 +176,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.handleEphemeralTimerModified(_:)), name: Event.ephemeralTimerModified, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.applicationDidBecomeActive(_:)), name: UIApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(ChatViewController.applicationWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
-
     }
 
     required init?(coder _: NSCoder) {

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -24,7 +24,7 @@ class ChatListViewModel: NSObject {
 
     // if searchfield is empty we show default chat list
     private var showSearchResults: Bool {
-        return searchActive && searchText.containsCharacters()
+        return searchActive && !searchText.isEmpty
     }
 
     var chatList: DcChatlist!
@@ -341,7 +341,7 @@ class ChatListViewModel: NSObject {
         let unreadMessages = dcContext.getUnreadMessages(chatId: chatId)
 
         var chatTitleIndexes: [Int] = []
-        if searchText.containsCharacters() {
+        if !searchText.isEmpty {
             let chatName = chat.name
             chatTitleIndexes = chatName.containsExact(subSequence: searchText)
         }


### PR DESCRIPTION
treat a search for a single space as any other space.

bug before was that there were two methods to check for "empty" string, just use a single one now, `isEmpty`

this is how the search for a single space looked liked - and tapping the result led to the scary ghost chat 👻

<img width=320  src=https://github.com/user-attachments/assets/f0aec69d-9ff0-4d9f-a348-91597cb7855e>
