### PR TITLE
truncate file names in the middle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
+- Truncate file names in the middle, not at the end; important information are more often at the end
 - Fix: Online indicator in the chat navigation bar now updates correctly when returning from background
 - Fix: Allow iframe srcdoc in webxdc 
+
 
 ## v2.35.0 Testflight
 2025-12

--- a/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
+++ b/deltachat-ios/View/Cell/DocumentGalleryFileCell.swift
@@ -31,6 +31,7 @@ class DocumentGalleryFileCell: UITableViewCell {
     private lazy var title: UILabel = {
         let title = UILabel()
         title.font = UIFont.preferredFont(forTextStyle: .headline)
+        title.lineBreakMode = .byTruncatingMiddle
         title.translatesAutoresizingMaskIntoConstraints = false
         return title
     }()


### PR DESCRIPTION
that way, the end is always visible,
which contains important information more often than the middle.

this is common knowledge since the 90's or so
however, as quite some previously stable ux patterns, lost on the way. (cmp. Scott Jensen, https://www.youtube.com/watch?v=1fZTOjd_bOQ )

i also checked the file names in the bubbles,
here they're wrapped, so that's fine
(wrapping in the list, otoh, would clutter the list, complicate ux and layout)

sidenote:  i'll aim to do the same for android, this issue might have been part of some ticket confusion, cc @hpk42

before / after:

<img width=280 src=https://github.com/user-attachments/assets/037f8ee3-8365-4cec-adcd-aa67c704560d> &nbsp; &nbsp; <img width=280 src=https://github.com/user-attachments/assets/600a4695-3b3d-4bd0-970e-264a5c5feb3a>

macOS for reference:

<img width="692" height="165" alt="Screenshot 2026-01-08 at 15 14 34" src="https://github.com/user-attachments/assets/a51401c0-6a04-4ef3-b5db-e06aa1e2589a" />

