### PR TITLE
fix voice messages for "worse quality" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Speed up opening profiles
 - Improve hint for app drafts
 - Show 'Disappearing Messages' state alrady in menu
+- Fix sending voice messages if "Settings / Chats / Media Quality" is set to "Worse Quality"
 - Fix: align avatar in groups to message
 - Fix: return correct results when searching for a space
 

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -192,9 +192,9 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
             oldSessionCategory = session.category
             try session.setCategory(AVAudioSession.Category.record)
             UIApplication.shared.isIdleTimerDisabled = true
-            audioRecorder?.prepareToRecord()
+            guard let audioRecorder, audioRecorder.prepareToRecord() else { logger.error("prepareToRecord() failed"); return }
             isRecordingPaused = false
-            audioRecorder?.record()
+            guard audioRecorder.record() else { logger.error("record() failed"); return }
         } catch {
             logger.error("Cannot start recording: \(error)")
         }
@@ -203,7 +203,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     @objc func continueRecording() {
         self.setToolbarItems([pauseButton], animated: true)
         isRecordingPaused = false
-        audioRecorder?.record()
+        guard let audioRecorder, audioRecorder.record() else { logger.error("continue recording failed"); return  }
     }
 
     @objc func pauseRecording() {

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -102,7 +102,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
         waveFormView.fill(view: view)
         noRecordingPermissionView.fill(view: view, paddingLeading: 10, paddingTrailing: 10)
 
-        let recordSettings = [AVFormatIDKey: kAudioFormatMPEG4AAC,
+        let recordSettings = [AVFormatIDKey: kAudioFormatMPEG4AAC_HE,
                               AVSampleRateKey: 44100.0,
                               AVEncoderBitRateKey: bitrate,
                               AVNumberOfChannelsKey: 1] as [String: Any]


### PR DESCRIPTION
~~for whatever reasons, on an iPhoneSE1 (note sure about iOS version), the  `kAudioFormatMPEG4AAC` is not working and `kAudioFormatMPEG4AAC_HE` is required.~~ thanks @Simon-Laux for figuring that out.

reason was the quality set to "worse quality", which was ignored until recently https://github.com/deltachat/deltachat-ios/pull/2706 was merged, which causes the issue - i can also reproduce that now.

i tested on iPhoneSE2, iPhone7, iPhone13 with iOS15 resp. iOS18, there things work now on both variations.

additionally, the PR cleans up the error handling and logs more errors.