### PR TITLE
Disable interactiveContentPopGestureRecognizer on webxdc vc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix some text direction issues in "Show full message" view
 - Fix: Do not try to resolve proxy IPv6 addresses in square brackets.
 - Fix: Do not fail to receive post-message with status updates for deleted webxdc
+- Fix: Disabled new iOS 26 pop gesture in webxdc to align with older versions
 - Update core to 2.51.0
 
 

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -292,6 +292,9 @@ class WebxdcViewController: WebViewViewController {
         super.willMove(toParent: parent)
         let willBeRemoved = parent == nil
         navigationController?.interactivePopGestureRecognizer?.isEnabled = willBeRemoved
+        if #available(iOS 26.0, *) {
+            navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = willBeRemoved
+        }
     }
 
     func refreshWebxdcInfo() {


### PR DESCRIPTION
The interactivePopGestureRecognizer was already disabled, also do this for interactiveContentPopGestureRecognizer