### PR TITLE
Improve QR code visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improve QR code visibility and use the new backup QR generation path
 - Allow to switch profile when sharing or forwarding
 - Add tab bar icon bounce animation on tap
 - Fix: remove meaningless address from vCard

--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import DcCore
 import SDWebImageSVGKitPlugin
 
-class BackupTransferViewController: UIViewController {
+class BackupTransferViewController: UIViewController, ScreenBrightnessOverrideSupporting {
 
     public enum TranferState {
         case unknown
@@ -34,6 +34,10 @@ class BackupTransferViewController: UIViewController {
         progress.translatesAutoresizingMaskIntoConstraints = false
         return progress
     }()
+
+    var shouldEnableScreenBrightnessOverride: Bool {
+        !qrContentView.isHidden && qrContentView.image != nil && transferState == TranferState.unknown
+    }
 
     init(dcAccounts: DcAccounts) {
         self.dcAccounts = dcAccounts
@@ -109,7 +113,7 @@ class BackupTransferViewController: UIViewController {
                                  + "\n\n➋ " + String.localized("multidevice_install_dc_on_other_device")
                                  + "\n\n➌ " + String.localized("multidevice_tap_scan_on_other_device")
                 self.updateMenuItems()
-                self.updateBrightness()
+                self.updateScreenBrightnessOverride()
                 DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                     guard let self else { return }
                     self.dcBackupProvider?.wait()
@@ -120,12 +124,12 @@ class BackupTransferViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        updateBrightness()
+        updateScreenBrightnessOverride()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        ScreenBrightnessOverrideManager.shared.setActive(false, for: self)
+        disableScreenBrightnessOverride()
     }
 
     override func didMove(toParent parent: UIViewController?) {
@@ -188,7 +192,7 @@ class BackupTransferViewController: UIViewController {
                 updateMenuItems()
             }
 
-            self.updateBrightness()
+            self.updateScreenBrightnessOverride()
         }
     }
 
@@ -233,13 +237,6 @@ class BackupTransferViewController: UIViewController {
 
         let svgData = svg.data(using: .utf8)
         return SDImageSVGKCoder.shared.decodedImage(with: svgData, options: [:])
-    }
-
-    private func updateBrightness() {
-        guard isViewLoaded, view.window != nil else { return }
-
-        let shouldUseMaxBrightness = !qrContentView.isHidden && qrContentView.image != nil && transferState == TranferState.unknown
-        ScreenBrightnessOverrideManager.shared.setActive(shouldUseMaxBrightness, for: self)
     }
 
     private func showLastErrorAlert(_ errorContext: String) {

--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -100,7 +100,7 @@ class BackupTransferViewController: UIViewController {
                     }
                     return
                 }
-                let image = self.getQrImage(svg: self.dcBackupProvider?.getQrSvg())
+                let image = self.getQrImage(qrPayload: self.dcBackupProvider?.getQr())
                 self.qrContentView.image = image
                 self.activityIndicator.stopAnimating()
                 self.activityIndicator.isHidden = true
@@ -109,12 +109,23 @@ class BackupTransferViewController: UIViewController {
                                  + "\n\n➋ " + String.localized("multidevice_install_dc_on_other_device")
                                  + "\n\n➌ " + String.localized("multidevice_tap_scan_on_other_device")
                 self.updateMenuItems()
+                self.updateBrightness()
                 DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                     guard let self else { return }
                     self.dcBackupProvider?.wait()
                 }
             }
         }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        updateBrightness()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        ScreenBrightnessOverrideManager.shared.setActive(false, for: self)
     }
 
     override func didMove(toParent parent: UIViewController?) {
@@ -176,6 +187,8 @@ class BackupTransferViewController: UIViewController {
                 self.qrContentView.isHidden = true
                 updateMenuItems()
             }
+
+            self.updateBrightness()
         }
     }
 
@@ -214,12 +227,19 @@ class BackupTransferViewController: UIViewController {
         activityIndicator.isHidden = false
         activityIndicator.startAnimating()
     }
