### PR TITLE
allow to clone email chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- Allow to clone email chats
+
+
 ## v2.10.0
 2025-08
 

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -340,7 +340,7 @@ class ProfileViewController: UITableViewController {
             }
 
             if let chat {
-                if (isOutBroadcast || (isMultiUser && chat.canSend)) && chat.isEncrypted {
+                if isMultiUser && !isMailinglist {
                     let image = if #available(iOS 15.0, *) { "rectangle.portrait.on.rectangle.portrait" } else { "square.on.square" }
                     moreOptions.append(action("clone_chat", image, showCloneChatController))
                 }


### PR DESCRIPTION
this was disallowed at a time where we had no api
to create ad-hoc "new email" chats

<img width=320 src=https://github.com/user-attachments/assets/8a38f285-5896-4e1a-9714-2529c48679ae>

counterpart of https://github.com/deltachat/deltachat-android/pull/3872

came over that via https://github.com/deltachat/deltachat-desktop/issues/5387#issuecomment-3166969826