### PR TITLE
Swipe to delete transport instead of edit

### DIFF
--- a/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
@@ -139,17 +139,6 @@ extension TransportListViewController {
         guard let transport = transports.get(at: indexPath.row) else { return nil }
         var actions: [UIContextualAction] = []
 
-        let editAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completion in
-            DispatchQueue.main.async {
-                self?.editTransport(at: indexPath)
-                completion(true)
-            }
-        }
-        editAction.backgroundColor = .lightGray
-        editAction.accessibilityLabel = String.localized("edit_transport")
-        editAction.image = Utils.makeImageWithText(image: UIImage(systemName: "pencil"), text: String.localized("global_menu_edit_desktop"))
-        actions.append(editAction)
-
         if !transport.isDefault(dcContext) {
             let deleteAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completion in
                 DispatchQueue.main.async {
@@ -163,8 +152,19 @@ extension TransportListViewController {
             actions.append(deleteAction)
         }
 
+        let editAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completion in
+            DispatchQueue.main.async {
+                self?.editTransport(at: indexPath)
+                completion(true)
+            }
+        }
+        editAction.backgroundColor = .lightGray
+        editAction.accessibilityLabel = String.localized("edit_transport")
+        editAction.image = Utils.makeImageWithText(image: UIImage(systemName: "pencil"), text: String.localized("global_menu_edit_desktop"))
+        actions.append(editAction)
+
         let actionsConfiguration = UISwipeActionsConfiguration(actions: actions)
-        actionsConfiguration.performsFirstActionWithFullSwipe = true
+        actionsConfiguration.performsFirstActionWithFullSwipe = !transport.isDefault(dcContext)
         return actionsConfiguration
     }
 


### PR DESCRIPTION
Previously the swipe action opened details of a transport, now it shows the delete warning prompt. 

This aligns with other swipe actions in the app and all over the system.

#skip-changelog