### PR TITLE
Prevent 2nd most occurring crash on Test Flight

### DIFF
--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -161,7 +161,7 @@ class ChatListViewModel: NSObject {
     }
 
     func isMessageSearchResult(indexPath: IndexPath) -> Bool {
-        if searchActive {
+        if searchActive, searchResultSections.count > indexPath.section {
             switch searchResultSections[indexPath.section] {
             case .messages:
                 return true


### PR DESCRIPTION
This crash is probably indicative of some logic going wrong here, and this fix does not attempt to address that. I just prevent the crash.

The `isMessageSearchResult` is called with an indexPath with section higher than searchResultSections, which caused the crash. I think this may happen during loading of search results? Not sure.