### PR TITLE
hide relays from contacts (unpublish relays)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Increase reply swipe sensitivity
 - Allow to switch profile when sharing or forwarding
+- Allow to hide a relay from contacts instead of removing, allowing smoother relay changes
 - Add tab bar icon bounce animation on tap
 - Explain at "Settings / Chats / Outgoing Media Quality" how to send original quality
 - Leave groups and channels before deletion

--- a/DcCore/DcCore.xcodeproj/project.pbxproj
+++ b/DcCore/DcCore.xcodeproj/project.pbxproj
@@ -26,13 +26,14 @@
 		30E8F2482449C98600CE2C90 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E8F2472449C98600CE2C90 /* UIView+Extensions.swift */; };
 		30E8F24D2449D30200CE2C90 /* DcColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E8F24C2449D30200CE2C90 /* DcColors.swift */; };
 		5F0FCC772DAE65AD00C4F9C3 /* UNMutableNotificationContent+init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0FCC762DAE65AD00C4F9C3 /* UNMutableNotificationContent+init.swift */; };
-		640BC0472DCC941D0049B475 /* DarwinNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640BC0462DCC941D0049B475 /* DarwinNotificationCenter.swift */; };
-		64E7AA642EBE43E400DB88B7 /* CallKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E7AA632EBE43DE00DB88B7 /* CallKit.swift */; };
 		640ACB472E1E3BA9000FBBCC /* ImageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640ACB462E1E3BA9000FBBCC /* ImageFormat.swift */; };
+		640BC0472DCC941D0049B475 /* DarwinNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640BC0462DCC941D0049B475 /* DarwinNotificationCenter.swift */; };
 		64E2FCC12E1AD9D200CA9662 /* CodableNSItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E2FCC02E1AD9D200CA9662 /* CodableNSItemProvider.swift */; };
+		64E7AA642EBE43E400DB88B7 /* CallKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E7AA632EBE43DE00DB88B7 /* CallKit.swift */; };
 		78072F172A040ED800EB7C98 /* libdeltachat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78072F162A040ED800EB7C98 /* libdeltachat.a */; };
 		7871729629BA495200F110DC /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7871729529BA495200F110DC /* SystemConfiguration.framework */; };
 		B2526A222DEA12A000EB90CC /* DcEnteredLoginParam.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2526A212DEA12A000EB90CC /* DcEnteredLoginParam.swift */; };
+		B2A830392F6D8C75006D1C8D /* DcTransportListEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A830382F6D8C75006D1C8D /* DcTransportListEntry.swift */; };
 		B2F691252C0790140010D9B1 /* DcVcard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F691242C0790140010D9B1 /* DcVcard.swift */; };
 		D8BBF0032B57D8E5008C96FD /* DcAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BBF0022B57D8E5008C96FD /* DcAccount.swift */; };
 		D8BBF0052B57D904008C96FD /* DcContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BBF0042B57D904008C96FD /* DcContext.swift */; };
