### PR TITLE
move reactions to the left

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
+++ b/deltachat-ios/Chat/Views/Cells/BaseMessageCell.swift
@@ -303,8 +303,8 @@ public class BaseMessageCell: UITableViewCell {
         contentView.addSubview(reactionsView)
 
         let reactionsViewConstraints = [
-            messageBackgroundContainer.leadingAnchor.constraint(lessThanOrEqualTo: reactionsView.leadingAnchor, constant: -10),
-            messageBackgroundContainer.trailingAnchor.constraint(equalTo: reactionsView.trailingAnchor, constant: 10),
+            messageBackgroundContainer.leadingAnchor.constraint(equalTo: reactionsView.leadingAnchor, constant: -10),
+            messageBackgroundContainer.trailingAnchor.constraint(greaterThanOrEqualTo: reactionsView.trailingAnchor, constant: 10),
             messageBackgroundContainer.bottomAnchor.constraint(equalTo: reactionsView.bottomAnchor, constant: -20)
         ]
 


### PR DESCRIPTION
move reactions to the left, still ensuring bubble is at least as wide as reactions.

this is for consistency mainly, desktop and android are doing the same, also many other messengers - but it also has a slightly nicer layout, as the area with the status is already dense

before / after:

<img width="320" src="https://github.com/user-attachments/assets/9db348cd-3813-473c-8964-e41156bdf8a9" />
<img width="320" src="https://github.com/user-attachments/assets/0e22f3e4-0741-41e4-9887-55193e5f7a39" />

in theory, the reactions could now also move a little more towards inside the bubble (half or so), however, to not overlap the status, that requires more changes (the status line has different heights for incoming/outgoing), so we leave vertical position as is for now