### PR TITLE
feat: configurable app picker url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Configurable app store url
 - Fix: do not crash when swiping keyboard down
 
 

--- a/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
@@ -61,7 +61,11 @@ public extension UserDefaults {
         UserDefaults.standard.string(forKey: appPickerUrl) ?? defaultAppPickerUrlString
     }
 
-    static func setAppPickerUrlString(_ url: String) {
-        UserDefaults.standard.set(url, forKey: appPickerUrl)
+    static func setAppPickerUrlString(_ url: String?) {
+        if let url {
+            UserDefaults.standard.set(url, forKey: appPickerUrl)
+        } else {
+            UserDefaults.standard.removeObject(forKey: appPickerUrl)
+        }
     }
 }

--- a/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
@@ -58,11 +58,7 @@ public extension UserDefaults {
     }
 
     static func getAppPickerUrlString() -> String {
-        if let url = UserDefaults.standard.string(forKey: appPickerUrl) {
-            return url
-        } else {
-            return defaultAppPickerUrlString
-        }
+        UserDefaults.standard.string(forKey: appPickerUrl) ?? defaultAppPickerUrlString
     }
 
     static func setAppPickerUrlString(_ url: String) {

--- a/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
@@ -7,6 +7,8 @@ public extension UserDefaults {
     static var mainIoRunningKey = "mainIoRunning"
     static var nseFetchingKey = "nseFetching"
     static var incomingCallPayloadKey = "incomingCallPayload"
+    static var appPickerUrl = "appPickerUrl"
+    static var defaultAppPickerUrlString = "https://webxdc.org/apps/"
 
     static var shared: UserDefaults? {
         return UserDefaults(suiteName: "group.chat.delta.ios")
@@ -53,5 +55,17 @@ public extension UserDefaults {
         }
         slidingValues.append(DateUtils.getExtendedAbsTimeSpanString(timeStamp: Date().timeIntervalSince1970) + "|" + value)
         shared.set(slidingValues, forKey: debugArrayKey)
+    }
+
+    static func getAppPickerUrlString() -> String {
+        if let url = UserDefaults.standard.string(forKey: appPickerUrl) {
+            return url
+        } else {
+            return defaultAppPickerUrlString
+        }
+    }
+
+    static func setAppPickerUrlString(_ url: String) {
+        UserDefaults.standard.set(url, forKey: appPickerUrl)
     }
 }

--- a/deltachat-ios/Chat/Apps/WebxdcStoreViewController.swift
+++ b/deltachat-ios/Chat/Apps/WebxdcStoreViewController.swift
@@ -10,11 +10,12 @@ protocol WebxdcStoreViewControllerDelegate: AnyObject {
 class WebxdcStoreViewController: UIViewController {
     weak var delegate: WebxdcStoreViewControllerDelegate?
     let webView: WKWebView
+    let appPickerUrl: URL?
 
-    init(url: URL = URL(string: "https://webxdc.org/apps/")!) {
+    init() {
         webView = WKWebView(frame: .zero)
         webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.load(URLRequest(url: url))
+        appPickerUrl = URL(string: UserDefaults.getAppPickerUrlString())
 
         super.init(nibName: nil, bundle: nil)
 
@@ -35,6 +36,14 @@ class WebxdcStoreViewController: UIViewController {
         ]
 
         NSLayoutConstraint.activate(constraints)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let appPickerUrl else { return }
+            webView.load(URLRequest(url: appPickerUrl))
+        }
     }
 }
 
@@ -62,7 +71,7 @@ extension WebxdcStoreViewController: WKNavigationDelegate {
                 delegate?.pickedAnDownloadedApp(self, fileURL: fileURL as URL)
                 decisionHandler(.cancel)
             }
-        } else if url.host == "webxdc.org" {
+        } else if url.host == appPickerUrl?.host {
             decisionHandler(.allow)
         } else if UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url)

