### PR TITLE
Remove "Watch Sent folder" preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Streamline 'All media' view width desktop and android
 - Update chatmail relay list
+- Remove "Watch Sent Folder" preference
 - Fix: Unify font of lettered avatars
 
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -58,15 +58,6 @@ internal final class AdvancedViewController: UITableViewController {
         return cell
     }()
 
-    lazy var sentboxWatchCell: SwitchCell = {
-        return SwitchCell(
-            textLabel: String.localized("pref_watch_sent_folder"),
-            on: dcContext.getConfigBool("sentbox_watch"),
-            action: { cell in
-                self.dcContext.setConfigBool("sentbox_watch", cell.isOn)
-        })
-    }()
-
     lazy var sendCopyToSelfCell: SwitchCell = {
         return SwitchCell(
             textLabel: String.localized("pref_send_copy_to_self"),
@@ -240,7 +231,7 @@ internal final class AdvancedViewController: UITableViewController {
             let serverSection = SectionConfigs(
                 headerTitle: String.localized("pref_server"),
                 footerTitle: String.localized("pref_only_fetch_mvbox_explain"),
-                cells: [accountSettingsCell, proxySettingsCell, showEmailsCell, sentboxWatchCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell])
+                cells: [accountSettingsCell, proxySettingsCell, showEmailsCell, sendCopyToSelfCell, mvboxMoveCell, onlyFetchMvboxCell])
             return [viewLogSection, experimentalSection, appAccessSection, encryptionSection, serverSection]
         }
     }()


### PR DESCRIPTION
It is going to be removed in the next core release: https://github.com/chatmail/core/pull/7189

counterpart of desktop PR at https://github.com/deltachat/deltachat-desktop/pull/5611