### PR TITLE
prepare for liquidglass: simplify swipe label

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -527,24 +527,22 @@ class ChatListViewController: UITableViewController {
 
         let pinned = chat.visibility==DC_CHAT_VISIBILITY_PINNED
         let pinTitle = String.localized(pinned ? "unpin" : "pin")
-        let pinAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
+        let pinAction = UIContextualAction(style: .destructive, title: pinTitle) { [weak self] _, _, completionHandler in
             self?.viewModel?.pinChatToggle(chatId: chat.id)
             self?.setEditing(false, animated: true)
             completionHandler(true)
         }
-        pinAction.accessibilityLabel = pinTitle
         pinAction.backgroundColor = UIColor.systemGreen
-        pinAction.image = Utils.makeImageWithText(image: UIImage(systemName: pinned ? "pin.slash" : "pin"), text: pinTitle)
+        pinAction.image = UIImage(systemName: pinned ? "pin.slash" : "pin")
 
         if dcContext.getUnreadMessages(chatId: chatId) > 0 {
-            let markReadAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
+            let markReadAction = UIContextualAction(style: .destructive, title: String.localized("mark_as_read_short")) { [weak self] _, _, completionHandler in
                 self?.dcContext.marknoticedChat(chatId: chatId)
                 completionHandler(true)
             }
-            markReadAction.accessibilityLabel = String.localized("mark_as_read_short")
             markReadAction.backgroundColor = UIColor.systemBlue
             let imageName = if #available(iOS 16, *) { "checkmark.message" } else { "checkmark.circle" }
-            markReadAction.image = Utils.makeImageWithText(image: UIImage(systemName: imageName), text: String.localized("mark_as_read_short"))
+            markReadAction.image = UIImage(systemName: imageName)
 
             return UISwipeActionsConfiguration(actions: [markReadAction, pinAction])
         } else {
@@ -564,17 +562,16 @@ class ChatListViewController: UITableViewController {
 
         let archived = chat.isArchived
         let archiveTitle: String = String.localized(archived ? "unarchive" : "archive")
-        let archiveAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
+        let archiveAction = UIContextualAction(style: .destructive, title: archiveTitle) { [weak self] _, _, completionHandler in
             self?.viewModel?.archiveChatToggle(chatId: chatId)
             self?.setEditing(false, animated: true)
             completionHandler(true)
         }
-        archiveAction.accessibilityLabel = archiveTitle
         archiveAction.backgroundColor = UIColor.lightGray
-        archiveAction.image = Utils.makeImageWithText(image: UIImage(systemName: archived ? "tray.and.arrow.up" : "tray.and.arrow.down"), text: archiveTitle)
+        archiveAction.image = UIImage(systemName: archived ? "tray.and.arrow.up" : "tray.and.arrow.down")
 
         let muteTitle = String.localized(chat.isMuted ? "menu_unmute" : "mute")
-        let muteAction = UIContextualAction(style: .normal, title: nil) { [weak self] _, _, completionHandler in
+        let muteAction = UIContextualAction(style: .normal, title: muteTitle) { [weak self] _, _, completionHandler in
             guard let self else { return }
             if chat.isMuted {
                 dcContext.setChatMuteDuration(chatId: chatId, duration: 0)
@@ -587,21 +584,19 @@ class ChatListViewController: UITableViewController {
                 }
             }
         }
-        muteAction.accessibilityLabel = muteTitle
         muteAction.backgroundColor = UIColor.systemOrange
-        muteAction.image = Utils.makeImageWithText(image: UIImage(systemName: chat.isMuted ? "speaker.wave.2" : "speaker.slash"), text: muteTitle)
+        muteAction.image = UIImage(systemName: chat.isMuted ? "speaker.wave.2" : "speaker.slash")
 
         if viewModel.isMessageSearchResult(indexPath: indexPath) {
             return UISwipeActionsConfiguration(actions: [archiveAction, muteAction])
         } else {
-            let deleteAction = UIContextualAction(style: .normal, title: nil) { [weak self] _, _, completionHandler in
+            let deleteAction = UIContextualAction(style: .normal, title: String.localized("delete")) { [weak self] _, _, completionHandler in
                 self?.showDeleteChatConfirmationAlert(chatId: chatId) {
                     completionHandler(true)
                 }
             }
-            deleteAction.accessibilityLabel = String.localized("delete")
             deleteAction.backgroundColor = UIColor.systemRed
-            deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("delete"))
+            deleteAction.image = UIImage(systemName: "trash")
             return UISwipeActionsConfiguration(actions: [archiveAction, muteAction, deleteAction])
         }
     }

--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -208,7 +208,7 @@ class NewChatViewController: UITableViewController {
         if indexPath.section == sectionContacts {
             let contactId = contactIdByRow(indexPath.row)
 
-            let profileAction = UIContextualAction(style: .normal, title: nil) { [weak self] _, _, completionHandler in
+            let profileAction = UIContextualAction(style: .normal, title: String.localized("profile")) { [weak self] _, _, completionHandler in
                 guard let self else { return }
                 if self.searchController.isActive {
                     self.searchController.dismiss(animated: false) {
@@ -219,18 +219,16 @@ class NewChatViewController: UITableViewController {
                 }
                 completionHandler(true)
             }
-            profileAction.accessibilityLabel = String.localized("profile")
             profileAction.backgroundColor = UIColor.systemBlue
-            profileAction.image = Utils.makeImageWithText(image: UIImage(systemName: "person.crop.circle"), text: String.localized("profile"))
+            profileAction.image = UIImage(systemName: "person.crop.circle")
 
-            let deleteAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
+            let deleteAction = UIContextualAction(style: .destructive, title: String.localized("delete")) { [weak self] _, _, completionHandler in
                 guard let self else { return }
                 self.askToDeleteContact(contactId: contactIdByRow(indexPath.row), indexPath: indexPath) {
                     completionHandler(true)
                 }
             }
-            deleteAction.accessibilityLabel = String.localized("delete")
-            deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("delete"))
+            deleteAction.image = UIImage(systemName: "trash")
 
             return UISwipeActionsConfiguration(actions: [profileAction, deleteAction])
         } else {

--- a/deltachat-ios/Controller/NewGroupController.swift
+++ b/deltachat-ios/Controller/NewGroupController.swift
@@ -247,13 +247,12 @@ class NewGroupController: UITableViewController, MediaPickerDelegate {
 
     override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         if sections[indexPath.section] == .members, groupContactIds[indexPath.row] != DC_CONTACT_ID_SELF {
-            let deleteAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
+            let deleteAction = UIContextualAction(style: .destructive, title: String.localized("remove_desktop")) { [weak self] _, _, completionHandler in
                 guard let self else { return }
                 self.removeGroupContactFromList(at: indexPath)
                 completionHandler(true)
             }
-            deleteAction.accessibilityLabel = String.localized("remove_desktop")
-            deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("remove_desktop"))
+            deleteAction.image = UIImage(systemName: "trash")
             return UISwipeActionsConfiguration(actions: [deleteAction])
         } else {
             return nil

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -804,7 +804,7 @@ class ProfileViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let chat else { return nil }
         if chat.canSend && chat.isEncrypted && sections[indexPath.section] == .members && !isMemberManagementRow(row: indexPath.row) && getMemberIdFor(indexPath.row) != DC_CONTACT_ID_SELF {
-            let deleteAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
+            let deleteAction = UIContextualAction(style: .destructive, title: String.localized("remove_desktop")) { [weak self] _, _, completionHandler in
                 guard let self else { return }
                 let otherContact = dcContext.getContact(id: getMemberIdFor(indexPath.row))
                 let title = String.localizedStringWithFormat(String.localized(isOutBroadcast ? "ask_remove_from_channel" : "ask_remove_members"), otherContact.displayName)
@@ -819,8 +819,7 @@ class ProfileViewController: UITableViewController {
                 alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
                 present(alert, animated: true, completion: nil)
             }
-            deleteAction.accessibilityLabel = String.localized("remove_desktop")
-            deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("remove_desktop"))
+            deleteAction.image = UIImage(systemName: "trash")
             return UISwipeActionsConfiguration(actions: [deleteAction])
         }
         return nil

--- a/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ProxySettingsViewController.swift
@@ -292,14 +292,14 @@ extension ProxySettingsViewController {
             indexPath.section == ProxySettingsSection.proxies.rawValue
         else { return nil }
 
-        let shareAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completion in
+        let shareAction = UIContextualAction(style: .destructive, title: String.localized("menu_share")) { [weak self] _, _, completion in
             DispatchQueue.main.async {
                 self?.shareProxy(at: indexPath)
                 completion(true)
             }
         }
         shareAction.backgroundColor = .systemGreen
-        shareAction.image = Utils.makeImageWithText(image: UIImage(systemName: "square.and.arrow.up"), text: String.localized("menu_share"))
+        shareAction.image = UIImage(systemName: "square.and.arrow.up")
 
         let configuration = UISwipeActionsConfiguration(actions: [shareAction])
         configuration.performsFirstActionWithFullSwipe = true
@@ -314,15 +314,14 @@ extension ProxySettingsViewController {
             indexPath.section == ProxySettingsSection.proxies.rawValue
         else { return nil }
 
-        let deleteAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completion in
+        let deleteAction = UIContextualAction(style: .destructive, title: String.localized("delete")) { [weak self] _, _, completion in
             DispatchQueue.main.async {
                 self?.deleteProxy(at: indexPath)
                 completion(true)
             }
         }
         deleteAction.backgroundColor = .systemRed
-        deleteAction.accessibilityLabel = String.localized("delete")
-        deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("delete"))
+        deleteAction.image = UIImage(systemName: "trash")
 
         let configuration = UISwipeActionsConfiguration(actions: [deleteAction])
         configuration.performsFirstActionWithFullSwipe = true

--- a/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
@@ -140,19 +140,18 @@ extension TransportListViewController {
         var actions: [UIContextualAction] = []
 
         if !transport.isDefault(dcContext) {
-            let deleteAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completion in
+            let deleteAction = UIContextualAction(style: .destructive, title: String.localized("delete")) { [weak self] _, _, completion in
                 DispatchQueue.main.async {
                     self?.deleteTransport(at: indexPath)
                     completion(true)
                 }
             }
             deleteAction.backgroundColor = .systemRed
-            deleteAction.accessibilityLabel = String.localized("delete")
-            deleteAction.image = Utils.makeImageWithText(image: UIImage(systemName: "trash"), text: String.localized("delete"))
+            deleteAction.image = UIImage(systemName: "trash")
             actions.append(deleteAction)
         }
 
-        let editAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completion in
+        let editAction = UIContextualAction(style: .destructive, title: String.localized("global_menu_edit_desktop")) { [weak self] _, _, completion in
             DispatchQueue.main.async {
                 self?.editTransport(at: indexPath)
                 completion(true)
@@ -160,7 +159,7 @@ extension TransportListViewController {
         }
         editAction.backgroundColor = .lightGray
         editAction.accessibilityLabel = String.localized("edit_transport")
-        editAction.image = Utils.makeImageWithText(image: UIImage(systemName: "pencil"), text: String.localized("global_menu_edit_desktop"))
+        editAction.image = UIImage(systemName: "pencil")
         actions.append(editAction)
 
         let actionsConfiguration = UISwipeActionsConfiguration(actions: actions)

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -56,39 +56,6 @@ struct Utils {
         return window?.safeAreaInsets.bottom ?? 0
     }
 
-    // Puts text below the given image and returns as a new image.
-    // The result is ready to be used with `UIContextualAction.image` -
-    // which shows the title otherwise only for large heightForRowAt (>= 91 in experiments).
-    // If you add an text to an image that way, set `UIContextualAction.title` to `nil` to be safe for cornercases - or if apple changes things -
-    // otherwise, one would see the title twice *drunk* :)
-    static func makeImageWithText(image: UIImage?, text: String) -> UIImage? {
-        guard let image = image?.withTintColor(UIColor.white) else { return nil }
-
-        let maxLen = 11
-        let shortText: String
-        if text.count > maxLen {
-            shortText = text.substring(0, maxLen - 1).trimmingCharacters(in: .whitespacesAndNewlines) + "…"
-        } else {
-            shortText = text
-        }
-
-        let spacing: CGFloat = 4
-        let textAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 14), .foregroundColor: UIColor.white]
-
-        let textSize = shortText.size(withAttributes: textAttributes)
-        let width = max(image.size.width, textSize.width)
-        let height = image.size.height + spacing + textSize.height
-
-        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height))
-        return renderer.image { _ in
-            let imageOrigin = CGPoint(x: (renderer.format.bounds.width - image.size.width) / 2, y: 0)
-            image.draw(at: imageOrigin)
-
-            let textOrigin = CGPoint(x: (renderer.format.bounds.width - textSize.width) / 2, y: image.size.height + spacing)
-            shortText.draw(at: textOrigin, withAttributes: textAttributes)
-        }
-    }
-
     public static func getInviteLink(context: DcContext, chatId: Int) -> String? {
         return context.getSecurejoinQr(chatId: chatId)
     }


### PR DESCRIPTION
this removes the hack of force showing text below the icon; this looks really bad on liquid glass - which anyway shows the text.

also before, the text was shown if there is room,
which, however, was less often the case, therefore the forcing - which was fine as long as no problems appear,
but this hase changed now.

of course, once could continue the hack depending on the OS, however, this is not worth the effort.
the icons used here are anyway self-explaining, and mostly also shown in the context menu - then including text.
so, just let the OS device on that part.

targets https://github.com/deltachat/deltachat-ios/issues/2973

#skip-changelog as being a minor