### PR TITLE
feat: mark messages as "unread"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- In the chat list, swipe a read chat to the right to mark it "unread"
 - Increase reply swipe sensitivity
 - Allow to switch profile when sharing or forwarding
 - Add tab bar icon bounce animation on tap

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -388,7 +388,7 @@ class ChatListViewController: UITableViewController {
 
     @objc func markReadPressed() {
         if isEditing {
-            viewModel?.markUnreadSelectedChats(in: tableView.indexPathsForSelectedRows)
+            viewModel?.markReadSelectedChats(in: tableView.indexPathsForSelectedRows)
             setLongTapEditing(false)
         } else if isArchive {
             dcContext.marknoticedChat(chatId: Int(DC_CHAT_ID_ARCHIVED_LINK))

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -548,6 +548,17 @@ class ChatListViewController: UITableViewController {
             markReadAction.image = UIImage(systemName: imageName)
 
             return UISwipeActionsConfiguration(actions: [markReadAction, pinAction])
+        } else if !chat.isSelfTalk {
+            let markUnreadAction = UIContextualAction(style: .destructive, title: String.localized("mark_as_unread_short")) { [weak self] _, _, completionHandler in
+                self?.dcContext.markfreshChat(chatId: chatId)
+                NotificationManager.updateBadgeCounters() // we do not get an INCOMING_MSG event, updated manually
+                completionHandler(true)
+            }
+            markUnreadAction.backgroundColor = UIColor.systemBlue
+            let imageName = if #available(iOS 16, *) { "message.badge" } else { "circle" }
+            markUnreadAction.image = UIImage(systemName: imageName)
+
+            return UISwipeActionsConfiguration(actions: [markUnreadAction, pinAction])
         } else {
             let actions = UISwipeActionsConfiguration(actions: [pinAction])
             actions.performsFirstActionWithFullSwipe = false

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -349,6 +349,10 @@ public class DcContext {
         dc_marknoticed_chat(self.contextPointer, UInt32(chatId))
     }
 
+    public func markfreshChat(chatId: Int) {
+        dc_markfresh_chat(self.contextPointer, UInt32(chatId))
+    }
+
     public func getSecurejoinQr(chatId: Int) -> String? {
         if let cString = dc_get_securejoin_qr(self.contextPointer, UInt32(chatId)) {
             let swiftString = String(cString: cString)

--- a/deltachat-ios/ViewModel/ChatListViewModel.swift
+++ b/deltachat-ios/ViewModel/ChatListViewModel.swift
@@ -241,7 +241,7 @@ class ChatListViewModel: NSObject {
         }
     }
 
-    func markUnreadSelectedChats(in indexPaths: [IndexPath]?) {
+    func markReadSelectedChats(in indexPaths: [IndexPath]?) {
         let chatIds = chatIdsFor(indexPaths: indexPaths)
         for chatId in chatIds {
             dcContext.marknoticedChat(chatId: chatId)


### PR DESCRIPTION
this PR adds an "mark unread" option at the place where otherwise "mark read" is shown on swiping.

this is kind of standard of standard on most messengers on iOS and one of the most often requested missing features in Delta Chat.

https://github.com/user-attachments/assets/a1d23c84-2d8a-430b-ac7a-2ed01fe291bb

~~the PR requires a core with https://github.com/chatmail/core/pull/7990 merged.~~ EDIT: core 2.46 on main comes with the required api