### PR TITLE
fix for not able to compress videos on iOS 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Fix: align avatar in groups to message
 - Fix: return correct results when searching for a space
 - Fix: show video recoding and similar errors in an alert
+- Fix: video compression on iOS 16
+- Fix: attaching GIFs and webP from gallery
+- Fix: drag and drop videos on iOS 15
 
 
 ## v1.58.5

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		5F153E9A2CC38BAA00871ABE /* GiveBackMyFirstResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F153E992CC38BAA00871ABE /* GiveBackMyFirstResponder.swift */; };
 		5F4945AB2D315E7000DCD50A /* UIPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */; };
 		5F785F6E2CB9344F003FFFB9 /* ReusableCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */; };
+		6430531D2DF0668600E26D1F /* NSItemProvider+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6430531C2DF0668600E26D1F /* NSItemProvider+Extensions.swift */; };
 		7070FB9B2101ECBB000DC258 /* NewGroupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7070FB9A2101ECBB000DC258 /* NewGroupController.swift */; };
 		70B8882E2091B8550074812E /* ContactCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B8882D2091B8550074812E /* ContactCell.swift */; };
 		767CFF56D7ABED1C190A3A8B /* Pods_DcShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF8DFC4D179F4CF1E83D78C9 /* Pods_DcShare.framework */; };
@@ -463,6 +464,7 @@
 		5F153E992CC38BAA00871ABE /* GiveBackMyFirstResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiveBackMyFirstResponder.swift; sourceTree = "<group>"; };
 		5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPasteboard.swift; sourceTree = "<group>"; };
 		5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableCellProtocol.swift; sourceTree = "<group>"; };
+		6430531C2DF0668600E26D1F /* NSItemProvider+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSItemProvider+Extensions.swift"; sourceTree = "<group>"; };
 		7070FB9A2101ECBB000DC258 /* NewGroupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGroupController.swift; sourceTree = "<group>"; };
 		70B8882D2091B8550074812E /* ContactCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCell.swift; sourceTree = "<group>"; };
 		7837B63F21E54DC600CDE126 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -773,6 +775,7 @@
 				D85DF9772C4A96CB00A01408 /* UserDefaults+Extensions.swift */,
 				D8083ACF2D14384F005DCB7D /* UserDefaults+Widgets.swift */,
 				D82AD24C2D27E47A009D6026 /* UIApplication+Orientation.swift */,
+				6430531C2DF0668600E26D1F /* NSItemProvider+Extensions.swift */,
 				5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */,
 			);
 			path = Extensions;
@@ -1708,6 +1711,7 @@
 				30238CFD28A5028300EF14AC /* WebxdcGridCell.swift in Sources */,
 				3080A036277DE30100E74565 /* NSMutableAttributedString+Extensions.swift in Sources */,
 				307A82CC25B8D26700748B57 /* ChatEditingBar.swift in Sources */,