@@ -71,15 +72,16 @@
 		30E8F2472449C98600CE2C90 /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		30E8F24C2449D30200CE2C90 /* DcColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DcColors.swift; sourceTree = "<group>"; };
 		5F0FCC762DAE65AD00C4F9C3 /* UNMutableNotificationContent+init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNMutableNotificationContent+init.swift"; sourceTree = "<group>"; };
-		640BC0462DCC941D0049B475 /* DarwinNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarwinNotificationCenter.swift; sourceTree = "<group>"; };
-		64E7AA632EBE43DE00DB88B7 /* CallKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallKit.swift; sourceTree = "<group>"; };
 		640ACB462E1E3BA9000FBBCC /* ImageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFormat.swift; sourceTree = "<group>"; };
+		640BC0462DCC941D0049B475 /* DarwinNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarwinNotificationCenter.swift; sourceTree = "<group>"; };
 		64E2FCC02E1AD9D200CA9662 /* CodableNSItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableNSItemProvider.swift; sourceTree = "<group>"; };
+		64E7AA632EBE43DE00DB88B7 /* CallKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallKit.swift; sourceTree = "<group>"; };
 		78072F162A040ED800EB7C98 /* libdeltachat.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdeltachat.a; path = "../deltachat-ios/libraries/libdeltachat.a"; sourceTree = "<group>"; };
 		7827C8882A04089900B8470D /* libraries */ = {isa = PBXFileReference; lastKnownFileType = folder; name = libraries; path = "../deltachat-ios/libraries"; sourceTree = "<group>"; };
 		7827C88A2A0408A700B8470D /* libdeltachat.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdeltachat.a; path = "../deltachat-ios/libraries/deltachat-core-rust/libdeltachat.a"; sourceTree = "<group>"; };
 		7871729529BA495200F110DC /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
 		B2526A212DEA12A000EB90CC /* DcEnteredLoginParam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DcEnteredLoginParam.swift; sourceTree = "<group>"; };
+		B2A830382F6D8C75006D1C8D /* DcTransportListEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DcTransportListEntry.swift; sourceTree = "<group>"; };
 		B2F691242C0790140010D9B1 /* DcVcard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DcVcard.swift; sourceTree = "<group>"; };
 		D8BBF0022B57D8E5008C96FD /* DcAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DcAccount.swift; sourceTree = "<group>"; };
 		D8BBF0042B57D904008C96FD /* DcContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DcContext.swift; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 		3042194B243DE15D00516852 /* DC */ = {
 			isa = PBXGroup;
 			children = (
+				B2A830382F6D8C75006D1C8D /* DcTransportListEntry.swift */,
 				B2526A212DEA12A000EB90CC /* DcEnteredLoginParam.swift */,
 				D8BBF0022B57D8E5008C96FD /* DcAccount.swift */,
 				D8BBF0162B57D99F008C96FD /* DcBackupProvider.swift */,
@@ -333,6 +336,7 @@
 				D8BBF0192B57D9AE008C96FD /* DcProvider.swift in Sources */,
 				30E8F2482449C98600CE2C90 /* UIView+Extensions.swift in Sources */,
 				3057028624C5C60000D84EFC /* UITableView+Extensions.swift in Sources */,
+				B2A830392F6D8C75006D1C8D /* DcTransportListEntry.swift in Sources */,
 				308198AB24866229003BE20D /* UserDefaults+Extensions.swift in Sources */,
 				B2526A222DEA12A000EB90CC /* DcEnteredLoginParam.swift in Sources */,
 				D8BBF00D2B57D949008C96FD /* DcChat.swift in Sources */,

--- a/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
@@ -269,10 +269,10 @@ class EditTransportViewController: UITableViewController {
         navigationItem.rightBarButtonItem = loginButton
 
         var loginParam: DcEnteredLoginParam?
-        let transports = dcContext.listTransports()
+        let transports = dcContext.listTransportsEx()
         for t in transports {
-            if t.addr == self.editAddr {
-                loginParam = t
+            if t.param.addr == self.editAddr {
+                loginParam = t.param
             }
         }
 

--- a/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
@@ -111,13 +111,29 @@ extension TransportListViewController {
             let parts = transport.param.addr.components(separatedBy: "@")
 
             cell.textLabel?.text = parts.last ?? transport.param.addr
-            cell.detailTextLabel?.text = (parts.first ?? "") + (isDefault ? (" · " + String.localized("def")) : "")
+
+            var details = (parts.first ?? "")
+            if isDefault {
+                details += " · " + String.localized("used_for_sending")
+            }
+            if transport.isUnpublished {
+                details += " · " + String.localized("hidden_from_contacts")
+            }
+            cell.detailTextLabel?.text = details
+
             cell.accessoryType = isDefault ? .checkmark : .none
 
             return cell
         } else {
             return addTransportCell
         }
+    }
+
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        if section == TransportSection.transports.rawValue {
+            return String.localized("transport_list_hint")
+        }
+        return nil
     }
 }
 

--- a/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
@@ -52,7 +52,7 @@ class TransportListViewController: UITableViewController {
     private func setDefaultTransport(at indexPath: IndexPath) {
         guard let transport = transports.get(at: indexPath.row) else { return }
         dcContext.setConfig("configured_addr", transport.param.addr)
-        tableView.reloadData()
+        reloadTransports()
     }
 
     private func editTransport(at indexPath: IndexPath) {
@@ -71,12 +71,21 @@ class TransportListViewController: UITableViewController {
         guard let transport = transports.get(at: indexPath.row) else { return }
 
         let parts = transport.param.addr.components(separatedBy: "@")
-        let text = String.localized(stringID: "confirm_remove_transport", parameter: parts.last ?? transport.param.addr)
+        let text = String.localized(stringID: "confirm_remove_or_hide_transport_x", parameter: parts.last ?? transport.param.addr)
         let alert = UIAlertController(title: text, message: nil, preferredStyle: .safeActionSheet)
+        alert.addAction(UIAlertAction(title: String.localized("hide_from_contacts"), style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            do {
+                try self.dcContext.setTransportUnpublished(addr: transport.param.addr, unpublished: true)
+            } catch {
+                logAndAlert(error: error.localizedDescription)
+            }
+            reloadTransports()
+        }))
         alert.addAction(UIAlertAction(title: String.localized("remove_transport"), style: .destructive, handler: { [weak self] _ in
             guard let self else { return }
             do {
-                _ = try self.dcContext.deleteTransport(addr: transport.param.addr)
+                try self.dcContext.deleteTransport(addr: transport.param.addr)
             } catch {
                 logAndAlert(error: error.localizedDescription)
             }

--- a/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
@@ -10,7 +10,7 @@ class TransportListViewController: UITableViewController {
     let dcContext: DcContext
     let dcAccounts: DcAccounts
 
-    var transports: [DcEnteredLoginParam]
+    var transports: [DcTransportListEntry]
 
     let addTransportCell: ActionCell
     private var qrCodeReader: QrCodeReaderController?
@@ -19,7 +19,7 @@ class TransportListViewController: UITableViewController {
     init(dcContext: DcContext, dcAccounts: DcAccounts, continueQrScan: String? = nil) {
         self.dcContext = dcContext
         self.dcAccounts = dcAccounts
-        self.transports = dcContext.listTransports()
+        self.transports = dcContext.listTransportsEx()
 
         addTransportCell = ActionCell()
         addTransportCell.actionTitle = String.localized("add_transport")
@@ -43,7 +43,7 @@ class TransportListViewController: UITableViewController {
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     private func reloadTransports() {
-        transports = dcContext.listTransports()
+        transports = dcContext.listTransportsEx()
         tableView.reloadData()
     }
 
@@ -51,13 +51,13 @@ class TransportListViewController: UITableViewController {
 
     private func setDefaultTransport(at indexPath: IndexPath) {
         guard let transport = transports.get(at: indexPath.row) else { return }
-        dcContext.setConfig("configured_addr", transport.addr)
+        dcContext.setConfig("configured_addr", transport.param.addr)
         tableView.reloadData()
     }
 
     private func editTransport(at indexPath: IndexPath) {
         guard let transport = transports.get(at: indexPath.row) else { return }
-        navigationController?.pushViewController(EditTransportViewController(dcAccounts: dcAccounts, editAddr: transport.addr), animated: true)
+        navigationController?.pushViewController(EditTransportViewController(dcAccounts: dcAccounts, editAddr: transport.param.addr), animated: true)
     }
 
     private func addTransport() {
@@ -70,13 +70,13 @@ class TransportListViewController: UITableViewController {
     private func deleteTransport(at indexPath: IndexPath) {
         guard let transport = transports.get(at: indexPath.row) else { return }
 
-        let parts = transport.addr.components(separatedBy: "@")
-        let text = String.localized(stringID: "confirm_remove_transport", parameter: parts.last ?? transport.addr)
+        let parts = transport.param.addr.components(separatedBy: "@")
+        let text = String.localized(stringID: "confirm_remove_transport", parameter: parts.last ?? transport.param.addr)
         let alert = UIAlertController(title: text, message: nil, preferredStyle: .safeActionSheet)
         alert.addAction(UIAlertAction(title: String.localized("remove_transport"), style: .destructive, handler: { [weak self] _ in
             guard let self else { return }
             do {
-                _ = try self.dcContext.deleteTransport(addr: transport.addr)
+                _ = try self.dcContext.deleteTransport(addr: transport.param.addr)
             } catch {
                 logAndAlert(error: error.localizedDescription)
             }
@@ -107,10 +107,10 @@ extension TransportListViewController {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: TransportCell.reuseIdentifier, for: indexPath) as? TransportCell else { fatalError() }
 
             let transport = transports[indexPath.row]
-            let isDefault = transport.isDefault(dcContext)
-            let parts = transport.addr.components(separatedBy: "@")
+            let isDefault = transport.param.isDefault(dcContext)
+            let parts = transport.param.addr.components(separatedBy: "@")
 
-            cell.textLabel?.text = parts.last ?? transport.addr
+            cell.textLabel?.text = parts.last ?? transport.param.addr
             cell.detailTextLabel?.text = (parts.first ?? "") + (isDefault ? (" · " + String.localized("def")) : "")
             cell.accessoryType = isDefault ? .checkmark : .none
 
@@ -139,7 +139,7 @@ extension TransportListViewController {
         guard let transport = transports.get(at: indexPath.row) else { return nil }
         var actions: [UIContextualAction] = []
 
-        if !transport.isDefault(dcContext) {
+        if !transport.param.isDefault(dcContext) {
             let deleteAction = UIContextualAction(style: .destructive, title: String.localized("remove_desktop")) { [weak self] _, _, completion in
                 DispatchQueue.main.async {
                     self?.deleteTransport(at: indexPath)
@@ -163,7 +163,7 @@ extension TransportListViewController {
         actions.append(editAction)
 
         let actionsConfiguration = UISwipeActionsConfiguration(actions: actions)
-        actionsConfiguration.performsFirstActionWithFullSwipe = !transport.isDefault(dcContext)
+        actionsConfiguration.performsFirstActionWithFullSwipe = !transport.param.isDefault(dcContext)
         return actionsConfiguration
     }
 
@@ -179,7 +179,7 @@ extension TransportListViewController {
                 var children: [UIMenuElement] = []
 
                 children.append(UIAction.menuAction(localizationKey: "edit_transport", systemImageName: "pencil", with: indexPath, action: editTransport))
-                if !transport.isDefault(dcContext) {
+                if !transport.param.isDefault(dcContext) {
                     children.append(UIAction.menuAction(localizationKey: "remove_transport", attributes: [.destructive], systemImageName: "trash", with: indexPath, action: deleteTransport))
                 }
 

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -595,6 +595,17 @@ public class DcContext {
         return []
     }
 
+    public func listTransportsEx() -> [DcTransportListEntry] {
+        do {
+            if let data = try DcAccounts.shared.blockingCall(method: "list_transports_ex", params: [id as AnyObject]) {
+                return try JSONDecoder().decode(DcTransportListEntryResult.self, from: data).result
+            }
+        } catch {
+            logger.error(error.localizedDescription)
+        }
+        return []
+    }
+
     public func addOrUpdateTransport(param: DcEnteredLoginParam) throws -> Bool {
         let res = try DcAccounts.shared.blockingCall(method: "add_or_update_transport", accountId: id, codable: param)
         return res != nil
@@ -603,6 +614,10 @@ public class DcContext {
     public func addTransportFromQr(qrCode: String) throws -> Bool {
         let res = try DcAccounts.shared.blockingCall(method: "add_transport_from_qr", params: [id as AnyObject, qrCode as AnyObject])
         return res != nil
+    }
+
+    public func setTransportUnpublished(addr: String, unpublished: Bool) throws {
+        try DcAccounts.shared.blockingCall(method: "set_transport_unpublished", params: [id as AnyObject, addr as AnyObject, unpublished as AnyObject])
     }
 
     public func deleteTransport(addr: String) throws {

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -584,17 +584,6 @@ public class DcContext {
         dc_send_text_msg(contextPointer, UInt32(id), message)
     }
 
-    public func listTransports() -> [DcEnteredLoginParam] {
-        do {
-            if let data = try DcAccounts.shared.blockingCall(method: "list_transports", params: [id as AnyObject]) {
-                return try JSONDecoder().decode(DcEnteredLoginParamResult.self, from: data).result
-            }
-        } catch {
-            logger.error(error.localizedDescription)
-        }
-        return []
-    }
-
     public func listTransportsEx() -> [DcTransportListEntry] {
         do {
             if let data = try DcAccounts.shared.blockingCall(method: "list_transports_ex", params: [id as AnyObject]) {

--- a/deltachat-ios/DC/DcEnteredLoginParam.swift
+++ b/deltachat-ios/DC/DcEnteredLoginParam.swift
@@ -27,7 +27,3 @@ public struct DcEnteredLoginParam: Codable {
         return false
     }
 }
-
-struct DcEnteredLoginParamResult: Decodable {
-    let result: [DcEnteredLoginParam]
-}

--- a/deltachat-ios/DC/DcTransportListEntry.swift
+++ b/deltachat-ios/DC/DcTransportListEntry.swift
@@ -5,6 +5,4 @@ public struct DcTransportListEntry: Decodable {
     public let param: DcEnteredLoginParam
 }
 
-struct DcTransportListEntryResult: Decodable {
-    let result: [DcTransportListEntry]
-}
+typealias DcTransportListEntryResult = JsonrpcResult<[DcTransportListEntry]>

--- a/deltachat-ios/DC/DcTransportListEntry.swift
+++ b/deltachat-ios/DC/DcTransportListEntry.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct DcTransportListEntry: Decodable {
+    public let isUnpublished: Bool
+    public let param: DcEnteredLoginParam
+}
+
+struct DcTransportListEntryResult: Decodable {
+    let result: [DcTransportListEntry]
+}


### PR DESCRIPTION
this PR adds the option "hide from contacts" to the "remove relay" alert and refine strings and wordings, saying "used for sending" instead of "default" and explaining what the other relays are for.

counterpart of https://github.com/deltachat/deltachat-android/pull/4289 and https://github.com/deltachat/deltachat-desktop/pull/6137

<img width="360" src="https://github.com/user-attachments/assets/d04661dc-0de6-433a-8d78-f62470b4b583" />
<img width="360" src="https://github.com/user-attachments/assets/43b8955a-0f2b-49cd-a7c2-19eace361a61" />


