### PR TITLE
fix circular reference between ChatListViewController and ChatListViewModel

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -93,7 +93,7 @@ class ChatListViewController: UITableViewController {
         DispatchQueue.global(qos: .userInteractive).async { [weak self] in
             guard let self else { return }
             self.viewModel = ChatListViewModel(dcContext: self.dcContext, isArchive: isArchive)
-            self.viewModel?.onChatListUpdate = self.handleChatListUpdate
+            self.viewModel?.onChatListUpdate = { [weak self] in self?.handleChatListUpdate() }
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 if !isArchive {


### PR DESCRIPTION
This fixes ChatListViewController leaking every time you switch profiles which is can cause lag on slower phones even with less than 10 of them.