### PR TITLE
don't show ... in subtitle on most left groups

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -849,7 +849,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             } else if dcChat.isOutBroadcast {
                 subtitle = String.localized(stringID: "n_recipients", parameter: chatContactIds.count)
             } else if dcChat.isMultiUser {
-                if chatContactIds.contains(Int(DC_CONTACT_ID_SELF)) {
+                if chatContactIds.count > 1 || chatContactIds.contains(Int(DC_CONTACT_ID_SELF)) {
                     subtitle = String.localized(stringID: "n_members", parameter: chatContactIds.count)
                 } else {
                     // do not show misleading "1 member" in case securejoin has not finished

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -387,7 +387,7 @@ class ProfileViewController: UITableViewController {
                 subtitle = String.localized(stringID: "n_recipients", parameter: chat.getContactIds(dcContext).count)
             } else if isGroup {
                 let chatContactIds = chat.getContactIds(dcContext)
-                if chatContactIds.contains(Int(DC_CONTACT_ID_SELF)) {
+                if chatContactIds.count > 1 || chatContactIds.contains(Int(DC_CONTACT_ID_SELF)) {
                     subtitle = String.localized(stringID: "n_members", parameter: chatContactIds.count)
                 } else {
                     // do not show misleading "1 member" in case securejoin has not finished


### PR DESCRIPTION
checking for self-in-group was introduced at #2895 to avoid showing misleading "1 member" during securejoin, when the member list is not known.

this has the disadvantage that the ... subtitle is also shown for left groups.

at https://github.com/deltachat/deltachat-android/pull/4017 we improved the condition for showing member count slightly to "member-count > 1 || self-in-group",
see there for more reasoning and discussion

this is still a bit hacky,
but that's it :)

#skip-changelog as already mentioned in changelog