### PR TITLE
disable 'disappearing messages' and 'enlarge avatar' for classic mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Disable non-functional 'disappearing messages' in classic email chats
+- Fix: Don't enlage email chats avatar placeholder
 - Fix contacts in global search sometimes displaying superfluous and wrong time
 
 

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -315,7 +315,7 @@ class ProfileViewController: UITableViewController {
             }
             actions.append(contentsOf: [primaryMenu])
 
-            if let chat, chat.canSend {
+            if let chat, chat.isEncrypted, chat.canSend {
                 let ephemeralTimer = dcContext.getChatEphemeralTimer(chatId: chatId)
                 let action = action("ephemeral_messages", "stopwatch", showEphemeralController)
                 action.state = ephemeralTimer > 0 ? .on : .off

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -466,11 +466,11 @@ class ProfileViewController: UITableViewController {
     }
 
     private func showEnlargedAvatar() {
-        if let chat, let url = chat.profileImageURL {
+        if let chat, chat.isEncrypted, let url = chat.profileImageURL {
             let previewController = PreviewController(dcContext: dcContext, type: .single(url))
             previewController.customTitle = chat.name
             navigationController?.pushViewController(previewController, animated: true)
-        } else if let contact, let url = contact.profileImageURL {
+        } else if let contact, contact.isKeyContact, let url = contact.profileImageURL {
             let previewController = PreviewController(dcContext: dcContext, type: .single(url))
             previewController.customTitle = contact.displayName
             navigationController?.pushViewController(previewController, animated: true)

--- a/deltachat-ios/DC/DcContact.swift
+++ b/deltachat-ios/DC/DcContact.swift
@@ -57,6 +57,10 @@ public class DcContact {
         return swiftString
     }
 
+    public var isKeyContact: Bool {
+        return dc_contact_is_key_contact(contactPointer) == 1
+    }
+
     public var isVerified: Bool {
         return dc_contact_is_verified(contactPointer) > 0
     }


### PR DESCRIPTION
this PR disables:

- "enlarge avatar" in profiles
- "disappearing messages" in the chat's profile three-dot-menu

counterpart of https://github.com/deltachat/deltachat-android/pull/3847 ("edit message" and "delete for all" for classic mail was already disabled before)

