### PR TITLE
do not enlarge default avatars, show avatar in 'saved messages title'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- Do not enlarge default icons as 'Saved Messages' or 'Device Chat'
+- show 'Saved Messages' icon in title
+
+
 ## v2.9.0
 
 - Fix: Display correct timer value for ephemeral timer changes

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -834,7 +834,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             } else if dcChat.isDeviceTalk {
                 subtitle = String.localized("device_talk_subtitle")
             } else if dcChat.isSelfTalk {
-                subtitle = nil
+                subtitle = String.localized("chat_self_talk_subtitle")
             } else if chatContactIds.count >= 1 {
                 let dcContact = dcContext.getContact(id: chatContactIds[0])
                 if dcContact.isBot {
@@ -858,13 +858,14 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             button.accessibilityLabel = String.localized("apps_and_media")
             rightBarButtonItems.append(button)
 
+            if let image = dcChat.profileImage {
+                titleView.initialsBadge.setImage(image)
+            } else {
+                titleView.initialsBadge.setName(dcChat.name)
+                titleView.initialsBadge.setColor(dcChat.color)
+            }
+
             if !dcChat.isSelfTalk {
-                if let image = dcChat.profileImage {
-                    titleView.initialsBadge.setImage(image)
-                } else {
-                    titleView.initialsBadge.setName(dcChat.name)
-                    titleView.initialsBadge.setColor(dcChat.color)
-                }
                 let recentlySeen = DcUtils.showRecentlySeen(context: dcContext, chat: dcChat)
                 titleView.initialsBadge.setRecentlySeen(recentlySeen)
             } else {

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -466,14 +466,18 @@ class ProfileViewController: UITableViewController {
     }
 
     private func showEnlargedAvatar() {
-        if let chat, chat.isEncrypted, let url = chat.profileImageURL {
-            let previewController = PreviewController(dcContext: dcContext, type: .single(url))
-            previewController.customTitle = chat.name
-            navigationController?.pushViewController(previewController, animated: true)
-        } else if let contact, contact.isKeyContact, let url = contact.profileImageURL {
-            let previewController = PreviewController(dcContext: dcContext, type: .single(url))
-            previewController.customTitle = contact.displayName
-            navigationController?.pushViewController(previewController, animated: true)
+        if let chat {
+            if chat.isEncrypted && !chat.isSelfTalk && !chat.isDeviceTalk, let url = chat.profileImageURL {
+                let previewController = PreviewController(dcContext: dcContext, type: .single(url))
+                previewController.customTitle = chat.name
+                navigationController?.pushViewController(previewController, animated: true)
+            }
+        } else if let contact {
+            if contact.isKeyContact, let url = contact.profileImageURL {
+                let previewController = PreviewController(dcContext: dcContext, type: .single(url))
+                previewController.customTitle = contact.displayName
+                navigationController?.pushViewController(previewController, animated: true)
+            }
         }
     }
 


### PR DESCRIPTION
see https://github.com/deltachat/deltachat-desktop/pull/5373 and https://github.com/deltachat/deltachat-android/issues/3855 for details and reasoning about not enlarging 'saved messages' and 'device chat'

moreover, while on the PR, i recoglized a little layout glitch, https://github.com/deltachat/deltachat-ios/issues/2800, which will be closed by this PR as well

closes #2800