--- a/deltachat-ios/Chat/Apps/WebxdcStoreViewController.swift
+++ b/deltachat-ios/Chat/Apps/WebxdcStoreViewController.swift
@@ -15,7 +15,11 @@ class WebxdcStoreViewController: UIViewController {
     init() {
         webView = WKWebView(frame: .zero)
         webView.translatesAutoresizingMaskIntoConstraints = false
+
         appPickerUrl = URL(string: UserDefaults.getAppPickerUrlString())
+        if let appPickerUrl {
+            webView.load(URLRequest(url: appPickerUrl))
+        }
 
         super.init(nibName: nil, bundle: nil)
 
@@ -36,14 +40,6 @@ class WebxdcStoreViewController: UIViewController {
         ]
 
         NSLayoutConstraint.activate(constraints)
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        DispatchQueue.main.async { [weak self] in
-            guard let self, let appPickerUrl else { return }
-            webView.load(URLRequest(url: appPickerUrl))
-        }
     }
 }
 

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -301,14 +301,14 @@ internal final class AdvancedViewController: UITableViewController {
         let alert = UIAlertController(title: String.localized("webxdc_store_url"), message: String.localized("webxdc_store_url_explain"), preferredStyle: .alert)
         alert.addTextField { textfield in
             textfield.placeholder = UserDefaults.defaultAppPickerUrlString
-            textfield.text = UserDefaults.getAppPickerUrlString()
+            textfield.text = UserDefaults.getAppPickerUrlString() == UserDefaults.defaultAppPickerUrlString ? nil : UserDefaults.getAppPickerUrlString()
         }
         alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
         alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default) { [weak self] _ in
             guard let self, let textfield = alert.textFields?.first else { return }
             guard let appPickerUrl = textfield.text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
             if appPickerUrl.isEmpty {
-                UserDefaults.setAppPickerUrlString(UserDefaults.defaultAppPickerUrlString)
+                UserDefaults.setAppPickerUrlString(nil)
             } else {
                 UserDefaults.setAppPickerUrlString(appPickerUrl)
             }

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -17,6 +17,7 @@ internal final class AdvancedViewController: UITableViewController {
         case viewLog
         case transportSettings
         case proxySettings
+        case appPickerUrl
     }
 
     private var dcContext: DcContext
@@ -156,6 +157,14 @@ internal final class AdvancedViewController: UITableViewController {
         })
     }()
 
+    private lazy var appPickerCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: nil)
+        cell.tag = CellTags.appPickerUrl.rawValue
+        cell.textLabel?.text = String.localized("webxdc_store_url")
+        cell.detailTextLabel?.text = UserDefaults.getAppPickerUrlString()
+        return cell
+    }()
+
     private lazy var viewLogCell: UITableViewCell = {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
         cell.tag = CellTags.viewLog.rawValue
@@ -176,7 +185,7 @@ internal final class AdvancedViewController: UITableViewController {
         let experimentalSection = SectionConfigs(
             headerTitle: String.localized("pref_experimental_features"),
             footerTitle: String.localized("pref_experimental_features_explain"),
-            cells: [broadcastListsCell, callsCell, locationStreamingCell])
+            cells: [broadcastListsCell, callsCell, locationStreamingCell, appPickerCell])
 
         if dcContext.isChatmail {
             return [viewLogSection, serverSection, experimentalSection]
@@ -242,6 +251,10 @@ internal final class AdvancedViewController: UITableViewController {
             }
         case .proxySettings:
             showProxySettings()
+
+        case .appPickerUrl:
+            editAppPickerUrl()
+
         case .defaultTagValue: break
         }
     }
@@ -282,6 +295,26 @@ internal final class AdvancedViewController: UITableViewController {
     private func showProxySettings() {
         let proxySettingsController = ProxySettingsViewController(dcContext: dcContext, dcAccounts: dcAccounts)
         navigationController?.pushViewController(proxySettingsController, animated: true)
+    }
+
+    private func editAppPickerUrl() {
+        let alert = UIAlertController(title: String.localized("webxdc_store_url"), message: String.localized("webxdc_store_url_explain"), preferredStyle: .alert)
+        alert.addTextField { textfield in
+            textfield.placeholder = UserDefaults.defaultAppPickerUrlString
+            textfield.text = UserDefaults.getAppPickerUrlString()
+        }
+        alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
+        alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default) { [weak self] _ in
+            guard let self, let textfield = alert.textFields?.first else { return }
+            guard let appPickerUrl = textfield.text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
+            if appPickerUrl.isEmpty {
+                UserDefaults.setAppPickerUrlString(UserDefaults.defaultAppPickerUrlString)
+            } else {
+                UserDefaults.setAppPickerUrlString(appPickerUrl)
+            }
+            appPickerCell.detailTextLabel?.text = UserDefaults.getAppPickerUrlString()
+        })
+        present(alert, animated: true)
     }
 
     private func presentError(message: String) {


### PR DESCRIPTION
this PR makes the app store url configurable, same as on android.

for testing, an alternative store url is `https://webxdc.github.io/website/apps/` (the default is `https://webxdc.org/apps/`)

first, i forgot to adapt the decisionHandler(), while checking for possible reasons that the page was not loaded, i realised that other webview were actually loaded in viewWillAppear, not in init. i adapted the loading accordingly, this seems more correct.

<img width="320" src="https://github.com/user-attachments/assets/7282849c-73f0-409e-a8c7-7c4b91dd82a2" /> <img width="320" src="https://github.com/user-attachments/assets/a9b90189-92ca-4d3a-861a-bac6e13d2680" />


