### PR TITLE
mark buttons and external links as such

### DIFF
--- a/DcCore/DcCore/Extensions/String+Extensions.swift
+++ b/DcCore/DcCore/Extensions/String+Extensions.swift
@@ -2,8 +2,12 @@ import Foundation
 import UIKit
 
 public extension String {
-    
-	static func localized(_ stringID: String) -> String {
+
+    static func markAsExternal(_ string: String) -> String {
+        return string + " ↗"
+    }
+
+    static func localized(_ stringID: String) -> String {
         let value = NSLocalizedString(stringID, comment: "")
         if value != stringID || NSLocale.preferredLanguages.first == "en" {
             return value

--- a/deltachat-ios/Assets/Help/help.css
+++ b/deltachat-ios/Assets/Help/help.css
@@ -34,6 +34,9 @@ p.back {
   padding: 0 2rem 0 0;
 }
 
+a[href^='http']::after {
+    content: " ↗";
+}
 
 /* ---------- colors, dark mode ---------- */
 

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingView.swift
@@ -151,10 +151,11 @@ class InstantOnboardingView: UIView {
     }
 
     func updateContent(with customProvider: String?) {
-        if let customProvider {
-            privacyButton.setTitle(String.localized(stringID: "instant_onboarding_agree_instance", parameter: customProvider), for: .normal)
+        let title = if let customProvider {
+            String.localized(stringID: "instant_onboarding_agree_instance", parameter: customProvider)
         } else {
-            privacyButton.setTitle(String.localized(stringID: "instant_onboarding_agree_default2", parameter: InstantOnboardingViewController.defaultChatmailDomain), for: .normal)
+            String.localized(stringID: "instant_onboarding_agree_default2", parameter: InstantOnboardingViewController.defaultChatmailDomain)
         }
+        privacyButton.setTitle(String.markAsExternal(title), for: .normal)
     }
 }

--- a/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/AccountSetup/Instand Onboarding/InstantOnboardingViewController.swift
@@ -172,7 +172,7 @@ class InstantOnboardingViewController: UIViewController {
 
     @objc private func showOtherOptions(_ sender: UIButton) {
         let alertController = UIAlertController(title: String.localized("instant_onboarding_show_more_instances"), message: nil, preferredStyle: .safeActionSheet)
-        let otherServersAction = UIAlertAction(title: String.localized("instant_onboarding_other_server"), style: .default) { [weak self] _ in
+        let otherServersAction = UIAlertAction(title: String.markAsExternal(String.localized("instant_onboarding_other_server")), style: .default) { [weak self] _ in
 
             self?.storeImageAndName()
 

--- a/deltachat-ios/Controller/HelpViewController.swift
+++ b/deltachat-ios/Controller/HelpViewController.swift
@@ -67,22 +67,22 @@ class HelpViewController: WebViewViewController {
 
     private func moreButtonMenu() -> UIMenu {
         let actions = [
-            UIAction(title: String.localized("delta_chat_homepage"), image: UIImage(systemName: "globe")) { _ in
+            UIAction(title: String.markAsExternal(String.localized("delta_chat_homepage"))) { _ in
                 if let url = URL(string: "https://delta.chat") {
                     UIApplication.shared.open(url)
                 }
             },
-            UIAction(title: String.localized("privacy_policy"), image: UIImage(systemName: "hand.raised")) { _ in
+            UIAction(title: String.markAsExternal(String.localized("privacy_policy"))) { _ in
                 if let url = URL(string: "https://delta.chat/gdpr") {
                     UIApplication.shared.open(url)
                 }
             },
-            UIAction(title: String.localized("contribute"), image: UIImage(systemName: "wrench.and.screwdriver")) { _ in
+            UIAction(title: String.markAsExternal(String.localized("contribute"))) { _ in
                 if let url = URL(string: "https://delta.chat/contribute") {
                     UIApplication.shared.open(url)
                 }
             },
-            UIAction(title: String.localized("global_menu_help_report_desktop"), image: UIImage(systemName: "ant")) { _ in
+            UIAction(title: String.markAsExternal(String.localized("global_menu_help_report_desktop"))) { _ in
                 if let url = URL(string: "https://github.com/deltachat/deltachat-ios/issues") {
                     UIApplication.shared.open(url)
                 }

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -456,7 +456,7 @@ class WebxdcViewController: WebViewViewController {
 
             if sourceCodeUrl != nil {
                 actions.append(UIMenu(options: [.displayInline], children: [
-                    UIAction(title: String.localized("source_code"), image: UIImage(systemName: "globe")) { [weak self] _ in
+                    UIAction(title: String.markAsExternal(String.localized("source_code"))) { [weak self] _ in
                         self?.openUrl()
                     },
                 ]))

--- a/deltachat-ios/View/ProviderInfoCell.swift
+++ b/deltachat-ios/View/ProviderInfoCell.swift
@@ -41,7 +41,7 @@ class ProviderInfoCell: UITableViewCell {
 
     private lazy var infoButton: UIButton = {
         let button = UIButton()
-        let title = String.localized("more_info_desktop")
+        let title = String.markAsExternal(String.localized("more_info_desktop"))
         button.setTitle(title, for: .normal)
         button.titleLabel?.font = UIFont.boldSystemFont(ofSize: fontSize)
         button.addTarget(self, action: #selector(infoButtonPressed(_:)), for: .touchUpInside)


### PR DESCRIPTION
this PR mark buttons that open external links as such; same for offline help

cmp https://support.delta.chat/t/do-not-suddenly-open-links-in-the-browser-without-warning/4327/2

example:

<img width=320 src=https://github.com/user-attachments/assets/3754a548-84bd-4bd3-97bf-fd3eecba4f21>
