### PR TITLE
set relay-delete-confirmation message as such

### DIFF
--- a/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
@@ -72,7 +72,7 @@ class TransportListViewController: UITableViewController {
 
         let parts = transport.param.addr.components(separatedBy: "@")
         let text = String.localized(stringID: "confirm_remove_or_hide_transport_x", parameter: parts.last ?? transport.param.addr)
-        let alert = UIAlertController(title: text, message: nil, preferredStyle: .safeActionSheet)
+        let alert = UIAlertController(title: nil, message: text, preferredStyle: .safeActionSheet)
         alert.addAction(UIAlertAction(title: String.localized("hide_from_contacts"), style: .default, handler: { [weak self] _ in
             guard let self else { return }
             do {


### PR DESCRIPTION
use 'message:' instead of 'title:' for the delete confirmation message, turns out, it is shown in bold then - when providing only title it is non-bold, when providing both, title is bold.

this is subject to change by apple, iirc, it was also at some point, maybe years ago, the other way round, that 'message only' is not-bold.

but it is semantically correct this way, so it makes sense in any case.

targeting comment at https://github.com/deltachat/deltachat-ios/pull/3059#issuecomment-4100767586

#skip-changelog as this is already covered by #3059 and there is no release since then

before / after:

<img width="350" src="https://github.com/user-attachments/assets/54106418-d3cf-4d70-aba5-e60c9dce4395" />
<img width="350" src="https://github.com/user-attachments/assets/ee0f47af-3748-4423-98e1-171f0c5389c2" />

