### PR TITLE
reconnected in case we set a PUSH token for a new account

### DIFF
--- a/deltachat-ios/AppDelegate.swift
+++ b/deltachat-ios/AppDelegate.swift
@@ -396,6 +396,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.info("Notifications: Token: \(notifyToken)")
         self.notifyToken = notifyToken
         dcAccounts.setPushToken(token: notifyToken)
+        if dcAccounts.isFreshlyAdded(id: dcAccounts.getSelected().id) {
+            dcAccounts.maybeNetwork()
+        }
     }
 
     // `didFailToRegisterForRemoteNotificationsWithError` is called by iOS


### PR DESCRIPTION
closes #2852 , but not sure this is the correct approach, see discussion in the issue