### PR TITLE
Attempt to prevent corruption when forwarding attachment

### DIFF
--- a/deltachat-ios/Extensions/URL+Extension.swift
+++ b/deltachat-ios/Extensions/URL+Extension.swift
@@ -47,10 +47,6 @@ extension URL {
                 completionHandler?(exportSession.outputURL, nil)
             default: break
             }
-            if inputURL != self {
-                // if FileHelper.copyIfPossible successfuly copied then we delete the temp file
-                FileHelper.deleteFile(inputURL.path)
-            }
         })
     }
 


### PR DESCRIPTION
I have had a few times that the original video is removed when I forward a video from QLPreviewController's share button into DC share extension. I cannot reliably reproduce this but it happened twice so out of caution I remove this deletion of temporary file as temp files will be deleted by the system anyway.