### PR TITLE
QuickLook swipe down (pre-iOS 18) and less message motion on every version

### DIFF
--- a/deltachat-ios.xcodeproj/xcshareddata/xcschemes/DcWidgetExtension.xcscheme
+++ b/deltachat-ios.xcodeproj/xcshareddata/xcschemes/DcWidgetExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1640"
+   LastUpgradeVersion = "1610"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction
@@ -44,19 +44,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "643B44762E0C2BD800AEE026"
-               BuildableName = "DcTests.xctest"
-               BlueprintName = "DcTests"
-               ReferencedContainer = "container:deltachat-ios.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2818,17 +2818,8 @@ extension ChatViewController: QLPreviewControllerDelegate {
             if tableView.indexPathsForVisibleRows?.contains(indexPath) == false {
                 tableView.scrollToRow(at: indexPath, at: .none, animated: false)
             }
-            if let cell = tableView.cellForRow(at: indexPath) as? BaseMessageCell,
-               let snapshot = cell.messageBackgroundContainer.snapshotView(afterScreenUpdates: true) {
-                if cell is ImageTextCell { // hide cell while transitioning
-                    cell.layer.opacity = 0
-                }
-                snapshot.clipsToBounds = true
-                snapshot.frame = cell.convert(cell.messageBackgroundContainer.frame, to: tableView.superview)
-                tableView.superview?.addSubview(snapshot)
-                previewControllerTargetSnapshot = snapshot
-                previewControllerTargetHiddenOriginal = cell
-                return snapshot
+            if let cell = tableView.cellForRow(at: indexPath) as? BaseMessageCell {
+                return cell.messageBackgroundContainer
             }
         }
         return nil

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -206,7 +206,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     private var previewControllerTargetSnapshot: UIView?
-    private var previewControllerTargetHiddenOriginal: UIView?
 
     init(dcContext: DcContext, chatId: Int, highlightedMsg: Int? = nil) {
         self.dcContext = dcContext
@@ -2810,9 +2809,7 @@ extension ChatViewController: QLPreviewControllerDelegate {
             previewControllerTargetSnapshot = snapshot
             return snapshot
         } else if let msgId = item.messageId, let row = messageIds.firstIndex(of: msgId) {
-            previewControllerTargetHiddenOriginal?.layer.opacity = 1
-            previewControllerTargetSnapshot?.removeFromSuperview()
-            // Scroll to the message that will be dismissed
+            // Scroll to the message related to the dismissing preview controller
             let indexPath = IndexPath(row: row, section: 0)
             if tableView.indexPathsForVisibleRows?.contains(indexPath) == false {
                 tableView.scrollToRow(at: indexPath, at: .none, animated: false)
@@ -2827,8 +2824,6 @@ extension ChatViewController: QLPreviewControllerDelegate {
     func previewControllerDidDismiss(_ controller: QLPreviewController) {
         previewControllerTargetSnapshot?.removeFromSuperview()
         previewControllerTargetSnapshot = nil
-        previewControllerTargetHiddenOriginal?.layer.opacity = 1
-        previewControllerTargetHiddenOriginal = nil
     }
 
     private func isDraftPreviewItem(_ item: QLPreviewItem) -> Bool {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2762,7 +2762,6 @@ extension ChatViewController: ChatContactRequestDelegate {
     }
 }
 
-
 // MARK: - QLPreviewControllerDelegate
 extension ChatViewController: QLPreviewControllerDelegate {
     override func responds(to aSelector: Selector!) -> Bool {
@@ -2805,8 +2804,8 @@ extension ChatViewController: QLPreviewControllerDelegate {
             // Place the snapshot below the tableView, outside of the screen so the
             // preview controller animates towards where the inputAccessoryView will
             // pop back in from, when firstResponder is returned.
-            snapshot.frame.origin.y = (tableView.superview ?? tableView).frame.maxY
-            tableView.superview?.addSubview(snapshot)
+            snapshot.frame.origin.y = view.frame.maxY
+            view.addSubview(snapshot)
             previewControllerTargetSnapshot?.removeFromSuperview()
             previewControllerTargetSnapshot = snapshot
             return snapshot

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -221,7 +221,7 @@ extension FilesViewController {
         guard let index = fileMessageIds.firstIndex(of: msgId) else {
             return
         }
-        let previewController = PreviewController(dcContext: dcContext, type: .multi(fileMessageIds, index))
+        let previewController = PreviewController(dcContext: dcContext, type: .multi(msgIds: fileMessageIds, index: index))
         navigationController?.pushViewController(previewController, animated: true)
     }
 

--- a/deltachat-ios/Controller/GalleryViewController.swift
+++ b/deltachat-ios/Controller/GalleryViewController.swift
@@ -199,7 +199,7 @@ extension GalleryViewController: UICollectionViewDataSource, UICollectionViewDel
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let previewController = PreviewController(dcContext: dcContext, type: .multi(mediaMessageIds, indexPath.row))
+        let previewController = PreviewController(dcContext: dcContext, type: .multi(msgIds: mediaMessageIds, index: indexPath.row))
         previewController.delegate = self
         navigationController?.pushViewController(previewController, animated: true)
 

--- a/deltachat-ios/Controller/PreviewController.swift
+++ b/deltachat-ios/Controller/PreviewController.swift
@@ -5,7 +5,7 @@ import DcCore
 class PreviewController: QLPreviewController {
     enum PreviewType {
         case single(URL)
-        case multi([Int], Int) // msgIds, index
+        case multi(msgIds: [Int], index: Int)
     }
 
     let previewType: PreviewType
@@ -49,7 +49,7 @@ extension PreviewController: QLPreviewControllerDataSource {
             return PreviewItem(url: url, title: self.customTitle)
         case .multi(let msgIds, _):
             let msg = dcContext.getMessage(id: msgIds[index])
-            return PreviewItem(url: msg.fileURL, title: self.customTitle)
+            return PreviewItem(url: msg.fileURL, title: self.customTitle, messageId: msg.id)
         }
     }
 }
@@ -58,9 +58,11 @@ extension PreviewController: QLPreviewControllerDataSource {
 class PreviewItem: NSObject, QLPreviewItem {
     var previewItemURL: URL?
     var previewItemTitle: String?
+    var messageId: Int?
 
-    init(url: URL?, title: String?) {
+    init(url: URL?, title: String?, messageId: Int? = nil) {
         self.previewItemURL = url
         self.previewItemTitle = title ?? ""
+        self.messageId = messageId
     }
 }

--- a/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
+++ b/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
@@ -33,9 +33,18 @@ extension UIViewController {
     /// QLPreviewController causes issues when dismissed using the swipe gesture if there was a first responder active when it was presented.
     /// Issues range from freezing the previous first responder to crashing the app.
     public func present(_ previewController: QLPreviewController, animated: Bool, completion: (() -> Void)? = nil) {
-        // QLPreviewController can not be used as child because it would not do its custom transitions
-        previewController.returnFirstRespondersOnDismiss()
-        present(previewController as UIViewController, animated: animated, completion: completion)
+        if #available(iOS 18, *), let navigationController {
+            // Pushing instead of presenting on iOS 18 makes sure it shows navigation
+            // and toolbar by default. On iOS 18 this still enables the swipe down to dismiss
+            // gesture and it still animates using previewController(_:transitionViewFor:)
+            navigationController.pushViewController(previewController, animated: animated)
+            completion?()
+        } else {
+            // QLPreviewController can not be used as child because it would not do its custom transitions
+            previewController.returnFirstRespondersOnDismiss()
+            present(previewController as UIViewController, animated: true, completion: completion)
+            previewController.setEditing(true, animated: true)
+        }
     }
 
     /// In iOS 16 and below and iOS 18 the UIImagePickerController does not give back the first responder when search was used.

--- a/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
+++ b/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
@@ -1,4 +1,5 @@
 import UIKit
+import QuickLook
 
 /// https://gist.github.com/Amzd/223979ef5a06d98ef17d2d78dbd96e22
 extension UIViewController {
@@ -27,6 +28,14 @@ extension UIViewController {
             documentPicker.returnFirstRespondersOnDismiss()
         }
         present(documentPicker as UIViewController, animated: animated, completion: completion)
+    }
+
+    /// QLPreviewController causes issues when dismissed using the swipe gesture if there was a first responder active when it was presented.
+    /// Issues range from freezing the previous first responder to crashing the app.
+    public func present(_ previewController: QLPreviewController, animated: Bool, completion: (() -> Void)? = nil) {
+        // QLPreviewController can not be used as child because it would not do its custom transitions
+        previewController.returnFirstRespondersOnDismiss()
+        present(previewController as UIViewController, animated: animated, completion: completion)
     }
 
     /// In iOS 16 and below and iOS 18 the UIImagePickerController does not give back the first responder when search was used.

--- a/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
+++ b/deltachat-ios/Helper/GiveBackMyFirstResponder.swift
@@ -36,7 +36,9 @@ extension UIViewController {
         if #available(iOS 18, *), let navigationController {
             // Pushing instead of presenting on iOS 18 makes sure it shows navigation
             // and toolbar by default. On iOS 18 this still enables the swipe down to dismiss
-            // gesture and it still animates using previewController(_:transitionViewFor:)
+            // gesture and it still animates using previewController(_:transitionViewFor:).
+            // Note: Do not return `.disabled` in `previewController(_:editingModeFor:)` as this
+            // causes a visual glitch in the navigation bar when pushing.
             navigationController.pushViewController(previewController, animated: animated)
             completion?()
         } else {

--- a/deltachat-ios/Helper/MediaPicker.swift
+++ b/deltachat-ios/Helper/MediaPicker.swift
@@ -177,6 +177,24 @@ extension MediaPicker: PHPickerViewControllerDelegate {
 
 extension MediaPicker: UIImagePickerControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        // This async basically makes sure the "Downloading from iCloud" alert is closed and
+        // the keyboard is opened again if the search bar was active. This edge case causes a crash
+        // in the KeyInput layer and prevents the keyboard from being opened until next launch (tested on iOS 16).
+        // To test this:
+        // - Remove this asyncAfter
+        // - Open Chat
+        // - Select text field so keyboard is open
+        // - Attach
+        // - Gallery
+        // - Tap search bar in image picker
+        // - Select an image that needs to be downloaded from iCloud
+        // - Keyboard should come up but it does not (on iOS 16)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.handleImagePickerController(picker, didFinishPickingMediaWithInfo: info)
+        }
+    }
+
+    private func handleImagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         if let type = info[.mediaType] as? String, let mediaType = PickerMediaType(rawValue: type) {
             switch mediaType {
             case .video:


### PR DESCRIPTION
This is a continuation of #2482, fixing the issue that were discussed in the original PR.

This also fixes #2918