### PR TITLE
add shortcut to start in-chat search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - "All Apps & Media" are available from the settings
 - Clearer app lists by removing redundant "App" subtitle
 - Speed up opening profiles
+- Long-tap chat title as a shortcut to start in-chat search
 - Improve hint for app drafts
 - Fix: align avatar in groups to message
 - Fix: return correct results when searching for a space

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -100,6 +100,10 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         UITapGestureRecognizer(target: self, action: #selector(chatProfilePressed))
     }()
 
+    private lazy var navBarLongTap: UILongPressGestureRecognizer = {
+        UILongPressGestureRecognizer(target: self, action: #selector(chatProfileLongPressed))
+    }()
+
     private lazy var cancelButton: UIBarButtonItem = {
         return UIBarButtonItem.init(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel, target: self, action: #selector(onCancelPressed))
     }()
@@ -276,6 +280,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         super.viewWillAppear(animated)
         // this will be removed in viewWillDisappear
         navigationController?.navigationBar.addGestureRecognizer(navBarTap)
+        navigationController?.navigationBar.addGestureRecognizer(navBarLongTap)
         updateTitle()
 
         if activateSearch {
@@ -345,6 +350,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
         // the navigationController will be used when chatDetail is pushed, so we have to remove that gestureRecognizer
         navigationController?.navigationBar.removeGestureRecognizer(navBarTap)
+        navigationController?.navigationBar.removeGestureRecognizer(navBarLongTap)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -857,9 +863,6 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
                 }
                 let recentlySeen = DcUtils.showRecentlySeen(context: dcContext, chat: dcChat)
                 titleView.initialsBadge.setRecentlySeen(recentlySeen)
-            } else {
-                let button = UIBarButtonItem(image: UIImage(systemName: "magnifyingglass"), style: .plain, target: self, action: #selector(searchPressed))
-                rightBarButtonItems.append(button)
             }
             
             navigationItem.rightBarButtonItems = rightBarButtonItems
@@ -1130,9 +1133,8 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
     }
 
     @objc private func chatProfilePressed() {
-        if tableView.isEditing {
-            return
-        }
+        guard !tableView.isEditing else { return }
+
         titleView.setEnabled(false) // immedidate feedback
         CATransaction.flush()
 
@@ -1143,7 +1145,9 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
         }
     }
 
-    @objc private func searchPressed() {
+    @objc private func chatProfileLongPressed() {
+        guard !tableView.isEditing, !searchController.isActive else { return }
+
         navigationItem.searchController = self.searchController
         DispatchQueue.main.async { [weak self] in
             self?.searchController.isActive = true


### PR DESCRIPTION
in-chat search is started usually from the profile menu, which is straight-forward,
but requires some taps (tap title, tap menu, tap search)

this adds an shortcut to open the search by long-tap title. this is known from telegram, it is advanced, but that is fine, as it should not disturb things if unused/unknown.

this also replaces the extra search icon for the saved messages - for consistency, but also as we have with the 'app & media' another button there.

