### PR TITLE
Implemented chat message lifecycle animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Allow to switch profile when sharing or forwarding
 - Add tab bar icon bounce animation on tap
+- Add animated insert/delete transitions for chat messages
 
 
 ## v2.43.0 Testflight


### PR DESCRIPTION
Added animation for new messages appearing in chat.
Added animation for message deletions.
Kept incoming behavior lightweight (fade-based) and avoided excessive motion.
Added guarded diff-based row updates with fallback conditions to prevent unstable animations (editing/search/context-menu/reduce-motion/move-heavy updates).
Ensured refresh correctness during rapid/coalesced updates by updating visible rows and preserving seen/scroll button state after deferred refreshes.

Demo:


https://github.com/user-attachments/assets/2fc0e6f9-8f19-4588-8f76-6eddd3a10c6e


https://github.com/user-attachments/assets/f28cdedf-3567-4083-9fd0-d27d4f912e1d

