### PR TITLE
add "Mark All as Read" to the profile switcher context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add "Mark All as Read" to the profile switcher context menu
 - "Calls" and "Channels" are available by default and are no longer experimental
 - Resend the last 10 messages to new broadcast channel member
 - Enable PQC (Post-Quantum Cryptography) support. We do not generate PQC keys yet, this step is needed for forward compatibility

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -214,7 +214,7 @@ class ChatListViewController: UITableViewController {
     @objc private func handleMessagesNoticed(_ notification: Notification) {
         refreshInBg()
         DispatchQueue.main.async { [weak self] in
-            self?.updateNextScreensBackButton()
+            self?.refreshUnreadIndicators()
         }
     }
 
@@ -705,6 +705,11 @@ class ChatListViewController: UITableViewController {
         return tableView.isEditing && editingConstraints != nil
     }
 
+    private func refreshUnreadIndicators() {
+        updateAccountButton()
+        updateNextScreensBackButton()
+    }
+
     private func updateAccountButton() {
         let unreadMessages = dcAccounts.getFreshMessagesCount(skipCurrent: true)
         accountButtonAvatar.setUnreadMessageCount(unreadMessages)
@@ -733,6 +738,9 @@ class ChatListViewController: UITableViewController {
 
     @objc private func accountButtonTapped() {
         let viewController = ProfileSwitchViewController(dcAccounts: dcAccounts)
+        viewController.onUnreadStateChanged = { [weak self] in
+            self?.refreshUnreadIndicators()
+        }
         let accountSwitchNavigationController = UINavigationController(rootViewController: viewController)
         if #available(iOS 15.0, *) {
             if let sheet = accountSwitchNavigationController.sheetPresentationController {

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -738,7 +738,7 @@ class ChatListViewController: UITableViewController {
 
     @objc private func accountButtonTapped() {
         let viewController = ProfileSwitchViewController(dcAccounts: dcAccounts)
-        viewController.onUnreadStateChanged = { [weak self] in
+        viewController.onUnreadIndicatorsChanged = { [weak self] in
             self?.refreshUnreadIndicators()
         }
         let accountSwitchNavigationController = UINavigationController(rootViewController: viewController)

--- a/deltachat-ios/Controller/ProfileSwitchViewController.swift
+++ b/deltachat-ios/Controller/ProfileSwitchViewController.swift
@@ -5,6 +5,7 @@ import DcCore
 class ProfileSwitchViewController: UITableViewController {
 
     private let dcAccounts: DcAccounts
+    var onUnreadStateChanged: (() -> Void)?
     private let accountSection = 0
     private let addSection = 1
 
@@ -92,6 +93,7 @@ class ProfileSwitchViewController: UITableViewController {
         let dcContext = dcAccounts.get(id: accountIds[indexPath.row])
         let muteTitle = dcContext.isMuted() ? "menu_unmute" : "menu_mute"
         let muteImage = dcContext.isMuted() ? "speaker.wave.2" : "speaker.slash"
+        let checkmarkImage = if #available(iOS 16, *) { "checkmark.message" } else { "checkmark.circle" }
 
         return UIContextMenuConfiguration(
             identifier: nil,
@@ -102,6 +104,7 @@ class ProfileSwitchViewController: UITableViewController {
                     UIAction.menuAction(localizationKey: muteTitle, systemImageName: muteImage, with: indexPath, action: toggleMute),
                     UIAction.menuAction(localizationKey: "profile_tag", systemImageName: "tag", with: indexPath, action: setProfileTag),
                     UIAction.menuAction(localizationKey: "move_to_top", systemImageName: "arrow.up", with: indexPath, action: moveToTop),
+                    UIAction.menuAction(localizationKey: "mark_all_as_read", systemImageName: checkmarkImage, with: indexPath, action: markAllAsRead),
                     UIAction.menuAction(localizationKey: "delete", attributes: [.destructive], systemImageName: "trash", with: indexPath, action: deleteAccount),
                 ]
                 return UIMenu(children: children)
@@ -113,6 +116,22 @@ class ProfileSwitchViewController: UITableViewController {
         let dcContext = dcAccounts.get(id: accountIds[indexPath.row])
         dcContext.setMuted(!dcContext.isMuted())
         tableView.reloadRows(at: [indexPath], with: .none)
+    }
+
+    func markAllAsRead(at indexPath: IndexPath) {
+        let accountId = accountIds[indexPath.row]
+        let dcContext = dcAccounts.get(id: accountId)
+        DispatchQueue.global().async { [weak self] in
+            dcContext.marknoticedAllChats()
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.onUnreadStateChanged?()
+                NotificationManager.removeNotificationsForAccount(accountId: accountId)
+                if let row = accountIds.firstIndex(of: accountId) {
+                    tableView.reloadRows(at: [IndexPath(row: row, section: accountSection)], with: .none)
+                }
+            }
+        }
     }
 
     func setProfileTag(at indexPath: IndexPath) {

--- a/deltachat-ios/Controller/ProfileSwitchViewController.swift
+++ b/deltachat-ios/Controller/ProfileSwitchViewController.swift
@@ -128,8 +128,9 @@ class ProfileSwitchViewController: UITableViewController {
                 guard let self else { return }
                 self.onUnreadIndicatorsChanged?()
                 NotificationManager.removeNotificationsForAccount(accountId: accountId)
-                if let row = accountIds.firstIndex(of: accountId) {
-                    tableView.reloadRows(at: [IndexPath(row: row, section: accountSection)], with: .none)
+                if let row = accountIds.firstIndex(of: accountId),
+                   let cell = tableView.cellForRow(at: IndexPath(row: row, section: accountSection)) as? AccountCell {
+                    cell.refreshUnreadState(dcContext: dcContext)
                 }
             }
         }
@@ -263,6 +264,7 @@ class AccountCell: UITableViewCell {
 
     private var selectedAccount: Int?
     private var accountId: Int?
+    private var accountTitle: String = ""
 
     private lazy var mutedIndicator: UIImageView = {
         let view = UIImageView()
@@ -336,26 +338,17 @@ class AccountCell: UITableViewCell {
         let accountId = dcContext.id
         self.accountId = accountId
         self.selectedAccount = selectedAccount
+        accountTitle = dcContext.displayname ?? dcContext.addr ?? ""
+
         let encrypted = dcContext.isDatabaseEncrypted() ? "⚠️ " : ""
-        let title = dcContext.displayname ?? dcContext.addr ?? ""
         let contact = dcContext.getContact(id: Int(DC_CONTACT_ID_SELF))
         accountAvatar.setColor(contact.color)
-        accountAvatar.setName(title)
+        accountAvatar.setName(accountTitle)
         if let image = contact.profileImage {
             accountAvatar.setImage(image)
         }
 
-        let unreadMessages = dcContext.getFreshMessagesCount()
-        accountAvatar.setUnreadMessageCount(unreadMessages, isMuted: dcContext.isMuted())
-
-        mutedIndicator.isHidden = !dcContext.isMuted()
-
-        accountName.text = encrypted + title
-        if unreadMessages > 0 {
-            accountName.accessibilityLabel = "\(title): \(String.localized(stringID: "n_messages", parameter: unreadMessages))"
-        } else {
-            accountName.accessibilityLabel = title
-        }
+        refreshUnreadState(dcContext: dcContext)
 
         let connectivityString = DcUtils.getConnectivityString(dcContext: dcContext, connectedString: "")
         if let label = dcContext.getConfig("private_tag") {
@@ -372,13 +365,30 @@ class AccountCell: UITableViewCell {
             tagLabel.isHidden = true
         }
 
+        accountName.text = encrypted + accountTitle
         accessoryType = selectedAccount == accountId ? .checkmark : .none
+    }
+
+    func refreshUnreadState(dcContext: DcContext) {
+        let unreadMessages = dcContext.getFreshMessagesCount()
+        accountAvatar.setUnreadMessageCount(unreadMessages, isMuted: dcContext.isMuted())
+
+        if unreadMessages > 0 {
+            accountName.accessibilityLabel = "\(accountTitle): \(String.localized(stringID: "n_messages", parameter: unreadMessages))"
+        } else {
+            accountName.accessibilityLabel = accountTitle
+        }
+
+        mutedIndicator.isHidden = !dcContext.isMuted()
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
         accountAvatar.reset()
         accountName.text = nil
+        accountName.accessibilityLabel = nil
+        mutedIndicator.isHidden = true
+        accountTitle = ""
         accountId = -1
     }
 }

--- a/deltachat-ios/Controller/ProfileSwitchViewController.swift
+++ b/deltachat-ios/Controller/ProfileSwitchViewController.swift
@@ -95,19 +95,22 @@ class ProfileSwitchViewController: UITableViewController {
         let muteTitle = dcContext.isMuted() ? "menu_unmute" : "menu_mute"
         let muteImage = dcContext.isMuted() ? "speaker.wave.2" : "speaker.slash"
         let checkmarkImage = if #available(iOS 16, *) { "checkmark.message" } else { "checkmark.circle" }
+        let hasUnreadMessages = dcContext.getFreshMessagesCount() > 0
 
         return UIContextMenuConfiguration(
             identifier: nil,
             previewProvider: nil,
             actionProvider: { [weak self] _ in
                 guard let self else { return nil }
-                let children: [UIMenuElement] = [
+                var children: [UIMenuElement] = [
                     UIAction.menuAction(localizationKey: muteTitle, systemImageName: muteImage, with: indexPath, action: toggleMute),
                     UIAction.menuAction(localizationKey: "profile_tag", systemImageName: "tag", with: indexPath, action: setProfileTag),
                     UIAction.menuAction(localizationKey: "move_to_top", systemImageName: "arrow.up", with: indexPath, action: moveToTop),
-                    UIAction.menuAction(localizationKey: "mark_all_as_read", systemImageName: checkmarkImage, with: indexPath, action: markAllAsRead),
-                    UIAction.menuAction(localizationKey: "delete", attributes: [.destructive], systemImageName: "trash", with: indexPath, action: deleteAccount),
                 ]
+                if hasUnreadMessages {
+                    children.append(UIAction.menuAction(localizationKey: "mark_all_as_read", systemImageName: checkmarkImage, with: indexPath, action: markAllAsRead))
+                }
+                children.append(UIAction.menuAction(localizationKey: "delete", attributes: [.destructive], systemImageName: "trash", with: indexPath, action: deleteAccount))
                 return UIMenu(children: children)
             }
         )

--- a/deltachat-ios/Controller/ProfileSwitchViewController.swift
+++ b/deltachat-ios/Controller/ProfileSwitchViewController.swift
@@ -5,9 +5,10 @@ import DcCore
 class ProfileSwitchViewController: UITableViewController {
 
     private let dcAccounts: DcAccounts
-    var onUnreadStateChanged: (() -> Void)?
     private let accountSection = 0
     private let addSection = 1
+
+    var onUnreadIndicatorsChanged: (() -> Void)?
 
     private lazy var accountIds: [Int] = {
         return dcAccounts.getAllSorted()
@@ -125,7 +126,7 @@ class ProfileSwitchViewController: UITableViewController {
             dcContext.marknoticedAllChats()
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                self.onUnreadStateChanged?()
+                self.onUnreadIndicatorsChanged?()
                 NotificationManager.removeNotificationsForAccount(accountId: accountId)
                 if let row = accountIds.firstIndex(of: accountId) {
                     tableView.reloadRows(at: [IndexPath(row: row, section: accountSection)], with: .none)

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -349,6 +349,14 @@ public class DcContext {
         dc_marknoticed_chat(self.contextPointer, UInt32(chatId))
     }
 
+    public func marknoticedAllChats() {
+        do {
+            try DcAccounts.shared.blockingCall(method: "marknoticed_all_chats", params: [id as AnyObject])
+        } catch {
+            logger.error(error.localizedDescription)
+        }
+    }
+
     public func markfreshChat(chatId: Int) {
         dc_markfresh_chat(self.contextPointer, UInt32(chatId))
     }

--- a/deltachat-ios/Helper/NotificationManager.swift
+++ b/deltachat-ios/Helper/NotificationManager.swift
@@ -76,6 +76,21 @@ public class NotificationManager {
         }
     }
 
+    public static func removeNotificationsForAccount(accountId: Int) {
+        DispatchQueue.global().async {
+            let nc = UNUserNotificationCenter.current()
+            nc.getDeliveredNotifications { notifications in
+                let toRemove = notifications.compactMap { notification in
+                    let notificationAccountId = notification.request.content.userInfo["account_id"] as? Int ?? 0
+                    return notificationAccountId == accountId ? notification.request.identifier : nil
+                }
+                nc.removeDeliveredNotifications(withIdentifiers: toRemove)
+            }
+
+            NotificationManager.updateBadgeCounters()
+        }
+    }
+
     // MARK: - Notifications
 
     @objc private func handleMessagesNoticed(_ notification: Notification) {


### PR DESCRIPTION
close: #3098 

demo: 

<details>
<summary>Details</summary>

https://github.com/user-attachments/assets/0d597c0a-e90e-4688-a13d-553197150960

</details>


*The issue with the entire profile row being redrawn, as seen in the video, has been fixed in this commit*: `f99be28f47d4bc3155e8dace39c7d3468812374b`