### PR TITLE
Prevent the drag preview from showing upside down when long pressing reaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Allow to clone email chats
 - Add Estonian translation, update other translations
+- Fix: Prevent the drag preview from showing upside down when long pressing reaction on an image
 
 
 ## v2.10.0

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2002,6 +2002,10 @@ extension ChatViewController: MCEmojiPickerDelegate {
 extension ChatViewController: UITableViewDragDelegate {
     func tableView(_ tableView: UITableView, itemsForBeginning session: any UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
         guard !tableView.isEditing else { return [] }
+        // Prevent the drag preview from an showing upside down preview
+        // by requiring a context menu to be shown first.
+        guard lastContextMenuPreviewSnapshot != nil else { return [] }
+        
         let messageId = messageIds[indexPath.row]
         let message = dcContext.getMessage(id: messageId)
 


### PR DESCRIPTION
Prevent the drag preview from an showing upside down preview by requiring a context menu to be shown first.

This is necessary because the preview that pops up before dragging cannot be customized other than through the context menu preview, which we already flip but do not show when user long-presses a reaction.

Fixes #2748