### PR TITLE
fix: do not crash when swiping keyboard down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Delta Chat iOS Changelog
 
-## v2.49.0 Testflight
+## Unreleased
+
+- Fix: do not crash when swiping keyboard down
+
+
+## v2.49.0
 2026-04
 
 - Fix: Mark a message as delivered only after it has been fully sent out

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -285,6 +285,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
         // Binding to the tableView will enable interactive dismissal
         keyboardManager?.bind(to: tableView)
+        tableView.keyboardDismissMode = .onDrag
         keyboardManager?.on(event: .willShow) { [weak self, tableView] notification in
             // Using superview instead of window here because in iOS 13+ a modal can change
             // the frame of the vc it is presented over which causes this calculation to be off.


### PR DESCRIPTION
actually fixed by @Amzd on my computer
with @adbenitez hanging around

closes https://github.com/deltachat/deltachat-ios/issues/3073