### PR TITLE
NSE check if main app is running 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@
 - Improve logging and error handling
 - Replace "Broadcast Lists" experiment by "Channels"
 - Indicate which message was scrolled to (eg by tapping a quote or a notification)
+- Fix: No longer missing notifications when app was terminated by the system
 - After some time, add a device message asking to donate. Can't wait? Donate today at https://delta.chat/donate
 - Update translations
-- Update to core 2.0.0
+- Update to core 2.2.0
 
 
 ## v1.58.6

--- a/DcCore/DcCore.xcodeproj/project.pbxproj
+++ b/DcCore/DcCore.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		30E8F2482449C98600CE2C90 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E8F2472449C98600CE2C90 /* UIView+Extensions.swift */; };
 		30E8F24D2449D30200CE2C90 /* DcColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E8F24C2449D30200CE2C90 /* DcColors.swift */; };
 		5F0FCC772DAE65AD00C4F9C3 /* UNMutableNotificationContent+init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0FCC762DAE65AD00C4F9C3 /* UNMutableNotificationContent+init.swift */; };
+		640BC0472DCC941D0049B475 /* DarwinNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640BC0462DCC941D0049B475 /* DarwinNotificationCenter.swift */; };
 		78072F172A040ED800EB7C98 /* libdeltachat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78072F162A040ED800EB7C98 /* libdeltachat.a */; };
 		7871729629BA495200F110DC /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7871729529BA495200F110DC /* SystemConfiguration.framework */; };
 		B2526A222DEA12A000EB90CC /* DcEnteredLoginParam.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2526A212DEA12A000EB90CC /* DcEnteredLoginParam.swift */; };
@@ -67,6 +68,7 @@
 		30E8F2472449C98600CE2C90 /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		30E8F24C2449D30200CE2C90 /* DcColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DcColors.swift; sourceTree = "<group>"; };
 		5F0FCC762DAE65AD00C4F9C3 /* UNMutableNotificationContent+init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNMutableNotificationContent+init.swift"; sourceTree = "<group>"; };
+		640BC0462DCC941D0049B475 /* DarwinNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarwinNotificationCenter.swift; sourceTree = "<group>"; };
 		78072F162A040ED800EB7C98 /* libdeltachat.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdeltachat.a; path = "../deltachat-ios/libraries/libdeltachat.a"; sourceTree = "<group>"; };
 		7827C8882A04089900B8470D /* libraries */ = {isa = PBXFileReference; lastKnownFileType = folder; name = libraries; path = "../deltachat-ios/libraries"; sourceTree = "<group>"; };
 		7827C88A2A0408A700B8470D /* libdeltachat.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdeltachat.a; path = "../deltachat-ios/libraries/deltachat-core-rust/libdeltachat.a"; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				306C324724460CDE001D89F3 /* DateUtils.swift */,
 				30E8F24C2449D30200CE2C90 /* DcColors.swift */,
 				5F0FCC762DAE65AD00C4F9C3 /* UNMutableNotificationContent+init.swift */,
+				640BC0462DCC941D0049B475 /* DarwinNotificationCenter.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -309,6 +312,7 @@
 				30B2BD04278F207000889AA4 /* KeychainManager.swift in Sources */,
 				30421952243DE15D00516852 /* wrapper.c in Sources */,
 				D8BBF0092B57D92E008C96FD /* DcEvent.swift in Sources */,
+				640BC0472DCC941D0049B475 /* DarwinNotificationCenter.swift in Sources */,
 				30E8F2212447357500CE2C90 /* DatabaseHelper.swift in Sources */,
 				D8BBF01B2B57D9BE008C96FD /* DcReaction.swift in Sources */,
 				3042195D243E23F100516852 /* DcUtils.swift in Sources */,

