### PR TITLE
feat: play voice/audio messages in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- Allow voice and audio messages to continue playing in the background
+
+
 ## v2.53.0
 2026-06
 

--- a/deltachat-ios/Calls/CallManager.swift
+++ b/deltachat-ios/Calls/CallManager.swift
@@ -84,12 +84,14 @@ class CallManager: NSObject {
                     logger.error("☎️ failed to start call: \(error.localizedDescription)")
                 } else if let currentCall {
                     logger.info("☎️ call started to \(nameToDisplay)")
+                    AudioController.stopBackgroundPlayback()
                     DispatchQueue.main.async {
                         CallWindow.shared?.showCallUI(for: currentCall)
                     }
                 }
             }
         } else if let currentCall {
+            AudioController.stopBackgroundPlayback()
             DispatchQueue.main.async {
                 CallWindow.shared?.showCallUI(for: currentCall)
             }
@@ -141,6 +143,7 @@ class CallManager: NSObject {
                 }
             }
         }
+        AudioController.stopBackgroundPlayback()
     }
 
     @objc private func handleIncomingCallAcceptedEvent(_ notification: Notification) {

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import AVFoundation
+import MediaPlayer
 import DcCore
 
 /// The `PlayerState` indicates the current audio controller state
@@ -23,11 +24,23 @@ public protocol AudioControllerDelegate: AnyObject {
 /// and also creates and manage an `AVAudioPlayer` states, play, pause and stop.
 open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDelegate {
 
+    private enum AudioPlaybackError: Error {
+        case missingFileURL
+        case playFailed
+    }
+
+    private static var backgroundPlaybackController: AudioController?
+    private static var remoteCommandsConfigured = false
+
     open weak var delegate: AudioControllerDelegate?
 
     lazy var audioSession: AVAudioSession = {
         let audioSession = AVAudioSession.sharedInstance()
-        _ = try? audioSession.setCategory(AVAudioSession.Category.playback, options: [.defaultToSpeaker])
+        do {
+            try audioSession.setCategory(AVAudioSession.Category.playback, options: [.defaultToSpeaker])
+        } catch {
+            logger.warning("setting audio session category failed: \(error.localizedDescription)")
+        }
         return audioSession
     }()
 
@@ -50,6 +63,9 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     /// The `Timer` that update playing progress
     internal var progressTimer: Timer?
 
+    private var lastNowPlayingInfoUpdate = Date.distantPast
+    private var playingArtwork: MPMediaItemArtwork?
+
     // MARK: - Init Methods
 
     public init(dcContext: DcContext, chatId: Int, delegate: AudioControllerDelegate? = nil) {
@@ -62,6 +78,10 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
                                                selector: #selector(audioRouteChanged),
                                                name: AVAudioSession.routeChangeNotification,
                                                object: AVAudioSession.sharedInstance())
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(appWillTerminate),
+                                               name: UIApplication.willTerminateNotification,
+                                               object: nil)
     }
 
     deinit {
@@ -69,6 +89,19 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     }
 
     // MARK: - Methods
+
+    static func stopBackgroundPlayback() {
+        performOnMainAndWait {
+            backgroundPlaybackController?.stopAnyOngoingPlaying()
+        }
+    }
+
+    static func stopBackgroundPlayback(forContextId contextId: Int) {
+        performOnMainAndWait {
+            guard let controller = backgroundPlaybackController, controller.dcContext.id == contextId else { return }
+            controller.stopAnyOngoingPlaying()
+        }
+    }
 
     /// - Parameters:
     ///   - cell: The `NewAudioMessageCell` that needs to be configure.
@@ -78,17 +111,19 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     ///   This protocol method is called by MessageKit every time an audio cell needs to be configure
     func update(_ cell: AudioMessageCell, with messageId: Int) {
         cell.delegate = self
-        if playingMessage?.id == messageId, let player = audioPlayer {
-            playingCell = cell
+        if let activeController = AudioController.backgroundPlaybackController,
+           activeController.isPlayingMessage(messageId: messageId, contextId: dcContext.id),
+           let player = activeController.audioPlayer {
+            activeController.playingCell = cell
             cell.audioPlayerView.setProgress((player.duration == 0) ? 0 : Float(player.currentTime/player.duration))
-            cell.audioPlayerView.showPlayLayout((player.isPlaying == true) ? true : false)
+            cell.audioPlayerView.showPlayLayout(player.isPlaying)
             cell.audioPlayerView.setDuration(duration: player.currentTime)
         }
     }
     
     public func getAudioDuration(messageId: Int, successHandler: @escaping (Int, Double) -> Void) {
         let message = dcContext.getMessage(id: messageId)
-        if playingMessage?.id == messageId {
+        if AudioController.backgroundPlaybackController?.isPlayingMessage(messageId: messageId, contextId: dcContext.id) == true {
             // irgnore messages that are currently playing or recently paused
             return
         }
@@ -122,24 +157,36 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     }
 
     public func playButtonTapped(cell: AudioMessageCell, messageId: Int) {
-            let message = dcContext.getMessage(id: messageId)
-            guard state != .stopped else {
-                // There is no audio sound playing - prepare to start playing for given audio message
-                playSound(for: message, in: cell)
+        let message = dcContext.getMessage(id: messageId)
+        if let activeController = AudioController.backgroundPlaybackController, activeController !== self {
+            if activeController.isPlayingMessage(messageId: message.id, contextId: dcContext.id) {
+                activeController.playingCell = cell
+                if activeController.state == .playing {
+                    activeController.pauseSound(in: cell)
+                } else {
+                    activeController.resumeSound()
+                }
                 return
             }
-            if playingMessage?.messageId == message.messageId {
-                // tap occur in the current cell that is playing audio sound
-                if state == .playing {
-                    pauseSound(in: cell)
-                } else {
-                    resumeSound()
-                }
+            AudioController.stopBackgroundPlayback()
+        }
+        guard state != .stopped else {
+            // There is no audio sound playing - prepare to start playing for given audio message
+            playSound(for: message, in: cell)
+            return
+        }
+        if isPlayingMessage(messageId: message.id, contextId: dcContext.id) {
+            // tap occur in the current cell that is playing audio sound
+            if state == .playing {
+                pauseSound(in: cell)
             } else {
-                // tap occur in a difference cell that the one is currently playing sound. First stop currently playing and start the sound for given message
-                stopAnyOngoingPlaying()
-                playSound(for: message, in: cell)
+                resumeSound()
             }
+        } else {
+            // tap occur in a difference cell that the one is currently playing sound. First stop currently playing and start the sound for given message
+            stopAnyOngoingPlaying()
+            playSound(for: message, in: cell)
+        }
     }
 
     /// Used to start play audio sound
@@ -148,21 +195,34 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     ///   - message: The `DcMsg` that contain the audio item to be played.
     ///   - audioCell: The `NewAudioMessageCell` that needs to be updated while audio is playing.
     open func playSound(for message: DcMsg, in audioCell: AudioMessageCell) {
-        if message.type == DC_MSG_AUDIO || message.type == DC_MSG_VOICE {
-            _ = try? audioSession.setActive(true)
+        guard message.type == DC_MSG_AUDIO || message.type == DC_MSG_VOICE else { return }
+        if let activeController = AudioController.backgroundPlaybackController, activeController !== self {
+            AudioController.stopBackgroundPlayback()
+        }
+        do {
+            guard let fileUrl = message.fileURL else { throw AudioPlaybackError.missingFileURL }
+            let player = try AVAudioPlayer(contentsOf: fileUrl)
+            try audioSession.setActive(true)
+            audioPlayer = player
             playingCell = audioCell
             playingMessage = message
-            if let fileUrl = message.fileURL, let player = try? AVAudioPlayer(contentsOf: fileUrl) {
-                audioPlayer = player
-                audioPlayer?.prepareToPlay()
-                audioPlayer?.delegate = self
-                audioPlayer?.play()
-                state = .playing
-                audioCell.audioPlayerView.showPlayLayout(true)  // show pause button on audio cell
-                startProgressTimer()
-            } else {
-                delegate?.onAudioPlayFailed()
+            loadArtwork(for: message)
+            AudioController.backgroundPlaybackController = self
+            AudioController.configureRemoteCommands()
+            player.prepareToPlay()
+            player.delegate = self
+            state = .playing
+            guard player.play() else {
+                state = .stopped
+                throw AudioPlaybackError.playFailed
             }
+            audioCell.audioPlayerView.showPlayLayout(true)  // show pause button on audio cell
+            updateNowPlayingInfo()
+            startProgressTimer()
+        } catch {
+            logger.warning("playing audio message \(message.id) failed: \(error.localizedDescription)")
+            stopAnyOngoingPlaying()
+            delegate?.onAudioPlayFailed()
         }
     }
 
@@ -171,63 +231,184 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     /// - Parameters:
     ///   - message: The `MessageType` that contain the audio item to be pause.
     ///   - audioCell: The `AudioMessageCell` that needs to be updated by the pause action.
-    open func pauseSound(in audioCell: AudioMessageCell) {
-        audioPlayer?.pause()
+    open func pauseSound(in audioCell: AudioMessageCell? = nil) {
+        guard let player = audioPlayer else { return }
+        player.pause()
         state = .pause
-        audioCell.audioPlayerView.showPlayLayout(false) // show play button on audio cell
+        (audioCell ?? playingCell)?.audioPlayerView.showPlayLayout(false) // show play button on audio cell
+        updateNowPlayingInfo()
         progressTimer?.invalidate()
     }
 
     /// Stops any ongoing audio playing if exists
     open func stopAnyOngoingPlaying() {
-        // If the audio player is nil then we don't need to go through the stopping logic
         guard let player = audioPlayer else { return }
+        let duration = player.duration
         player.stop()
         state = .stopped
         if let cell = playingCell {
             cell.audioPlayerView.setProgress(0.0)
             cell.audioPlayerView.showPlayLayout(false)
-            cell.audioPlayerView.setDuration(duration: player.duration)
+            cell.audioPlayerView.setDuration(duration: duration)
         }
         progressTimer?.invalidate()
         progressTimer = nil
         audioPlayer = nil
         playingMessage = nil
         playingCell = nil
-        try? audioSession.setActive(false)
+        playingArtwork = nil
+        lastNowPlayingInfoUpdate = .distantPast
+        if AudioController.backgroundPlaybackController === self {
+            AudioController.backgroundPlaybackController = nil
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        }
+        do {
+            try audioSession.setActive(false)
+        } catch {
+            logger.warning("deactivating audio session failed: \(error.localizedDescription)")
+        }
     }
 
     /// Resume a currently pause audio sound
     open func resumeSound() {
-        guard let player = audioPlayer, let cell = playingCell else {
+        guard let player = audioPlayer else {
             stopAnyOngoingPlaying()
             return
         }
         player.prepareToPlay()
-        player.play()
+        guard player.play() else {
+            logger.warning("resuming audio playback failed")
+            stopAnyOngoingPlaying()
+            delegate?.onAudioPlayFailed()
+            return
+        }
         state = .playing
+        updateNowPlayingInfo()
         startProgressTimer()
-        cell.audioPlayerView.showPlayLayout(true) // show pause button on audio cell
+        playingCell?.audioPlayerView.showPlayLayout(true) // show pause button on audio cell
     }
 
     // MARK: - Fire Methods
     @objc private func didFireProgressTimer(_ timer: Timer) {
-        guard let player = audioPlayer, let cell = playingCell else {
+        guard let player = audioPlayer else {
             return
         }
-        cell.audioPlayerView.setProgress((player.duration == 0) ? 0 : Float(player.currentTime/player.duration))
-        cell.audioPlayerView.setDuration(duration: player.currentTime)
+        playingCell?.audioPlayerView.setProgress((player.duration == 0) ? 0 : Float(player.currentTime/player.duration))
+        playingCell?.audioPlayerView.setDuration(duration: player.currentTime)
+        updateNowPlayingInfoIfNeeded()
     }
 
     // MARK: - Private Methods
     private func startProgressTimer() {
         progressTimer?.invalidate()
         progressTimer = nil
-        progressTimer = Timer.scheduledTimer(timeInterval: 0.1,
-                                             target: self,
-                                             selector: #selector(AudioController.didFireProgressTimer(_:)),
-                                             userInfo: nil,
-                                             repeats: true)
+        let timer = Timer(timeInterval: 0.1,
+                          target: self,
+                          selector: #selector(AudioController.didFireProgressTimer(_:)),
+                          userInfo: nil,
+                          repeats: true)
+        progressTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    private func isPlayingMessage(messageId: Int, contextId: Int) -> Bool {
+        return dcContext.id == contextId && playingMessage?.id == messageId
+    }
+
+    private func updateNowPlayingInfoIfNeeded() {
+        guard Date().timeIntervalSince(lastNowPlayingInfoUpdate) >= 1 else { return }
+        updateNowPlayingInfo()
+    }
+
+    private func loadArtwork(for message: DcMsg) {
+        playingArtwork = nil
+        let contact = dcContext.getContact(id: message.fromContactId)
+        guard let imageURL = contact.profileImageURL else {
+            playingArtwork = nil
+            return
+        }
+        DispatchQueue.global(qos: .userInitiated).async { [weak self, messageId = message.id, contextId = self.dcContext.id] in
+            guard let data = try? Data(contentsOf: imageURL), let image = UIImage(data: data) else { return }
+            let artwork = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
+            DispatchQueue.main.async {
+                guard let self,
+                      self.isPlayingMessage(messageId: messageId, contextId: contextId) else { return }
+                self.playingArtwork = artwork
+                self.updateNowPlayingInfo()
+            }
+        }
+    }
+
+    private static func configureRemoteCommands() {
+        guard !remoteCommandsConfigured else { return }
+        remoteCommandsConfigured = true
+        let commandCenter = MPRemoteCommandCenter.shared()
+        commandCenter.playCommand.addTarget { _ in
+            return enqueueRemoteCommand { $0.resumeSound() }
+        }
+        commandCenter.pauseCommand.addTarget { _ in
+            return enqueueRemoteCommand { $0.pauseSound() }
+        }
+        commandCenter.togglePlayPauseCommand.addTarget { _ in
+            return enqueueRemoteCommand { controller in
+                if controller.state == .playing {
+                    controller.pauseSound()
+                } else {
+                    controller.resumeSound()
+                }
+            }
+        }
+        commandCenter.stopCommand.addTarget { _ in
+            return enqueueRemoteCommand { $0.stopAnyOngoingPlaying() }
+        }
+        commandCenter.changePlaybackPositionCommand.isEnabled = true
+        commandCenter.changePlaybackPositionCommand.addTarget { event in
+            guard let event = event as? MPChangePlaybackPositionCommandEvent else { return .noActionableNowPlayingItem }
+            return enqueueRemoteCommand { controller in
+                guard let player = controller.audioPlayer else { return }
+                player.currentTime = event.positionTime
+                controller.updateNowPlayingInfo()
+            }
+        }
+    }
+
+    private static func enqueueRemoteCommand(_ action: @escaping (AudioController) -> Void) -> MPRemoteCommandHandlerStatus {
+        guard let controller = backgroundPlaybackController else { return .noActionableNowPlayingItem }
+        DispatchQueue.main.async { [weak controller] in
+            guard let controller,
+                  backgroundPlaybackController === controller else { return }
+            action(controller)
+        }
+        return .success
+    }
+
+    private static func performOnMainAndWait(_ action: () -> Void) {
+        if Thread.isMainThread {
+            action()
+        } else {
+            DispatchQueue.main.sync(execute: action)
+        }
+    }
+
+    private func updateNowPlayingInfo() {
+        guard let player = audioPlayer, let message = playingMessage else { return }
+        var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+        if let text = message.text, !text.isEmpty {
+            nowPlayingInfo[MPMediaItemPropertyTitle] = text
+        } else {
+            nowPlayingInfo[MPMediaItemPropertyTitle] = String.localized(message.type == DC_MSG_VOICE ? "voice_message" : "audio")
+        }
+        nowPlayingInfo[MPMediaItemPropertyArtist] = chat.name
+        if let playingArtwork {
+            nowPlayingInfo[MPMediaItemPropertyArtwork] = playingArtwork
+        } else {
+            nowPlayingInfo.removeValue(forKey: MPMediaItemPropertyArtwork)
+        }
+        nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = player.duration
+        nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = player.currentTime
+        nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = player.isPlaying ? 1.0 : 0.0
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+        lastNowPlayingInfoUpdate = Date()
     }
 
     // MARK: - AVAudioPlayerDelegate
@@ -239,15 +420,19 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
         stopAnyOngoingPlaying()
     }
 
+    @objc private func appWillTerminate() {
+        guard AudioController.backgroundPlaybackController === self else { return }
+        stopAnyOngoingPlaying()
+    }
+
     // MARK: - AVAudioSession.routeChangeNotification handler
     @objc func audioRouteChanged(note: Notification) {
-      if let userInfo = note.userInfo {
-        if let reason = userInfo[AVAudioSessionRouteChangeReasonKey] as? Int {
-            if reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue {
+        if let userInfo = note.userInfo,
+           let reason = userInfo[AVAudioSessionRouteChangeReasonKey] as? Int,
+           reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue,
+           AudioController.backgroundPlaybackController === self {
             // headphones plugged out
-            resumeSound()
-          }
+            pauseSound()
         }
-      }
     }
 }

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -37,7 +37,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     lazy var audioSession: AVAudioSession = {
         let audioSession = AVAudioSession.sharedInstance()
         do {
-            try audioSession.setCategory(AVAudioSession.Category.playback, options: [.defaultToSpeaker])
+            try audioSession.setCategory(AVAudioSession.Category.playback)
         } catch {
             logger.warning("setting audio session category failed: \(error.localizedDescription)")
         }

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -75,10 +75,6 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
                                                selector: #selector(audioSessionInterrupted),
                                                name: AVAudioSession.interruptionNotification,
                                                object: AVAudioSession.sharedInstance())
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(appWillTerminate),
-                                               name: UIApplication.willTerminateNotification,
-                                               object: nil)
     }
 
     deinit {
@@ -435,11 +431,6 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     }
 
     open func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
-        stopAnyOngoingPlaying()
-    }
-
-    @objc private func appWillTerminate() {
-        guard AudioController.backgroundPlaybackController === self else { return }
         stopAnyOngoingPlaying()
     }
 

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -388,13 +388,18 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     }
 
     private static func enqueueRemoteCommand(_ action: @escaping (AudioController) -> Void) -> MPRemoteCommandHandlerStatus {
-        guard let controller = backgroundPlaybackController else { return .noActionableNowPlayingItem }
-        DispatchQueue.main.async { [weak controller] in
-            guard let controller,
-                  backgroundPlaybackController === controller else { return }
+        let execute = {
+            guard let controller = backgroundPlaybackController else {
+                return MPRemoteCommandHandlerStatus.noActionableNowPlayingItem
+            }
             action(controller)
+            return MPRemoteCommandHandlerStatus.success
         }
-        return .success
+        if Thread.isMainThread {
+            return execute()
+        } else {
+            return DispatchQueue.main.sync(execute: execute)
+        }
     }
 
     private static func performOnMainAndWait(_ action: () -> Void) {

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -65,6 +65,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
 
     private var lastNowPlayingInfoUpdate = Date.distantPast
     private var playingArtwork: MPMediaItemArtwork?
+    private var shouldResumeAfterInterruption = false
 
     // MARK: - Init Methods
 
@@ -77,6 +78,10 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(audioRouteChanged),
                                                name: AVAudioSession.routeChangeNotification,
+                                               object: AVAudioSession.sharedInstance())
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(audioSessionInterrupted),
+                                               name: AVAudioSession.interruptionNotification,
                                                object: AVAudioSession.sharedInstance())
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(appWillTerminate),
@@ -258,6 +263,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
         playingMessage = nil
         playingCell = nil
         playingArtwork = nil
+        shouldResumeAfterInterruption = false
         lastNowPlayingInfoUpdate = .distantPast
         if AudioController.backgroundPlaybackController === self {
             AudioController.backgroundPlaybackController = nil
@@ -425,6 +431,47 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     @objc private func appWillTerminate() {
         guard AudioController.backgroundPlaybackController === self else { return }
         stopAnyOngoingPlaying()
+    }
+
+    // MARK: - AVAudioSession.interruptionNotification handler
+    @objc private func audioSessionInterrupted(note: Notification) {
+        guard let typeValue = note.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
+        let optionsValue = note.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
+        let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+
+        let handleInterruption = { [weak self] in
+            guard let self,
+                  AudioController.backgroundPlaybackController === self else { return }
+            switch type {
+            case .began:
+                shouldResumeAfterInterruption = state == .playing
+                if shouldResumeAfterInterruption {
+                    pauseSound()
+                }
+            case .ended:
+                let shouldResume = shouldResumeAfterInterruption && options.contains(.shouldResume)
+                shouldResumeAfterInterruption = false
+                if shouldResume {
+                    do {
+                        try audioSession.setActive(true)
+                        resumeSound()
+                    } catch {
+                        logger.warning("reactivating audio session after interruption failed: \(error.localizedDescription)")
+                        stopAnyOngoingPlaying()
+                        delegate?.onAudioPlayFailed()
+                    }
+                }
+            @unknown default:
+                break
+            }
+        }
+
+        if Thread.isMainThread {
+            handleInterruption()
+        } else {
+            DispatchQueue.main.async(execute: handleInterruption)
+        }
     }
 
     // MARK: - AVAudioSession.routeChangeNotification handler

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -96,6 +96,25 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
         }
     }
 
+    static func stopPlaybackForDeletedChat(chatId: Int, contextId: Int) {
+        stopPlaybackSynchronouslyOnMain {
+            guard let controller = backgroundPlaybackController,
+                  controller.dcContext.id == contextId,
+                  controller.chatId == chatId else { return }
+            controller.stopAnyOngoingPlaying()
+        }
+    }
+
+    static func stopPlaybackForDeletedMessages(messageIds: [Int], contextId: Int) {
+        stopPlaybackSynchronouslyOnMain {
+            guard let controller = backgroundPlaybackController,
+                  controller.dcContext.id == contextId,
+                  let playingMessageId = controller.playingMessage?.id,
+                  messageIds.contains(playingMessageId) else { return }
+            controller.stopAnyOngoingPlaying()
+        }
+    }
+
     /// - Parameters:
     ///   - cell: The `NewAudioMessageCell` that needs to be configure.
     ///   - message: The `DcMsg` that configures the cell.

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -482,12 +482,20 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
 
     // MARK: - AVAudioSession.routeChangeNotification handler
     @objc func audioRouteChanged(note: Notification) {
-        if let userInfo = note.userInfo,
-           let reason = userInfo[AVAudioSessionRouteChangeReasonKey] as? Int,
-           reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue,
-           AudioController.backgroundPlaybackController === self {
+        guard let reason = note.userInfo?[AVAudioSessionRouteChangeReasonKey] as? Int,
+              reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue else { return }
+
+        let pauseAfterRouteChange = { [weak self] in
+            guard let self,
+                  AudioController.backgroundPlaybackController === self else { return }
             // headphones plugged out
             pauseSound()
+        }
+
+        if Thread.isMainThread {
+            pauseAfterRouteChange()
+        } else {
+            DispatchQueue.main.async(execute: pauseAfterRouteChange)
         }
     }
 }

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -34,15 +34,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
 
     open weak var delegate: AudioControllerDelegate?
 
-    lazy var audioSession: AVAudioSession = {
-        let audioSession = AVAudioSession.sharedInstance()
-        do {
-            try audioSession.setCategory(AVAudioSession.Category.playback)
-        } catch {
-            logger.warning("setting audio session category failed: \(error.localizedDescription)")
-        }
-        return audioSession
-    }()
+    lazy var audioSession = AVAudioSession.sharedInstance()
 
     /// The `AVAudioPlayer` that is playing the sound
     open var audioPlayer: AVAudioPlayer?
@@ -207,7 +199,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
         do {
             guard let fileUrl = message.fileURL else { throw AudioPlaybackError.missingFileURL }
             let player = try AVAudioPlayer(contentsOf: fileUrl)
-            try audioSession.setActive(true)
+            try activatePlaybackAudioSession()
             audioPlayer = player
             playingCell = audioCell
             playingMessage = message
@@ -283,7 +275,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
             return
         }
         do {
-            try audioSession.setActive(true)
+            try activatePlaybackAudioSession()
         } catch {
             logger.warning("activating audio session before resuming playback failed: \(error.localizedDescription)")
             stopAnyOngoingPlaying()
@@ -328,6 +320,11 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
 
     private func isPlayingMessage(messageId: Int, contextId: Int) -> Bool {
         return dcContext.id == contextId && playingMessage?.id == messageId
+    }
+
+    private func activatePlaybackAudioSession() throws {
+        try audioSession.setCategory(.playback, mode: .default)
+        try audioSession.setActive(true)
     }
 
     private func updateNowPlayingInfoIfNeeded() {

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -96,13 +96,13 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
     // MARK: - Methods
 
     static func stopBackgroundPlayback() {
-        performOnMainAndWait {
+        stopPlaybackSynchronouslyOnMain {
             backgroundPlaybackController?.stopAnyOngoingPlaying()
         }
     }
 
     static func stopBackgroundPlayback(forContextId contextId: Int) {
-        performOnMainAndWait {
+        stopPlaybackSynchronouslyOnMain {
             guard let controller = backgroundPlaybackController, controller.dcContext.id == contextId else { return }
             controller.stopAnyOngoingPlaying()
         }
@@ -402,11 +402,11 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
         }
     }
 
-    private static func performOnMainAndWait(_ action: () -> Void) {
+    /// Runs playback cleanup on the main queue and waits until it finishes before the caller continues.
+    private static func stopPlaybackSynchronouslyOnMain(_ action: () -> Void) {
         if Thread.isMainThread {
             action()
         } else {
-            // Wait until playback is fully stopped before callers continue and possibly start another audio session.
             DispatchQueue.main.sync(execute: action)
         }
     }

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -176,7 +176,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
             return
         }
         if isPlayingMessage(messageId: message.id, contextId: dcContext.id) {
-            // tap occur in the current cell that is playing audio sound
+            // tap occurred in the cell that is currently playing audio
             if state == .playing {
                 pauseSound(in: cell)
             } else {

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -235,7 +235,8 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
         guard let player = audioPlayer else { return }
         player.pause()
         state = .pause
-        (audioCell ?? playingCell)?.audioPlayerView.showPlayLayout(false) // show play button on audio cell
+        let cell = audioCell ?? playingCell
+        cell?.audioPlayerView.showPlayLayout(false) // show play button on audio cell
         updateNowPlayingInfo()
         progressTimer?.invalidate()
     }

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -264,7 +264,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
             MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
         }
         do {
-            try audioSession.setActive(false)
+            try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
         } catch {
             logger.warning("deactivating audio session failed: \(error.localizedDescription)")
         }

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -226,11 +226,11 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
         }
     }
 
-    /// Used to pause the audio sound
+    /// Pauses the currently playing audio sound.
     ///
     /// - Parameters:
-    ///   - message: The `MessageType` that contain the audio item to be pause.
     ///   - audioCell: The `AudioMessageCell` that needs to be updated by the pause action.
+    ///     Pass `nil` to update the current `playingCell`.
     open func pauseSound(in audioCell: AudioMessageCell? = nil) {
         guard let player = audioPlayer else { return }
         player.pause()
@@ -387,6 +387,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
         if Thread.isMainThread {
             action()
         } else {
+            // Wait until playback is fully stopped before callers continue and possibly start another audio session.
             DispatchQueue.main.sync(execute: action)
         }
     }

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -282,6 +282,14 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
             stopAnyOngoingPlaying()
             return
         }
+        do {
+            try audioSession.setActive(true)
+        } catch {
+            logger.warning("activating audio session before resuming playback failed: \(error.localizedDescription)")
+            stopAnyOngoingPlaying()
+            delegate?.onAudioPlayFailed()
+            return
+        }
         player.prepareToPlay()
         guard player.play() else {
             logger.warning("resuming audio playback failed")
@@ -453,14 +461,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
                 let shouldResume = shouldResumeAfterInterruption && options.contains(.shouldResume)
                 shouldResumeAfterInterruption = false
                 if shouldResume {
-                    do {
-                        try audioSession.setActive(true)
-                        resumeSound()
-                    } catch {
-                        logger.warning("reactivating audio session after interruption failed: \(error.localizedDescription)")
-                        stopAnyOngoingPlaying()
-                        delegate?.onAudioPlayFailed()
-                    }
+                    resumeSound()
                 }
             @unknown default:
                 break

--- a/deltachat-ios/Chat/AudioController.swift
+++ b/deltachat-ios/Chat/AudioController.swift
@@ -183,7 +183,7 @@ open class AudioController: NSObject, AVAudioPlayerDelegate, AudioMessageCellDel
                 resumeSound()
             }
         } else {
-            // tap occur in a difference cell that the one is currently playing sound. First stop currently playing and start the sound for given message
+            // tap occurred in a different cell than the one that is currently playing sound. First stop currently playing and start the sound for given message
             stopAnyOngoingPlaying()
             playSound(for: message, in: cell)
         }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1333,6 +1333,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         confirmationAlert(title: title, actionTitle: String.localized("delete_for_me"), actionStyle: .destructive,
                           actionHandler: { [weak self] _ in
             guard let self else { return }
+            AudioController.stopPlaybackForDeletedChat(chatId: self.chatId, contextId: self.dcContext.id)
             self.dcContext.deleteReferencesAndChat(chatId: self.chatId)
             self.navigationController?.popViewController(animated: true)
         })
@@ -1365,6 +1366,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     private func askToDeleteMessages(ids: [Int]) {
         func deleteInUi(ids: [Int]) {
+            AudioController.stopPlaybackForDeletedMessages(messageIds: ids, contextId: self.dcContext.id)
             if #available(iOS 17.0, *) {
                 ids.forEach { UserDefaults.shared?.removeWebxdcFromHomescreen(accountId: self.dcContext.id, messageId: $0) }
             }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -493,7 +493,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         super.viewDidDisappear(animated)
         AppStateRestorer.shared.resetLastActiveChat()
         handleUserVisibility(isVisible: false)
-        audioController.stopAnyOngoingPlaying()
         if #available(iOS 26.0, *), let previousValue = wasInteractiveContentPopGestureRecognizerEnabled {
             navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = previousValue
         }
@@ -2098,6 +2097,7 @@ extension ChatViewController {
         let msgIds = dcContext.getChatMedia(chatId: chatId, messageType: Int32(message.type), messageType2: 0, messageType3: 0)
         let index = msgIds.firstIndex(of: message.id) ?? 0
 
+        stopMessageAudioBeforeSoundPreview(for: Int32(message.type))
         navigationController?.pushViewController(PreviewController(dcContext: dcContext, type: .multi(msgIds, index)), animated: true)
     }
 
@@ -2526,6 +2526,7 @@ extension ChatViewController {
                     previewController.setEditing(true, animated: true)
                     previewController.delegate = self
                 }
+                stopMessageAudioBeforeSoundPreview(for: draft.viewType)
                 navigationController?.pushViewController(previewController, animated: true)
             }
         }
@@ -2694,6 +2695,19 @@ extension ChatViewController: QLPreviewControllerDelegate {
 extension ChatViewController: AudioControllerDelegate {
     func onAudioPlayFailed() {
         self.logAndAlert(error: String.localized("cannot_play_audio_file"))
+    }
+}
+
+// MARK: - Audio Playback
+private extension ChatViewController {
+    func stopMessageAudioBeforeSoundPreview(for viewType: Int32?) {
+        guard let viewType else { return }
+        switch viewType {
+        case DC_MSG_AUDIO, DC_MSG_VOICE, DC_MSG_VIDEO, DC_MSG_FILE:
+            AudioController.stopBackgroundPlayback()
+        default:
+            break
+        }
     }
 }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2090,6 +2090,7 @@ extension ChatViewController {
 
     func showWebxdcViewFor(message: DcMsg, href: String? = nil) {
         let webxdcViewController = WebxdcViewController(dcContext: dcContext, messageId: message.id, href: href)
+        AudioController.stopBackgroundPlayback()
         navigationController?.pushViewController(webxdcViewController, animated: true)
     }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2700,6 +2700,10 @@ extension ChatViewController: AudioControllerDelegate {
 
 // MARK: - Audio Playback
 private extension ChatViewController {
+    /// Stops currently playing chat audio before opening a media preview that may play audio itself.
+    ///
+    /// Call this before presenting previews for audio-like attachments, videos, and files so
+    /// an existing voice/audio message does not keep playing over the preview playback.
     func stopMessageAudioBeforeSoundPreview(for viewType: Int32?) {
         guard let viewType else { return }
         switch viewType {

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -180,6 +180,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func startRecording() {
+        AudioController.stopBackgroundPlayback()
         do {
             self.setToolbarItems([pauseButton], animated: true)
             doneButton.isEnabled = true
@@ -199,6 +200,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     @objc func continueRecording() {
+        AudioController.stopBackgroundPlayback()
         self.setToolbarItems([pauseButton], animated: true)
         isRecordingPaused = false
         guard let audioRecorder, audioRecorder.record() else { logger.error("continue recording failed"); return  }

--- a/deltachat-ios/Controller/ProfileSwitchViewController.swift
+++ b/deltachat-ios/Controller/ProfileSwitchViewController.swift
@@ -199,6 +199,7 @@ class ProfileSwitchViewController: UITableViewController {
                 guard let self else { return }
 
                 appDelegate.locationManager.disableLocationStreamingInAllChats()
+                AudioController.stopBackgroundPlayback(forContextId: accountId)
                 _ = dcAccounts.remove(id: accountId)
                 KeychainManager.deleteAccountSecret(id: accountId)
                 INInteraction.delete(with: "\(accountId)", completion: nil)


### PR DESCRIPTION
Moves chat audio/voice playback from chat-screen lifetime to a global background-capable playback controller. The active player survives chat view disappearance and profile switches, while still updating visible cells if the user returns to the playing message.

 Playback now integrates with `MPNowPlayingInfoCenter` and `MPRemoteCommandCenter` for system controls:
     * toggle play/pause
     * seek

Playback is stopped for audio-conflicting flows:
     * voice recording start / continue
     * outgoing call start
     * incoming call report
     * account deletion for the playing account
     * eadphone unplug pauses playback instead of resuming, to avoid blasting audio through the speaker.

demo (with sound):

<details>
<summary>Details</summary>


https://github.com/user-attachments/assets/998da0b7-304c-43cd-b2de-2eba202e6d84



</details>

part of: #2987 