### PR TITLE
show envelope only when download done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Share email address for email contacts instead of vCard
 - In case of errors, tapping message text or status opens "message info" directly
+- Fix: do not show letter icon for partially downloaded messages
 
 
 ## v2.11.0

--- a/deltachat-ios/Chat/Views/StatusView.swift
+++ b/deltachat-ios/Chat/Views/StatusView.swift
@@ -87,11 +87,11 @@ public class StatusView: UIView {
         editedLabel.isHidden = !message.isEdited
         editedLabel.textColor = tintColor
 
-        if message.showPadlock() {
-            envelopeView.isHidden = true
-        } else {
+        if message.showEnvelope() {
             envelopeView.image = UIImage(systemName: "envelope")?.maskWithColor(color: tintColor)
             envelopeView.isHidden = false
+        } else {
+            envelopeView.isHidden = true
         }
 
         if message.hasLocation {
@@ -146,6 +146,6 @@ public class StatusView: UIView {
         default:
             state = ""
         }
-        return "\(message.formattedSentDate()), \(state)\(message.showPadlock() ? "" : (", " + String.localized("email")))"
+        return "\(message.formattedSentDate()), \(state)\(message.showEnvelope() ? (", " + String.localized("email")) : "")"
     }
 }

--- a/deltachat-ios/DC/DcMsg.swift
+++ b/deltachat-ios/DC/DcMsg.swift
@@ -344,8 +344,8 @@ public class DcMsg {
         return DcLot(dcLotPointer)
     }
 
-    public func showPadlock() -> Bool {
-        return dc_msg_get_showpadlock(messagePointer) == 1
+    public func showEnvelope() -> Bool {
+        return dc_msg_get_showpadlock(messagePointer) == 0 && downloadState == DC_DOWNLOAD_DONE
     }
 
     public func getVideoChatUrl() -> String {


### PR DESCRIPTION
this PR shows the envelope in messages only of the download is actually done successfully

closes https://github.com/deltachat/deltachat-ios/issues/2813