### PR TITLE
Setup zizmor (static analysis for GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   push:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: macos-15
@@ -10,6 +12,7 @@ jobs:
         with:
           submodules: true
           show-progress: false
+          persist-credentials: false
       - run: sudo xcode-select --switch /Applications/Xcode_26.1.app/Contents/Developer
       - run: cargo install cargo-lipo
       - run: pod install

--- a/.github/workflows/zizmor-scan.yml
+++ b/.github/workflows/zizmor-scan.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        dependabot/*: ref-pin


### PR DESCRIPTION
This one is straightforward because there are no secrets in CI and we don't build previews or releases in CI. Can be useful if we introduce something later. At least this prevents test build workflow from creating releases and doing similar things with default permissions. See https://github.com/deltachat/deltachat-desktop/pull/6307 for desktop PR, there it was more useful.