### PR TITLE
feat: clear all storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- Add option to clear all storage to connectivity view
+
+
 ## v2.49.0 Testflight
 2026-04
 

--- a/deltachat-ios/Controller/ConnectivityViewController.swift
+++ b/deltachat-ios/Controller/ConnectivityViewController.swift
@@ -4,6 +4,11 @@ import Network
 
 class ConnectivityViewController: WebViewViewController {
 
+    private lazy var moreButton: UIBarButtonItem = {
+        let image = UIImage(systemName: "ellipsis.circle")
+        return UIBarButtonItem(image: image, menu: moreButtonMenu())
+    }()
+
     override init(dcContext: DcContext) {
         super.init(dcContext: dcContext)
 
@@ -22,6 +27,7 @@ class ConnectivityViewController: WebViewViewController {
         self.webView.isOpaque = false
         self.webView.backgroundColor = .clear
         view.backgroundColor = DcColors.defaultBackgroundColor
+        navigationItem.rightBarButtonItems = [moreButton]
     }
     
     // called everytime the view will appear
@@ -34,6 +40,18 @@ class ConnectivityViewController: WebViewViewController {
         guard dcContext.id == notification.userInfo?["account_id"] as? Int else { return }
 
         loadHtml()
+    }
+
+    private func moreButtonMenu() -> UIMenu {
+        let clearImage = if #available(iOS 16.0, *) { "eraser" } else { "rectangle.portrait" }
+        let actions = [
+            UIAction(title: String.localized("clear_all_relay_storage"), image: UIImage(systemName: clearImage)) { [weak self] _ in
+                guard let self else { return }
+                dcContext.clearAllRelayStorage()
+                loadHtml()
+            },
+        ]
+        return UIMenu(children: actions)
     }
 
     private func loadHtml() {

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -853,4 +853,12 @@ public class DcContext {
         }
         return "ErrUsageReport"
     }
+
+    public func clearAllRelayStorage() {
+        do {
+            try DcAccounts.shared.blockingCall(method: "clear_all_relay_storage", params: [id as AnyObject])
+        } catch {
+            logger.error(error.localizedDescription)
+        }
+    }
 }

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -1065,3 +1065,4 @@
 "backup_successful_explain_ios" = "You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.";
 "location_denied" = "Location access denied";
 "location_denied_explain_ios" = "In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".";
+"clear_all_relay_storage" = "Clear All Storage";

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -1065,4 +1065,4 @@
 "backup_successful_explain_ios" = "You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.";
 "location_denied" = "Location access denied";
 "location_denied_explain_ios" = "In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".";
-"clear_all_relay_storage" = "Clear All Storage";
+"clear_all_relay_storage" = "Clear All Relay Storage";

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -7,5 +7,5 @@
     <string name="backup_successful_explain_ios">You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.</string>
     <string name="location_denied">Location access denied</string>
     <string name="location_denied_explain_ios">In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".</string>
-    <string name="clear_all_relay_storage">Clear All Storage</string>
+    <string name="clear_all_relay_storage">Clear All Relay Storage</string>
 </resources>

--- a/scripts/untranslated.xml
+++ b/scripts/untranslated.xml
@@ -7,4 +7,5 @@
     <string name="backup_successful_explain_ios">You can find the backup in the \"Delta Chat\" folder using the \"Files\" app.\n\nMove the backup out of this folder to keep it when deleting Delta Chat.</string>
     <string name="location_denied">Location access denied</string>
     <string name="location_denied_explain_ios">In the system settings, enable \"Privacy/Location Services\" and set \"Delta Chat/Location\" to \"Always\" and \"Precise\".</string>
+    <string name="clear_all_relay_storage">Clear All Storage</string>
 </resources>


### PR DESCRIPTION
add a "Clear All Storage" button to the three dot menu.

it is on purpose, that the option is not directly in the main UI; if ppl are in trouble because of storage, they will find it. maybe we also want to add it as actionable item to the storage warnings, cmp https://github.com/chatmail/core/issues/7730

counterpart of https://github.com/deltachat/deltachat-desktop/pull/6207

requires core with https://github.com/chatmail/core/pull/8105


<img width="320" src="https://github.com/user-attachments/assets/e25827db-322b-434c-a4d0-49e63b3106d9" />
