### PR TITLE
get_message_reactions result is optional

### DIFF
--- a/deltachat-ios/DC/DcReaction.swift
+++ b/deltachat-ios/DC/DcReaction.swift
@@ -18,5 +18,5 @@ public struct DcReactions: Decodable {
 }
 
 struct DcReactionResult: Decodable {
-    let result: DcReactions
+    let result: DcReactions?
 }


### PR DESCRIPTION
the swift function also expects an optional,
however, the jsonrpc struct did not use one.

at some point, it would make more sense to check for "result" one level deeper in jsonrpc, but for now, it is fine