### PR TITLE
Properly close webxdc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix: attaching GIFs and webP from gallery
 - Fix: drag and drop videos on iOS 15
 - Fix: attaching files on iOS 15
+- Fix: properly close webxdc
 
 
 ## v1.58.5

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -422,7 +422,8 @@ class WebxdcViewController: WebViewViewController {
     }
 
     private func moreButtonMenu() -> UIMenu {
-        func actions() -> [UIMenuElement] {
+        let actions: () -> [UIMenuElement] = { [weak self] in
+            guard let self else { return [] }
             var actions = [UIMenuElement]()
             actions.append(UIAction(title: String.localized("show_in_chat"), image: UIImage(systemName: "doc.text.magnifyingglass")) { [weak self] _ in
                 guard let self, let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
@@ -454,13 +455,11 @@ class WebxdcViewController: WebViewViewController {
             }
 
             if sourceCodeUrl != nil {
-                actions.append(UIMenu(options: [.displayInline],
-                    children: [
-                        UIAction(title: String.localized("source_code"), image: UIImage(systemName: "globe")) { [weak self] _ in
-                            self?.openUrl()
-                        },
-                    ]
-                ))
+                actions.append(UIMenu(options: [.displayInline], children: [
+                    UIAction(title: String.localized("source_code"), image: UIImage(systemName: "globe")) { [weak self] _ in
+                        self?.openUrl()
+                    },
+                ]))
             }
             return actions
         }


### PR DESCRIPTION
Fixes memory leak in WebxdcViewController which caused realtime to continue in the background.

Previously the local scope function `actions` captured self strongly which caused the leak in iOS 15+ because the self capturing function was stored on the menu button (on self) through `UIDeferredMenuElement.uncached` closure. I have changed the function to a closure which makes it hopefully more clear that we need to weak ref there.

Regression from #2545