### PR TITLE
feat: Show the group description when tapping its info message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - VoiceOver: Voice messages now no longer silence the VoiceOver permanently
 - Display message views count for channel owners
 - Improve mini-app summaries
+- Show the group description when tapping its info message
 - Update translations and local help
 - Update core to 2.44.0
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -819,6 +819,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             showProtectionEnabledDialog()
         case (_, DC_INFO_INVALID_UNENCRYPTED_MAIL):
             showInvalidUnencryptedDialog()
+        case (_, DC_INFO_GROUP_DESCRIPTION_CHANGED):
+            navigationController?.pushViewController(ProfileViewController(dcContext, chatId: chatId), animated: true)
         default:
             if let contactId = message.infoContactId, contactId != DC_CONTACT_ID_SELF {
                 navigationController?.pushViewController(ProfileViewController(dcContext, contactId: contactId), animated: true)


### PR DESCRIPTION
this PR opens the chat's profile when tapping an "chat description changed" info message

closes https://github.com/deltachat/deltachat-ios/issues/3020