### PR TITLE
disappearing messages options range from 5 minutes to 1 year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Disappearing messages options range from 5 minutes to 1 year now
 - Share email address for email contacts instead of vCard
 - In case of errors, tapping message text or status opens "message info" directly
 - Flatten profile menu

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -715,6 +715,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         dcContext.setStockTranslation(id: DC_STR_EPHEMERAL_TIMER_DAYS_BY_OTHER, localizationKey: "ephemeral_timer_days_by_other")
         dcContext.setStockTranslation(id: DC_STR_EPHEMERAL_TIMER_WEEKS_BY_YOU, localizationKey: "ephemeral_timer_weeks_by_you")
         dcContext.setStockTranslation(id: DC_STR_EPHEMERAL_TIMER_WEEKS_BY_OTHER, localizationKey: "ephemeral_timer_weeks_by_other")
+        dcContext.setStockTranslation(id: DC_STR_EPHEMERAL_TIMER_1_YEAR_BY_YOU, localizationKey: "ephemeral_timer_1_year_by_you")
+        dcContext.setStockTranslation(id: DC_STR_EPHEMERAL_TIMER_1_YEAR_BY_OTHER, localizationKey: "ephemeral_timer_1_year_by_other")
         dcContext.setStockTranslation(id: DC_STR_BACKUP_TRANSFER_QR, localizationKey: "multidevice_qr_subtitle")
         dcContext.setStockTranslation(id: DC_STR_BACKUP_TRANSFER_MSG_BODY, localizationKey: "multidevice_transfer_done_devicemsg")
         dcContext.setStockTranslation(id: DC_STR_CHAT_PROTECTION_ENABLED, localizationKey: "chat_protection_enabled_tap_to_learn_more")

--- a/deltachat-ios/Controller/EphemeralMessagesViewController.swift
+++ b/deltachat-ios/Controller/EphemeralMessagesViewController.swift
@@ -7,7 +7,7 @@ class EphemeralMessagesViewController: UITableViewController {
     var currentIndex: Int = 0
 
     private lazy var options: [Int] = {
-        return [0, Time.oneMinute, Time.fiveMinutes, Time.thirtyMinutes, Time.oneHour, Time.oneDay, Time.oneWeek, Time.fiveWeeks]
+        return [0, Time.fiveMinutes, Time.oneHour, Time.oneDay, Time.oneWeek, Time.fiveWeeks, Time.oneYear]
     }()
 
     private lazy var cancelButton: UIBarButtonItem = {
@@ -65,12 +65,8 @@ class EphemeralMessagesViewController: UITableViewController {
         switch val {
         case 0:
             return String.localized("off")
-        case Time.oneMinute:
-            return String.localized("after_1_minute")
         case Time.fiveMinutes:
             return String.localized("after_5_minutes")
-        case Time.thirtyMinutes:
-            return String.localized("after_30_minutes")
         case Time.oneHour:
             return String.localized("autodel_after_1_hour")
         case Time.oneDay:
@@ -79,6 +75,8 @@ class EphemeralMessagesViewController: UITableViewController {
             return String.localized("autodel_after_1_week")
         case Time.fiveWeeks:
             return String.localized("after_5_weeks")
+        case Time.oneYear:
+            return String.localized("autodel_after_1_year")
         default:
             return nil
         }

--- a/deltachat-ios/Helper/Constants.swift
+++ b/deltachat-ios/Helper/Constants.swift
@@ -19,7 +19,6 @@ struct Constants {
 }
 
 struct Time {
-    static let oneMinute = 60
     static let fiveMinutes = 5 * 60
     static let thirtyMinutes = 30 * 60
     static let oneHour = 60 * 60
@@ -29,4 +28,5 @@ struct Time {
     static let oneDay = 24 * 60 * 60
     static let oneWeek = 7 * 24 * 60 * 60
     static let fiveWeeks = 5 * 7 * 24 * 60 * 60
+    static let oneYear = 365 * 24 * 60 * 60
 }


### PR DESCRIPTION
for disappearing messages, this PR adds the options "1 year" and removes the options "1 minute" and "30 minutes".

status messages using the old values are unchanged; when about selecting another option, a "close" value is preselected, this is not changed by this PR as was fine also for previous changes.

closes https://github.com/deltachat/deltachat-ios/issues/2816, see there and linked issues for reasoning