### PR TITLE
never show address for key contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Share email address for email contacts instead of vCard
 - In case of errors, tapping message text or status opens "message info" directly
 - Flatten profile menu
+- Show addresses for address contacts only
 - Fix: do not show letter icon for partially downloaded messages
 
 

--- a/deltachat-ios/View/ContactCell.swift
+++ b/deltachat-ios/View/ContactCell.swift
@@ -388,7 +388,7 @@ class ContactCell: UITableViewCell {
         case .contact(let contactData):
             let contact = cellViewModel.dcContext.getContact(id: contactData.contactId)
             titleLabel.attributedText = cellViewModel.title.boldAt(indexes: cellViewModel.titleHighlightIndexes, fontSize: titleLabel.font.pointSize)
-            subtitleLabel.isHidden = contact.isVerified
+            subtitleLabel.isHidden = contact.isKeyContact
 
             if let profileImage = contact.profileImage {
                 avatar.setImage(profileImage)


### PR DESCRIPTION
the new isKeyContact is a better option
to decide if to show the email address or not.