### PR TITLE
Make av capture session lazy

### DIFF
--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -6,7 +6,7 @@ class QrCodeReaderController: UIViewController {
 
     weak var delegate: QrCodeReaderDelegate?
 
-    private let captureSession = AVCaptureSession()
+    private lazy var captureSession = AVCaptureSession()
 
     private let addHints: String?
     private let showTroubleshooting: Bool


### PR DESCRIPTION
Xcode 26 complained about creating AVCaptureSession during application launch so I delayed it to when it is needed.

#skip-changelog