### PR TITLE
open message info when tapping erroneous messages

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -754,6 +754,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
             updateTitle()
             return
         }
+        // handle taps outside textTapped(), imageTapped(), avatarTapped(), statusTapped() etc.
         let messageId = messageIds[indexPath.row]
         let message = dcContext.getMessage(id: messageId)
         switch (message.type, message.infoType) {
@@ -1651,10 +1652,7 @@ class ChatViewController: UITableViewController, UITableViewDropDelegate {
 
     private func info(for msgId: Int) {
         let msg = self.dcContext.getMessage(id: msgId)
-        let msgViewController = MessageInfoViewController(dcContext: self.dcContext, message: msg)
-        if let ctrl = self.navigationController {
-            ctrl.pushViewController(msgViewController, animated: true)
-        }
+        navigationController?.pushViewController(MessageInfoViewController(dcContext: self.dcContext, message: msg), animated: true)
     }
 
     private func forward(_ msgId: Int) {
@@ -2233,7 +2231,9 @@ extension ChatViewController: BaseMessageCellDelegate {
         if handleSelection(indexPath: indexPath) { return }
 
         let message = dcContext.getMessage(id: messageIds[indexPath.row])
-        if message.type == DC_MSG_VCARD {
+        if message.state == DC_STATE_OUT_FAILED {
+            info(for: message.id)
+        } else if message.type == DC_MSG_VCARD {
             didTapVcard(msg: message)
         } else if message.type == DC_MSG_WEBXDC {
             showWebxdcViewFor(message: message)
@@ -2277,7 +2277,6 @@ extension ChatViewController: BaseMessageCellDelegate {
         }
     }
 
-
     @objc func imageTapped(indexPath: IndexPath, previewError: Bool) {
         if handleSelection(indexPath: indexPath) { return }
 
@@ -2316,6 +2315,15 @@ extension ChatViewController: BaseMessageCellDelegate {
         }
 
         self.present(navigationController, animated: true)
+    }
+
+    @objc func statusTapped(indexPath: IndexPath) {
+        if handleSelection(indexPath: indexPath) { return }
+
+        let message = dcContext.getMessage(id: messageIds[indexPath.row])
+        if message.state == DC_STATE_OUT_FAILED {
+            info(for: message.id)
+        }
     }
 }
 

--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -295,6 +295,9 @@ public class BaseMessageCell: UITableViewCell {
         quoteViewGestureRecognizer.numberOfTapsRequired = 1
         quoteView.addGestureRecognizer(quoteViewGestureRecognizer)
 
+        let statusGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(onStatusTapped))
+        statusGestureRecognizer.numberOfTapsRequired = 1
+        statusView.addGestureRecognizer(statusGestureRecognizer)
 
         contentView.addSubview(reactionsView)
 
@@ -342,6 +345,11 @@ public class BaseMessageCell: UITableViewCell {
         }
     }
 
+    @objc func onStatusTapped() {
+        if let tableView = self.superview as? UITableView, let indexPath = tableView.indexPath(for: self) {
+            baseDelegate?.statusTapped(indexPath: indexPath)
+        }
+    }
     public override func willTransition(to state: UITableViewCell.StateMask) {
         super.willTransition(to: state)
         // while the content view gets intended by the appearance of the edit control,
@@ -720,6 +728,7 @@ public protocol BaseMessageCellDelegate: AnyObject {
     func textTapped(indexPath: IndexPath)
     func quoteTapped(indexPath: IndexPath)
     func actionButtonTapped(indexPath: IndexPath)
+    func statusTapped(indexPath: IndexPath)
     func gotoOriginal(indexPath: IndexPath)
     func reactionsTapped(indexPath: IndexPath)
 }


### PR DESCRIPTION
this PR opens the "message info" when an text or status of erroneous messages tapped. 

this is how it is done on android since "forever".

for the text, default actions are overwritten, but still possible by other ways (tapping vcard or webxdc button)