### PR TITLE
Notifications when inactive in foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Show addresses for address contacts only
 - Option to copy contact profile's "Encryption Info" to the clipboard
 - Fix: do not show letter icon for partially downloaded messages
+- Fix: notifications now show up while the app is inactive in foreground (eg when in the app switcher)
 
 
 ## v2.11.0

--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -524,8 +524,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // This method will be called if an incoming message was received while the app was in foreground.
     // We don't show foreground notifications in the notification center because they don't get grouped properly
     func userNotificationCenter(_: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        logger.info("Notifications: foreground notification")
-        completionHandler([.badge])
+        if appIsInForeground() { // This is necessary as this function is called when in app switcher
+            logger.info("Notifications: foreground notification")
+            completionHandler([.badge])
+        } else {
+            completionHandler([.badge, .banner, .list, .sound])
+        }
     }
 
     // this method will be called if the user tapped on a notification


### PR DESCRIPTION
How to reproduce the bug that this PR fixes:

- open Delta Chat
- close Delta Chat by opening the application switcher
- receive a message

expected: receive a notification
previously: no notification