### PR TITLE
Increase reply swipe sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Increase reply swipe sensitivity
 - Allow to switch profile when sharing or forwarding
 - Add tab bar icon bounce animation on tap
 - Explain at "Settings / Chats / Outgoing Media Quality" how to send original quality

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -144,7 +144,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     /// it if the cell was considered "swiped" by the system (aka when the leading actions stay open).
     /// This means the required swipe distance to activate the reply is just the distance to open the leading swipe action
     /// instead of the much further "performsFirstActionWithFullSwipe".
-    /// This also prevents issues stemming from the tableview being in editing state while sipe actions are open by just instantly closing the actions.
+    /// This also prevents issues stemming from the tableview being in editing state while swipe actions are open by just instantly closing the actions.
     private lazy var performReplyOnOpeningSwipeActionsGestureRecognizer: UIPanGestureRecognizer = {
         let panGestureRecognizer = UIPanGestureRecognizer()
         panGestureRecognizer.publisher(for: \.state, options: .new)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -140,6 +140,35 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         return false
     }
 
+    /// This is used to detect when a user finished swiping on a cell and then trigger the reply action for
+    /// it if the cell was considered "swiped" by the system (aka when the leading actions stay open).
+    /// This means the required swipe distance to activate the reply is just the distance to open the leading swipe action
+    /// instead of the much further "performsFirstActionWithFullSwipe".
+    /// This also prevents issues stemming from the tableview being in editing state while sipe actions are open by just instantly closing the actions.
+    private lazy var performReplyOnOpeningSwipeActionsGestureRecognizer: UIPanGestureRecognizer = {
+        let panGestureRecognizer = UIPanGestureRecognizer()
+        panGestureRecognizer.publisher(for: \.state, options: .new)
+            .filter { $0 == .ended }
+            .sink { [weak self] _ in
+                // Wait one runloop for the configurationState.isSwiped to be updated
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    if let swipedCell = tableView.visibleCells.first(where: \.configurationState.isSwiped),
+                       let indexPath = tableView.indexPath(for: swipedCell) {
+                        tableView.setEditing(false, animated: true)
+                        let messageId = messages[indexPath.row].id
+                        let message = dcContext.getMessage(id: messageId)
+                        guard canReply(to: message) else { return }
+                        replyToMessage(messageId)
+                    }
+                }
+            }
+            .store(in: &bag)
+        panGestureRecognizer.cancelsTouchesInView = false
+        panGestureRecognizer.delegate = self
+        return panGestureRecognizer
+    }()
+
     private lazy var navBarTap: UITapGestureRecognizer = {
         UITapGestureRecognizer(target: self, action: #selector(chatProfilePressed))
     }()
@@ -245,6 +274,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         super.viewDidLoad()
         view.addSubview(tableView)
         tableView.fillSuperview()
+
+        view.addGestureRecognizer(performReplyOnOpeningSwipeActionsGestureRecognizer)
 
         navigationController?.setNavigationBarHidden(false, animated: false)
         navigationController?.navigationBar.scrollEdgeAppearance = navigationController?.navigationBar.standardAppearance
@@ -721,11 +752,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             return nil
         }
 
-        let action = UIContextualAction(style: .normal, title: nil) { [weak self] (_, _, completionHandler) in
-            self?.replyToMessage(messageId)
-            completionHandler(true)
-        }
-
+        let action = UIContextualAction(style: .normal, title: nil) { (_, _, _) in }
         action.image = UIImage(systemName: "arrowshape.turn.up.left.fill")?
             .sd_tintedImage(with: DcColors.defaultInverseColor)?
             .sd_flippedImage(withHorizontal: false, vertical: true)
@@ -733,7 +760,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         action.backgroundColor = .systemGray.withAlphaComponent(0.0) // nil or .clear do not result in transparence
         action.accessibilityLabel = String.localized("notify_reply_button")
         let configuration = UISwipeActionsConfiguration(actions: [action])
-
+        // we perform the reply action on open in performFirstActionOnOpeningLeadingSwipeActionsPanGestureRecognizer
+        configuration.performsFirstActionWithFullSwipe = false
         return configuration
     }
 
@@ -2861,5 +2889,11 @@ extension ChatViewController: AppPickerViewControllerDelegate {
         configureDraftArea(draft: draft)
         focusInputTextView()
         FileHelper.deleteFileAsync(atPath: url.relativePath)
+    }
+}
+
+extension ChatViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return gestureRecognizer == performReplyOnOpeningSwipeActionsGestureRecognizer
     }
 }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -760,7 +760,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         action.backgroundColor = .systemGray.withAlphaComponent(0.0) // nil or .clear do not result in transparence
         action.accessibilityLabel = String.localized("notify_reply_button")
         let configuration = UISwipeActionsConfiguration(actions: [action])
-        // we perform the reply action on open in performFirstActionOnOpeningLeadingSwipeActionsPanGestureRecognizer
+        // we perform the reply action on open in performReplyOnOpeningSwipeActionsGestureRecognizer
         configuration.performsFirstActionWithFullSwipe = false
         return configuration
     }


### PR DESCRIPTION
This PR makes it:
- Easier to swipe reply as you no longer need to swipe the full width of the screen
- Impossible to end up in the editing state where a bubble is swiped to the right with the reply action showing.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/84a9ee9b-3fb4-4ac3-9799-2a716efe2e4b" />


This fixes #2864 and general UX complaints that I don't think we had an issue for.

| Old (half swipe) | Old (full swipe) | New (both) |
| --- | --- | --- |
| <video src="https://github.com/user-attachments/assets/f0e6a1c1-6ca1-428f-a3f0-57083f258db8"> | <video src="https://github.com/user-attachments/assets/435ed51f-4641-4503-b534-098d23b3a43e"> | <video src="https://github.com/user-attachments/assets/9050e7fa-3081-4f28-8df3-2c984c7d581e"> | 