--- a/DcCore/DcCore/Helper/DarwinNotificationCenter.swift
+++ b/DcCore/DcCore/Helper/DarwinNotificationCenter.swift
@@ -109,12 +109,17 @@ extension DarwinNotificationCenter {
 
     public func didReply(_ reply: DarwinNotification, to: DarwinNotification, timeout: DispatchTime) async -> Bool {
         await withCheckedContinuation { continuation in
+            var didContinue = false
             let observer = addObserver(for: reply) { _ in
+                guard !didContinue else { return }
+                didContinue = true
                 continuation.resume(returning: true)
             }
             post(to)
             DispatchQueue.main.asyncAfter(deadline: timeout) {
                 DarwinNotificationCenter.current.removeObserver(observer)
+                guard !didContinue else { return }
+                didContinue = true
                 continuation.resume(returning: false)
             }
         }

--- a/DcCore/DcCore/Helper/DarwinNotificationCenter.swift
+++ b/DcCore/DcCore/Helper/DarwinNotificationCenter.swift
@@ -1,0 +1,133 @@
+import notify
+
+@objc public enum DarwinNotification: Int {
+    case appRunningQuestion
+    case appRunningConfirmation
+    case nseFetchingQuestion
+    case nseFetchingConfirmation
+
+    var name: String {
+        switch self {
+        case .appRunningQuestion: "chat.delta.app_running_question"
+        case .appRunningConfirmation: "chat.delta.app_running_confirmation"
+        case .nseFetchingQuestion: "chat.delta.nse_fetching_question"
+        case .nseFetchingConfirmation: "chat.delta.nse_fetching_confirmation"
+        }
+    }
+}
+
+public class DarwinNotificationCenter {
+    public static var current = DarwinNotificationCenter()
+
+    private init() {}
+
+    private var dispatchTable: [DarwinNotification: [ObjectIdentifier: (DarwinNotification) -> Void]] = [:]
+    private var actingObservers: [ObjectIdentifier: DarwinNotificationCenterActingObserver] = [:]
+    private var notifyTokens: [DarwinNotification: Int32] = [:]
+
+    /// Adds an entry to the notification center to receive notifications that passed to the provided block.
+    ///
+    /// - Parameters:
+    ///     - notification: The notification to register for delivery to the observer.
+    ///     - callback:
+    ///         The closure that executes when receiving a notification.
+    ///         The notification center copies the closure. The notification center strongly holds the copied closure until you remove the observer registration.
+    ///         The closure takes one argument: the notification.
+    /// - Returns: An opaque object to act as the observer. Notification center strongly holds this return value until you remove the observer registration.
+    public func addObserver(for notification: DarwinNotification, using callback: @escaping (DarwinNotification) -> Void) -> AnyObject {
+        let actingObserver = DarwinNotificationCenterActingObserver(callback: callback)
+        actingObservers[ObjectIdentifier(actingObserver)] = actingObserver
+        addObserver(actingObserver, selector: #selector(DarwinNotificationCenterActingObserver.callback), for: notification)
+        return actingObserver
+    }
+
+    /// Adds an entry to the notification center to call the provided selector with the notification.
+    ///
+    /// - Parameters:
+    ///     - observer: An object to register as an observer.
+    ///     - selector: A selector that specifies the message the receiver sends observer to alert it to the notification posting. The method that selector specifies must have one and only one argument (an instance of DarwinNotification).
+    ///     - notification: The notification to register for delivery to the observer.
+    public func addObserver(_ observer: AnyObject, selector: Selector, for notification: DarwinNotification, on queue: DispatchQueue = .main) {
+        // Start observing if this is the first observer with this notification name
+        if dispatchTable[notification, default: [:]].isEmpty {
+            notify_register_dispatch(notification.name, &notifyTokens[notification, default: NOTIFY_TOKEN_INVALID], queue) { _ in
+                DarwinNotificationCenter.current.dispatchTable[notification]?.values.forEach { $0(notification) }
+            }
+        }
+
+        // Save observer
+        let id = ObjectIdentifier(observer)
+        dispatchTable[notification, default: [:]][id] = { [weak observer] notification in
+            if let observer {
+                _ = observer.perform(selector, with: notification)
+            } else { // observer has been deallocated so remove it
+                Self.current.removeObserver(id: id, name: notification)
+            }
+        }
+    }
+
+    /// Removes all entries specifying an observer from the notification center’s dispatch table.
+    public func removeObserver(_ observer: AnyObject) {
+        let id = ObjectIdentifier(observer)
+        dispatchTable.filter { $0.value[id] != nil }.keys.forEach { subscribedNotification in
+            removeObserver(id: id, name: subscribedNotification)
+        }
+    }
+
+    /// Removes matching entries from the notification center’s dispatch table.
+    public func removeObserver(_ observer: AnyObject, name notification: DarwinNotification) {
+        removeObserver(id: ObjectIdentifier(observer), name: notification)
+    }
+
+    private func removeObserver(id: ObjectIdentifier, name notification: DarwinNotification) {
+        // prevent leak in the case where user might strongly reference the acting observer inside the callback
+        actingObservers[id]?._callback = nil
+        actingObservers[id] = nil
+        dispatchTable[notification]?[id] = nil
+        if dispatchTable[notification, default: [:]].isEmpty, let token = notifyTokens[notification] {
+            notify_cancel(token)
+            notifyTokens[notification] = nil
+        }
+    }
+
+    /// Posts a given notification to the notification center.
+    public func post(_ notification: DarwinNotification) {
+        notify_post(notification.name)
+    }
+}
+
+extension DarwinNotificationCenter {
+    public func didReplyBlocking(_ reply: DarwinNotification, to: DarwinNotification, timeout: DispatchTime) -> Bool {
+        let group = DispatchGroup()
+        group.enter()
+        let observer = addObserver(for: reply) { _ in group.leave() }
+        post(to)
+        let result = group.wait(timeout: timeout)
+        removeObserver(observer)
+        return result == .success
+    }
+
+    public func didReply(_ reply: DarwinNotification, to: DarwinNotification, timeout: DispatchTime) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let observer = addObserver(for: reply) { _ in
+                continuation.resume(returning: true)
+            }
+            post(to)
+            DispatchQueue.main.asyncAfter(deadline: timeout) {
+                DarwinNotificationCenter.current.removeObserver(observer)
+                continuation.resume(returning: false)
+            }
+        }
+    }
+}
+
+/// An Acting Observer for subscribing to darwin notifications using a closure
+private class DarwinNotificationCenterActingObserver {
+    var _callback: ((DarwinNotification) -> Void)?
+    init(callback: @escaping (DarwinNotification) -> Void) {
+        self._callback = callback
+    }
+    @objc func callback(notification: DarwinNotification) {
+        _callback?(notification)
+    }
+}

--- a/DcCore/DcCore/Helper/DarwinNotificationCenter.swift
+++ b/DcCore/DcCore/Helper/DarwinNotificationCenter.swift
@@ -123,7 +123,7 @@ extension DarwinNotificationCenter {
 
 /// An Acting Observer for subscribing to darwin notifications using a closure
 private class DarwinNotificationCenterActingObserver {
-    var _callback: ((DarwinNotification) -> Void)?
+    fileprivate var _callback: ((DarwinNotification) -> Void)?
     init(callback: @escaping (DarwinNotification) -> Void) {
         self._callback = callback
     }

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -5,14 +5,17 @@ class NotificationService: UNNotificationServiceExtension {
     let dcAccounts = DcAccounts.shared
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
-        let bestAttemptContent = request.content
-        func newNotificationContent() -> UNMutableNotificationContent {
-            bestAttemptContent.mutableCopy() as? UNMutableNotificationContent ?? .init()
+        Task {
+            didReceive(request, withContentHandler: contentHandler)
         }
+    }
+
+    func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) async {
+        let bestAttemptContent = request.content
         let nowTimestamp = Date().timeIntervalSince1970
         UserDefaults.pushToDebugArray("🤜")
 
-        if UserDefaults.mainIoRunning {
+        if await DarwinNotificationCenter.current.didReply(.appRunningConfirmation, to: .appRunningQuestion, timeout: .now() + .seconds(2)) {
             UserDefaults.pushToDebugArray("ABORT4_AS_MAIN_RUNS")
             contentHandler(silentNotification())
             return

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -36,7 +36,7 @@ class NotificationService: UNNotificationServiceExtension {
         var exitedDueToCriticalMemory = false
         let memoryPressureSource = DispatchSource.makeMemoryPressureSource(eventMask: .critical)
         memoryPressureSource.setEventHandler { [weak memoryPressureSource] in
-            guard let memoryPressureSource, !memoryPressureSource.isCancelled else { return }
+            guard let memoryPressureSource, !memoryPressureSource.isCancelled, !exitedDueToCriticalMemory else { return }
             memoryPressureSource.cancel()
             // Order of importance because we might crash very soon
             exitedDueToCriticalMemory = true

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -46,6 +46,7 @@ class NotificationService: UNNotificationServiceExtension {
             return
         }
         UserDefaults.setNseFetchingDone()
+        memoryPressureSource.cancel()
 
         var notifications: [UNMutableNotificationContent] = []
         while true {

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -21,6 +21,11 @@ class NotificationService: UNNotificationServiceExtension {
             contentHandler(silentNotification())
             return
         }
+        if UserDefaults.nseFetching {
+            UserDefaults.pushToDebugArray("ABORT5_AS_NSE_RUNS")
+            contentHandler(silentNotification())
+            return
+        }
         UserDefaults.setNseFetching(for: 26)
 
         dcAccounts.openDatabase(writeable: false)

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -6,7 +6,7 @@ class NotificationService: UNNotificationServiceExtension {
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
         Task {
-            didReceive(request, withContentHandler: contentHandler)
+            await didReceive(request, withContentHandler: contentHandler)
         }
     }
 
@@ -15,7 +15,8 @@ class NotificationService: UNNotificationServiceExtension {
         let nowTimestamp = Date().timeIntervalSince1970
         UserDefaults.pushToDebugArray("🤜")
 
-        if await DarwinNotificationCenter.current.didReply(.appRunningConfirmation, to: .appRunningQuestion, timeout: .now() + .seconds(2)) {
+        let dnc = DarwinNotificationCenter.current
+        if await dnc.didReply(.appRunningConfirmation, to: .appRunningQuestion, timeout: .now() + .seconds(2)) {
             UserDefaults.pushToDebugArray("ABORT4_AS_MAIN_RUNS")
             contentHandler(silentNotification())
             return
@@ -82,10 +83,10 @@ class NotificationService: UNNotificationServiceExtension {
         // Queue all notifications
         for notification in notifications {
             let req = UNNotificationRequest(identifier: UUID().uuidString, content: notification, trigger: nil)
-            UNUserNotificationCenter.current().add(req) { error in
-                if error != nil {
-                    UserDefaults.pushToDebugArray("ERR6_UNUNC")
-                }
+            do {
+                try await UNUserNotificationCenter.current().add(req)
+            } catch {
+                UserDefaults.pushToDebugArray("ERR6_UNUNC")
             }
         }
 

--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -26,7 +26,8 @@ class NotificationService: UNNotificationServiceExtension {
         // by the system soon and any notification is better than nothing.
         var exitedDueToCriticalMemory = false
         let memoryPressureSource = DispatchSource.makeMemoryPressureSource(eventMask: .critical)
-        memoryPressureSource.setEventHandler {
+        memoryPressureSource.setEventHandler { [weak memoryPressureSource] in
+            guard let memoryPressureSource, !memoryPressureSource.isCancelled else { return }
             memoryPressureSource.cancel()
             // Order of importance because we might crash very soon
             exitedDueToCriticalMemory = true

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -35,6 +35,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     /// Other processes like the Notification Service Extension can post
     /// DarwinNotification.appRunningQuestion in which case we reply with .appRunningConfirmation
     @objc func appRunningQuestion(notification: DarwinNotification) {
+        guard UserDefaults.mainIoRunning else { return }
         DarwinNotificationCenter.current.post(.appRunningConfirmation)
     }
 


### PR DESCRIPTION
This changes the mechanism to check if the app is running from a UserDefaults boolean to pinging back and forth between app and NSE process using Darwin notification center. This was needed because the UserDefaults boolean would sometimes not be updated when the app was terminated by the system. This meant that notification service extension thought the app was running and did not fetch notifications, resulting in no notifications until the user opened the app again.

This is point 1 on #2673 