### PR TITLE
update documentation wrt 'Keychain Access' and push cert generation

### DIFF
--- a/docs/renew-push-certificate.md
+++ b/docs/renew-push-certificate.md
@@ -27,11 +27,10 @@ These are the steps needed for renewal:
 ## 3. convert to `.p12` [^1]
 
 - create `certificates/YEAR-push-renew-NUMBER/password.txt` containing nothing but a suffciently secure password
-- double click downloaded `aps.cer` file, this opens again the app "KeyChain Access"
-  (if that is not working, open "KeyChain Access", select "login" keychain and then "File / Import Item" and select `aps.cer`)
-- select "Certificates" and then expand the new item (the new one is usally the one expiration date most far in the future)
-- select **both**, "certificate" and "private key" (but not "public key")
-- right click, "Export 2 items"
+- in "Keychain Access", select "login" keychain, "Certificates" tab, then "File / Import Items" and select `aps.cer` (double click may work as well)
+- expand the new item (the new one is usally the one expiration date most far in the future)
+- select "delta-apns"
+- right click, "Export delta-apns"
 - save locally as `certificates/YEAR-push-renew-NUMBER/Certificates.p12`,
   you'll be prompted for a password, enter the one from `password.txt`
 


### PR DESCRIPTION
there seems no longer to be options to select "certificate" or "private key", only "delta-apns", so this is what i did:

<img width="595" height="251" alt="Screenshot 2026-01-22 at 17 50 35" src="https://github.com/user-attachments/assets/c5b10a33-258f-4535-87a5-de7e4315810f" />

if this works out, we can merge the PR - otherwise, there is also an "export option" one level up, at "Apple Push Services: chat.delta" - that also generates a .p12, no idea what the difference is and if there is any