+				6430531D2DF0668600E26D1F /* NSItemProvider+Extensions.swift in Sources */,
 				30703B6D27AA80FF00BDADE6 /* WebxdcCell.swift in Sources */,
 				303492952565AABC00A523D0 /* DraftModel.swift in Sources */,
 				78E45E3A21D3CFBC00D4B15E /* SettingsViewController.swift in Sources */,

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2371,14 +2371,16 @@ extension ChatViewController: MediaPickerDelegate {
                         if !progressAlertHandler.cancelled {
                             if itemProvider.hasItemConformingToTypeIdentifier(UTType.movie.identifier) {
                                 itemProvider.loadInPlaceFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { [weak self] url, _, error in
-                                    if !progressAlertHandler.cancelled {
-                                        url?.convertToMp4 { [weak self] url, error in
-                                            if let url, !progressAlertHandler.cancelled {
-                                                self?.sendVideo(url: url)
-                                            } else if let error {
-                                                progressAlertHandler.updateProgressAlert(error: error.localizedDescription)
+                                    if !progressAlertHandler.cancelled, let url {
+                                        NSFileCoordinator().coordinate(readingItemAt: url, error: nil) { url in
+                                            url.convertToMp4 { [weak self] url, error in
+                                                if let url, !progressAlertHandler.cancelled {
+                                                    self?.sendVideo(url: url)
+                                                } else if let error {
+                                                    progressAlertHandler.updateProgressAlert(error: error.localizedDescription)
+                                                }
+                                                increaseProcessed()
                                             }
-                                            increaseProcessed()
                                         }
                                     }
                                 }
@@ -2428,14 +2430,16 @@ extension ChatViewController: MediaPickerDelegate {
                 progressAlertHandler.dataSource = self
                 progressAlertHandler.showProgressAlert(title: nil, dcContext: self.dcContext)
                 itemProvider.loadInPlaceFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { [weak self] url, _, error in
-                    if !progressAlertHandler.cancelled {
-                        url?.convertToMp4 { [weak self] url, error in
-                            DispatchQueue.main.async {
-                                if let url, !progressAlertHandler.cancelled {
-                                    self?.stageVideo(url: (url as NSURL))
-                                    progressAlertHandler.updateProgressAlertSuccess()
-                                } else if let error {
-                                    progressAlertHandler.updateProgressAlert(error: error.localizedDescription)
+                    if !progressAlertHandler.cancelled, let url {
+                        NSFileCoordinator().coordinate(readingItemAt: url, error: nil) { url in
+                            url.convertToMp4 { [weak self] url, error in
+                                DispatchQueue.main.async {
+                                    if let url, !progressAlertHandler.cancelled {
+                                        self?.stageVideo(url: (url as NSURL))
+                                        progressAlertHandler.updateProgressAlertSuccess()
+                                    } else if let error {
+                                        progressAlertHandler.updateProgressAlert(error: error.localizedDescription)
+                                    }
                                 }
                             }
                         }

--- a/deltachat-ios/Extensions/NSItemProvider+Extensions.swift
+++ b/deltachat-ios/Extensions/NSItemProvider+Extensions.swift
@@ -64,6 +64,7 @@ extension NSItemProvider {
         // Note: UTType.movie's doc implies that an mp4 file should have
         // both .mpeg4Movie and .movie but it does not on iOS 15
         hasItemConformingToTypeIdentifier(UTType.mpeg4Movie.identifier) ||
+        hasItemConformingToTypeIdentifier(UTType.quickTimeMovie.identifier) ||
         hasItemConformingToTypeIdentifier(UTType.movie.identifier) ||
         hasItemConformingToTypeIdentifier(UTType.video.identifier)
     }
@@ -89,6 +90,8 @@ extension NSItemProvider {
         }
         let progress = if hasItemConformingToTypeIdentifier(UTType.mpeg4Movie.identifier) {
             loadInPlaceFileRepresentation(forTypeIdentifier: UTType.mpeg4Movie.identifier, completionHandler: compress)
+        } else if hasItemConformingToTypeIdentifier(UTType.quickTimeMovie.identifier) {
+            loadInPlaceFileRepresentation(forTypeIdentifier: UTType.quickTimeMovie.identifier, completionHandler: compress)
         } else if hasItemConformingToTypeIdentifier(UTType.movie.identifier) {
             loadInPlaceFileRepresentation(forTypeIdentifier: UTType.movie.identifier, completionHandler: compress)
         } else {

--- a/deltachat-ios/Extensions/NSItemProvider+Extensions.swift
+++ b/deltachat-ios/Extensions/NSItemProvider+Extensions.swift
@@ -1,0 +1,101 @@
+import UniformTypeIdentifiers
+import SDWebImage
+import UIKit
+
+extension NSItemProvider {
+    // MARK: - Image
+    
+    public enum LoadImageError: Error {
+        case failedToConvertGIFDataToImage
+        case failedToConvertWebPDataToImage
+        /// Should never be returned but in case loadObject returns nil for both image and error
+        case loadObjectFailed
+        case failedToConvertDataToImage
+    }
+    
+    /// Wether loadImage is applicable to this provider
+    public func canLoadImage(allowAnimated: Bool = true) -> Bool {
+        (allowAnimated && hasItemConformingToTypeIdentifier(UTType.gif.identifier)) ||
+        hasItemConformingToTypeIdentifier(UTType.webP.identifier) ||
+        canLoadObject(ofClass: UIImage.self) ||
+        hasItemConformingToTypeIdentifier(UTType.image.identifier)
+    }
+    
+    /// Load any image including webP and gif
+    /// Unlike native load functions this calls completion on the main thread
+    @discardableResult
+    public func loadImage(allowAnimated: Bool = true, completion: @escaping (UIImage?, Error?) -> Void) -> Progress {
+        return if allowAnimated && hasItemConformingToTypeIdentifier(UTType.gif.identifier) {
+            loadDataRepresentation(forTypeIdentifier: UTType.gif.identifier) { data, error in
+                callCompletion(data.flatMap(SDAnimatedImage.init(data:)), error, or: .failedToConvertGIFDataToImage)
+            }
+        } else if hasItemConformingToTypeIdentifier(UTType.webP.identifier) {
+            // If webP is provided and eg JPEG (or another type that is supported by loadObject),
+            // always pick webP because it might have transparancy unlike JPEG.
+            loadDataRepresentation(forTypeIdentifier: UTType.webP.identifier) { webPData, error in
+                callCompletion(webPData.flatMap(UIImage.sd_image(withWebPData:)), error, or: .failedToConvertWebPDataToImage)
+            }
+        } else if canLoadObject(ofClass: UIImage.self) {
+            loadObject(ofClass: UIImage.self) { imageItem, error in
+                callCompletion(imageItem as? UIImage, error, or: .loadObjectFailed)
+            }
+        } else {
+            // Some images (like webP) can't be loaded into UIImage by `loadObject` so we fall back on SD.
+            // See `UIImage.readableTypeIdentifiersForItemProvider` for ones that can.
+            loadDataRepresentation(forTypeIdentifier: UTType.image.identifier) { data, error in
+                callCompletion(data.flatMap(UIImage.sd_image(with:)), error, or: .failedToConvertDataToImage)
+            }
+        }
+        func callCompletion(_ image: UIImage?, _ error: Error?, or backupError: LoadImageError) {
+            DispatchQueue.main.async {
+                switch (image, error) {
+                case (.none, .some): completion(nil, error)
+                case (.some, .none): completion(image, nil)
+                default: completion(nil, backupError)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Video
+    
+    /// Wether loadCompressedVideo is applicable to this provider
+    public func canLoadVideo() -> Bool {
+        // Note: UTType.movie's doc implies that an mp4 file should have
+        // both .mpeg4Movie and .movie but it does not on iOS 15
+        hasItemConformingToTypeIdentifier(UTType.mpeg4Movie.identifier) ||
+        hasItemConformingToTypeIdentifier(UTType.movie.identifier) ||
+        hasItemConformingToTypeIdentifier(UTType.video.identifier)
+    }
+    
+    /// Loads a video, converts it to mp4, and compresses the video.
+    /// Unlike native load functions this calls completion on the main thread
+    @discardableResult
+    public func loadCompressedVideo(completion: @escaping (URL?, Error?) -> Void) -> Progress {
+        var progressLater: Progress?
+        let compress = { (url: URL?, _: Bool, error: Error?) in
+            if let url {
+                // Note: NSFileCoordinator is required on iOS 15
+                NSFileCoordinator().coordinate(readingItemAt: url, error: nil) { url in
+                    url.convertToMp4 { url, error in
+                        progressLater?.completedUnitCount += 10
+                        DispatchQueue.main.async { completion(url, error) }
+                    }
+                }
+            } else {
+                progressLater?.completedUnitCount += 10
+                DispatchQueue.main.async { completion(url, error) }
+            }
+        }
+        let progress = if hasItemConformingToTypeIdentifier(UTType.mpeg4Movie.identifier) {
+            loadInPlaceFileRepresentation(forTypeIdentifier: UTType.mpeg4Movie.identifier, completionHandler: compress)
+        } else if hasItemConformingToTypeIdentifier(UTType.movie.identifier) {
+            loadInPlaceFileRepresentation(forTypeIdentifier: UTType.movie.identifier, completionHandler: compress)
+        } else {
+            loadInPlaceFileRepresentation(forTypeIdentifier: UTType.video.identifier, completionHandler: compress)
+        }
+        progressLater = progress
+        progress.totalUnitCount += 10
+        return progress
+    }
+}

--- a/deltachat-ios/Helper/ChatDropInteraction.swift
+++ b/deltachat-ios/Helper/ChatDropInteraction.swift
@@ -10,6 +10,8 @@ public class ChatDropInteraction {
     public func dropInteraction(canHandle session: UIDropSession) -> Bool {
         session.items.count == 1 && session.hasItemsConforming(toTypeIdentifiers: [
             UTType.image.identifier,
+            UTType.mpeg4Movie.identifier,
+            UTType.quickTimeMovie.identifier,
             UTType.video.identifier,
             UTType.movie.identifier,
             UTType.text.identifier,

--- a/deltachat-ios/Helper/ChatDropInteraction.swift
+++ b/deltachat-ios/Helper/ChatDropInteraction.swift
@@ -22,59 +22,36 @@ public class ChatDropInteraction {
     }
 
     public func dropInteraction(performDrop session: UIDropSession) {
-        if #available(iOS 15.0, *) {
-            if session.hasItemsConforming(toTypeIdentifiers: [UTType.image.identifier]) {
-                loadImageObjects(session: session)
-            } else if session.hasItemsConforming(toTypeIdentifiers: [UTType.movie.identifier, UTType.video.identifier]) {
-                loadFileObjects(session: session, isVideo: true)
-            } else if session.hasItemsConforming(toTypeIdentifiers: [UTType.url.identifier]) {
-                loadTextObjects(session: session)
-            } else if session.hasItemsConforming(toTypeIdentifiers: [UTType.item.identifier]) {
-                loadFileObjects(session: session)
-            } else if session.hasItemsConforming(toTypeIdentifiers: [UTType.text.identifier]) {
-                loadTextObjects(session: session)
-            }
-        } else {
-            if session.hasItemsConforming(toTypeIdentifiers: [kUTTypeImage as String]) {
-                loadImageObjects(session: session)
-            } else if session.hasItemsConforming(toTypeIdentifiers: [kUTTypeMovie as String, kUTTypeVideo as String]) {
-                loadFileObjects(session: session, isVideo: true)
-            } else if session.hasItemsConforming(toTypeIdentifiers: [kUTTypeURL as String]) {
-                loadTextObjects(session: session)
-            } else if session.hasItemsConforming(toTypeIdentifiers: [kUTTypeItem as String]) {
-                loadFileObjects(session: session)
-            } else if session.hasItemsConforming(toTypeIdentifiers: [kUTTypeText as String]) {
-                loadTextObjects(session: session)
-            }
+        if session.hasItemsConforming(toTypeIdentifiers: [UTType.image.identifier]) {
+            loadImageObjects(session: session)
+        } else if session.items.first?.itemProvider.canLoadVideo() == true {
+            loadVideoObjects(session: session)
+        } else if session.hasItemsConforming(toTypeIdentifiers: [UTType.url.identifier]) {
+            loadTextObjects(session: session)
+        } else if session.hasItemsConforming(toTypeIdentifiers: [UTType.item.identifier]) {
+            loadFileObjects(session: session)
+        } else if session.hasItemsConforming(toTypeIdentifiers: [UTType.text.identifier]) {
+            loadTextObjects(session: session)
         }
     }
 
     private func loadImageObjects(session: UIDropSession) {
         guard let droppedItem = session.items.first else { return }
-
-        // If webP is provided and eg JPEG (or another type that is supported by loadObject),
-        // always pick webP because it might have transparancy unlike JPEG.
-        if #available(iOS 14, *), droppedItem.itemProvider.hasItemConformingToTypeIdentifier(UTType.webP.identifier) {
-            droppedItem.itemProvider.loadDataRepresentation(forTypeIdentifier: UTType.webP.identifier) { [weak self] webPData, _ in
-                guard let self, let image = UIImage.sd_image(withWebPData: webPData) else { return }
-                self.delegate?.onImageDragAndDropped(image: image)
-            }
-        } else if droppedItem.itemProvider.canLoadObject(ofClass: UIImage.self) {
-            droppedItem.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] imageItem, _ in
-                guard let image = imageItem as? UIImage else { return }
-                self?.delegate?.onImageDragAndDropped(image: image)
-            }
-        } else {
-            // Some images (like webP) can't be loaded into UIImage by UIDropSession so we fall back on SD.
-            // See `UIImage.readableTypeIdentifiersForItemProvider` for ones that can.
-            droppedItem.itemProvider.loadDataRepresentation(forTypeIdentifier: kUTTypeImage as String) { [weak self] data, _ in
-                guard let self, let image = UIImage.sd_image(with: data) else { return }
-                self.delegate?.onImageDragAndDropped(image: image)
-            }
+        droppedItem.itemProvider.loadImage(allowAnimated: true) { [weak self] image, _ in
+            guard let image else { return }
+            self?.delegate?.onImageDragAndDropped(image: image)
+        }
+    }
+    
+    private func loadVideoObjects(session: UIDropSession) {
+        guard let droppedItem = session.items.first else { return }
+        droppedItem.itemProvider.loadCompressedVideo { [weak self] videoUrl, _ in
+            guard let videoUrl else { return }
+            self?.delegate?.onVideoDragAndDropped(url: videoUrl as NSURL)
         }
     }
 
-    private func loadFileObjects(session: UIDropSession, isVideo: Bool = false) {
+    private func loadFileObjects(session: UIDropSession) {
         guard let item = session.items.first else { return }
         item.itemProvider.loadFileRepresentation(forTypeIdentifier: kUTTypeItem as String) { [weak self] (url, error) in
             guard let url = url else {
@@ -92,11 +69,7 @@ public class ChatDropInteraction {
                                                          suffix: url.pathExtension,
                                                          directory: .cachesDirectory) else { return }
                 DispatchQueue.main.async {
-                    if isVideo {
-                        self?.delegate?.onVideoDragAndDropped(url: NSURL(fileURLWithPath: fileName))
-                    } else {
-                        self?.delegate?.onFileDragAndDropped(url: NSURL(fileURLWithPath: fileName))
-                    }
+                    self?.delegate?.onFileDragAndDropped(url: NSURL(fileURLWithPath: fileName))
                 }
             }
         }

--- a/deltachat-ios/Helper/FileHelper.swift
+++ b/deltachat-ios/Helper/FileHelper.swift
@@ -89,6 +89,7 @@ public class FileHelper {
     }
 
     static func copyIfPossible(src: URL, dest: URL) -> URL {
+        guard src != dest else { return }
         do {
             if FileManager.default.fileExists(atPath: dest.path) {
                 try FileManager.default.removeItem(at: dest)

--- a/deltachat-ios/Helper/FileHelper.swift
+++ b/deltachat-ios/Helper/FileHelper.swift
@@ -89,7 +89,7 @@ public class FileHelper {
     }
 
     static func copyIfPossible(src: URL, dest: URL) -> URL {
-        guard src != dest else { return }
+        guard src != dest else { return src }
         do {
             if FileManager.default.fileExists(atPath: dest.path) {
                 try FileManager.default.removeItem(at: dest)

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -168,12 +168,10 @@ class MediaPicker: NSObject, UINavigationControllerDelegate {
 
 extension MediaPicker: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        assert(Thread.isMainThread)
         let itemProviders = results.compactMap { $0.itemProvider }
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            picker.dismiss(animated: true)
-            self.delegate?.onMediaSelected(mediaPicker: self, itemProviders: itemProviders, sendAsFile: sendAsFile)
-        }
+        picker.dismiss(animated: true)
+        delegate?.onMediaSelected(mediaPicker: self, itemProviders: itemProviders, sendAsFile: sendAsFile)
     }
 }
 


### PR DESCRIPTION
This PR addresses missing features some of which forgotten when switching from UIImagePicker to PHPicker:

- Attach videos (on iOS 15 and iOS 16)
- Attach webP 
- Attach GIF
- Drop videos (on iOS 15)

I did some refactoring;
- Moved the logic for loading videos and images to a NSItemProvider extension so it can be used from drag/drop and the attach menu (in the future maybe the share sheet too but putting this extension in DcCore requires it to depend on SDWebImage). This means we no longer have slightly different logic for these areas (at least for image and video).
- Made the custom loading functions for videos and images return on main thread which saves a lot of swapping around everywhere. 
- That allowed a simpler `onMediaSelected`