### PR TITLE
flatten profile menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Share email address for email contacts instead of vCard
 - In case of errors, tapping message text or status opens "message info" directly
+- Flatten profile menu
 - Fix: do not show letter icon for partially downloaded messages
 
 

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -353,22 +353,20 @@ class ProfileViewController: UITableViewController {
                     }))
                     moreOptions.append(action("clear_chat", clearImage, attributes: [.destructive], showClearConfirmationAlert))
                 } else if isInBroadcast {
-                    actions.append(action("menu_leave_channel", leaveImage, attributes: [.destructive], { [weak self] in
+                    moreOptions.append(action("menu_leave_channel", leaveImage, attributes: [.destructive], { [weak self] in
                         self?.showLeaveAlert("menu_leave_channel")
                     }))
-                    actions.append(action("clear_chat", clearImage, attributes: [.destructive], showClearConfirmationAlert))
+                    moreOptions.append(action("clear_chat", clearImage, attributes: [.destructive], showClearConfirmationAlert))
                 } else {
                     moreOptions.append(action("clear_chat", clearImage, attributes: [.destructive], showClearConfirmationAlert))
                 }
 
-                actions.append(action("menu_delete_chat", "trash", attributes: [.destructive], showDeleteConfirmationAlert))
+                moreOptions.append(action("menu_delete_chat", "trash", attributes: [.destructive], showDeleteConfirmationAlert))
             }
 
             if !moreOptions.isEmpty {
                 actions.append(contentsOf: [
-                    UIMenu(options: [.displayInline], children: [
-                        UIMenu(title: String.localized("menu_more_options"), image: UIImage(systemName: "ellipsis.circle"), children: moreOptions)
-                    ])
+                    UIMenu(options: [.displayInline], children: moreOptions)
                 ])
             }
 

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -340,7 +340,7 @@ class ProfileViewController: UITableViewController {
             }
 
             if let chat {
-                if isMultiUser && !isMailinglist {
+                if isMultiUser && !isMailinglist && !isInBroadcast {
                     let image = if #available(iOS 15.0, *) { "rectangle.portrait.on.rectangle.portrait" } else { "square.on.square" }
                     moreOptions.append(action("clone_chat", image, showCloneChatController))
                 }


### PR DESCRIPTION
in contrast to message bubbles' context menu,
there is no place issue in the profile's context menu.

by 'clone group' becoming more important,
there are few options left in the submenu,
so it seems better to show all options directly.
but even if one regards clone as minor, the flat thing seems to be better.
the separator line still splits global/less important things off

clean/delete may be combined at some point,
similar to whatsapp, showing the options only in the final alert,

before:


<img width="320"  alt="IMG_0118 2" src="https://github.com/user-attachments/assets/4868db69-ecba-4e8d-a8c5-768d8267d7ef" />
<img width="320" alt="IMG_0117 2" src="https://github.com/user-attachments/assets/a0246b73-3cc6-4c17-8434-06bce96b5911" />

after:

<img width="320" alt="IMG_0116 2" src="https://github.com/user-attachments/assets/921dc398-a290-4979-a1f5-899954eb57ce" />
<img width="320" alt="IMG_0115 2" src="https://github.com/user-attachments/assets/b43964d6-16cd-4033-98f1-4f1307c709de" />
