### PR TITLE
share email contacts as email addresses

### DIFF
--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -515,8 +515,13 @@ class ProfileViewController: UITableViewController {
     }
 
     private func shareContact() {
-        guard let vcardData = dcContext.makeVCard(contactIds: [contactId]) else { return }
-        RelayHelper.shared.setForwardVCard(vcardData: vcardData)
+        guard let contact else { return }
+        if contact.isKeyContact {
+            guard let vcardData = dcContext.makeVCard(contactIds: [contactId]) else { return }
+            RelayHelper.shared.setForwardVCard(vcardData: vcardData)
+        } else {
+            RelayHelper.shared.setForwardMessage(dialogTitle: String.localized("chat_share_with_title"), text: contact.email, fileData: nil, fileName: nil)
+        }
         navigationController?.popToRootViewController(animated: true)
     }
 


### PR DESCRIPTION
this PR shares email contacts as plain text (instead of vcard)

reasons is that the vcards are displayed wrongly, and also not needed, as the raw address is more flexible

closes  https://github.com/deltachat/deltachat-ios/issues/2801 