### PR TITLE
prefer weak pointers in UIAlertAction callbacks

### DIFF
--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -69,8 +69,8 @@ class ShareViewController: UIViewController {
     func logAndAlert(error: any Error) {
         logger.error(error.localizedDescription)
         let alert = UIAlertController(title: nil, message: error.localizedDescription, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default) { _ in
-            self.extensionContext!.cancelRequest(withError: error)
+        alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default) { [weak self] _ in
+            self?.extensionContext!.cancelRequest(withError: error)
         })
         present(alert, animated: true)
     }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1238,8 +1238,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
                                       preferredStyle: .safeActionSheet)
         alert.addAction(UIAlertAction(title: actionTitle, style: actionStyle, handler: actionHandler))
 
-        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: cancelHandler ?? { _ in
-            self.dismiss(animated: true, completion: nil)
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: cancelHandler ?? { [weak self] _ in
+            self?.dismiss(animated: true, completion: nil)
         }))
         present(alert, animated: true, completion: nil)
     }
@@ -1336,18 +1336,18 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
 
         let alert = UIAlertController(title: Utils.askDeleteMsgsText(count: ids.count, chat: dcChat), message: nil, preferredStyle: .safeActionSheet)
-        alert.addAction(UIAlertAction(title: String.localized(dcChat.isSelfTalk ? "delete" : "delete_for_me"), style: .destructive, handler: { _ in
-            self.dcContext.deleteMessages(msgIds: ids)
+        alert.addAction(UIAlertAction(title: String.localized(dcChat.isSelfTalk ? "delete" : "delete_for_me"), style: .destructive, handler: { [weak self] _ in
+            self?.dcContext.deleteMessages(msgIds: ids)
             deleteInUi(ids: ids)
         }))
         if canDeleteForEveryone {
-            alert.addAction(UIAlertAction(title: String.localized("delete_for_everyone"), style: .destructive, handler: { _ in
-                self.dcContext.sendDeleteRequest(msgIds: ids)
+            alert.addAction(UIAlertAction(title: String.localized("delete_for_everyone"), style: .destructive, handler: { [weak self] _ in
+                self?.dcContext.sendDeleteRequest(msgIds: ids)
                 deleteInUi(ids: ids)
             }))
         }
-        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
-            self.dismiss(animated: true, completion: nil)
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { [weak self] _ in
+            self?.dismiss(animated: true, completion: nil)
         }))
         present(alert, animated: true, completion: nil)
     }
@@ -1512,8 +1512,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     private func addDurationSelectionAction(to alert: UIAlertController, key: String, duration: Int) {
-        let action = UIAlertAction(title: String.localized(key), style: .default, handler: { _ in
-            self.locationStreamingFor(seconds: duration)
+        let action = UIAlertAction(title: String.localized(key), style: .default, handler: { [weak self] _ in
+            self?.locationStreamingFor(seconds: duration)
         })
         alert.addAction(action)
     }
@@ -2078,7 +2078,8 @@ extension ChatViewController {
               let vcard = vcards.first else { return }
 
         let alert = UIAlertController(title: String.localizedStringWithFormat(String.localized("ask_start_chat_with"), vcard.displayName), message: nil, preferredStyle: .safeActionSheet)
-        alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { _ in
+        alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { [weak self] _ in
+            guard let self = self else { return }
             if let contactIds = self.dcContext.importVcard(path: file) {
                 logger.info("imported contacts: \(contactIds)")
                 if let contactId = contactIds.first {
@@ -2324,8 +2325,8 @@ extension ChatViewController: BaseMessageCellDelegate {
             // (the latter returns `true` for .webm - which is not wrong as _something_ is shown, even if the video cannot be played)
             if previewError && message.type == DC_MSG_VIDEO {
                 let alert = UIAlertController(title: "To play this video, share to apps as VLC on the following page.", message: nil, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .default, handler: { _ in
-                    self.showMediaGalleryFor(message: message)
+                alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .default, handler: { [weak self] _ in
+                    self?.showMediaGalleryFor(message: message)
                 }))
                 alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
                 present(alert, animated: true, completion: nil)
@@ -2403,7 +2404,8 @@ extension ChatViewController: MediaPickerDelegate {
             // (sendAsFile can be ignored as forced to be only a single file at showFilesLibrary()
             let message = String.localized(stringID: "ask_send_files_to_chat", parameter: itemProviders.count, dcChat.name)
             let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: String.localized("menu_send"), style: .default) { _ in
+            alert.addAction(UIAlertAction(title: String.localized("menu_send"), style: .default) { [weak self] _ in
+                guard let self = self else { return }
                 let progressAlertHandler = ProgressAlertHandler()
                 progressAlertHandler.dataSource = self
                 progressAlertHandler.showProgressAlert(title: nil, dcContext: self.dcContext)

--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -241,8 +241,8 @@ class BackupTransferViewController: UIViewController {
         case .unknown:
             let addInfo = warnAboutCopiedQrCodeOnAbort ? String.localized("multidevice_abort_will_invalidate_copied_qr") : nil
             let alert = UIAlertController(title: String.localized("multidevice_abort"), message: addInfo, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: { _ in
-                self.navigationController?.popViewController(animated: true)
+            alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
             }))
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
             navigationController?.present(alert, animated: true, completion: nil)

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -880,8 +880,8 @@ class ChatListViewController: UITableViewController {
             message: String.localizedStringWithFormat(String.localized("ask_delete_named_chat"), dcContext.getChat(chatId: chatId).name),
             preferredStyle: .safeActionSheet
         )
-        alert.addAction(UIAlertAction(title: String.localized("menu_delete_chat"), style: .destructive, handler: { _ in
-            self.deleteChat(chatId: chatId, animated: true)
+        alert.addAction(UIAlertAction(title: String.localized("menu_delete_chat"), style: .destructive, handler: { [weak self] _ in
+            self?.deleteChat(chatId: chatId, animated: true)
             didDelete?()
         }))
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -360,11 +360,11 @@ extension NewChatViewController {
             let alert = UIAlertController(title: String.localizedStringWithFormat(String.localized("ask_start_chat_with"), dcContact.displayName),
                                           message: nil,
                                           preferredStyle: .safeActionSheet)
-            alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { _ in
-                self.showNewChat(contactId: contactId)
+            alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { [weak self] _ in
+                self?.showNewChat(contactId: contactId)
             }))
-            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
-                self.reactivateSearchBarIfNeeded()
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { [weak self] _ in
+                self?.reactivateSearchBarIfNeeded()
             }))
             present(alert, animated: true, completion: nil)
         }

--- a/deltachat-ios/Controller/ProfileSetup/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/ProfileSetup/InstantOnboardingViewController.swift
@@ -183,7 +183,7 @@ class InstantOnboardingViewController: UIViewController {
             }
         }
 
-        let manualAccountSetup = UIAlertAction(title: String.localized("manual_account_setup_option"), style: .default) { _ in
+        let manualAccountSetup = UIAlertAction(title: String.localized("manual_account_setup_option"), style: .default) { [weak self] _ in
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -61,10 +61,10 @@ internal final class AdvancedViewController: UITableViewController {
                     let alert = UIAlertController(title: String.localized("pref_multidevice"),
                         message: String.localized("pref_multidevice_change_warn"),
                         preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .destructive, handler: { _ in
-                        self.dcContext.setConfigBool("bcc_self", false)
+                    alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .destructive, handler: { [weak self] _ in
+                        self?.dcContext.setConfigBool("bcc_self", false)
                     }))
-                    alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
+                    alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { [weak self] _ in
                         cell.uiSwitch.setOn(true, animated: true)
                     }))
                     self.navigationController?.present(alert, animated: true, completion: nil)
@@ -90,10 +90,10 @@ internal final class AdvancedViewController: UITableViewController {
                     let alert = UIAlertController(title: String.localized("pref_only_fetch_mvbox_title"),
                         message: String.localized("pref_imap_folder_warn_disable_defaults"),
                         preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .destructive, handler: { _ in
-                        self.dcContext.setConfigBool("only_fetch_mvbox", true)
+                    alert.addAction(UIAlertAction(title: String.localized("perm_continue"), style: .destructive, handler: { [weak self] _ in
+                        self?.dcContext.setConfigBool("only_fetch_mvbox", true)
                     }))
-                    alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
+                    alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { [weak self] _ in
                         cell.uiSwitch.setOn(false, animated: true)
                     }))
                     self.navigationController?.present(alert, animated: true, completion: nil)

--- a/deltachat-ios/Controller/Settings/AutodelOptionsViewController.swift
+++ b/deltachat-ios/Controller/Settings/AutodelOptionsViewController.swift
@@ -129,11 +129,11 @@ class AutodelOptionsViewController: UITableViewController {
                 title: String.localized(fromServer ? "autodel_server_title" : "autodel_device_title"),
                 message: msg,
                 preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: String.localized("autodel_confirm"), style: .destructive, handler: { _ in
+            alert.addAction(UIAlertAction(title: String.localized("autodel_confirm"), style: .destructive, handler: { [weak self] _ in
                 oldSelectedCell?.accessoryType = .none
                 newSelectedCell?.accessoryType = .checkmark
-                self.currVal = newVal
-                self.tableView.reloadData() // needed to update footer
+                self?.currVal = newVal
+                self?.tableView.reloadData() // needed to update footer
             }))
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
             present(alert, animated: true, completion: nil)

--- a/deltachat-ios/Controller/Settings/BlockedContactsViewController.swift
+++ b/deltachat-ios/Controller/Settings/BlockedContactsViewController.swift
@@ -45,14 +45,16 @@ class BlockedContactsViewController: GroupMembersViewController, GroupMemberSele
             let dcContact = dcContext.getContact(id: contactId)
             let title = dcContact.displayName
             let alert = UIAlertController(title: title, message: String.localized("ask_unblock_contact"), preferredStyle: .safeActionSheet)
-            alert.addAction(UIAlertAction(title: String.localized("menu_unblock_contact"), style: .default, handler: { _ in
+            alert.addAction(UIAlertAction(title: String.localized("menu_unblock_contact"), style: .default, handler: { [weak self] _ in
+                guard let self else { return }
                 self.dcContext.unblockContact(id: contactId)
                 self.contactIds = self.dcContext.getBlockedContacts()
                 self.selectedContactIds = Set(self.contactIds)
                 self.tableView.reloadData()
                 self.updateEmtpyStateView()
             }))
-            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { [weak self] _ in
+                guard let self else { return }
                 self.selectedContactIds = Set(self.contactIds)
                 self.tableView.reloadData()
             }))

--- a/deltachat-ios/Handler/ProgressAlertHandler.swift
+++ b/deltachat-ios/Handler/ProgressAlertHandler.swift
@@ -87,8 +87,8 @@ class ProgressAlertHandler {
         guard let dataSource else { return assertionFailure("No DataSource") }
 
         let progressAlertController = UIAlertController(title: title, message: String.localized("one_moment"), preferredStyle: .alert)
-        let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { _ in
-            self.cancelled = true
+        let cancelAction = UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: { [weak self] _ in
+            self?.cancelled = true
             dcContext.stopOngoingProcess()
         })
         progressAlertController.addAction(cancelAction)


### PR DESCRIPTION
this is non-exhaustive, also callbacks easily hold strong references - which, however, are not always evil.

but these were easy to fix and the pattern we want is clearly "weak self", also to avoid creating retain cycles by copy+paste, where the original might have been fine