### PR TITLE
fix: clear quote constraints

### DIFF
--- a/DcCore/DcCore/Extensions/UIView+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UIView+Extensions.swift
@@ -95,23 +95,6 @@ public extension UIView {
         return constraint
     }
 
-    /**
-     ensure the top of self is aligned with or lower than another view
-     can be used in conjunction with constraintAlignCenterY
-     */
-    func constraintAlignTopMaxTo(_ view: UIView, paddingTop: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
-        let constraint = NSLayoutConstraint(
-            item: self,
-            attribute: .top,
-            relatedBy: .greaterThanOrEqual,
-            toItem: view,
-            attribute: .top,
-            multiplier: 1.0,
-            constant: paddingTop)
-        constraint.priority = priority
-        return constraint
-    }
-
     func constraintAlignBottomTo(_ view: UIView, paddingBottom: CGFloat = 0.0, priority: UILayoutPriority = .required) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(
             item: self,

--- a/deltachat-ios/Chat/Views/QuoteView.swift
+++ b/deltachat-ios/Chat/Views/QuoteView.swift
@@ -61,7 +61,6 @@ public class QuoteView: UIView {
             imagePreview.constraintAlignTrailingTo(self, paddingTrailing: 16),
             imagePreview.constraintHeightTo(36),
             imagePreview.constraintCenterYTo(citeBar),
-            imagePreview.constraintAlignTopMaxTo(self),
             senderTitle.constraintAlignTopTo(self),
             senderTitle.constraintAlignLeadingTo(self, paddingLeading: 28),
             senderTitle.constraintTrailingToLeadingOf(imagePreview, paddingTrailing: 8),


### PR DESCRIPTION
remove imagePreview top clamp
that caused unstable layout for short/nameless quotes.

the clamp was introduced at
https://github.com/deltachat/deltachat-ios/commit/4012fb4417b51f9ab545e8b67bec2c7ac76a783f but seems not to be needed,
even if the quote is only one line without title
(eg. if the original is removed)

closes https://github.com/deltachat/deltachat-ios/issues/2867