### PR TITLE
feat: ignore taps on widget background

### DIFF
--- a/DcWidget/DcWidget.swift
+++ b/DcWidget/DcWidget.swift
@@ -10,7 +10,7 @@ struct DcShortcutWidgetView: View {
             Text(String.localized("shortcuts_widget_description"))
         } else {
             let rows = [GridItem(.fixed(56)), GridItem(.fixed(56))]
-            LazyHGrid(rows: rows) {
+            let content = LazyHGrid(rows: rows) {
                 ForEach(entry.shortcuts) { shortcut in
                     switch shortcut {
                     case .app(let app):
@@ -19,6 +19,17 @@ struct DcShortcutWidgetView: View {
                         ChatShortcutView(chat: chat)
                     }
                 }
+            }
+            if #available(iOS 18.0, *) {
+                ZStack {
+                    Button(intent: DummyIntent()) {
+                        Color.clear.frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }.buttonStyle(PlainButtonStyle())
+                    .accessibilityHidden(true)
+                    content
+                }
+            } else {
+                content
             }
         }
     }

--- a/DcWidget/DummyIntent.swift
+++ b/DcWidget/DummyIntent.swift
@@ -1,0 +1,16 @@
+import AppIntents
+import os
+
+/// This intent does nothing, it is used by the widget
+/// when clicking outside of the buttons to not open the app.
+/// This makes it harder to miss a tab.
+struct DummyIntent: AppIntent {
+    static var title: LocalizedStringResource = "Dummy Intent"
+
+    // so this does not land in shortcuts or siri by accident
+    static var isDiscoverable: Bool = false
+
+    func perform() async throws -> some IntentResult {
+        return .result()
+    }
+}

--- a/DcWidget/WidgetProvider.swift
+++ b/DcWidget/WidgetProvider.swift
@@ -57,6 +57,8 @@ struct Provider: TimelineProvider {
                 switch entry.type {
                 case .app(let messageId):
                     let msg = dcContext.getMessage(id: messageId)
+                    if !msg.isValid { return nil }
+                    
                     let name = msg.getWebxdcAppName()
                     let image = msg.getWebxdcPreviewImage()
 
@@ -72,6 +74,8 @@ struct Provider: TimelineProvider {
 
                 case .chat(let chatId):
                     let chat = dcContext.getChat(chatId: chatId)
+                    if !chat.isValid { return nil }
+                    
                     let title = chat.name
                     let image = chat.profileImage
                     let color = chat.color

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -1336,8 +1336,6 @@
 				643B44782E0C2BD900AEE026 /* DcTests */,
 			);
 			name = DcTests;
-			packageProductDependencies = (
-			);
 			productName = DcTests;
 			productReference = 643B44772E0C2BD800AEE026 /* DcTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -1605,13 +1603,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-deltachat-ios/Pods-deltachat-ios-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-deltachat-ios/Pods-deltachat-ios-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Because it is annoying that it opens the app when you miss the chat/app
that you wanted to press.

This uses a large invisible button in the background with a no-op
AppIntent.


This is activated conditionally only on iOS 18+.
And it was tested by me on iOS 26.0.1