-    
-    private func getQrImage(svg: String?) -> UIImage? {
-        guard let svg else { return nil }
+
+    private func getQrImage(qrPayload: String?) -> UIImage? {
+        guard let qrPayload, !qrPayload.isEmpty, let svg = dcContext.createQRSVG(for: qrPayload) else { return nil }
 
         let svgData = svg.data(using: .utf8)
         return SDImageSVGKCoder.shared.decodedImage(with: svgData, options: [:])
+    }
+
+    private func updateBrightness() {
+        guard isViewLoaded, view.window != nil else { return }
+
+        let shouldUseMaxBrightness = !qrContentView.isHidden && qrContentView.image != nil && transferState == TranferState.unknown
+        ScreenBrightnessOverrideManager.shared.setActive(shouldUseMaxBrightness, for: self)
     }
 
     private func showLastErrorAlert(_ errorContext: String) {

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -26,6 +26,7 @@ class QrViewController: UIViewController {
             let svg = dcContext.getSecurejoinQrSVG(chatId: chatId)
             qrContentView.image = getQrImage(svg: svg)
             qrContentView.accessibilityHint = newValue
+            updateBrightness()
         }
     }
     private let chatId: Int
@@ -126,6 +127,22 @@ class QrViewController: UIViewController {
     }
 
     // MARK: - lifecycle
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        updateBrightness()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        ScreenBrightnessOverrideManager.shared.setActive(false, for: self)
+    }
+
+    private func updateBrightness() {
+        guard isViewLoaded, view.window != nil else { return }
+
+        ScreenBrightnessOverrideManager.shared.setActive(qrContentView.image != nil, for: self)
+    }
+
     func getQrImage(svg: String?) -> UIImage? {
         guard let svg else { return nil }
 

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import DcCore
 import SDWebImageSVGKitPlugin
 
-class QrViewController: UIViewController {
+class QrViewController: UIViewController, ScreenBrightnessOverrideSupporting {
 
     private let dcContext: DcContext
 
@@ -21,12 +21,16 @@ class QrViewController: UIViewController {
     var contentTopAnchor: NSLayoutConstraint?
     var contentBottomAnchor: NSLayoutConstraint?
 
+    var shouldEnableScreenBrightnessOverride: Bool {
+        qrContentView.image != nil
+    }
+
     var qrCodeHint: String {
         willSet {
             let svg = dcContext.getSecurejoinQrSVG(chatId: chatId)
             qrContentView.image = getQrImage(svg: svg)
             qrContentView.accessibilityHint = newValue
-            updateBrightness()
+            updateScreenBrightnessOverride()
         }
     }
     private let chatId: Int
@@ -129,18 +133,12 @@ class QrViewController: UIViewController {
     // MARK: - lifecycle
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        updateBrightness()
+        updateScreenBrightnessOverride()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        ScreenBrightnessOverrideManager.shared.setActive(false, for: self)
-    }
-
-    private func updateBrightness() {
-        guard isViewLoaded, view.window != nil else { return }
-
-        ScreenBrightnessOverrideManager.shared.setActive(qrContentView.image != nil, for: self)
+        disableScreenBrightnessOverride()
     }
 
     func getQrImage(svg: String?) -> UIImage? {

--- a/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import DcCore
 import SDWebImageSVGKitPlugin
 
-class ShareProxyViewController: UIViewController {
+class ShareProxyViewController: UIViewController, ScreenBrightnessOverrideSupporting {
     private let dcContext: DcContext
 
     private let contentStackView: UIStackView
@@ -16,6 +16,10 @@ class ShareProxyViewController: UIViewController {
     var verticalCenterConstraint: NSLayoutConstraint?
     var contentTopAnchor: NSLayoutConstraint?
     var contentBottomAnchor: NSLayoutConstraint?
+
+    var shouldEnableScreenBrightnessOverride: Bool {
+        qrContentView.image != nil
+    }
 
     init(dcContext: DcContext, proxyUrlString: String) {
         self.dcContext = dcContext
@@ -114,18 +118,12 @@ class ShareProxyViewController: UIViewController {
     // MARK: - lifecycle
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        updateBrightness()
+        updateScreenBrightnessOverride()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        ScreenBrightnessOverrideManager.shared.setActive(false, for: self)
-    }
-
-    private func updateBrightness() {
-        guard isViewLoaded, view.window != nil else { return }
-
-        ScreenBrightnessOverrideManager.shared.setActive(qrContentView.image != nil, for: self)
+        disableScreenBrightnessOverride()
     }
 
     func getQrImage(svg: String?) -> UIImage? {

--- a/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
+++ b/deltachat-ios/Controller/Settings/Proxy/ShareProxyViewController.swift
@@ -112,6 +112,22 @@ class ShareProxyViewController: UIViewController {
     }
 
     // MARK: - lifecycle
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        updateBrightness()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        ScreenBrightnessOverrideManager.shared.setActive(false, for: self)
+    }
+
+    private func updateBrightness() {
+        guard isViewLoaded, view.window != nil else { return }
+
+        ScreenBrightnessOverrideManager.shared.setActive(qrContentView.image != nil, for: self)
+    }
+
     func getQrImage(svg: String?) -> UIImage? {
         guard let svg else { return nil }
 

--- a/deltachat-ios/DC/DcBackupProvider.swift
+++ b/deltachat-ios/DC/DcBackupProvider.swift
@@ -32,14 +32,7 @@ public class DcBackupProvider {
         return swiftString
     }
 
-    public func getQrSvg() -> String? {
-        guard let cString = dc_backup_provider_get_qr_svg(dcBackupProviderPointer) else { return nil }
-        let swiftString = String(cString: cString)
-        dc_str_unref(cString)
-        return swiftString
-    }
-
     public func wait() {
         dc_backup_provider_wait(dcBackupProviderPointer)
     }
- }
+}

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -3,6 +3,8 @@ import UIKit
 import DcCore
 import LocalAuthentication
 
+private var screenBrightnessOverrideManagerClaimObserverKey: UInt8 = 0
+
 extension URL {
     var isDeltaChatInvitation: Bool {
         if let host, host == Utils.inviteDomain {
@@ -13,8 +15,42 @@ extension URL {
     }
 }
 
+protocol ScreenBrightnessOverrideSupporting: AnyObject {
+    var shouldEnableScreenBrightnessOverride: Bool { get }
+}
+
+extension ScreenBrightnessOverrideSupporting where Self: UIViewController {
+    func updateScreenBrightnessOverride() {
+        guard isViewLoaded, view.window != nil else { return }
+
+        ScreenBrightnessOverrideManager.shared.setOverrideEnabled(shouldEnableScreenBrightnessOverride, for: self)
+    }
+
+    func disableScreenBrightnessOverride() {
+        ScreenBrightnessOverrideManager.shared.setOverrideEnabled(false, for: self)
+    }
+}
+
 final class ScreenBrightnessOverrideManager: NSObject {
     static let shared = ScreenBrightnessOverrideManager()
+
+    private enum Constants {
+        static let maxBrightness: CGFloat = 1.0
+        static let brightnessEpsilon: CGFloat = 0.0001
+    }
+
+    private final class ClaimDeinitObserver: NSObject {
+        private let onDeinit: () -> Void
+
+        init(onDeinit: @escaping () -> Void) {
+            self.onDeinit = onDeinit
+            super.init()
+        }
+
+        deinit {
+            onDeinit()
+        }
+    }
 
     private struct Claim {
         weak var owner: AnyObject?
@@ -47,42 +83,36 @@ final class ScreenBrightnessOverrideManager: NSObject {
         )
     }
 
-    func setActive(_ isActive: Bool, for owner: AnyObject) {
-        performOnMainQueue { [weak self] in
+    // MARK: - Public API
+
+    func setOverrideEnabled(_ isEnabled: Bool, for owner: AnyObject) {
+        performOnMainThread { [weak self] in
             guard let self else { return }
 
             self.removeClaim(for: owner)
 
-            if isActive {
+            if isEnabled {
+                self.installClaimDeinitObserver(for: owner)
                 self.claims.append(Claim(owner: owner))
             }
 
-            if self.claims.isEmpty {
-                self.restoreBrightnessIfNeeded()
-            } else if UIApplication.shared.applicationState == .active {
-                self.applyCurrentBrightnessIfNeeded()
-            }
+            self.reconcileBrightnessOverrideIfNeeded()
         }
     }
 
-    private func applyCurrentBrightnessIfNeeded() {
-        removeReleasedClaims()
+    // MARK: - Brightness state
 
-        guard !claims.isEmpty else {
-            restoreBrightnessIfNeeded()
-            return
-        }
-
+    private func applyOverrideIfNeeded() {
         if originalBrightness == nil {
             originalBrightness = UIScreen.main.brightness
         }
 
-        if !brightnessesMatch(UIScreen.main.brightness, 1.0) {
-            setBrightness(1.0)
+        if !brightnessesMatch(UIScreen.main.brightness, Constants.maxBrightness) {
+            setBrightness(Constants.maxBrightness)
         }
     }
 
-    private func restoreBrightnessIfNeeded() {
+    private func restoreOriginalBrightnessIfNeeded() {
         guard let originalBrightness else { return }
 
         if !brightnessesMatch(UIScreen.main.brightness, originalBrightness) {
@@ -106,23 +136,15 @@ final class ScreenBrightnessOverrideManager: NSObject {
         guard !claims.isEmpty else { return }
 
         originalBrightness = currentBrightness
-        guard UIApplication.shared.applicationState == .active else { return }
-        applyCurrentBrightnessIfNeeded()
+        reconcileBrightnessOverrideIfNeeded()
     }
 
     private func setBrightness(_ brightness: CGFloat) {
         let clampedBrightness = min(max(brightness, 0), 1)
 
+        // Keep the pending value until the corresponding system notification arrives.
         pendingProgrammaticBrightness = clampedBrightness
         UIScreen.main.brightness = clampedBrightness
-
-        DispatchQueue.main.async { [weak self] in
-            guard let self,
-                  let pendingProgrammaticBrightness = self.pendingProgrammaticBrightness,
-                  self.brightnessesMatch(pendingProgrammaticBrightness, clampedBrightness) else { return }
-
-            self.pendingProgrammaticBrightness = nil
-        }
     }
 
     private func removeClaim(for owner: AnyObject) {
@@ -136,7 +158,34 @@ final class ScreenBrightnessOverrideManager: NSObject {
         claims.removeAll { $0.owner == nil }
     }
 
-    private func performOnMainQueue(_ work: @escaping () -> Void) {
+    private func reconcileBrightnessOverrideIfNeeded() {
+        removeReleasedClaims()
+
+        guard !claims.isEmpty else {
+            restoreOriginalBrightnessIfNeeded()
+            return
+        }
+
+        guard UIApplication.shared.applicationState == .active else { return }
+        applyOverrideIfNeeded()
+    }
+
+    // MARK: - Claims
+
+    private func installClaimDeinitObserver(for owner: AnyObject) {
+        guard objc_getAssociatedObject(owner, &screenBrightnessOverrideManagerClaimObserverKey) == nil else { return }
+
+        let observer = ClaimDeinitObserver { [weak self] in
+            self?.performOnMainThread { [weak self] in
+                self?.reconcileBrightnessOverrideIfNeeded()
+            }
+        }
+        objc_setAssociatedObject(owner, &screenBrightnessOverrideManagerClaimObserverKey, observer, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    // MARK: - Threading
+
+    private func performOnMainThread(_ work: @escaping () -> Void) {
         if Thread.isMainThread {
             work()
         } else {
@@ -144,26 +193,28 @@ final class ScreenBrightnessOverrideManager: NSObject {
         }
     }
 
+    // MARK: - Notifications
+
     @objc private func restoreBrightnessForLifecycleChange(_ notification: Notification) {
-        performOnMainQueue { [weak self] in
-            self?.restoreBrightnessIfNeeded()
+        performOnMainThread { [weak self] in
+            self?.restoreOriginalBrightnessIfNeeded()
         }
     }
 
     @objc private func applyBrightnessForLifecycleChange(_ notification: Notification) {
-        performOnMainQueue { [weak self] in
-            self?.applyCurrentBrightnessIfNeeded()
+        performOnMainThread { [weak self] in
+            self?.reconcileBrightnessOverrideIfNeeded()
         }
     }
 
     @objc private func handleScreenBrightnessDidChangeNotification(_ notification: Notification) {
-        performOnMainQueue { [weak self] in
+        performOnMainThread { [weak self] in
             self?.handleScreenBrightnessDidChange()
         }
     }
 
     private func brightnessesMatch(_ lhs: CGFloat, _ rhs: CGFloat) -> Bool {
-        abs(lhs - rhs) < 0.0001
+        abs(lhs - rhs) < Constants.brightnessEpsilon
     }
 }
 

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -12,6 +12,161 @@ extension URL {
         }
     }
 }
+
+final class ScreenBrightnessOverrideManager: NSObject {
+    static let shared = ScreenBrightnessOverrideManager()
+
+    private struct Claim {
+        weak var owner: AnyObject?
+    }
+
+    private var claims = [Claim]()
+    private var originalBrightness: CGFloat?
+    private var pendingProgrammaticBrightness: CGFloat?
+
+    private override init() {
+        super.init()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(restoreBrightnessForLifecycleChange(_:)),
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applyBrightnessForLifecycleChange(_:)),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleScreenBrightnessDidChangeNotification(_:)),
+            name: UIScreen.brightnessDidChangeNotification,
+            object: UIScreen.main
+        )
+    }
+
+    func setActive(_ isActive: Bool, for owner: AnyObject) {
+        performOnMainQueue { [weak self] in
+            guard let self else { return }
+
+            self.removeClaim(for: owner)
+
+            if isActive {
+                self.claims.append(Claim(owner: owner))
+            }
+
+            if self.claims.isEmpty {
+                self.restoreBrightnessIfNeeded()
+            } else if UIApplication.shared.applicationState == .active {
+                self.applyCurrentBrightnessIfNeeded()
+            }
+        }
+    }
+
+    private func applyCurrentBrightnessIfNeeded() {
+        removeReleasedClaims()
+
+        guard !claims.isEmpty else {
+            restoreBrightnessIfNeeded()
+            return
+        }
+
+        if originalBrightness == nil {
+            originalBrightness = UIScreen.main.brightness
+        }
+
+        if !brightnessesMatch(UIScreen.main.brightness, 1.0) {
+            setBrightness(1.0)
+        }
+    }
+
+    private func restoreBrightnessIfNeeded() {
+        guard let originalBrightness else { return }
+
+        if !brightnessesMatch(UIScreen.main.brightness, originalBrightness) {
+            setBrightness(originalBrightness)
+        }
+
+        self.originalBrightness = nil
+    }
+
+    private func handleScreenBrightnessDidChange() {
+        removeReleasedClaims()
+
+        let currentBrightness = UIScreen.main.brightness
+
+        if let pendingProgrammaticBrightness,
+           brightnessesMatch(currentBrightness, pendingProgrammaticBrightness) {
+            self.pendingProgrammaticBrightness = nil
+            return
+        }
+
+        guard !claims.isEmpty else { return }
+
+        originalBrightness = currentBrightness
+        guard UIApplication.shared.applicationState == .active else { return }
+        applyCurrentBrightnessIfNeeded()
+    }
+
+    private func setBrightness(_ brightness: CGFloat) {
+        let clampedBrightness = min(max(brightness, 0), 1)
+
+        pendingProgrammaticBrightness = clampedBrightness
+        UIScreen.main.brightness = clampedBrightness
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  let pendingProgrammaticBrightness = self.pendingProgrammaticBrightness,
+                  self.brightnessesMatch(pendingProgrammaticBrightness, clampedBrightness) else { return }
+
+            self.pendingProgrammaticBrightness = nil
+        }
+    }
+
+    private func removeClaim(for owner: AnyObject) {
+        claims.removeAll { claim in
+            guard let claimOwner = claim.owner else { return true }
+            return claimOwner === owner
+        }
+    }
+
+    private func removeReleasedClaims() {
+        claims.removeAll { $0.owner == nil }
+    }
+
+    private func performOnMainQueue(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.async(execute: work)
+        }
+    }
+
+    @objc private func restoreBrightnessForLifecycleChange(_ notification: Notification) {
+        performOnMainQueue { [weak self] in
+            self?.restoreBrightnessIfNeeded()
+        }
+    }
+
+    @objc private func applyBrightnessForLifecycleChange(_ notification: Notification) {
+        performOnMainQueue { [weak self] in
+            self?.applyCurrentBrightnessIfNeeded()
+        }
+    }
+
+    @objc private func handleScreenBrightnessDidChangeNotification(_ notification: Notification) {
+        performOnMainQueue { [weak self] in
+            self?.handleScreenBrightnessDidChange()
+        }
+    }
+
+    private func brightnessesMatch(_ lhs: CGFloat, _ rhs: CGFloat) -> Bool {
+        abs(lhs - rhs) < 0.0001
+    }
+}
+
 struct Utils {
     public static let inviteDomain = "i.delta.chat"
 


### PR DESCRIPTION
QR codes are now easier to scan because the app temporarily turns the screen brightness up while they are shown, then restores the previous brightness when you leave the screen or the app goes to the background.

This also updates backup QR rendering ( #2989 )

## demo ( for new qr backup): 

<details>
<summary>Details</summary>

<img width="550" height="1041" alt="Screenshot 2026-03-04 at 8 22 46 PM" src="https://github.com/user-attachments/assets/fa5b0307-f3a1-41ba-9aca-ab0b8176fa21" />

</details>

close: #2989 

