### PR TITLE
show count on forwarding, update translations

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1407,7 +1407,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     private func askToForwardMessage() {
         let chat = dcContext.getChat(chatId: chatId)
         confirmationAlert(
-            title: String.localizedStringWithFormat(String.localized("ask_forward"), chat.name),
+            title: String.localized(stringID: "ask_forward_messages", parameter: RelayHelper.shared.forwardIdsCount(), chat.name),
             actionTitle: String.localized("forward"),
             actionHandler: { [weak self] _ in
                 guard let self else { return }

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -97,6 +97,13 @@ class RelayHelper {
         finishRelaying()
     }
 
+    func forwardIdsCount() -> Int {
+        if case .forwardMessages(_, let messageIds) = data {
+            return messageIds.count
+        }
+        return 0
+    }
+
     func finishRelaying() {
         dialogTitle = ""
         data = nil

--- a/deltachat-ios/ar.lproj/Localizable.strings
+++ b/deltachat-ios/ar.lproj/Localizable.strings
@@ -178,6 +178,7 @@
 "pref_other" = "أخرى";
 // No need to translate "Wallpaper" literally. Chose what is common in your language for a "Wallpaper" or a "Background". Avoid adding the term "image" here, as the "Wallpaper" may also be just a single color.
 "pref_background" = "الخلفية";
+// deprecated
 "pref_show_emails_all" = "كلها";
 "qrscan_fingerprint_label" = "البصمة";
 // notifications

--- a/deltachat-ios/az.lproj/Localizable.strings
+++ b/deltachat-ios/az.lproj/Localizable.strings
@@ -133,11 +133,13 @@
 "mute_for_one_day" = "1 günlük söndür";
 "mute_for_seven_days" = "7 günlük söndür";
 "mute_forever" = "Həmişə səssiz";
+// deprecated
 "share_location_for_5_minutes" = "5 dəqiqə üçün";
 "share_location_for_30_minutes" = "30 qəqiqə üçün";
 "share_location_for_one_hour" = "1 saat üçün";
 "share_location_for_two_hours" = "2 saat üçün ";
 "share_location_for_six_hours" = "6 saat üçün";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Mesajları yönləndirin %1$@ə-?";
 "ask_export_attachment" = "Faylı ixrac etmək? Faylların ixracı cihazınızdakı hər hansı digər tətbiqlərə daxil olmağa imkan verəcəkdir. \n\n Razısan?";
 "ask_block_contact" = "Bu kontaktı bloklamaq? Bu kontaktdan artıq mesaj qəbul etməyəcəksiniz.";
@@ -270,11 +272,17 @@
 "pref_background" = "Fon";
 "pref_background_btn_default" = "Hal hazırdaki şəkili istifadə edin";
 "pref_background_btn_gallery" = "Fotoalbomdan götürün";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Bu seçimi ləğv etsəniz, serverinizin və digər müştərilərinizin müvafiq olaraq konfiqurasiya olunduğundan əmin olun. \n\nAyrıca şeylər işləməyəcəkdir.";
+// deprecated
 "pref_auto_folder_moves" = "DeltaChat qovluğuna avtomatik keçid";
+// deprecated
 "pref_show_emails" = "Klassik e-poçtları göstər";
+// deprecated
 "pref_show_emails_no" = "Xeyir, ancaq çatlar";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Qəbul edilən kontaktlar üçün";
+// deprecated
 "pref_show_emails_all" = "Hamısı";
 "pref_background_default" = "Özünəməxsus arxa fon";
 "pref_background_default_color" = "Özünəməxsus rəng";

--- a/deltachat-ios/bg.lproj/Localizable.strings
+++ b/deltachat-ios/bg.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "always" = "Винаги";
 "always_load_remote_images" = "Винаги да се зареждат отдалечените изображения";
 "once" = "Веднъж";
+// deprecated
 "show_warning" = "Показване на предупреждение";
 "not_now" = "Не сега";
 "never" = "Никога";
@@ -126,6 +127,7 @@
 "camera" = "Камера";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Заснемане";
+// Switch eg. from front to back camera
 "switch_camera" = "Превключване на камерата";
 "toggle_fullscreen" = "Включване/изключване на пълноекранния режим";
 "location" = "Местоположение";
@@ -248,12 +250,14 @@
 "mute_for_one_day" = "Спиране на звука за 1 ден";
 "mute_for_seven_days" = "Спиране на звука за 7 дни";
 "mute_forever" = "Спиране на звука за постоянно";
+// deprecated
 "share_location_for_5_minutes" = "За 5 минути";
 "share_location_for_30_minutes" = "За 30 минути";
 "share_location_for_one_hour" = "За 1 час";
 "share_location_for_two_hours" = "За 2 часа";
 "share_location_for_six_hours" = "За 6 часа";
 "file_saved_to" = "Файлът е записан в \"%1$@\"";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Да бъдат ли препратени съобщенията на %1$@?";
 "ask_forward_multiple" = "Да бъдат ли препратени съобщенията към %1$d чата?";
 "ask_export_attachment" = "Експортирането на прикачените файлове ще даде възможност други приложения на Вашето устройство да имат достъп до тях.\n\nИскате ли да продължите?";
@@ -490,6 +494,7 @@
 "pref_notifications_priority" = "Приоритет";
 "pref_notifications_explain" = "Да бъдат разрешени системните уведомления за нови съобщения";
 "pref_show_notification_content" = "Да се показва в уведомлението съдържанието на съобщението";
+// deprecated
 "pref_show_notification_content_explain" = "Да се показва в уведомлението подателят и първите думи на съобщението";
 "pref_led_color" = "Цвят на LED светлината";
 "pref_sound" = "Звук";
@@ -528,12 +533,19 @@
 "pref_background" = "Фон";
 "pref_background_btn_default" = "Да се използва подразбиращото се изображение";
 "pref_background_btn_gallery" = "Избор от галерията";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Ако промение тази опция, се уверете, че Вашият сървър и другите Ви клиенти са конфигурирани по съответен начин.\n\nВ противен случай е възможно нещата въобще да не работят.";
+// deprecated
 "pref_auto_folder_moves" = "Автоматично преместване в папката DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Да се извлича само от папката DeltaChat";
+// deprecated
 "pref_show_emails" = "Да се показват класически e-mail съобщения";
+// deprecated
 "pref_show_emails_no" = "Не, само чатове";
+// deprecated
 "pref_show_emails_accepted_contacts" = "За приетите контакти";
+// deprecated
 "pref_show_emails_all" = "Всички";
 "pref_experimental_features" = "Експериментални възможности";
 "pref_on_demand_location_streaming" = "Поточно излъчване на местоположението при поискване";
@@ -577,12 +589,13 @@
 // automatically delete message
 "delete_old_messages" = "Изтриване на старите съобщения";
 "autodel_device_title" = "Изтриване на съобщенията от устройството";
+// deprecated
 "autodel_server_title" = "Изтриване на съобщенията от сървъра";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Искате ли да изтриете %1$d съобщения сега, както и всички съобщения \"%2$@\", които ще бъдат изтегляни в бъдеще?\n\n• Това включва всички медийни файлове\n\n• Съобщенията ще бъдат изтрити, независимо от това дали са видени или не\n\n• Съобщенията от \"Запазени съобщения\" няма да бъдат изтривани локално";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Искате ли да изтриете %1$d съобщения сега и всички съобщения \"%2$@\", които ще бъдат изтегляни в бъдеще?\n\n⚠️ Това включва електронна поща, медийни файлове и съобщенията от \"Записани съобщения\" във всички папки на сървъра\n\n⚠️ Не ползвайте тази функция, ако искате да запазите данните на сървъра\n\n⚠️ Не ползвайте тази функция, ако работите с други клиенти за електронна поща освен Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Това включва електронна поща, медийни файлове и \"Запазени съобщения\" във всички папки на сървъра. Не ползвайте тази функция, ако искате да запазите данните на сървъра или ако работите с други клиенти за електронна поща освен Delta Chat.";
 "autodel_confirm" = "Разбирам. Всички тези съобщения да бъдат изтрити";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -659,7 +672,7 @@
 "invalid_unencrypted_explanation" = "За да установите криптиране от край до край, бихте могли да се срещате с лицата, с които желаете да контактувате, лично и да сканирате техните QR кодове, за да ги въведете.";
 "learn_more" = "Научете повече";
 "devicemsg_self_deleted" = "Изтрихте чата \"Запазени съобщения\".\n\nℹ️ За да използвате възможността \"Запазени съобщения\" отново, създайте нов чат със себе си.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Мястото за съхранение, предоставено от Вашия доставчик, скоро ще бъде изчерпано:%1$@%% вече са използвани.\n\nМоже да нямате възможност да получавате съобщения, ако мястото за съхранение е заето напълно.\n\n👉 Моля, проверете дали не бихте могли да изтриете стари данни през уеб интерфейса на доставчика и обмислете дали да не включите \"Настройки / Изтриване на старите съобщения\". Можете по всяко време да проверите текущо използваното място за съхранение в \"Настройки / Свързаност\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Изглежда датата и часът на Вашето устройство са неточни (%1$@).\n\nНастройте часовника ⏰🔧, за да имате сигурност, че Вашите съобщения се получават правилно.";

--- a/deltachat-ios/bg.lproj/Localizable.stringsdict
+++ b/deltachat-ios/bg.lproj/Localizable.stringsdict
@@ -141,9 +141,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Да бъде ли изпратен следният файл на%s?</string>
+			<string>Да бъде ли изпратен следният файл на %2$@?</string>
 			<key>other</key>
-			<string>Да бъдат ли изпратени следните %d файлове на %s?</string>
+			<string>Да бъдат ли изпратени следните %d файлове на %2$@?</string>
 		</dict>
 	</dict>
 	<key>chat_archived</key>

--- a/deltachat-ios/bqi.lproj/Localizable.strings
+++ b/deltachat-ios/bqi.lproj/Localizable.strings
@@ -57,7 +57,9 @@
 "media" = "وارسگر";
 "apps_and_media" = "برنومه یل وو وارسگرا";
 "profile" = "پوروفایل";
+// deprecated
 "all_profiles" = "پوی پوروفایلا";
+// deprecated
 "current_profile" = "پوروفایل هیم سکویی";
 "main_menu" = "نومگه ٱسلی";
 "start_chat" = "ناڌن پا گوفت وو لوفت";
@@ -76,6 +78,7 @@
 "always" = "همیشه";
 "always_load_remote_images" = "شؽواتا دیر ز دسرس هی بوگوئشن";
 "once" = "هیم ی کرت";
+// deprecated
 "show_warning" = "نشووݩ داڌن هوشدار";
 "not_now" = "سکو ن";
 "never" = "هیچ";
@@ -144,6 +147,7 @@
 "camera" = "شؽواتگر";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "گرؽڌن";
+// Switch eg. from front to back camera
 "switch_camera" = "آلشت شؽواتگر";
 "toggle_fullscreen" = "آلشت وزیت پوی بلگه";
 "location" = "جاگه";
@@ -274,6 +278,7 @@
 "mute_for_one_day" = "بؽ دونگ کردن سی 1 رۊ";
 "mute_for_seven_days" = "بؽ دونگ کردن سی 7 رۊ";
 "mute_forever" = "بؽ دونگ کردن سی همیشه";
+// deprecated
 "share_location_for_5_minutes" = "سی 5 دؽقه";
 "share_location_for_30_minutes" = "سی 30 دؽقه";
 "share_location_for_one_hour" = "سی 1 ساعت";
@@ -343,6 +348,7 @@
 "pref_chats" = "گوفت وو لوفتا";
 "pref_log_header" = "گوزارش";
 "pref_background_btn_gallery" = "پسند ز شؽوات مال";
+// deprecated
 "pref_show_emails_all" = "پوی";
 // %1$s will be replaced by a human-readable number of bytes, eg. 32 KiB, 1 MiB
 "up_to_x" = "تا سقف %1$@";
@@ -356,6 +362,7 @@
 // automatically delete message
 "delete_old_messages" = "پاک کردن پیوما قڌیمی";
 "autodel_device_title" = "پاک کردن پیوما ز دسگا";
+// deprecated
 "autodel_server_title" = "پاک کردن پیوما ز سرور";
 // "At once" in the meaning of "Immediately", without any intervening time.
 "autodel_at_once" = "ی کرت دیندا دانلود";

--- a/deltachat-ios/ca.lproj/Localizable.strings
+++ b/deltachat-ios/ca.lproj/Localizable.strings
@@ -57,7 +57,9 @@
 "media" = "Multimèdia";
 "apps_and_media" = "Apps & Multimèdia";
 "profile" = "Perfil";
+// deprecated
 "all_profiles" = "Tots els Perfils";
+// deprecated
 "current_profile" = "Perfil Actual";
 "main_menu" = "Menú principal";
 "start_chat" = "Inicia un xat";
@@ -80,6 +82,7 @@
 "always" = "Sempre";
 "always_load_remote_images" = "Carrega sempre les imatges remotes";
 "once" = "Una vegada";
+// deprecated
 "show_warning" = "Mostra l\'advertiment";
 "not_now" = "Ara no";
 "never" = "Mai";
@@ -155,6 +158,7 @@
 "camera" = "Càmera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Captura";
+// Switch eg. from front to back camera
 "switch_camera" = "Canvia la càmera";
 "toggle_fullscreen" = "Alterna el mode de pantalla completa";
 "location" = "Ubicació";
@@ -322,6 +326,7 @@
 "mute_for_one_day" = "Silencia 1 dia";
 "mute_for_seven_days" = "Silencia 7 dies";
 "mute_forever" = "Sempre silenciat";
+// deprecated
 "share_location_for_5_minutes" = "Durant 5 minuts";
 "share_location_for_30_minutes" = "Durant 30 minuts";
 "share_location_for_one_hour" = "Durant 1 hora";
@@ -365,6 +370,7 @@
 "ask_leave_group" = "Segur que vols sortir?";
 "ask_delete_named_chat" = "¿Esborrar xat \"%1$@\" de tots els teus dispositius?";
 "ask_delete_message" = "¿Esborra aquest missatge de tots els teus dispositius?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Reenvia missatges a %1$@?";
 "ask_forward_multiple" = "Voleu reenviar els missatges a %1$d xats?";
 "ask_export_attachment" = "En exportar els adjunts permetreu que altres aplicacions del dispositiu hi puguin accedir.\n\nVoleu continuar?";
@@ -660,6 +666,7 @@
 "pref_notifications_priority" = "Prioritat";
 "pref_notifications_explain" = "Habilita les notificacions del sistema per als missatges nous";
 "pref_show_notification_content" = "Mostra el contingut del missatge a la notificació";
+// deprecated
 "pref_show_notification_content_explain" = "Mostra el remitent i les primeres paraules del missatge en les notificacions";
 "pref_led_color" = "Color LED";
 "pref_sound" = "So";
@@ -700,16 +707,23 @@
 "pref_background" = "Fons";
 "pref_background_btn_default" = "Usa la imatge per defecte";
 "pref_background_btn_gallery" = "Trieu de la galeria";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Si desactiveu aquesta opció, assegureu-vos que el vostre servidor i els altres programes estiguin configurats de la mateixa manera.\n\nAltrament podeu tenir problemes de funcionament.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Mode multidispositiu";
 "pref_multidevice_explain" = "Sincronitza els vostres missatges amb els vostres altres dispositius. Activat automàticament quan s\'afegeix un segon dispositiu.";
 "pref_multidevice_change_warn" = "El mode multidispositiu ha d\'estar habilitat quan feu servir el mateix perfil des de diferents dispositius. Desactiva aquesta opció només si has esborrat aquest perfil de tots els altres dispositius.\n\nDesactivar aquesta opció mentre es fa servir el mateix perfil en múltiples dispositius farà que es perdin missatges i hi hagi altres problemes.";
+// deprecated
 "pref_auto_folder_moves" = "Moure automàticament a la carpeta de Delta Chat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Agafa només de la carpeta de DeltaChat";
+// deprecated
 "pref_show_emails" = "Mostra els correus clàssics";
+// deprecated
 "pref_show_emails_no" = "No, només xats";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Per a contactes acceptats";
+// deprecated
 "pref_show_emails_all" = "Tot";
 "pref_experimental_features" = "Funcionalitats experimentals";
 "pref_experimental_features_explain" = "Aquestes funcionalitats poden ser inestables i poden canviar o ser suprimides";
@@ -761,14 +775,17 @@
 // automatically delete message
 "delete_old_messages" = "Esborra els missatges antics";
 "autodel_device_title" = "Esborra els missatges del dispositiu";
+// deprecated
 "autodel_server_title" = "Esborra els missatges del servidor";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Voleu esborrar ara %1$d missatges i tots els missatges \"%2$@\" futurs?\n\n• Això inclou tot el contingut multimèdia\n\n• S\'esborraran els missatges fins i tot si no s\'han llegit\n\n• Els \"Missatges desats\" no s\'esborraran de l\'emmagatzematge local";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Voleu esborrar ara %1$d missatges i tots els missatges nous \"%2$@\" futurs?\n\n⚠️ Això inclou els correus, contingut multimèdia i \"Missatges desats\" a totes les carpetes del servidor\n\n⚠️ No utilitzeu aquesta funció si voleu conservar les dades al servidor\n\n⚠️ No utilitzeu aquesta funció si feu servir un client de correu diferent a Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Això inclou els correus electrònics, contingut multimèdia i «Missatges desats» en totes les carpetes del servidor. No useu aquesta funció si voleu conservar dades al servidor o si useu altres clients de correu més enllà de Delta Chat.";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Activa l\'esborrament immediat";
+// deprecated
 "autodel_server_warn_multi_device" = "Si habiliteu l\'esborrament immediat no podeu usar múltiples dispositius en aquest perfil.";
 "autodel_confirm" = "Ho entenc, esborra tots aquests missatges";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -860,7 +877,7 @@
 "invalid_unencrypted_explanation" = "Per a establir xifratge d\'extrem a extrem, heu de trobar-vos amb els contactes en persona i escanejar el seu codi QR per a afegir-los.";
 "learn_more" = "Més informació";
 "devicemsg_self_deleted" = "Heu esborrat el xat «Missatges desats».\n\nℹ️ Per a usar altre cop la funcionalitat de «Missatges desats», creeu un xat nou amb vós mateix.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Esteu a punt de quedar-vos sense espai d\'emmagatzematge al vostre proveïdor: ja esteu utilitzant %1$@%% .\n\nPodríeu deixar de rebre missatges si s\'emplena.\n\n👉 Reviseu a la interfície web del proveïdor si podeu esborrar dades antigues i considereu habilitar \"Preferències / Xats i multimèdia / Esborra els missatges antics\". Podeu veure sempre el nivell d\'ocupació a \"Preferències / Connectivitat\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ La data o l\'hora del vostre dispositiu no semblen correctes (%1$@).\n\nAdjusteu el rellotge ⏰🔧 per a assegurar que els missatges es reben correctament.";

--- a/deltachat-ios/ca.lproj/Localizable.stringsdict
+++ b/deltachat-ios/ca.lproj/Localizable.stringsdict
@@ -189,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Voleu enviar el següent fitxer a %s?</string>
+			<string>Voleu enviar el següent fitxer a %2$@?</string>
 			<key>other</key>
-			<string>Voleu enviar els següents %d fitxers a %s?</string>
+			<string>Voleu enviar els següents %d fitxers a %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/ckb.lproj/Localizable.strings
+++ b/deltachat-ios/ckb.lproj/Localizable.strings
@@ -176,12 +176,14 @@
 "mute_for_one_day" = "بێدەنگ کردن بۆ ماوەی 1 ڕۆژ";
 "mute_for_seven_days" = "بێدەنگ کردن بۆ ماوەی 7 ڕۆژ";
 "mute_forever" = "بێدەنگ کردن بۆ هەمیشە";
+// deprecated
 "share_location_for_5_minutes" = "بۆ ماوەی 5 خولەک";
 "share_location_for_30_minutes" = "بۆ ماوەی 30 خولەک";
 "share_location_for_one_hour" = "بۆ ماوەی 1 کاتژمێر";
 "share_location_for_two_hours" = "بۆ ماوەی 2 کاتژمێر";
 "share_location_for_six_hours" = "بۆ ماوەی 6 کاتژمێر";
 "file_saved_to" = "پەڕگەکە پاشەکەوت کرا لە \"%1$@\".";
+// deprecated, use ask_forward_messages
 "ask_forward" = "ئەو پەیامانە دەنێریت بۆ %1$@؟";
 "ask_forward_multiple" = "ئەو پەیامانە دەنێریت بۆ نێو %1$dوتووێژ؟";
 "ask_export_attachment" = "پێوەلکاوەکە هەناردە دەکەیت؟ هەناردەکردنی پێوەلکاوەکان وادەکات نەرمامێرەکانی دیکەی سەر مۆبایلەکەت بتوانن دەستیان بەو بەڵگە هەناردەکراوە بگات.\n\n بەردەوام دەبیت؟";
@@ -300,6 +302,7 @@
 "pref_notifications_priority" = "پێشترێتی";
 "pref_notifications_explain" = "وریاکەرەوەکانی سیستەم بۆ پەیامە نوێکان چالاک بکە";
 "pref_show_notification_content" = "دەقی پەیامەکە لەنێو وریاکەرەوەکاندا پیشان بدە";
+// deprecated
 "pref_show_notification_content_explain" = "ناوی پەیامنێرەکە و وشە سەرەتاییەکانی دەقی پەیامەکە لەناو وریاکەرەوەکەدا پیشان بدە";
 "pref_led_color" = "ڕەنگی چرای LED";
 "pref_sound" = "دەنگ";
@@ -330,10 +333,15 @@
 "pref_background" = "پشتخان";
 "pref_background_btn_default" = "بەکارهێنانی وێنەی بنەڕەتی";
 "pref_background_btn_gallery" = "هەڵبژاردن لە پیشانگا";
+// deprecated
 "pref_auto_folder_moves" = "هەناردنی خۆکار بۆ بوخچەی دێڵتاچات";
+// deprecated
 "pref_show_emails" = "پیشاندانی ئیمەیلە کلاسیکەکان";
+// deprecated
 "pref_show_emails_no" = "نا، بەس چاتەکان";
+// deprecated
 "pref_show_emails_accepted_contacts" = "بۆ بەردەنگە پەسندکراوەکان";
+// deprecated
 "pref_show_emails_all" = "هەموو";
 "pref_experimental_features" = "ئەو تایبەتمەندییانەی بۆ تاقی کردنەوەن";
 "pref_background_default" = "پشتخانی بنەڕەتی";
@@ -359,6 +367,7 @@
 // automatically delete message
 "delete_old_messages" = "سڕینەوەی پەیامە کۆنەکان";
 "autodel_device_title" = "سڕینەوەی پەیامەکان لەسەر مۆبایەلەکت";
+// deprecated
 "autodel_server_title" = "سڕینەوەی پەیامەکان لەسەر سێرڤەر";
 "autodel_confirm" = "تێگەیشتم، هەموو ئەم پەیامانە بسڕەوە";
 // "At once" in the meaning of "Immediately", without any intervening time.

--- a/deltachat-ios/ckb.lproj/Localizable.stringsdict
+++ b/deltachat-ios/ckb.lproj/Localizable.stringsdict
@@ -109,9 +109,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>ئەم پەڕگەیە دەنێریت بۆ %s؟</string>
+			<string>ئەم پەڕگەیە دەنێریت بۆ %2$@؟</string>
 			<key>other</key>
-			<string>ئەم %d پەڕگەیە دەنێریت بۆ %s؟</string>
+			<string>ئەم %d پەڕگەیە دەنێریت بۆ %2$@؟</string>
 		</dict>
 	</dict>
 	<key>chat_archived</key>

--- a/deltachat-ios/cs.lproj/Localizable.strings
+++ b/deltachat-ios/cs.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 "downloading" = "Stahování...";
 "open_attachment" = "Otevřít přílohu";
 "join" = "Připojit se";
+"join_group" = "Připojit se ke skupině";
+"join_channel" = "Připojte se ke kanálu";
 "rejoin" = "Znovu se připojit";
 "delete" = "Smazat";
 "delete_for_me" = "Smazat pro mě";
@@ -57,7 +59,9 @@
 "media" = "Multimédia";
 "apps_and_media" = "Aplikace a multimédia";
 "profile" = "Profil";
+// deprecated
 "all_profiles" = "Všechny profily";
+// deprecated
 "current_profile" = "Aktuální profil";
 "main_menu" = "Hlavní nabídka";
 "start_chat" = "Začít chatovat";
@@ -68,6 +72,10 @@
 "mark_as_read" = "Označit jako přečtené";
 // Used beside an icon with very few space. Shortest text for "Mark as being read". In english, this could be "Read" (past tense of "to read"), in german, this could be "Gelesen".
 "mark_as_read_short" = "Přečteno";
+// Used as an menu entry or button
+"mark_as_unread" = "Označit jako nepřečtené";
+// Used beside an icon with very few space. Shortest text for "Mark as being unread". In english, this could be "Unread" (past tense of "to unread"), in german, this could be "Ungelesen".
+"mark_as_unread_short" = "Nepřečtené";
 // Placeholder text when something is loading
 "loading" = "Načítání...";
 "hide" = "Skrýt";
@@ -78,6 +86,7 @@
 "always" = "Vždy";
 "always_load_remote_images" = "Vždy načítat vzdálené obrázky";
 "once" = "Jednou";
+// deprecated
 "show_warning" = "Zobrazovat varování";
 "not_now" = "Teď ne";
 "never" = "Nikdy";
@@ -87,6 +96,7 @@
 "offline" = "Offline";
 // For the next view or as "continue". Should be as short as possible.
 "next" = "Další";
+"warning" = "Varování";
 "error" = "Chyba";
 "error_x" = "Chyba: %1$@";
 "no_app_to_handle_data" = "Aplikace pro tento typ dat nenalezena.";
@@ -114,10 +124,14 @@
 // Refers to the time a contact was last seen. Shown below contact name in the profile. The placeholder will be replaced by a relative point in time as "3 minutes ago" (see https://momentjs.com for more examples and languages)
 "last_seen_relative" = "Naposledy viděni %1$@";
 "last_seen_unknown" = "Naposledy viděno: Neznámý";
+// Call duration as shown in the call bubbles. There is some risk to mix with the sending time, so the word "Duration" may be helpful. Might also be "Duration: %d minutes", "%d-minute duration", "%d-minute length" or "%d-minute call"
+// Call duration as shown in the call bubbles in case the call is less than one minute. If the context is not clear enough, one may want to add the word "Duration".
+"call_duration_less_than_a_minute" = "Méně než 1 minuta";
 // Shown beside messages that are "N minutes old". Prefer short strings, or well-known abbreviations.
 // Shown beside messages that are "N hours old". Prefer short strings, or well-known abbreviations.
 // Short form for "N Items Selected"
 "selected_colon" = "Vybráno:";
+"selected" = "Vybráno";
 "self" = "Já";
 "draft" = "Rozepsané";
 "image" = "Obrázek";
@@ -131,6 +145,9 @@
 "add_stickers_instructions" = "Přejete-li si přidat nálepky, klepněte na „Otevřít složku nálepek“, vytvořte podsložku pro balíček nálepek a přetáhněte do ní soubory obrázků a nálepek";
 // deprecated
 "open_sticker_folder" = "Otevřít složku nálepek";
+"ask_add_sticker_to_collection" = "Přidat tuto nálepku do své sbírky?";
+"ask_delete_sticker" = "Smazat tuto nálepku?";
+"sticker_picker_empty_hint" = "Klepnutím na nálepku ji sem přidáte.";
 "images" = "Obrázky";
 // a noun, used for "Music" and other "Audio" files
 "audio" = "Zvukové záznamy";
@@ -146,6 +163,7 @@
 "camera" = "Fotoaparát";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Spoušť";
+// Switch eg. from front to back camera
 "switch_camera" = "Přepnout kameru";
 "toggle_fullscreen" = "Přepnout režim celé obrazovky";
 "location" = "Poloha";
@@ -311,6 +329,7 @@
 "mute_for_one_day" = "Ztlumit na 1 den";
 "mute_for_seven_days" = "Ztlumit na 7 dní";
 "mute_forever" = "Ztlumit navždy";
+// deprecated
 "share_location_for_5_minutes" = "Na 5 minut";
 "share_location_for_30_minutes" = "Na 30 minut";
 "share_location_for_one_hour" = "Na 1 hodinu";
@@ -331,6 +350,7 @@
 "ask_leave_group" = "Jste si jistý, že chcete odejít?";
 "ask_delete_named_chat" = "Smazat chat \"%1$@\" ze všech vašich zařízení?";
 "ask_delete_message" = "Smazat tuto zprávu ze všech vašich zařízení?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Přejete si přeposlat zprávy do chatu %1$@?";
 "ask_forward_multiple" = "Přejete si přeposlat zprávy do %1$d chatů?";
 "ask_export_attachment" = "Uložením příloh je zpřístupníte ostatním aplikacím na tomto zařízení.\n\nPřejete si pokračovat?";
@@ -613,6 +633,7 @@
 "pref_notifications_priority" = "Priorita";
 "pref_notifications_explain" = "Povolit systémová oznámení nových zpráv";
 "pref_show_notification_content" = "Zobrazit obsah zprávy uvnitř oznámení";
+// deprecated
 "pref_show_notification_content_explain" = "Zobrazit odesílatele a první slova zprávy uvnitř oznámení";
 "pref_led_color" = "Barva diody";
 "pref_sound" = "Zvuk";
@@ -653,16 +674,23 @@
 "pref_background" = "Pozadí";
 "pref_background_btn_default" = "Použít výchozí obrázek";
 "pref_background_btn_gallery" = "Vybrat z galerie";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Při změně této volby se ujistěte, že váš server a ostatní klientské aplikace mají odpovídající nastavení.\n\nJinak může vše přestat fungovat.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Režim pro více zařízení";
 "pref_multidevice_explain" = "Synchronizujte zprávy s ostatními zařízeními. Automaticky povoleno při přidání druhého zařízení";
 "pref_multidevice_change_warn" = "Při použití stejného profilu na více zařízeních musí být povolen \"režim více zařízení\". Toto nastavení zakažte pouze v případě, že jste tento profil odstranili ze všech ostatních zařízení. \n\n Zakázání režimu \"režim více zařízení\" při používání profilu na více zařízeních bude mít za následek zmeškané zprávy a další problémy.";
+// deprecated
 "pref_auto_folder_moves" = "Automaticky přesouvat do složky DeltaChat ";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Načítat pouze ze složky DeltaChat";
+// deprecated
 "pref_show_emails" = "Zobrazovat běžné e-maily";
+// deprecated
 "pref_show_emails_no" = "Ne, pouze chaty";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Pro přijaté kontakty";
+// deprecated
 "pref_show_emails_all" = "Vše";
 "pref_experimental_features" = "Experimentální funkce ";
 "pref_experimental_features_explain" = "Tyto funkce mohou být nestabilní a mohou být změněny nebo odstraněny.";
@@ -708,14 +736,17 @@
 // automatically delete message
 "delete_old_messages" = "Mazat staré zprávy";
 "autodel_device_title" = "Mazat zprávy ze zařízení";
+// deprecated
 "autodel_server_title" = "Mazat zprávy ze serveru";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Skutečně smazat %1$d zpráv a všechny v budoucnu stažené zprávy \"%2$@\"?\n\n• Toto zahrnuje všechna multimédia\n\n• Zprávy budou smazány bez ohledu na jejich přečtení\n\n• \"Uložené zprávy\" budou ponechány";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Skutečně smazat %1$d zprávy a všechny v budoucnu stažené zprávy \"%2$@\"?\n\n⚠️ Toto zahrnuje e-maily, multimédia a \"Uložené zprávy\" ve všech složkách na serveru\n\n⚠️ Nepoužívejte tuto funkci, pokud si přejete ponechat data na serveru\n\n⚠️ Nepoužívejte tuto funkci, pokud používáte i jiné e-mailové klienty mimo Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Toto zahrnuje e-maily, multimédia a \"Uložené zprávy\" ve všech složkách na serveru. Nepoužívejte tuto funkci, pokud chcete ponechat data na serveru, nebo pokud používáte i jiné e-mailové programy mimo Delta Chat";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Zapnout okamžité mazání";
+// deprecated
 "autodel_server_warn_multi_device" = "Pokud zapnete okamžité mazání, nemůžete tento profil používat na více zařízeních.";
 "autodel_confirm" = "Rozumím. Smazat všechny tyto zprávy";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -803,7 +834,7 @@
 "invalid_unencrypted_explanation" = "Pro navázání koncově šifrovaného spojení se můžete se svými kontakty setkat osobně a naskenovat jejich QR kódy.";
 "learn_more" = "Další informace";
 "devicemsg_self_deleted" = "Smazali jste chat „Uložené zprávy“.\n\nℹ️ Chcete-li znovu použít funkci „Uložené zprávy“, založte nový chat sami se sebou.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Úložiště u vašeho poskytovatele je téměř vyčerpané: %1$@ %% je již využito.\n\nPokud se úložiště zaplní, nebudete moci přijímat zprávy.\n\n👉 Zkuste smazat stará data ve webovém prostředí poskytovatele a zvažte povolení volby \"Nastavení / Chaty a multimédia / Mazat staré zprávy\". Aktuální využití úložiště můžete kdykoliv zkontrolovat v \"Nastavení / Připojení\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Datum a čas na vašem zařízení se zdají být nepřesné (%1$@).\n\nUpravte si čas ⏰🔧, abyste mohli přijímat své zprávy.";

--- a/deltachat-ios/cs.lproj/Localizable.stringsdict
+++ b/deltachat-ios/cs.lproj/Localizable.stringsdict
@@ -2,6 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>call_duration_minutes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@localized_format_key@</string>
+		<key>localized_format_key</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minutové trvání</string>
+			<key>few</key>
+			<string>%d minut trvání</string>
+			<key>many</key>
+			<string>%d minut trvání</string>
+			<key>other</key>
+			<string>%d minut trvání</string>
+		</dict>
+	</dict>
 	<key>n_minutes</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -193,13 +213,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Odeslat následující soubor do chatu %s?</string>
+			<string>Odeslat následující soubor do chatu %2$@?</string>
 			<key>few</key>
-			<string>Odeslat následující %d soubory do chatu %s?</string>
+			<string>Odeslat následující %d soubory do chatu %2$@?</string>
 			<key>many</key>
-			<string>Odeslat následujících %d souborů do chatu %s?</string>
+			<string>Odeslat následujících %d souborů do chatu %2$@?</string>
 			<key>other</key>
-			<string>Odeslat následujících %d souborů do chatu %s?</string>
+			<string>Odeslat následujících %d souborů do chatu %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/da.lproj/Localizable.strings
+++ b/deltachat-ios/da.lproj/Localizable.strings
@@ -98,6 +98,7 @@
 "documents" = "Dokumenter";
 "contact" = "Kontakt";
 "camera" = "Kamera";
+// Switch eg. from front to back camera
 "switch_camera" = "Skift kamera";
 "location" = "Placering";
 "gallery" = "Galleri";
@@ -194,12 +195,14 @@
 "mute_for_one_day" = "Dæmp i 1 dag";
 "mute_for_seven_days" = "Dæmp i 7 dage";
 "mute_forever" = "Stille for altid";
+// deprecated
 "share_location_for_5_minutes" = "i 5 minutter";
 "share_location_for_30_minutes" = "i 30 minutter";
 "share_location_for_one_hour" = "i 1 time";
 "share_location_for_two_hours" = "i 2 timer";
 "share_location_for_six_hours" = "i 6 timer";
 "file_saved_to" = "Fil gemt til \"%1$@\".";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Videresend beskeder til %1$@?";
 "ask_forward_multiple" = "Videresend beskeder til %1$d samtaler?  ";
 "ask_export_attachment" = "Eksportér vedhæftninger? Eksport af vedhæftninger vil tillade alle programmer på din enhed adgang til dem.\n\nFortsæt?";
@@ -346,6 +349,7 @@
 "pref_notifications_priority" = "Prioritet";
 "pref_notifications_explain" = "Aktivér systemnotifikationer for nye beskeder";
 "pref_show_notification_content" = "Vis beskedindhold i notifikationer";
+// deprecated
 "pref_show_notification_content_explain" = "Viser afsender og første ord af beskeden i notifikationer";
 "pref_led_color" = "LED farve";
 "pref_sound" = "Lyd";
@@ -380,11 +384,17 @@
 "pref_background" = "Baggrund";
 "pref_background_btn_default" = "Brug standardbillede";
 "pref_background_btn_gallery" = "Vælg fra galleri";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Ved deaktivering af denne indstiiling vær sikker på at server og andre klienter er indstillet tilsvarende.\n\nEllers fungerer det måske slet ikke.";
+// deprecated
 "pref_auto_folder_moves" = "Flytter automatisk til DeltaChat mappe";
+// deprecated
 "pref_show_emails" = "Vis klassisk e-mail";
+// deprecated
 "pref_show_emails_no" = "Nej, kun samtaler";
+// deprecated
 "pref_show_emails_accepted_contacts" = "For godkendte kontakter";
+// deprecated
 "pref_show_emails_all" = "Alle";
 "pref_experimental_features" = "Eksperimentelle features";
 "pref_on_demand_location_streaming" = "On-demand lokationsstreaming";
@@ -411,12 +421,13 @@
 // automatically delete message
 "delete_old_messages" = "Slet gamle beskeder";
 "autodel_device_title" = "Slet beskeder fra enhed";
+// deprecated
 "autodel_server_title" = "Slet beskeder fra server";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Vil du slette %1$d beskeder nu og alle nyligt hentede beskeder \"%2$@\" i fremtiden?\n\n• Dette inkluderer alle medier\n\n• Beskeder vil blive slettet uanset om de er set eller ej\n\n• \"Gemte beskeder\" vil ikke blive slettet lokalt";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Vil du slette %1$d beskeder nu og alle nyligt hentede beskeder \"%2$@\" fremover?\n\n⚠️ Dette inkluderer e-mails, medier og \"Gemte beskeder\" i alle mapper på serveren\n\n⚠️ Brug ikke denne funktion hvis du vil beholde data på serveren\n\n⚠️ Brug ikke denne funktion hvis du benytter andre e-mail klienter end Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Dette inkluderer email, medier og \"Gemte beskeder\" i alle server mapper. Brug ikke denne funktion hvis du vil beholde data på serveren eller hvis du bruger andre emailklienter end Delta Chat.";
 "autodel_confirm" = "Jeg forstår, slet alle disse beskeder";
 // "At once" in the meaning of "Immediately", without any intervening time.

--- a/deltachat-ios/da.lproj/Localizable.stringsdict
+++ b/deltachat-ios/da.lproj/Localizable.stringsdict
@@ -109,9 +109,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Send den følgende fil til 2%s?</string>
+			<string>Send den følgende fil til %2$@?</string>
 			<key>other</key>
-			<string>Send de følgende %d filer til %s?</string>
+			<string>Send de følgende %d filer til %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_messages</key>

--- a/deltachat-ios/de.lproj/Localizable.strings
+++ b/deltachat-ios/de.lproj/Localizable.strings
@@ -59,7 +59,9 @@
 "media" = "Medien";
 "apps_and_media" = "Apps & Medien";
 "profile" = "Profil";
+// deprecated
 "all_profiles" = "Alle Profile";
+// deprecated
 "current_profile" = "Aktuelles Profil";
 "main_menu" = "Hauptmenü";
 "start_chat" = "Chat starten";
@@ -84,6 +86,7 @@
 "always" = "Immer";
 "always_load_remote_images" = "Bilder immer nachladen";
 "once" = "Einmal";
+// deprecated
 "show_warning" = "Warnung anzeigen";
 "not_now" = "Nicht jetzt";
 "never" = "Nie";
@@ -160,7 +163,10 @@
 "camera" = "Kamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Aufnehmen";
+// Switch eg. from front to back camera
 "switch_camera" = "Kamera wechseln";
+// Toggle camera on/off eg. during an video call
+"toggle_camera" = "Kamera wechseln";
 "toggle_fullscreen" = "Vollbildmodus umschalten";
 "location" = "Standort";
 "locations" = "Standorte";
@@ -327,11 +333,13 @@
 "mute_for_one_day" = "Stumm für 1 Tag";
 "mute_for_seven_days" = "Stumm für 7 Tage";
 "mute_forever" = "Stumm für immer";
+// deprecated
 "share_location_for_5_minutes" = "für 5 Minuten";
 "share_location_for_30_minutes" = "für 30 Minuten";
 "share_location_for_one_hour" = "für 1 Stunde";
 "share_location_for_two_hours" = "für 2 Stunden";
 "share_location_for_six_hours" = "für 6 Stunden";
+"share_location_for_24_hours" = "für 24 Stunden";
 "file_saved_to" = "Datei gespeichert unter \"%1$@\".";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "Anrufen";
@@ -343,6 +351,8 @@
 "answer_call" = "Annehmen";
 // the action "to decline" a call, not: "the decline"
 "end_call" = "Ablehnen";
+// the action to end a call
+"end_call2" = "Anruf beenden";
 // Used in call bubbles, summaries, notifications
 "audio_call" = "Sprachanruf";
 // Used in call bubbles, summaries, notifications
@@ -366,12 +376,19 @@
 "missed_call" = "Verpasster Anruf";
 "already_in_call" = "Bereits im Anruf";
 "call_answered_elsewhere" = "Anruf auf einem anderen Gerät beantwortet";
+"call_requires_camera_permission" = "Kamerazugriff für Videoanrufe erforderlich";
 "call_requires_mic_permission" = "Mikrofonzugriff für Anrufe erforderlich";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "Anruf mit %1$@";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "%1$@ anrufen…";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Diesen Chat verlassen?";
 "ask_delete_named_chat" = "Chat \"%1$@\" löschen?";
 "ask_delete_message" = "Diese Nachricht löschen?";
+// First placeholder gets replaced by the number of messages to forward. Second placeholder gets replaced by the name of the destination chat
+// deprecated, use ask_forward_messages
 "ask_forward" = "Nachricht weiterleiten an %1$@?";
 "ask_forward_multiple" = "Nachrichten an %1$d Chats weiterleiten?";
 "ask_export_attachment" = "Das Exportieren von Anhängen ermöglicht es allen anderen Anwendungen auf deinem Gerät, auf diese zuzugreifen.\n\nFortfahren? ";
@@ -652,9 +669,9 @@
 "pref_enter_sends" = "Enter-Taste sendet";
 "pref_enter_sends_explain" = "Durch Drücken der Eingabetaste werden Textnachrichten gesendet.";
 "pref_outgoing_media_quality" = "Medienqualität beim Senden";
-"pref_outgoing_media_quality_hint" = "Um Originalqualität zu senden, hänge Medien als „Datei“ an. Dies verbraucht deutlich mehr Datenvolumen für dich und die Empfänger.";
+"pref_outgoing_media_quality_hint" = "Um Originalqualität zu senden, hänge Medien als „Datei“ an. Dies verbraucht deutlich mehr Daten für dich und die Empfänger.";
 "pref_outgoing_balanced" = "Ausgewogen";
-"pref_outgoing_worse" = "Schlechte Qualität, kleine Dateien";
+"pref_outgoing_worse" = "Schlechte Qualität, Daten sparen";
 "pref_vibrate" = "Vibrieren";
 "pref_screen_security" = "Bildschirmsicherheit";
 // Translators: Must indicate that there is no guarantee as the system may not honor our request.
@@ -671,6 +688,7 @@
 "pref_notifications_priority" = "Priorität";
 "pref_notifications_explain" = "System-Benachrichtigungen bei neuen Nachrichten aktivieren";
 "pref_show_notification_content" = "Textinhalt in Benachrichtigungen anzeigen";
+// deprecated
 "pref_show_notification_content_explain" = "Absender und Textbeginn in Benachrichtigungen anzeigen";
 "pref_led_color" = "LED-Farbe";
 "pref_sound" = "Ton";
@@ -713,16 +731,23 @@
 "pref_background" = "Hintergrund";
 "pref_background_btn_default" = "Standard-Bild verwenden";
 "pref_background_btn_gallery" = "Aus Galerie auswählen";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Wenn du diese Option änderst, stelle sicher, dass der Server und die anderen Geräte entsprechend konfiguriert sind\n\nAndernfalls funktionieren Dinge möglicherweise nicht wie erwartet.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Mehrgerätemodus";
 "pref_multidevice_explain" = "Synchronisiere deine Nachrichten mit deinen anderen Geräten. Wird beim Hinzufügen eines zweiten Geräts automatisch aktiviert.";
 "pref_multidevice_change_warn" = "Der Mehrgerätemodus muss aktiviert sein, wenn dasselbe Profil auf mehreren Geräten verwendet wird. Deaktiviere diese Einstellung nur, wenn du dieses Profil von allen anderen Geräten entfernt hast.\n\nDie Deaktivierung des Mehrgerätemodus bei Verwendung des Profils auf mehreren Geräten führt zu verlorenen Nachrichten und anderen Problemen.";
+// deprecated
 "pref_auto_folder_moves" = "Autom. Verschieben in den DeltaChat-Ordner";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Nur aus DeltaChat-Ordner lesen";
+// deprecated
 "pref_show_emails" = "Normale E-Mails anzeigen";
+// deprecated
 "pref_show_emails_no" = "Nein, nur Chats";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Akzeptierte Kontakte";
+// deprecated
 "pref_show_emails_all" = "Alle";
 "pref_experimental_features" = "Experimentelle Features";
 "pref_experimental_features_explain" = "Die Features können instabil sein und geändert oder entfernt werden";
@@ -774,14 +799,17 @@
 // automatically delete message
 "delete_old_messages" = "Alte Nachrichten löschen";
 "autodel_device_title" = "Nachrichten vom Gerät löschen";
+// deprecated
 "autodel_server_title" = "Nachrichten vom Server löschen";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Wirklich %1$d Nachrichten jetzt und zukünftig alle neuen Nachrichten \"%2$@\" löschen?\n\n• Dies schliesst alle Medien mit ein\n\n• Nachrichten werden gelöscht, auch wenn sie nicht angesehen wurden\n\n• \"Gespeicherte Nachrichten\" werden nicht gelöscht";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Wirklich %1$d Nachrichten jetzt und zukünftig alle neuen Nachrichten \"%2$@\" löschen?\n\n⚠️ Dies schließt E-Mails, Medien und \"Gespeicherte Nachrichten\" aus allen Server-Ordnern mit ein\n\n⚠️ Verwende diese Funktion nicht, wenn du Daten auf dem Server behalten möchtest oder auch klassische E-Mail-Clients verwendest";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Dies schließt E-Mails, Medien und \"Gespeicherte Nachrichten\" aus allen Server-Ordnern mit ein. Verwenden diese Funktion nicht, wenn du Daten auf dem Server behalten möchtest oder auch klassische E-Mail-Clients verwendest.";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Sofortiges Löschen einschalten";
+// deprecated
 "autodel_server_warn_multi_device" = "Wenn sofortiges Löschen aktiviert ist, können nicht mehrere Geräte für dieses Profil verwendet werden.";
 "autodel_confirm" = "Verstanden, all diese Nachrichten löschen";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -876,7 +904,7 @@
 "invalid_unencrypted_explanation" = "Um eine Ende-zu-Ende-Verschlüsselung herzustellen, kannst du Kontakte persönlich treffen und ihren QR-Code scannen.";
 "learn_more" = "Mehr erfahren";
 "devicemsg_self_deleted" = "Du hast den Chat \"Gespeicherte Nachrichten\" gelöscht.\n\nℹ️ Um die Funktion \"Gespeicherte Nachrichten\" erneut zu verwenden, erstelle einfach einen Chat mit dir selbst.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Der Speicherplatz deines Anbieters ist bald erschöpft; bereits %1$@%% sind verbraucht.\n\nDu kannst möglicherweise keine Nachrichten mehr empfangen, wenn der Speicherplatz komplett verbraucht ist.\n\n👉 Bitte prüfe, ob du alte Daten im Webinterface des Anbieters löschen kannst, und erwäge, \"Einstellungen / Chats / Alte Nachrichten löschen\" zu aktivieren. Den aktuellen Speicherverbrauch kannst du jederzeit unter \"Einstellungen / Verbindungsstatus\" überprüfen.";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Dein Gerät scheint ein falsches Datum oder eine falsche Uhrzeit (%1$@) zu verwenden.\n\nStelle deine Uhr ⏰🔧 richtig ein, um sicherzustellen, dass deine Nachrichten korrekt empfangen werden.";
@@ -956,8 +984,6 @@
 "new_messages_body" = "Du hast neue Nachrichten";
 "n_messages_in_m_chats" = "%1$d Nachrichten in %2$d Chats";
 // location streaming
-"location_streaming_channel_desc" = "Kanal für Standortübertragung";
-"location_streaming_notification_title" = "Standardübertragung";
 "location_streaming_notification_text" = "Du teilst deinen Standort";
 "location_rationale" = "Damit du deinen aktuellen Standort teilen kannst, musst du Delta Chat die Nutzung deiner Standortdaten erlauben.\n\nDamit die Standortanzeige nahtlos funktioniert, werden Standortdaten auch dann verwendet, wenn die App geschlossen ist oder nicht genutzt wird.";
 // permissions
@@ -1048,6 +1074,8 @@
 "a11y_message_context_menu_btn_label" = "Nachrichtaktionen";
 "a11y_background_preview_label" = "Vorschau für Hintergrundbild";
 "a11y_disappearing_messages_activated" = "Verschwindende Nachrichten eingeschaltet";
+// The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility.
+"open_link" = "Öffne %1$@";
 // iOS specific strings, developers: please take care to remove strings that are no longer used!
 "stop_sharing_location" = "Teilen des Standorts beenden";
 "a11y_voice_message_hint_ios" = "Nach der Aufnahme zum Senden doppelt tippen. Um die Aufnahme zu verwerfen, mit zwei Fingern links-rechts hin- und herwischen.";

--- a/deltachat-ios/de.lproj/Localizable.stringsdict
+++ b/deltachat-ios/de.lproj/Localizable.stringsdict
@@ -189,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Die folgende Datei an %s senden?</string>
+			<string>Die folgende Datei an %2$@ senden?</string>
 			<key>other</key>
-			<string>Die folgenden %d Dateien an %s senden?</string>
+			<string>Die folgenden %d Dateien an %2$@ senden?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>
@@ -224,6 +224,22 @@
 			<string>%d Nachricht löschen?</string>
 			<key>other</key>
 			<string>%d Nachrichten löschen?</string>
+		</dict>
+	</dict>
+	<key>ask_forward_messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@localized_format_key@</string>
+		<key>localized_format_key</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Nachricht an %2$@ weiterleiten?</string>
+			<key>other</key>
+			<string>%d Nachrichten an %2$@ weiterleiten?</string>
 		</dict>
 	</dict>
 	<key>chat_archived</key>

--- a/deltachat-ios/el.lproj/Localizable.strings
+++ b/deltachat-ios/el.lproj/Localizable.strings
@@ -110,6 +110,7 @@
 "camera" = "Κάμερα";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Λήψη";
+// Switch eg. from front to back camera
 "switch_camera" = "Αλλαγή κάμερας";
 "toggle_fullscreen" = "Εναλλαγή Λειτουργίας Πλήρους Οθόνης";
 "location" = "Τοποθεσία";
@@ -219,12 +220,14 @@
 "mute_for_one_day" = "Σίγαση για 1 ημέρα";
 "mute_for_seven_days" = "Σίγαση για 7 ημέρες";
 "mute_forever" = "Μόνιμη Σίγαση";
+// deprecated
 "share_location_for_5_minutes" = "Για 5 λεπτά";
 "share_location_for_30_minutes" = "Για 30 λεπτά";
 "share_location_for_one_hour" = "Για 1 ώρα";
 "share_location_for_two_hours" = "Για 2 ώρες";
 "share_location_for_six_hours" = "Για 6 ώρες";
 "file_saved_to" = "Αποθήκευση στο \"%1$@\".";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Κοινοποίηση μηνύματος στο %1$@;";
 "ask_forward_multiple" = "Κοινοποίηση μηνύματος σε %1$d συνομιλίες;";
 "ask_export_attachment" = "Η εξαγωγή συνημμένων θα επιτρέψει σε άλλες εφαρμογές της συσκευής σας να έχουν πρόσβαση σε αυτά.\n\nΣυνέχεια;";
@@ -402,6 +405,7 @@
 "pref_notifications_priority" = "Προτεραιότητα";
 "pref_notifications_explain" = "Ενεργοποιήστε τις ειδοποιήσεις συστήματος για νέα μηνύματα";
 "pref_show_notification_content" = "Εμφάνιση περιεχομένου μηνύματος στην ειδοποίηση";
+// deprecated
 "pref_show_notification_content_explain" = "Εμφανίζει τον αποστολέα και τις πρώτες λέξεις του μηνύματος στις ειδοποιήσεις";
 "pref_led_color" = "Χρώμα LED";
 "pref_sound" = "Ήχος";
@@ -436,12 +440,19 @@
 "pref_background" = "Ταπετσαρία συνομιλίας";
 "pref_background_btn_default" = "Χρήση προκαθορισμένου";
 "pref_background_btn_gallery" = "Επιλογή";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Εάν αλλάξετε αυτήν την επιλογή, βεβαιωθείτε ότι ο διακομιστής σας και οι άλλοι πελάτες σας έχουν διαμορφωθεί ανάλογα.\n\nΔιαφορετικά, τα πράγματα ενδέχεται να μην λειτουργούν καθόλου.";
+// deprecated
 "pref_auto_folder_moves" = "Μετακίνηση αυτόματα στον φάκελο DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Λήψη μόνο από τον φάκελο DeltaChat";
+// deprecated
 "pref_show_emails" = "Εμφάνιση κλασικών E-Mails";
+// deprecated
 "pref_show_emails_no" = "Όχι, μόνο συνομιλίες";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Για αποδεκτές επαφές";
+// deprecated
 "pref_show_emails_all" = "Όλα";
 "pref_experimental_features" = "Πειραματικά Χαρακτηριστικά";
 "pref_on_demand_location_streaming" = "Ροή τοποθεσίας κατ\' απαίτηση";
@@ -476,12 +487,13 @@
 // automatically delete message
 "delete_old_messages" = "Διαγραφή Παλιών Μηνυμάτων";
 "autodel_device_title" = "Διαγραφή Μηνυμάτων από Συσκευή";
+// deprecated
 "autodel_server_title" = "Διαγραφή Μηνυμάτων από Διακομιστή";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Θέλετε να διαγράψετε %1$d μηνύματα τώρα και όλα τα πρόσφατα ληφθέντα μηνύματα \"%2$@\" στο μέλλον;\n\n• Αυτό περιλαμβάνει όλα τα μέσα\n\n• Τα μηνύματα θα διαγραφούν είτε εμφανίστηκαν είτε όχι\n\n• \"Αποθηκευμένα μηνύματα \" θα παραλειφθεί από την τοπική διαγραφή";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Θέλετε να διαγράψετε %1$d μηνύματα τώρα και όλα τα πρόσφατα ληφθέντα μηνύματα \"%2$@\" στο μέλλον;\n\n⚠️ Αυτό περιλαμβάνει μηνύματα ηλεκτρονικού ταχυδρομείου, πολυμέσα και τα \"Αποθηκευμένα μηνύματα\" σε όλους τους φακέλους διακομιστή\n\n⚠️ Μην χρησιμοποιείτε αυτήν τη λειτουργία εάν θέλετε να διατηρήσετε δεδομένα στο διακομιστή\n\n⚠️ Μην χρησιμοποιείτε αυτήν τη λειτουργία εάν χρησιμοποιείτε άλλους πελάτες ηλεκτρονικού ταχυδρομείου εκτός από το Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Αυτό περιλαμβάνει e-mail, πολυμέσα και \"Αποθηκευμένα μηνύματα\" σε όλους τους φακέλους διακομιστή. Μην χρησιμοποιείτε αυτήν τη λειτουργία εάν θέλετε να διατηρήσετε δεδομένα στο διακομιστή ή εάν χρησιμοποιείτε άλλα προγράμματα-πελάτες ηλεκτρονικού ταχυδρομείου εκτός από το Delta Chat.";
 "autodel_confirm" = "Καταλαβαίνω, διαγράψτε όλα αυτά τα μηνύματα";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -551,7 +563,7 @@
 // %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name of the contact
 "ephemeral_timer_weeks_by_other" = "Ο/Η %2$@ όρισε το χρόνο εξαφάνισης των μηνυμάτων σε %1$@ εβδομάδες.";
 "devicemsg_self_deleted" = "Διαγράψατε τη συνομιλία \"Αποθηκευμένα μηνύματα\".\n\nℹ️ Για να χρησιμοποιήσετε ξανά τη λειτουργία \"Αποθηκευμένα μηνύματα\", δημιουργήστε μια νέα συνομιλία με τον εαυτό σας.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Ο αποθηκευτικός χώρος του παρόχου σας πρόκειται να εξαντληθεί: %1$@ %% χρησιμοποιούνται ήδη.\n\nΕνδέχεται να μην μπορείτε να λαμβάνετε μηνύματα εάν ο χώρος αποθήκευσης είναι πλήρης.\n\n👉 Ελέγξτε εάν μπορείτε να διαγράψετε παλιά δεδομένα στη διεπαφή ιστού του παρόχου και εξετάστε το ενδεχόμενο ενεργοποίηση \"Ρυθμίσεις / Διαγραφή παλαιών μηνυμάτων\". Μπορείτε να ελέγξετε την τρέχουσα χρήση αποθηκευτικού χώρου ανά πάσα στιγμή στις \"Ρυθμίσεις / Συνδεσιμότητα\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Η ημερομηνία ή η ώρα στη συσκευή σας φαίνεται να είναι μην είναι ακριβής (%1$@).\n\nΠροσαρμόστε το ρολόι σας ⏰🔧 για να βεβαιωθείτε ότι τα μηνύματά σας λαμβάνονται σωστά.";

--- a/deltachat-ios/el.lproj/Localizable.stringsdict
+++ b/deltachat-ios/el.lproj/Localizable.stringsdict
@@ -141,9 +141,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Αποστολή του παρακάτω αρχείου στο %s;</string>
+			<string>Αποστολή του παρακάτω αρχείου στο %2$@;</string>
 			<key>other</key>
-			<string>Αποστολή των παρακάτω %d αρχείων στο %s;</string>
+			<string>Αποστολή των παρακάτω %d αρχείων στο %2$@;</string>
 		</dict>
 	</dict>
 	<key>ask_delete_messages</key>

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -59,7 +59,9 @@
 "media" = "Media";
 "apps_and_media" = "Apps & Media";
 "profile" = "Profile";
+// deprecated
 "all_profiles" = "All Profiles";
+// deprecated
 "current_profile" = "Current Profile";
 "main_menu" = "Main Menu";
 "start_chat" = "Start Chat";
@@ -84,6 +86,7 @@
 "always" = "Always";
 "always_load_remote_images" = "Always Load Remote Images";
 "once" = "Once";
+// deprecated
 "show_warning" = "Show Warning";
 "not_now" = "Not now";
 "never" = "Never";
@@ -160,7 +163,10 @@
 "camera" = "Camera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Capture";
+// Switch eg. from front to back camera
 "switch_camera" = "Switch Camera";
+// Toggle camera on/off eg. during an video call
+"toggle_camera" = "Toggle Camera";
 "toggle_fullscreen" = "Toggle Full Screen Mode";
 "location" = "Location";
 "locations" = "Locations";
@@ -327,11 +333,13 @@
 "mute_for_one_day" = "Mute for 1 day";
 "mute_for_seven_days" = "Mute for 7 days";
 "mute_forever" = "Mute forever";
+// deprecated
 "share_location_for_5_minutes" = "For 5 minutes";
 "share_location_for_30_minutes" = "For 30 minutes";
 "share_location_for_one_hour" = "For 1 hour";
 "share_location_for_two_hours" = "For 2 hours";
 "share_location_for_six_hours" = "For 6 hours";
+"share_location_for_24_hours" = "For 24 hours";
 "file_saved_to" = "File saved to \"%1$@\".";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "Call";
@@ -343,6 +351,8 @@
 "answer_call" = "Answer";
 // the action "to decline" a call, not: "the decline"
 "end_call" = "Decline";
+// the action to end a call
+"end_call2" = "End Call";
 // Used in call bubbles, summaries, notifications
 "audio_call" = "Audio call";
 // Used in call bubbles, summaries, notifications
@@ -366,12 +376,19 @@
 "missed_call" = "Missed call";
 "already_in_call" = "Already in a call";
 "call_answered_elsewhere" = "Call answered on another device";
+"call_requires_camera_permission" = "Camera permission is required for video calls";
 "call_requires_mic_permission" = "Microphone permission is required for calls";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "Call with %1$@";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "Calling %1$@…";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Are you sure you want to leave?";
 "ask_delete_named_chat" = "Delete chat \"%1$@\"?";
 "ask_delete_message" = "Delete this message?";
+// First placeholder gets replaced by the number of messages to forward. Second placeholder gets replaced by the name of the destination chat
+// deprecated, use ask_forward_messages
 "ask_forward" = "Forward messages to %1$@?";
 "ask_forward_multiple" = "Forward messages to %1$d chats?";
 "ask_export_attachment" = "Exporting attachments will allow other apps on your device to access them.\n\nContinue?";
@@ -654,7 +671,7 @@
 "pref_outgoing_media_quality" = "Outgoing Media Quality";
 "pref_outgoing_media_quality_hint" = "To send original quality, attach media as a \"File\". This uses significantly more data for you and your recipients.";
 "pref_outgoing_balanced" = "Balanced";
-"pref_outgoing_worse" = "Worse quality, small size";
+"pref_outgoing_worse" = "Worse quality, save data";
 "pref_vibrate" = "Vibrate";
 "pref_screen_security" = "Screen Security";
 // Translators: Must indicate that there is no guarantee as the system may not honor our request.
@@ -666,11 +683,12 @@
 // Title for the "Calls" notification setting. This is a plural noun, not a verb.
 "pref_calls" = "Calls";
 // Details about what the "Calls" notification setting does
-"pref_calls_explain" = "Show call screen on incoming calls";
+"pref_calls_explain" = "Show call screen for accepted contacts";
 "pref_notifications_show" = "Show";
 "pref_notifications_priority" = "Priority";
 "pref_notifications_explain" = "Enable system notifications for new messages";
 "pref_show_notification_content" = "Show message content in notification";
+// deprecated
 "pref_show_notification_content_explain" = "Shows sender and first words of the message in notifications";
 "pref_led_color" = "LED Color";
 "pref_sound" = "Sound";
@@ -713,20 +731,27 @@
 "pref_background" = "Wallpaper";
 "pref_background_btn_default" = "Use Default Image";
 "pref_background_btn_gallery" = "Select From Gallery";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "If you change this option, make sure, your server and your other clients are configured accordingly.\n\nOtherwise things may not work at all.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Multi-Device Mode";
 "pref_multidevice_explain" = "Synchronize your messages with your other devices. Automatically enabled on adding a second device";
 "pref_multidevice_change_warn" = "Multi-Device Mode must be enabled when using the same profile on multiple devices. Only disable this setting if you have removed this profile from all your other devices.\n\nDisabling Multi-Device Mode while using the profile on multiple devices will result in missed messages and other problems.";
+// deprecated
 "pref_auto_folder_moves" = "Move automatically to DeltaChat Folder";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Only Fetch from DeltaChat Folder";
+// deprecated
 "pref_show_emails" = "Show Classic Emails";
+// deprecated
 "pref_show_emails_no" = "No, chats only";
+// deprecated
 "pref_show_emails_accepted_contacts" = "For accepted contacts";
+// deprecated
 "pref_show_emails_all" = "All";
 "pref_experimental_features" = "Experimental Features";
 "pref_experimental_features_explain" = "These features may be unstable and may be changed or removed";
-"pref_on_demand_location_streaming" = "On-demand Location Streaming";
+"pref_on_demand_location_streaming" = "Location Streaming";
 "pref_background_default" = "Default image";
 "pref_background_default_color" = "Default color";
 "pref_background_custom_image" = "Custom image";
@@ -774,14 +799,17 @@
 // automatically delete message
 "delete_old_messages" = "Delete Old Messages";
 "autodel_device_title" = "Delete Messages from Device";
+// deprecated
 "autodel_server_title" = "Delete Messages from Server";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Do you want to delete %1$d messages now and all newly fetched messages \"%2$@\" in the future?\n\n• This includes all media\n\n• Messages will be deleted whether they were seen or not\n\n• \"Saved messages\" will be skipped from local deletion";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Do you want to delete %1$d messages now and all newly fetched messages \"%2$@\" in the future?\n\n⚠️ This includes emails, media and \"Saved messages\" in all server folders\n\n⚠️ Do not use this function if you want to keep data on the server or if you use classic email clients as well";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "This includes emails, media and \"Saved messages\" in all server folders. Do not use this function if you want to keep data on the server or if you use classic email clients as well";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Turn on at-once deletion";
+// deprecated
 "autodel_server_warn_multi_device" = "If you enable at-once deletion you cannot use multiple devices on this profile.";
 "autodel_confirm" = "I understand, delete all these messages";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -876,7 +904,7 @@
 "invalid_unencrypted_explanation" = "To establish end-to-end-encryption, you may meet contacts in person and scan their QR Code to introduce them.";
 "learn_more" = "Learn More";
 "devicemsg_self_deleted" = "You deleted the \"Saved messages\" chat.\n\nℹ️ To use the \"Saved messages\" feature again, create a new chat with yourself.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Your provider\'s storage is about to run out: %1$@%% are already used.\n\nYou may not be able to receive messages if storage is full.\n\n👉 Please check if you can delete old data in the provider\'s web interface and consider enabling \"Settings / Chats / Delete Old Messages\". You can check your current storage usage anytime at \"Settings / Connectivity\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Date or time on your device seems to be inaccurate (%1$@).\n\nAdjust your clock ⏰🔧 to ensure your messages are received correctly.";
@@ -956,8 +984,6 @@
 "new_messages_body" = "You have new messages";
 "n_messages_in_m_chats" = "%1$d messages in %2$d chats";
 // location streaming
-"location_streaming_channel_desc" = "Channel for On-demand Location Streaming";
-"location_streaming_notification_title" = "Location Streaming";
 "location_streaming_notification_text" = "You are sharing your location";
 "location_rationale" = "To share your live location with chat members, allow Delta Chat to use your location data.\n\nTo make live location work gaplessly, location data is used even when the app is closed or not in use.";
 // permissions
@@ -1048,6 +1074,8 @@
 "a11y_message_context_menu_btn_label" = "Message actions";
 "a11y_background_preview_label" = "Wallpaper preview";
 "a11y_disappearing_messages_activated" = "Disappearing messages activated";
+// The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility.
+"open_link" = "Open %1$@";
 // iOS specific strings, developers: please take care to remove strings that are no longer used!
 "stop_sharing_location" = "Stop sharing location";
 "a11y_voice_message_hint_ios" = "After recording, double-tap to send. To discard the recording, scrub with two fingers.";

--- a/deltachat-ios/en.lproj/Localizable.stringsdict
+++ b/deltachat-ios/en.lproj/Localizable.stringsdict
@@ -189,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Send the following file to %s?</string>
+			<string>Send the following file to %2$@?</string>
 			<key>other</key>
-			<string>Send the following %d files to %s?</string>
+			<string>Send the following %d files to %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>
@@ -224,6 +224,22 @@
 			<string>Delete %d message?</string>
 			<key>other</key>
 			<string>Delete %d messages?</string>
+		</dict>
+	</dict>
+	<key>ask_forward_messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@localized_format_key@</string>
+		<key>localized_format_key</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Forward message to %2$@?</string>
+			<key>other</key>
+			<string>Forward %d messages to %2$@?</string>
 		</dict>
 	</dict>
 	<key>chat_archived</key>

--- a/deltachat-ios/eo.lproj/Localizable.strings
+++ b/deltachat-ios/eo.lproj/Localizable.strings
@@ -52,7 +52,9 @@
 "media" = "Aŭdovidaĵoj";
 "apps_and_media" = "Apoj kaj vidaĵoj";
 "profile" = "Profilo";
+// deprecated
 "all_profiles" = "Ĉiuj profiloj";
+// deprecated
 "current_profile" = "Aktuala profilo";
 "main_menu" = "Ĉefa menuo";
 "start_chat" = "Komenci Babiladon";
@@ -73,6 +75,7 @@
 "always" = "Ĉiam";
 "always_load_remote_images" = "Ĉiam ŝargu forajn bildojn";
 "once" = "Unufoje";
+// deprecated
 "show_warning" = "Afiŝu averton";
 "not_now" = "Ne nun";
 "never" = "Neniam";
@@ -134,6 +137,7 @@
 "camera" = "Fotilo";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Kapti";
+// Switch eg. from front to back camera
 "switch_camera" = "Elektu alian kameraon";
 "toggle_fullscreen" = "Baskulu el/al la plena ekrano";
 "location" = "Loko";
@@ -241,12 +245,14 @@
 "mute_for_one_day" = "Silentigi por 1 tago";
 "mute_for_seven_days" = "Silentigi por 7 tagoj";
 "mute_forever" = "Silentigi por ĉiam";
+// deprecated
 "share_location_for_5_minutes" = "por 5 minutoj";
 "share_location_for_30_minutes" = "por 30 minutoj";
 "share_location_for_one_hour" = "por 1 horo";
 "share_location_for_two_hours" = "por 2 horoj";
 "share_location_for_six_hours" = "por 6 horoj";
 "file_saved_to" = "Dosiero konservita kiel \"%1$@\".";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Plusendi mesaĝojn al %1$@?";
 "ask_start_chat_with" = "Babili kun %1$@?";
 // %1$s is replaced by a comma-separated list of names
@@ -364,6 +370,7 @@
 "pref_background" = "Fono";
 "pref_background_btn_default" = "Uzi defaŭltan bildon";
 "pref_background_btn_gallery" = "Elekti el galerio";
+// deprecated
 "pref_show_emails_all" = "Ĉiuj";
 // notifications
 "notify_reply_button" = "Respondi";

--- a/deltachat-ios/es.lproj/Localizable.strings
+++ b/deltachat-ios/es.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 "downloading" = "Descargando…";
 "open_attachment" = "Abrir adjunto";
 "join" = "Unirse";
+"join_group" = "Unirse al grupo";
+"join_channel" = "Unirse al canal";
 "rejoin" = "Volver a unirse";
 "delete" = "Eliminar";
 "delete_for_me" = "Eliminar solo para mí";
@@ -57,7 +59,9 @@
 "media" = "Multimedia";
 "apps_and_media" = "Apps y multimedia";
 "profile" = "Perfil";
+// deprecated
 "all_profiles" = "Todos perfiles";
+// deprecated
 "current_profile" = "Perfil actual";
 "main_menu" = "Menú principal";
 "start_chat" = "Comenzar chat";
@@ -68,6 +72,8 @@
 "mark_as_read" = "Marcar como leído";
 // Used beside an icon with very few space. Shortest text for "Mark as being read". In english, this could be "Read" (past tense of "to read"), in german, this could be "Gelesen".
 "mark_as_read_short" = "Leído";
+// Used as an menu entry or button
+"mark_as_unread" = "Marcar como leído";
 // Used beside an icon with very few space. Shortest text for "Mark as being unread". In english, this could be "Unread" (past tense of "to unread"), in german, this could be "Ungelesen".
 "mark_as_unread_short" = "No leído";
 // Placeholder text when something is loading
@@ -80,6 +86,7 @@
 "always" = "Siempre";
 "always_load_remote_images" = "Cargar siempre imágenes remotas";
 "once" = "Una vez";
+// deprecated
 "show_warning" = "Mostrar advertencia";
 "not_now" = "Ahora no";
 "never" = "Nunca";
@@ -89,6 +96,7 @@
 "offline" = "Fuera de línea";
 // For the next view or as "continue". Should be as short as possible.
 "next" = "Siguiente";
+"warning" = "Advertencia";
 "error" = "Error";
 "error_x" = "Error: %1$@";
 "no_app_to_handle_data" = "No se puede encontrar una aplicación compatible con este tipo de contenido";
@@ -155,6 +163,7 @@
 "camera" = "Cámara";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Capturar";
+// Switch eg. from front to back camera
 "switch_camera" = "Alternar cámara";
 "toggle_fullscreen" = "Alternar modo pantalla completa";
 "location" = "Ubicación";
@@ -322,11 +331,13 @@
 "mute_for_one_day" = "Silenciar por 1 día";
 "mute_for_seven_days" = "Silenciar por 7 días";
 "mute_forever" = "Silenciar por siempre";
+// deprecated
 "share_location_for_5_minutes" = "Por 5 minutos ";
 "share_location_for_30_minutes" = "Por 30 minutos";
 "share_location_for_one_hour" = "Por 1 hora";
 "share_location_for_two_hours" = "Por 2 horas";
 "share_location_for_six_hours" = "Por 6 horas";
+"share_location_for_24_hours" = "Por 24 horas";
 "file_saved_to" = "Archivo guardado en \"%1$@\".";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "Llamar";
@@ -360,11 +371,18 @@
 "canceled_call" = "Llamada cancelada";
 "missed_call" = "Llamada perdida";
 "already_in_call" = "Ya estás en una llamada";
+"call_answered_elsewhere" = "Llamada contestada en otro dispositivo";
+"call_requires_mic_permission" = "Se requiere permiso de micrófono para las llamadas";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "Llamada con %1$@";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "Llamando a %1$@";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "¿Seguro que quieres abandonar este canal?";
 "ask_delete_named_chat" = "¿Eliminar chat \"%1$@\" de todos tus dispositivos?";
 "ask_delete_message" = "¿Eliminar este mensaje de todos tus dispositivos?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "¿Reenviar mensajes a %1$@?";
 "ask_forward_multiple" = "¿Reenviar mensajes a %1$d chats?";
 "ask_export_attachment" = "Los adjuntos exportados serán accesibles desde cualquier otra aplicación en su dispositivo. ¿Continuar?";
@@ -435,8 +453,11 @@
 // search
 "search" = "Buscar";
 "search_in_chat" = "Buscar en el chat";
+// Placeholder will be replaced by the chat name
+"search_in" = "Buscar en %1$@";
 "search_files" = "Buscar archivos";
 "search_explain" = "Buscar chats, contactos, y mensajes";
+"search_result_for_x" = "Resultado para \"%1$@\"";
 "search_no_result_for_x" = "No se encontraron resultados para \"%1$@\"";
 // Adjective, as in "Show Unread Messages"
 "search_unread" = "No leído";
@@ -448,6 +469,7 @@
 "group_create_button" = "Crear grupo";
 // deprecated, use please_enter_chat_name
 "group_please_enter_group_name" = "Por favor introduzca un nombre para el grupo.";
+"please_enter_chat_name" = "Por favor, introduce un nombre.";
 "group_add_members" = "Añadir miembros";
 "group_self_not_in_group" = "Debes ser un miembro del grupo para realizar esta acción.";
 "profile_encryption" = "Cifrado";
@@ -660,6 +682,7 @@
 "pref_notifications_priority" = "Prioridad";
 "pref_notifications_explain" = "Habilitar las notificaciones del sistema para nuevos mensajes";
 "pref_show_notification_content" = "Mostrar el contenido del mensaje en la notificación";
+// deprecated
 "pref_show_notification_content_explain" = "Mostrar el remitente y las primeras palabras del mensaje en las notificaciones";
 "pref_led_color" = "Color de LED";
 "pref_sound" = "Sonido";
@@ -678,6 +701,8 @@
 "pref_incognito_keyboard_explain" = "Solicitar al teclado deshabilitar el aprendizaje personalizado";
 "pref_read_receipts" = "Notificaciones de lectura";
 "pref_read_receipts_explain" = "Si las notificaciones de lectura están desactivadas, no podrás comprobar cuándo se han leído tus mensajes.";
+// Title above a list of contacts who read a message
+"read_by" = "Leído por";
 "pref_server" = "Servidor";
 "pref_encryption" = "Cifrado";
 "pref_manage_keys" = "Administrar claves";
@@ -700,16 +725,23 @@
 "pref_background" = "Fondo";
 "pref_background_btn_default" = "Usar imagen por defecto";
 "pref_background_btn_gallery" = "Seleccionar de la galería";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Si deshabilita esta opción, asegúrese de que su servidor y sus otros clientes estén configurados en consecuencia.\n\nDe lo contrario, las cosas pueden no funcionar en absoluto.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Modo multidispositivo";
 "pref_multidevice_explain" = "Sincroniza tus mensajes con tus otros dispositivos. Se activa automáticamente al añadir un segundo dispositivo";
 "pref_multidevice_change_warn" = "El modo multidispositivo debe estar activado cuando usas el mismo perfil en varios dispositivos. Desactiva este ajuste solo si has eliminado este perfil de todos tus demás dispositivos.\n\nSi desactivas el modo multidispositivo mientras usas el perfil en varios dispositivos, se perderán mensajes y se producirán otros problemas.";
+// deprecated
 "pref_auto_folder_moves" = "Mover automáticamente a la carpeta DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Solo obtener de la carpeta DeltaChat";
+// deprecated
 "pref_show_emails" = "Mostrar correos clásicos";
+// deprecated
 "pref_show_emails_no" = "No, sólo chats";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Para contactos aceptados";
+// deprecated
 "pref_show_emails_all" = "Todos";
 "pref_experimental_features" = "Características experimentales";
 "pref_experimental_features_explain" = "Estas funciones pueden ser inestables y pueden ser modificadas o eliminadas";
@@ -761,14 +793,17 @@
 // automatically delete message
 "delete_old_messages" = "Borrar mensajes antiguos";
 "autodel_device_title" = "Borrar mensajes del dispositivo";
+// deprecated
 "autodel_server_title" = "Borrar mensajes del servidor";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "¿Desea borrar %1$d mensajes ahora y todos los mensajes recientemente alcanzados \"%2$@\" en el futuro?\n\n• Esto incluye toda la multimedia\n\n• Los mensajes serán eliminados siendo vistos o no\n\n• \"Mensajes guardados\" serán saltados de este proceso local";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "¿Deseas borrar %1$d mensajes ahora y todos los mensajes recibidos en \"%2$@\" al futuro?\n\n⚠️ Esto incluye correos, multimedia y \"Mensajes guardados\" en todas las carpetas del servidor. No uses esta función si quieres mantener tus datos en el servidor o si estas usando otros clientes de correo más allá de Delta Chat\n\n⚠️ No uses esta función si deseas mantener tus datos en el servidor\n\n⚠️ No uses esta función si estás usando otros clientes de correo más allá de Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Esto incluye correos, multimedia y \"Mensajes guardados\" en todas las carpetas del servidor. No uses esta función si quieres mantener tus datos en el servidor o si estas usando otros clientes de correo además de Delta Chat";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Activar la eliminación inmediata";
+// deprecated
 "autodel_server_warn_multi_device" = "Si habilita la eliminación inmediata, no podrá utilizar varios dispositivos en este perfil.";
 "autodel_confirm" = "Comprendo, borrar todos estos mensajes";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -786,9 +821,12 @@
 "group_name_changed_by_you" = "Cambiaste el nombre del grupo de \"%1$@\" a \"%2$@\".";
 // %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action.
 "group_name_changed_by_other" = "El nombre del grupo fue cambiado de \"%1$@\" a \"%2$@\" por %3$@.";
+// %1$s will be replaced by the old channel name, %2$s will be replaced by the new channel name
+"channel_name_changed" = "Nombre del canal cambiado de \"%1$@\" a \"%2$@\".";
 "group_image_changed_by_you" = "Cambiaste la imagen del grupo.";
 // %1$s will be replaced by name of the contact who did the action
 "group_image_changed_by_other" = "Imagen del grupo cambiada por %1$@.";
+"channel_image_changed" = "Imagen del canal cambiada.";
 "chat_description_changed_by_you" = "Cambiaste la descripción del chat.";
 // %1$s will be replaced by name of the contact who did the action
 "chat_description_changed_by_other" = "Descripción del chat modificada por %1$@.";
@@ -860,7 +898,7 @@
 "invalid_unencrypted_explanation" = "Para establecer un cifrado de extremo a extremo, puede reunirse con los contactos en persona y escanear su código QR.";
 "learn_more" = "Aprender más";
 "devicemsg_self_deleted" = "Eliminaste los chats de los \"Mensajes guardados\". \n\nℹ️ Para volver a usar los\"Mensajes guardados\", debes crear un chat contigo mismo.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ El almacenamiento de tu proveedor está por excederse, ya tienes %1$@%% en uso.\n\nQuizás no puedas recibir mensajes cuando el almacenamiento esté al 100%% de uso.\n\n👉 Por favor chequea si puedes eliminar los datos antiguos en la página web del proveedor y considera habilitar \"Ajustes / Eliminar mensajes antiguos\". Puedes chequear tu almacenamiento actual en cualquier momento en \"Ajustes / Conectividad\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Fecha y hora de tu dispositivo parecen ser inexactas (%1$@).\n\nAjusta tu reloj ⏰🔧 para asegurarte que los mensajes sean recibidos correctamente.";
@@ -922,6 +960,8 @@
 // first placeholder is the name of the chat
 "confirm_replace_draft" = "%1$@ ya tiene un mensaje borrador, ¿quieres reemplazarlo?";
 "mailto_link_could_not_be_decoded" = "El enlace mailto no se pudo decodificar: %1$@";
+"remove_quote" = "Eliminar cita";
+"remove_attachment" = "Eliminar adjunto";
 // notifications
 "notify_reply_button" = "Responder";
 "notify_new_message" = "Nuevo mensaje";
@@ -937,6 +977,9 @@
 // Body text for a generic "New messages" notification. Shown if we do not have more information about a new messages. Note, that the string is also referenced at https://github.com/deltachat/notifiers
 "new_messages_body" = "Tienes mensajes nuevos";
 "n_messages_in_m_chats" = "%1$d mensajes en %2$d chats";
+// location streaming
+"location_streaming_notification_text" = "Estás compartiendo tu ubicación";
+"location_rationale" = "Para compartir tu ubicación en directo con los miembros del chat, permite que Delta Chat utilice tus datos de ubicación.\n\nPara que la ubicación en directo funcione sin interrupciones, los datos de ubicación se utilizan incluso cuando la aplicación está cerrada o no se está utilizando.";
 // permissions
 "perm_required_title" = "Permiso requerido";
 "perm_continue" = "Continuar";
@@ -976,6 +1019,7 @@
 "global_menu_help_about_desktop" = "Sobre Delta Chat";
 "global_menu_file_open_desktop" = "Abrir Delta Chat";
 "global_menu_minimize_to_tray" = "Minimizar";
+"no_account_selected" = "Selecciona un perfil o crea uno nuevo";
 "no_chat_selected_suggestion_desktop" = "Selecciona un chat o crea uno nuevo";
 "write_message_desktop" = "Escribe un mensaje";
 "encryption_info_title_desktop" = "Información de cifrado";
@@ -997,8 +1041,15 @@
 // deprecated, used on desktop although there is not spell checker
 "no_spellcheck_suggestions_found" = "No se encontraron sugerencias ortográficas.";
 "show_window" = "Mostrar ventana";
+"data_found_other_installation_message" = "Sus perfiles de otra instalación de Delta Chat no son accesibles - las diferentes instalaciones almacenan sus datos en ubicaciones separadas.\n\nPara mantener los perfiles existentes:\n1. Salga ahora\n2. Abra el otro Delta Chat - si es necesario, reinstálelo desde %1$@\n3. Haga una copia de seguridad de cada perfil en \"Configuración/Chats\"\n4. Vuelva a iniciar esta versión\n5. Restaura las copias de seguridad usando \"Ya tengo un perfil\"\n¿Continúas sin tus perfiles anteriores?";
 // title of the "keybindings" dialog (for the keybindings names as such, where possible the normal command strings are used)
 "keybindings" = "Atajos de tecla";
+// subtitle in the "keybindings" dialog
+"navigation_shortcut_section" = "Navegación";
+// subtitle in the "keybindings" dialog
+"message_input_shortcut_section" = "Entrada de mensajes";
+// subtitle in the "keybindings" dialog
+"message_selected_shortcut_section" = "Mensaje seleccionado";
 "switch_between_chats" = "Alternar entre chats";
 "scroll_messages" = "Desplazarse por los mensajes";
 // command to put the cursor to the search input field
@@ -1017,6 +1068,8 @@
 "a11y_message_context_menu_btn_label" = "Acciones del mensaje";
 "a11y_background_preview_label" = "Previsualización del fondo";
 "a11y_disappearing_messages_activated" = "Desaparición de mensajes activada";
+// The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility.
+"open_link" = "Abrir %1$@";
 // iOS specific strings, developers: please take care to remove strings that are no longer used!
 "stop_sharing_location" = "Dejar de compartir ubicación";
 "a11y_voice_message_hint_ios" = "Después de grabar, toque dos veces para enviar. Para descartar la grabación, deslice de izquierda a derecha con dos dedos.";

--- a/deltachat-ios/es.lproj/Localizable.stringsdict
+++ b/deltachat-ios/es.lproj/Localizable.stringsdict
@@ -211,11 +211,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>¿Enviar el archivo a %s?</string>
+			<string>¿Enviar el archivo a %2$@?</string>
 			<key>many</key>
-			<string>¿Enviar los siguientes %d archivos a %s?</string>
+			<string>¿Enviar los siguientes %d archivos a %2$@?</string>
 			<key>other</key>
-			<string>¿Enviar los siguientes %d archivos a %s?</string>
+			<string>¿Enviar los siguientes %d archivos a %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/et.lproj/Localizable.strings
+++ b/deltachat-ios/et.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 "downloading" = "Allalaadimisel…";
 "open_attachment" = "Ava manus";
 "join" = "Liitu";
+"join_group" = "Liitu grupiga";
+"join_channel" = "Liitu kanaliga";
 "rejoin" = "Liitu uuesti";
 "delete" = "Kustuta";
 "delete_for_me" = "Kustuta minu jaoks";
@@ -57,7 +59,9 @@
 "media" = "Meedia";
 "apps_and_media" = "Rakendused ja meedia";
 "profile" = "Profiil";
+// deprecated
 "all_profiles" = "Kõik profiilid";
+// deprecated
 "current_profile" = "Praegune profiil";
 "main_menu" = "Põhimenüü";
 "start_chat" = "Alusta vestlust";
@@ -68,6 +72,8 @@
 "mark_as_read" = "Märgi loetuks";
 // Used beside an icon with very few space. Shortest text for "Mark as being read". In english, this could be "Read" (past tense of "to read"), in german, this could be "Gelesen".
 "mark_as_read_short" = "Märgi loetuks";
+// Used as an menu entry or button
+"mark_as_unread" = "Märgi mitteloetuks";
 // Used beside an icon with very few space. Shortest text for "Mark as being unread". In english, this could be "Unread" (past tense of "to unread"), in german, this could be "Ungelesen".
 "mark_as_unread_short" = "Märgi mitteloetuks";
 // Placeholder text when something is loading
@@ -80,6 +86,7 @@
 "always" = "Alati";
 "always_load_remote_images" = "Alati laadi kaugseadmes asuvaid pilte";
 "once" = "Vaid see kord";
+// deprecated
 "show_warning" = "Näita hoiatust";
 "not_now" = "Mitte praegu";
 "never" = "Mitte kunagi";
@@ -89,6 +96,7 @@
 "offline" = "Pole võrgus";
 // For the next view or as "continue". Should be as short as possible.
 "next" = "Järgmine";
+"warning" = "Hoiatus";
 "error" = "Viga";
 "error_x" = "Viga: %1$@";
 "no_app_to_handle_data" = "Ei leidu rakendust, mis oskaks sellist tüüpi andmeid kasutada.";
@@ -155,7 +163,10 @@
 "camera" = "Kaamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Salvesta pilt või video";
+// Switch eg. from front to back camera
 "switch_camera" = "Vaheta kaamerat";
+// Toggle camera on/off eg. during an video call
+"toggle_camera" = "Lülita kaamera sisse/välja";
 "toggle_fullscreen" = "Lülita täisekraanivaate sisse/välja";
 "location" = "Asukoht";
 "locations" = "Asukohad";
@@ -322,11 +333,13 @@
 "mute_for_one_day" = "Summuta üheks päevaks";
 "mute_for_seven_days" = "Summuta seitsmeks päevaks";
 "mute_forever" = "Summuta alatiseks";
+// deprecated
 "share_location_for_5_minutes" = "Kestusega 5 minutit";
 "share_location_for_30_minutes" = "Kestusega 30 minutit";
 "share_location_for_one_hour" = "Kestusega 1 tund";
 "share_location_for_two_hours" = "Kestusega 2 tundi";
 "share_location_for_six_hours" = "Kestusega 6 tundi";
+"share_location_for_24_hours" = "Kestusega 24 tundi";
 "file_saved_to" = "Fail on salvestatud: „%1$@“.";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "Helista";
@@ -338,6 +351,8 @@
 "answer_call" = "Vasta";
 // the action "to decline" a call, not: "the decline"
 "end_call" = "Keeldu";
+// the action to end a call
+"end_call2" = "Lõpeta kõne";
 // Used in call bubbles, summaries, notifications
 "audio_call" = "Häälkõne";
 // Used in call bubbles, summaries, notifications
@@ -360,11 +375,20 @@
 "canceled_call" = "katkestatud kõne";
 "missed_call" = "Märkamata kõne";
 "already_in_call" = "Kõne  juba on pooleli";
+"call_answered_elsewhere" = "Kõne on vastatud muus seadmes";
+"call_requires_camera_permission" = "Videokõnede tegemiseks peab rakendusel olema õigus kasutada kaamerat";
+"call_requires_mic_permission" = "Helistamiseks peab rakendusel olema õigus kasutada mikrofoni";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "Kõne kasutajaga %1$@";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "Helistan kasutajale %1$@…";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Kas oled kindel, et soovid lahkuda?";
 "ask_delete_named_chat" = "Kas kustutad „%1$@“ vestluse kõikidest oma seadmetest?";
 "ask_delete_message" = "Kas kustutad selle sõnumi kõikidest oma seadmetest?";
+// First placeholder gets replaced by the number of messages to forward. Second placeholder gets replaced by the name of the destination chat
+// deprecated, use ask_forward_messages
 "ask_forward" = "Kas edastad sõnumi kasutajale %1$@?";
 "ask_forward_multiple" = "Kas edastad sõnumid %1$d vestlusesse?";
 "ask_export_attachment" = "Kui ekspordid manused, siis sinu nutiseadme muud rakendused saavad neile ligi.\n\nKas soovid jätkata?";
@@ -435,8 +459,11 @@
 // search
 "search" = "Otsi";
 "search_in_chat" = "Otsi vestlusest";
+// Placeholder will be replaced by the chat name
+"search_in" = "Otsi vestlusest „%1$@“";
 "search_files" = "Otsi failidest";
 "search_explain" = "Otsi vestlusi, kontakte või sõnumeid";
+"search_result_for_x" = "Otsingutulemused märksõnale „%1$@“";
 "search_no_result_for_x" = "„%1$@“ otsingul pole tulemusi";
 // Adjective, as in "Show Unread Messages"
 "search_unread" = "Lugemata";
@@ -448,6 +475,7 @@
 "group_create_button" = "Loo grupp";
 // deprecated, use please_enter_chat_name
 "group_please_enter_group_name" = "Palun sisesta grupi nimi.";
+"please_enter_chat_name" = "Palun sisesta nimi";
 "group_add_members" = "Lisa liikmeid";
 "group_self_not_in_group" = "Selle tegevuse jaoks pead olemagrupi liige.";
 "profile_encryption" = "Krüptimine";
@@ -583,7 +611,7 @@
 "hide_from_contacts" = "Peida kontaktidest";
 "hidden_from_contacts" = "Peidetud kontaktidest";
 // Hint for the list of relays
-"transport_list_hint" = "Sõnumid saavad kõik alusühendused (edastusserverid).\n\n⚠️ Kui muudad siin midagi, siis palun kontrolli, et kõikides sinu seadmetes on kasutusel vähemalt versioon 2.47.0. Vastasel juhul võivad vanema tarkvaraga seadmetes jääta sõnumid saabumata.";
+"transport_list_hint" = "Sõnumid saavad kõik alusühendused (edastusserverid).\n\n⚠️ Kui muudad siin midagi, siis palun kontrolli, et kõikides sinu seadmetes on kasutusel vähemalt versioon 2.47.0. Vastasel juhul võivad vanema tarkvaraga seadmetes jääda sõnumid saabumata.";
 // shown if a QR code was scanned that can be used as a relay
 "confirm_add_transport" = "Kas lisad selle alusühenduse (edastusserveri)?";
 "invalid_transport_qr" = "Skaneeritud QR-koodis pole korrektset alusühendust (edastusserverid)";
@@ -660,6 +688,7 @@
 "pref_notifications_priority" = "Prioriteet";
 "pref_notifications_explain" = "Kasuta uute sõnumite puhul süsteemi teavitusi";
 "pref_show_notification_content" = "Näita teavituses sõnumi sisu";
+// deprecated
 "pref_show_notification_content_explain" = "Näitab teavituses sõnumi saatjat ja esimesi sõnu";
 "pref_led_color" = "LED-värv";
 "pref_sound" = "Heli";
@@ -678,6 +707,8 @@
 "pref_incognito_keyboard_explain" = "Palu, et operatsioonisüsteem ei jätaks meelde klahvistikust sisestatud (aga see ei pruugi alati toimida)";
 "pref_read_receipts" = "Lugemisteatised";
 "pref_read_receipts_explain" = "Kui sinu lugemisteatised on lülitatud välja, siis ka sina ei näe teiste lugemisteatisi.";
+// Title above a list of contacts who read a message
+"read_by" = "Seda on lugenud";
 "pref_server" = "Server";
 "pref_encryption" = "Krüptimine";
 "pref_manage_keys" = "Halda võtmeid";
@@ -700,16 +731,23 @@
 "pref_background" = "Taustapilt";
 "pref_background_btn_default" = "Kasuta vaikimisi pilti";
 "pref_background_btn_gallery" = "Vali galeriist";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Kui sa seda eelistust muudad, siis palun kontrolli, et server ja muud kliendid on vastavalt seadistatud.\n\nVastasel juhul võib minna nii, et mitte miski ei toimi.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Mitme seadme tugi";
 "pref_multidevice_explain" = "Sünkrooni oma sõnumid oma muude seadmetega. Teise seadme lisamisel lülitatakse automaatselt sisse.";
 "pref_multidevice_change_warn" = "Kui kasutad sama profiili mitmes seadmes, siis peab mitme seadme režiimi sisse lülitama. Lülita see seadistus välja vaid siis, kui oled selle profiili eemaldanud kõikidest muudest oma seadmetest.\n\nKui aga lülitad välja siis, kui profiil on kasutusel mitmes seadmes, on tulemuseks kadunud sõnumid ja muud imelikud juhtumised.";
+// deprecated
 "pref_auto_folder_moves" = "Tõsta automaatselt DeltaChati kausta";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Laadi vaid DeltaChati kasutast";
+// deprecated
 "pref_show_emails" = "Näita klassikalisi e-kirju";
+// deprecated
 "pref_show_emails_no" = "Ei, vaid vestlustele";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Kinnitatud kontaktidele";
+// deprecated
 "pref_show_emails_all" = "Kõik";
 "pref_experimental_features" = "Katselised funktsionaalsused";
 "pref_experimental_features_explain" = "Need funktsionaalsused ei pruugi korralikult toimida ning nad võivad tulevikus muutuda või sootuks olla eemaldatud";
@@ -761,14 +799,17 @@
 // automatically delete message
 "delete_old_messages" = "Kustuta vanad sõnumid";
 "autodel_device_title" = "Kustuta sõnumid seadmest";
+// deprecated
 "autodel_server_title" = "Kustuta sõnumid serverist";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Kas soovid kustutada %1$d sõnumit kohe ja kõik uued sõnumid ajavahemikus „%2$@“\n\n• Sealhulgas saavad olema kõik meediafailid\n\n• Sõnumid saavad kustutatud sõltumata sellest, kas oled neid näinud või mitte\n\n• „Salvestatud sõnumid“ ei kuulu kohalikus seadmes kustutamisele";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Kas soovid kustutada %1$d sõnumit kohe ja kõik uued sõnumid ajavahemikus „%2$@“\n\n⚠️ Sealhulgas e-kirjad, meediafailid ja „Salvestatud sõnumid“ kõikides serveri kasutades.\n\n⚠️ Ära kasuta seda võimalust, kui tahad andmeid hoida serveris või pruugid ka klassikalisi e-posti kliente";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Sealhulgas e-kirjad, meediafailid ja „Salvestatud sõnumid“ kõikides serveri kasutades. Ära kasuta seda võimalust, kui tahad andmeid hoida serveris või pruugid ka klassikalisi e-posti kliente";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Lülita kohene kustutamine sisse";
+// deprecated
 "autodel_server_warn_multi_device" = "Kui lülitad kohese kustutamise sisse, siis sa ei saa selles profiilis kasutada mitut seadet.";
 "autodel_confirm" = "Ma saan aru, kustuta kõik need sõnumid";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -786,9 +827,12 @@
 "group_name_changed_by_you" = "Sa muutsid grupi nime: „%1$@“ → „%2$@“.";
 // %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action.
 "group_name_changed_by_other" = "%3$@ muutis grupi nime: „%1$@“ → „%2$@“.";
+// %1$s will be replaced by the old channel name, %2$s will be replaced by the new channel name
+"channel_name_changed" = "Kanali nimi on muutunud: „%1$@“ → „%2$@“.";
 "group_image_changed_by_you" = "Sina muutsid grupi tunnuspilti.";
 // %1$s will be replaced by name of the contact who did the action
 "group_image_changed_by_other" = "%1$@ muutis grupi tunnuspilti.";
+"channel_image_changed" = "Kanali pilt on muutunud";
 "chat_description_changed_by_you" = "Sa muutsid vestluse kirjeldust.";
 // %1$s will be replaced by name of the contact who did the action
 "chat_description_changed_by_other" = "%1$@ muutis vestluse kirjeldust.";
@@ -860,7 +904,7 @@
 "invalid_unencrypted_explanation" = "Läbiva krüptimise kasutuselevõtmiseks oarim viis on omavahel kohtuda ning teise osapoole QR-koodi skaneerimisega lisada ta vestlusesse.";
 "learn_more" = "Lisateave";
 "devicemsg_self_deleted" = "Sa kustutasid vestluse nimega „Salvestatud sõnumid“.\n\nℹ️ Kui tahad uuesti kasutada võimalust „Salvestatud sõnumid“, siis lisa vestlus iseendaga.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Sinu poolt teenusepakkuja juures kasutatav andmeruum hakkab täis saama: %1$@%% on juba kasutusel.\n\nKui andmeruum on täis, siis sa ilmselt ei pruugi enam sõnumeid saada.\n\n👉 Palun kontrolli, kas sul on võimalik teenusepakkuja veebiliidesest vanu sõnumeid kustutada või veelgi parem on, kui kasutad automaatse kustutamise võimalust: „Seadistused“ → „Vestlused“ → „Kustuta vanad sõnumid“. Hetkel kasutatavat andmeruumi mahutu saad alati kontrollida siit: „Seadistused“ → „Ühenduvus“.";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Sinu seadme kuupäev või kellaaeg tundub olema ebatäpne (%1$@).\n\nPalun seadista kella ⏰🔧 ja taga, et sõnumivahetus, sh selle krüptimine toimib korrektselt.";
@@ -922,6 +966,8 @@
 // first placeholder is the name of the chat
 "confirm_replace_draft" = "Vestluses „%1$@“ juba on üks sõnumi kavand, kas sa soovid selle asendada?";
 "mailto_link_could_not_be_decoded" = "mailto lingi dekodeerimine ei õnnestunud: %1$@";
+"remove_quote" = "Eemalda tsiteerimine";
+"remove_attachment" = "Eemalda manus";
 // notifications
 "notify_reply_button" = "Vasta";
 "notify_new_message" = "Uus sõnum";
@@ -937,6 +983,9 @@
 // Body text for a generic "New messages" notification. Shown if we do not have more information about a new messages. Note, that the string is also referenced at https://github.com/deltachat/notifiers
 "new_messages_body" = "Sulle on uusi sõnumeid";
 "n_messages_in_m_chats" = "%1$d sõnumit %2$d-s vestluses";
+// location streaming
+"location_streaming_notification_text" = "Sa jada oma asukohta teistega";
+"location_rationale" = "Jagamaks reaalajas oma asukohta teiste vestluse liikmetega, palun luba Delta Chatil kasutada sinu asukohaandmeid.\n\nEt asukoha edastamine toimiks sujuvalt, on asukohaandmed kasutusel ka siis, kui rakendus on suletud või pole kasutusel.";
 // permissions
 "perm_required_title" = "Õigused on vajalikud";
 "perm_continue" = "Jätka";
@@ -976,6 +1025,7 @@
 "global_menu_help_about_desktop" = "Rakenduse teave: Delta Chat";
 "global_menu_file_open_desktop" = "Ava Delta Chat";
 "global_menu_minimize_to_tray" = "Minimeeri";
+"no_account_selected" = "Vali olemasolev profiil või loo uus profiil";
 "no_chat_selected_suggestion_desktop" = "Vali olemasolev vestlus või liitu uuega";
 "write_message_desktop" = "Koosta sõnum";
 "encryption_info_title_desktop" = "Krüptimise teave";
@@ -997,8 +1047,15 @@
 // deprecated, used on desktop although there is not spell checker
 "no_spellcheck_suggestions_found" = "Õigekirjasoovitusi ei leidu.";
 "show_window" = "Näita akent";
+"data_found_other_installation_message" = "Sinu profiilid teisest Delta Chati paigaldusest ei ole kättesaadavad -erinevad paigaldused salvestavad oma andmed eraldi kohtadesse.\n\nOlemasolevate profiilide säilitamiseks:\n1. Sulge rakendus\n2. Ava teine Delta Chat - vajadusel paigalda see uuesti siit:%1$@\n3. Tee igast profiilist varukoopia menüüs „Seadistused/Vestlused“\n4. Käivita see versioon uuesti\n5. Taasta varukoopiad valikust „Mul juba on profiil olemas“\n\nVõi jätkad ilma oma varasemate profiilideta?";
 // title of the "keybindings" dialog (for the keybindings names as such, where possible the normal command strings are used)
 "keybindings" = "Klahvide seosed";
+// subtitle in the "keybindings" dialog
+"navigation_shortcut_section" = "Liikumine rakenduses";
+// subtitle in the "keybindings" dialog
+"message_input_shortcut_section" = "Sõnumi sisestus";
+// subtitle in the "keybindings" dialog
+"message_selected_shortcut_section" = "Valitud sõnum";
 "switch_between_chats" = "Vaheta vestlusi";
 "scroll_messages" = "Keri sõnumeid";
 // command to put the cursor to the search input field
@@ -1017,6 +1074,8 @@
 "a11y_message_context_menu_btn_label" = "Tegevused sõnumiga";
 "a11y_background_preview_label" = "Taustapildi eelvaade";
 "a11y_disappearing_messages_activated" = "Isekustuvad sõnumid on kasutusel";
+// The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility.
+"open_link" = "Ava %1$@";
 // iOS specific strings, developers: please take care to remove strings that are no longer used!
 "stop_sharing_location" = "Lõpeta asukoha jagamine";
 "a11y_voice_message_hint_ios" = "Peale salvestamist saad topeltpuudutusega saata. Salvestisest saad loobuda hõõrudes kahe sõrmega.";

--- a/deltachat-ios/et.lproj/Localizable.stringsdict
+++ b/deltachat-ios/et.lproj/Localizable.stringsdict
@@ -189,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Kas saadame järgnevad faili kasutajale %s?</string>
+			<string>Kas saadame järgnevad faili kasutajale %2$@?</string>
 			<key>other</key>
-			<string>Kas saadame järgnevad %d faili kasutajale %s?</string>
+			<string>Kas saadame järgnevad %d faili kasutajale %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>
@@ -224,6 +224,22 @@
 			<string>Kas kustutad %d sõnumi kõikidest oma seadmetest?</string>
 			<key>other</key>
 			<string>Kas kustutad %d sõnumit kõikidest oma seadmetest?</string>
+		</dict>
+	</dict>
+	<key>ask_forward_messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@localized_format_key@</string>
+		<key>localized_format_key</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Kas edastad sõnumi vestlusesse „%2$@“?</string>
+			<key>other</key>
+			<string>Kas edastad %d sõnumit vestlusesse „%2$@“?</string>
 		</dict>
 	</dict>
 	<key>chat_archived</key>

--- a/deltachat-ios/eu.lproj/Localizable.strings
+++ b/deltachat-ios/eu.lproj/Localizable.strings
@@ -40,7 +40,7 @@
 "later" = "Geroago";
 // "Resend" means "Sending the selected message(s) again to the same chat". The string is used in a menu and should be as short as possible. Resending may be needed after failures or to repost old messages to new members.
 "resend" = "Berriro bidali";
-"edited" = "Editatu egin da";
+"edited" = "Editatu egin da:";
 "edit_message" = "Mezua editatu";
 // Verb "to archive", as in "put a chat in the archive", not a noun "The Archive".
 "archive" = "Artxibatu";
@@ -57,7 +57,9 @@
 "media" = "Multimedia";
 "apps_and_media" = "Aplikazioak eta multimedia";
 "profile" = "Kontua";
+// deprecated
 "all_profiles" = "Kontu guztiak";
+// deprecated
 "current_profile" = "Oraingo kontua";
 "main_menu" = "Menu nagusia";
 "start_chat" = "Hasi txata";
@@ -80,6 +82,7 @@
 "always" = "Beti";
 "always_load_remote_images" = "Kargatu urrutiko irudiak beti";
 "once" = "Behin";
+// deprecated
 "show_warning" = "Erakutsi abisua";
 "not_now" = "Orain ez";
 "never" = "Inoiz ez";
@@ -155,6 +158,7 @@
 "camera" = "Kamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Harrapatu";
+// Switch eg. from front to back camera
 "switch_camera" = "Aldatu kamera";
 "toggle_fullscreen" = "Aldatu pantaila osoa modua";
 "location" = "Kokalekua";
@@ -296,7 +300,7 @@
 "menu_learn_spelling" = "Ikasi ortografia";
 "jump_to_message" = "Joan mezura";
 "replace_draft" = "Ordeztu zirriborroa";
-"title_share_location" = "Partekatu kokalekua taldeko kide guztiak";
+"title_share_location" = "Partekatu kokalekua kide guztiekin";
 "device_talk" = "Gailuaren mezuak";
 "device_talk_subtitle" = "Lokalki sortutako mezuak";
 "device_talk_explain" = "Txat honetako mezuak zure Delta Chat aplikazioak sortu ditu lokalki. Egileek aplikazioaren eguneraketei buruz eta erabileran arazoei buruz informatzeko erabiltzen dute.";
@@ -322,9 +326,10 @@
 "mute_for_one_day" = "Mututu egun bat";
 "mute_for_seven_days" = "Mututu 7 egun";
 "mute_forever" = "Mututu betirako";
+// deprecated
 "share_location_for_5_minutes" = "5 minutuz";
 "share_location_for_30_minutes" = "30 minutuz";
-"share_location_for_one_hour" = "Ordu 1";
+"share_location_for_one_hour" = "Ordubetez";
 "share_location_for_two_hours" = "2 orduz";
 "share_location_for_six_hours" = "6 orduz";
 "file_saved_to" = "Fitxategia \"%1$@\" helbidean gordeta";
@@ -365,6 +370,7 @@
 "ask_leave_group" = "Ziur irten nahi duzula?";
 "ask_delete_named_chat" = "Ezabatu \"%1$@\" txata?";
 "ask_delete_message" = "Ezabatu mezu hau?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Birbidali mezuak %1$@ erabiltzaileari?";
 "ask_forward_multiple" = "Bidali mezuak %1$d txatetara?";
 "ask_export_attachment" = "Esportatu eranskina? Eranskinak esportatzeak zure beste gailuko beste aplikazioek atzitzea ahalbidetuko du.\n\nJarraitu?";
@@ -660,6 +666,7 @@
 "pref_notifications_priority" = "Lehentasuna";
 "pref_notifications_explain" = "Gaitu sistemaren jakinarazpenak mezu berrientzat";
 "pref_show_notification_content" = "Erakutsi mezuaren edukia jakinarazpenean";
+// deprecated
 "pref_show_notification_content_explain" = "Erakutsi bidaltzailea eta mezuaren lehen hitza jakinarazpenetan";
 "pref_led_color" = "LED kolorea";
 "pref_sound" = "Soinua";
@@ -700,16 +707,23 @@
 "pref_background" = "Atzealdea";
 "pref_background_btn_default" = "Erabili irudi lehenetsia";
 "pref_background_btn_gallery" = "Hautatu galeriatik";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Aukera hau desaktibatuz gero, egiaztatu zure zerbitzaria eta beste bezeroen konfigurazioa bat datorrela.\n\nBestela agian gauzak ez dabiltza.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Gailu anitzeko modua";
 "pref_multidevice_explain" = "Sinkronizatu zure mezuak zure beste gailuekin. Automatikoki gaitzen da bigarren gailu bat gehitzean.";
 "pref_multidevice_change_warn" = "Gailu anitzeko moduak gaituta egon behar du kontu bera hainbat gailutan erabiltzean. Desaktibatu ezarpen hau soilik kontu hau beste gailu guztietatik kendu baduzu.\n\nGailu anitzeko modua desaktibatzeak kontua hainbat gailutan erabiltzen ari den bitartean, mezuak galtzea eta bestelako arazoak eragingo ditu.";
+// deprecated
 "pref_auto_folder_moves" = "Automatikoki mugitzen du DeltaChat karpetara";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Delta Chat karpetatik soilik berreskuratu";
+// deprecated
 "pref_show_emails" = "Erakutsi ohiko e-mailak";
+// deprecated
 "pref_show_emails_no" = "Ez, txatak besterik ez";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Onartutako kontaktuena";
+// deprecated
 "pref_show_emails_all" = "Denak";
 "pref_experimental_features" = "Ezaugarri esperimentalak";
 "pref_experimental_features_explain" = "Baliteke ezaugarri hauek ezegonkorrak izatea eta gerora aldatzea edo kentzea.";
@@ -761,14 +775,17 @@
 // automatically delete message
 "delete_old_messages" = "Ezabatu mezu zaharrak";
 "autodel_device_title" = "Ezabatu mezuak gailutik";
+// deprecated
 "autodel_server_title" = "Ezabatu mezuak zerbitzaritik";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "%1$d mezu ezabatu nahi dituzu orain eta \"%2$@\" etorkizunean jasotako mezuak ere?\n\n• Honek multimedia ere barne hartzen du\n\n• Mezuak ikusi ala ez ezabatuko dira\n\n• \"Gordetako mezuak\" ez dira lokalki ezabatuko";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "%1$d mezu ezabatu nahi dituzu orain eta \"%2$@\" etorkizunean jasotako mezuak ere?\n\n⚠️ Honek mezu elektronikoak, multimedia eta \"Gordetako mezuak\" barne hartzen ditu zerbitzariko karpeta guztietan\n\n⚠️ Ez erabili funtzio hau datuak zerbitzarian gorde nahi badituzu edo posta bezero klasikoak ere erabiltzen badituzu";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Honek barne hartzen ditu mezu elektronikoak, multimedia eta \"Gordetako mezuak\" zerbitzariko karpeta guztietan. Ez erabili funtzio hau datuak zerbitzarian gorde nahi badituzu edo mezu elektronikoen bezero klasikoak ere erabiltzen badituzu.";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Berehalako ezabatzea aktibatu";
+// deprecated
 "autodel_server_warn_multi_device" = "Berehalako ezabaketa gaitzen baduzu, ezin izango dituzu gailu anitz erabili profil honetan.";
 "autodel_confirm" = "Ulertzen dut, ezabatu mezuk guzti hauek";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -860,7 +877,7 @@
 "invalid_unencrypted_explanation" = "Muturretik muturrera zifratzeko, kontaktuekin aurrez aurre elkartu zaitezke eta haien QR kodea eskaneatu dezakezu elkar egiaztatzeko.";
 "learn_more" = "Ikasi gehiago";
 "devicemsg_self_deleted" = "\"Gordetako mezuak\" txata ezabatu duzu.\n\nℹ️ \"Gordetako mezuak\" funtzioa berriro erabiltzeko, sortu txat berri bat zure buruarekin.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Zure hornitzailearen biltegiratzea agortzear dago: %%-tik %1$@ erabili dituzu dagoeneko.\n\nLitekeena da mezuak jaso ezin izatea biltegiratzea beteta badago.\n\n👉 Mesedez, egiaztatu datu zaharrak hornitzailearen web-interfazean ezaba ditzakezun eta kontuan hartu \"Ezarpenak / Txatak / Ezabatu mezu zaharrak\" aukera aktibatzea. Zure uneko biltegiratze-erabilera edozein unetan egiaztatu dezakezu \"Ezarpenak / Konektibitatea\" atalean.";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Zure gailuko data edo ordua okerra dela dirudi (%1$@).\n\nEgokitu zure erlojua ⏰🔧 zure mezuak zuzen jasotzen direla ziurtatzeko.";

--- a/deltachat-ios/eu.lproj/Localizable.stringsdict
+++ b/deltachat-ios/eu.lproj/Localizable.stringsdict
@@ -189,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Bidali hurrengo fitxategia %s-(e)ra?</string>
+			<string>Bidali hurrengo fitxategia %2$@-(e)ra?</string>
 			<key>other</key>
-			<string>Bidali hurrengo %d fitxategiak %s(e)ra?</string>
+			<string>Bidali hurrengo %d fitxategiak %2$@(e)ra?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/fa.lproj/Localizable.strings
+++ b/deltachat-ios/fa.lproj/Localizable.strings
@@ -57,7 +57,9 @@
 "media" = "رسانه";
 "apps_and_media" = "برنامه‌ها و رسانه‌ها";
 "profile" = "نمایه";
+// deprecated
 "all_profiles" = "تمام نمایه‌ها";
+// deprecated
 "current_profile" = "نمایهٔ فعلی";
 "main_menu" = "فهرست اصلی";
 "start_chat" = "شروع گپ";
@@ -78,6 +80,7 @@
 "always" = "همیشه";
 "always_load_remote_images" = "تصاویر با منبع بیرونی همیشه بارگیری شوند";
 "once" = "همین یک بار";
+// deprecated
 "show_warning" = "نمایش هشدار";
 "not_now" = "اکنون نه";
 "never" = "هرگز";
@@ -146,6 +149,7 @@
 "camera" = "دوربین";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "گرفتن";
+// Switch eg. from front to back camera
 "switch_camera" = "تغییر دوربین";
 "toggle_fullscreen" = "تغییر وضعیت تمام صفحه";
 "location" = "موقعیت مکانی";
@@ -311,6 +315,7 @@
 "mute_for_one_day" = "ساکت کردن به مدت ۱ روز";
 "mute_for_seven_days" = "ساکت کردن به مدت۷ روز";
 "mute_forever" = "ساکت کردن دائمی";
+// deprecated
 "share_location_for_5_minutes" = "به مدت ۵ دقیقه";
 "share_location_for_30_minutes" = "به مدت ۳۰ دقیقه";
 "share_location_for_one_hour" = "به مدت ۱ ساعت";
@@ -343,6 +348,7 @@
 "ask_leave_group" = "آیا مطمئنید می‌خواهید بروید؟";
 "ask_delete_named_chat" = "حذف گپ «%1$@»؟";
 "ask_delete_message" = "حذف این پیام؟";
+// deprecated, use ask_forward_messages
 "ask_forward" = "پیام‌ها به %1$@ هدایت شوند؟";
 "ask_forward_multiple" = "انتقال پیام‌ها به %1$d گپ؟";
 "ask_export_attachment" = "ضمیمه صادر شود؟ صادر کردن ضمیمه باعث می‌شود دیگر نرم‌افزارهای روی دستگاه شما بتوانند به آن دسترسی داشته باشند. \n\nادامه می‌دهید؟";
@@ -625,6 +631,7 @@
 "pref_notifications_priority" = "اولویت";
 "pref_notifications_explain" = "فعال کردن اعلان‌های سیستم برای پیام‌های جدید";
 "pref_show_notification_content" = "نمایش محتوای پیام در اعلان";
+// deprecated
 "pref_show_notification_content_explain" = "نمایش ارسال کننده و اولین کلمات پیام در اعلان";
 "pref_led_color" = " LED رنگ";
 "pref_sound" = "صدا";
@@ -665,16 +672,23 @@
 "pref_background" = "پس‌زمینه";
 "pref_background_btn_default" = "استفاده از تصویر پیش‌فرض";
 "pref_background_btn_gallery" = "انتخاب از گالری";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "اگر این گزینه را غیر فعال می‌کنید از اینکه سرور شما و حساب‌هایتان هم بر این اساس تنظیم شده باشند.\n\n در غیر این صورت ممکن است هیچ چیز کار نکند. ";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "حالت چند دستگاهی";
 "pref_multidevice_explain" = "همگام‌سازی پیام‌های شما با دیگر دستگاه‌هایتان. در صورت اضافه کردن دستگاه دوم به صورت خودکار فعال می‌شود.";
 "pref_multidevice_change_warn" = "حالت چند دستگاهی زمانی که از یک نمایه روی چند دستگاه استفاده می‌کنید باید فعال شود. تنها در صورتی این تنظیم را غیرفعال کنید که این نمایه را از روی همهٔ دیگر دستگاه‌هایتان حذف کرده‌اید. \n\n غیرفعال کردن حالت چند دستگاهی زمانی که یک نمایه را روی چند دستگاه دارید باعث می‌شود که بعضی پیام‌ها گم شوند و همچنین مشکل‌های دیگری به وجود می‌آورد.";
+// deprecated
 "pref_auto_folder_moves" = "انتقال خودکار به پوشه دلتاچت";
+// deprecated
 "pref_only_fetch_mvbox_title" = "فقط پوشه دلتاچت را بررسی کن";
+// deprecated
 "pref_show_emails" = "نمایش رایانامه‌های معمولی";
+// deprecated
 "pref_show_emails_no" = "نه، فقط گپ‌ها";
+// deprecated
 "pref_show_emails_accepted_contacts" = "برای مخاطبین پذیرفته شده";
+// deprecated
 "pref_show_emails_all" = "همه";
 "pref_experimental_features" = "ویژگی‌های آزمایشی";
 "pref_experimental_features_explain" = "این ویژگی‌ها ممکن است ناپایدار باشند و همچنین ممکن است بعدا تغییر کنند یا حذف شوند";
@@ -726,14 +740,17 @@
 // automatically delete message
 "delete_old_messages" = "پاک کردن پیام‌های قدیمی";
 "autodel_device_title" = "پاک کردن پیام‌ها از دستگاه";
+// deprecated
 "autodel_server_title" = "پاک کردن پیام‌ها از سرور";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "آیا می‌خواهید %1$d پیام جدید و دریافت شده را در زمان%2$@ در آینده پاک کنید؟\n\n• این شامل همه رسانه‌ها هم می‌شود\n\n• پیام‌ها جدای از اینکه دیده شده باشند یا نه پاک می‌شوند. \"پیام های ذخیره شده\" شامل این پاک کردن محلی نمی‌شوند. ";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "آیا می‌خواهید %1$d پیام را اکنون و تمام پیام‌های آیندهٔ «%2$@» را پاک کنید؟/n/n⚠️ این شامل رایانامه‌ها، رسانه و «پیام‌های ذخیره شده» در همه پوشه‌های کارساز(سرور) می‌شود/n/n⚠️ اگر می‌خواهید داده‌ها در کارساز باقی بمانند از این قابلیت استفاده نکنید/n/n⚠️ اگر به‌جز دلتاچت از دیگر نرم‌افزارهای رایانامه هم استفاده می‌کنید این قابلیت را به کار نگیرید.";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "این شامل رایانامه‌ها، رسانه‌ها و «پیام‌های ذخیره شده» در تمام پوشه‌های کارساز(سرور) می‌شود. اگر می‌خواهید داده‌ها را در کارساز نگه دارید از این قابلیت استفاده نکنید. اگر از دیگر نرم‌افزارهای رایانامه به‌جز دلتاچت استفاده می‌کنید هم از این قابلیت استفاده نکنید.";
+// deprecated
 "autodel_server_warn_multi_device_title" = "فعال‌سازی حذف بلافاصله";
+// deprecated
 "autodel_server_warn_multi_device" = "اگر حذف بلافاصله را فعال کنید، نمی‌توانید این نمایه را روی چند دستگاه داشته باشید.";
 "autodel_confirm" = "متوجه هستم، همه پیام‌ها حذف شوند";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -821,7 +838,7 @@
 "invalid_unencrypted_explanation" = "برای برقراری رمزنگاری سراسری، می‌توانید به صورت حضوری با مخاطب‌های خود دیدار کنید و کد کیوآر آن‌ها را برای معرفی اسکن کنید.";
 "learn_more" = "بیشتر بدانید";
 "devicemsg_self_deleted" = "شما گپ «پیام‌های ذخیره شده» را پاک کردید.\n\nℹ️ برای استفادهٔ دوباره از «پیام‌های ذخیره شده» کافی است یک گپ جدید با خودتان درست کنید. ";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = " ⚠️ میزان فضای در دسترس کارساز رایانامه شما در حال تمام شدن است. %1$@ از %% استفاده شده است. اگر فضا کاملا پر شده باشد دیگر امکان دریافت پیام را نخواهید داشت. 👈 لطفا پیام‌های قدیمی در رایانامه خود را از طریق نسخهٔ وب رایانامه پاک کنید. همچنین می‌توانید گزینه پاک کردن پیام‌های قدیمی در دلتاچت را فعال نمایید. هروقت خواستید می‌توانید فضای در دسترس را از «تنظیم‌ها / اتصال‌ها» بررسی کنید. ";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "هشدار⚠️ به نظر می‌رسد زمان و تاریخ دستگاه شما دقیق نیست(%1$@). ساعت دستگاه خود را تنظیم کنید ⏰🔧 تا پیام‌ها به درستی دریافت شوند. ";

--- a/deltachat-ios/fa.lproj/Localizable.stringsdict
+++ b/deltachat-ios/fa.lproj/Localizable.stringsdict
@@ -157,9 +157,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>ارسال این پرونده به %s؟</string>
+			<string>ارسال این پرونده به %2$@؟</string>
 			<key>other</key>
-			<string>ارسال این %d پرونده به %s؟</string>
+			<string>ارسال این %d پرونده به %2$@؟</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/fi.lproj/Localizable.strings
+++ b/deltachat-ios/fi.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "always" = "Aina";
 "always_load_remote_images" = "Lataa aina kuvat verkosta";
 "once" = "Kerran";
+// deprecated
 "show_warning" = "Näytä varoitus";
 "not_now" = "Ei nyt";
 "never" = "Ei koskaan";
@@ -126,6 +127,7 @@
 "camera" = "Kamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Kuvaa";
+// Switch eg. from front to back camera
 "switch_camera" = "Vaihda kameraa";
 "toggle_fullscreen" = "Koko näytön tila";
 "location" = "Sijainti";
@@ -248,12 +250,14 @@
 "mute_for_one_day" = "Mykistä 1 päiväksi";
 "mute_for_seven_days" = "Mykistä 7 päiväksi";
 "mute_forever" = "Mykistä ikuisesti";
+// deprecated
 "share_location_for_5_minutes" = "5 minuutiksi";
 "share_location_for_30_minutes" = "30 minuutiksi";
 "share_location_for_one_hour" = "1 tunniksi";
 "share_location_for_two_hours" = "2 tunniksi";
 "share_location_for_six_hours" = "6 tunniksi";
 "file_saved_to" = "Tiedosto tallennettu \"%1$@\".";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Välitä viestit yhteystiedolle %1$@?";
 "ask_forward_multiple" = "Välitä viestit %1$d keskustelulle?";
 "ask_export_attachment" = "Liitteiden vieminen antaa muille laitteen sovelluksille mahdollisuuden lukea niitä.\n\nJatka?";
@@ -490,6 +494,7 @@
 "pref_notifications_priority" = "Prioriteetti";
 "pref_notifications_explain" = "Ota järjestelmäilmoitukset käyttöön uusista viesteistä";
 "pref_show_notification_content" = "Näytä viestien sisältö ilmoituksissa";
+// deprecated
 "pref_show_notification_content_explain" = "Näytä lähettäjä ja viestin ensimmäiset sanat ilmoituksissa";
 "pref_led_color" = "LEDin väri";
 "pref_sound" = "Ääni";
@@ -528,12 +533,19 @@
 "pref_background" = "Taustakuva";
 "pref_background_btn_default" = "Käytä oletuskuvaa";
 "pref_background_btn_gallery" = "Valitse galleriasta";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Jos muutat tätä asetusta, varmista että palvelimesi ja muut päätelaitteesi ovat määritetty vastaavasti.\n\nMuutoin ne eivät ehkä toimi lainkaan.";
+// deprecated
 "pref_auto_folder_moves" = "Siirrä automaattisesti DeltaChat -kansioon";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Hae vain DeltaChat -kansiosta";
+// deprecated
 "pref_show_emails" = "Näytä tavanomaiset sähköpostiviestit";
+// deprecated
 "pref_show_emails_no" = "Ei, vain pikaviestit";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Hyväksytyille yhteystiedoille";
+// deprecated
 "pref_show_emails_all" = "Kaikki";
 "pref_experimental_features" = "Kokeelliset ominaisuudet";
 "pref_on_demand_location_streaming" = "Tarvittaessa sijainnin jatkuva jakaminen";
@@ -577,12 +589,13 @@
 // automatically delete message
 "delete_old_messages" = "Poista vanhat viestit";
 "autodel_device_title" = "Poista viestit laitteelta";
+// deprecated
 "autodel_server_title" = "Poista viestit palvelimelta";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Haluatko poistaa %1$d viestiä heti ja kaikki uudet viestit \"%2$@\" jatkossa?\n\n• Tämä sisältää kaiken median\n\n• Viestit poistetaan riippumatta siitä onko ne nähty vai ei\n\n• \"Tallennetut viestit\" jätetään paikalliselle laitteelle";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Haluatko poistaa %1$d viestiä heti ja kaikki uudet viestit \"%2$@\" jatkossa?\n\n⚠️ Tämä sisältää sähköpostiviestit, median ja kaikki \"Tallennetut viestit\" kaikissa palvelimen kansioissa\n\n⚠️ Älä käytä tätä toimintoa, jos haluat säilyttää tiedot palvelimella\n\n⚠️ Älä käytä tätä toimintoa, jos käytät muita sähköpostisovelluksia Delta Chatin lisäksi";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Tämä sisältää sähköpostit, median ja \"Tallennetut viestit\" kaikissa palvelimen kansioissa. Älä käytä tätä toimintoa, jos haluat pitää tietosi palvelimella tai jos käytät muita sähköpostisovelluksia Delta Chatin lisäksi.";
 "autodel_confirm" = "Ymmärrän, poista kaikki nämä viestit";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -661,7 +674,7 @@
 "invalid_unencrypted_explanation" = "Päästä-päähän salauksen saat käyttöön tapaamalla yhteystietosi ja skannaamalla hänen QR -koodinsa.";
 "learn_more" = "Lue lisää";
 "devicemsg_self_deleted" = "Poistit \"Tallennetut viestit\" -keskustelun.\n\nℹ️ Aloita uusi keskustelu itsesi kanssa, niin voit jälleen käyttää \"Tallennetut viestit\" -ominaisuutta.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Palveluntarjoajasi tallennuskiintiö ylitetään pian, käytössä on jo %1$@ / %%.\n\nEt välttämättä enää voi vastaanottaa viestejäsi, kun 100 %% on käytössä.\n\n👉 Kokeile poistaa viestejä palveluntarjoajasi internetkäyttöliittymästä. Kannattaa myös ehkä kytkeä päälle \"Asetukset / Poista vanhat viestit\". Voit tarkistaa tämän hetkisen tallennustilan käytön \"Asetukset / Yhteys\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Laitteesi päivämäärä tai aika vaikuttaa olevan väärässä (%1$@).\n\nAseta kellonaika ⏰🔧 varmistaaksesi, että viestin vastaanottaminen onnistuu.";

--- a/deltachat-ios/fi.lproj/Localizable.stringsdict
+++ b/deltachat-ios/fi.lproj/Localizable.stringsdict
@@ -141,9 +141,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Lähetä seuraava tiedosto yhteystiedolle%s?</string>
+			<string>Lähetä seuraava tiedosto yhteystiedolle %2$@?</string>
 			<key>other</key>
-			<string>Lähetä seuraavat %dtiedostot yhteystiedolle%s?</string>
+			<string>Lähetä seuraavat %d tiedostot yhteystiedolle %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_messages</key>

--- a/deltachat-ios/fr.lproj/Localizable.strings
+++ b/deltachat-ios/fr.lproj/Localizable.strings
@@ -57,7 +57,9 @@
 "media" = "Média";
 "apps_and_media" = "Applis & fichiers multimédias";
 "profile" = "Profil";
+// deprecated
 "all_profiles" = "Tous les profils";
+// deprecated
 "current_profile" = "Profil actuel";
 "main_menu" = "Menu principal";
 "start_chat" = "Commencer la discussion";
@@ -80,6 +82,7 @@
 "always" = "Toujours";
 "always_load_remote_images" = "Toujours charger les images distantes";
 "once" = "Une fois";
+// deprecated
 "show_warning" = "Montrer l\'avertissement";
 "not_now" = "Pas maintenant";
 "never" = "Jamais";
@@ -155,6 +158,7 @@
 "camera" = "Caméra";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Enregistrer";
+// Switch eg. from front to back camera
 "switch_camera" = "Changer de caméra";
 "toggle_fullscreen" = "Activer le plein écran";
 "location" = "Position";
@@ -322,6 +326,7 @@
 "mute_for_one_day" = "Sourdine pendant 1 jour";
 "mute_for_seven_days" = "Sourdine pendant 7 jours";
 "mute_forever" = "Toujours en sourdine";
+// deprecated
 "share_location_for_5_minutes" = "pour 5 minutes";
 "share_location_for_30_minutes" = "pour 30 minutes";
 "share_location_for_one_hour" = "pour 1 heure";
@@ -365,6 +370,7 @@
 "ask_leave_group" = "Voulez-vous vraiment quitter la discussion ?";
 "ask_delete_named_chat" = "Supprimer la discussion \"%1$@\" ?";
 "ask_delete_message" = "Supprimer ce message ?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Faire suivre les messages à %1$@ ?";
 "ask_forward_multiple" = "Faire suivre les messages à %1$d discussions ?";
 "ask_export_attachment" = "Exporter des pièces jointes permettra aux autres applications sur votre appareil d\'y accéder.\n\nContinuer ?";
@@ -658,6 +664,7 @@
 "pref_notifications_priority" = "Priorité";
 "pref_notifications_explain" = "Activer les notifications système pour les nouveaux messages";
 "pref_show_notification_content" = "Montrer le contenu du message dans la notification";
+// deprecated
 "pref_show_notification_content_explain" = "Montre l\'expéditeur et les premiers mots du message dans les notifications";
 "pref_led_color" = "Couleur de LED";
 "pref_sound" = "Son";
@@ -698,16 +705,23 @@
 "pref_background" = "Arrière-plan";
 "pref_background_btn_default" = "Utilisez l\'image par défaut";
 "pref_background_btn_gallery" = "Sélectionner depuis la galerie";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Si vous désactivez cette option, assurez-vous que votre serveur et vos autres clients sont configurés en conséquence.\n\nSinon des choses pourraient ne pas fonctionner du tout.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Mode appareils multiples";
 "pref_multidevice_explain" = "Synchronise vos messages avec vos autres appareils. Activé automatiquement lorsque vous ajoutez un deuxième appareil";
 "pref_multidevice_change_warn" = "Le mode appareils multiples doit être activé quand vous utilisez le même profil sur plusieurs appareils. Désactivez cette option seulement si vous avez supprimé ce profil de tous vos autres appareils.\n\nDésactiver ce mode alors que vous utilisez un profil sur plusieurs appareils causera un certain nombre de problèmes, dont des messages perdus.";
+// deprecated
 "pref_auto_folder_moves" = "Déplacer automatiquement vers le dossier DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Ne consulter que le dossier DeltaChat";
+// deprecated
 "pref_show_emails" = "Voir les courriels classiques";
+// deprecated
 "pref_show_emails_no" = "Non, seulement les discussions";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Pour les contacts acceptés";
+// deprecated
 "pref_show_emails_all" = "Tout";
 "pref_experimental_features" = "Fonctionnalités expérimentales";
 "pref_experimental_features_explain" = "Ces fonctionnalités peuvent présenter des instabilités, être modifiées ou supprimées";
@@ -759,14 +773,17 @@
 // automatically delete message
 "delete_old_messages" = "Supprimer les anciens messages";
 "autodel_device_title" = "Supprimer les messages de l\'appareil";
+// deprecated
 "autodel_server_title" = "Supprimer les messages du serveur";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Voulez-vous supprimer %1$d messages maintenant ainsi que tous les nouveaux futurs messages reçus « %2$@ » ?\n\n• Cela inclut tous les fichiers multimédia\n\n• Les messages seront effacés qu\'ils aient été vus ou non\n\n• Les « Messages sauvegardés » seront préservés de la suppression locale";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Voulez-vous supprimer %1$d messages maintenant ainsi que tous les futurs messages reçus « %2$@ » ?\n\n⚠️ Cela inclut les courriels, les fichier multimédias et les « Messages enregistrés » dans tous les répertoires du serveur\n\n⚠️ N\'utilisez pas cette fonctionnalité si vous voulez conserver vos données sur le serveur ou si vous utilisez des clients de courriel classiques en plus de Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Cela inclut les courriels, les fichiers multimédias et les « Messages enregistrés » dans tous les répertoires du serveur. N\'utilisez pas cette fonctionnalité si vous voulez conserver vos données sur le serveur ou si vous utilisez des clients de courriel classiques en plus de Delta Chat";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Activer la suppression immédiate";
+// deprecated
 "autodel_server_warn_multi_device" = "Si vous activez la suppression immédiate, vous ne pourrez pas utiliser plusieurs appareils sur ce profil.";
 "autodel_confirm" = "J\'ai compris, supprimer tous ces messages";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -858,7 +875,7 @@
 "invalid_unencrypted_explanation" = "Pour mettre en place le chiffrement de bout en bout, vous pouvez rencontrer vos contacts en personne et scanner leur code QR pour les ajouter à votre liste de contacts connus.";
 "learn_more" = "En savoir plus";
 "devicemsg_self_deleted" = "Vous avez supprimé la discussion « Messages enregistrés ».\n\nℹ️ Pour utiliser la fonctionnalité « Messages enregistrés » à nouveau, commencez une nouvelle discussion avec vous-même.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Bientôt plus d\'espace de stockage chez votre fournisseur : %1$@%% utilisés.\n\nQuand il sera plein, vous ne pourrez probablement plus recevoir de messages.\n\n👉 Vérifiez si vous pouvez supprimer des éléments anciens directement via l\'interface web de votre fournisseur, et envisagez d\'activer l\'option « Paramètres/ Discussions/ Supprimer les anciens messages ». Vous pouvez vérifier à tout moment le volume utilisé dans votre espace de stockage depuis « Paramètres/ Connectivité ».";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ L\'heure ou la date de votre appareil semble erronée (%1$@).\n\nRéglez votre horloge ⏰🔧 pour que vos messages soient bien reçus.";

--- a/deltachat-ios/fr.lproj/Localizable.stringsdict
+++ b/deltachat-ios/fr.lproj/Localizable.stringsdict
@@ -211,11 +211,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Envoyer le fichier suivant à %s ?</string>
+			<string>Envoyer le fichier suivant à %2$@ ?</string>
 			<key>many</key>
-			<string>Envoyer les %d fichiers suivants à %s ?</string>
+			<string>Envoyer les %d fichiers suivants à %2$@ ?</string>
 			<key>other</key>
-			<string>Envoyer les %d fichiers suivants à %s ?</string>
+			<string>Envoyer les %d fichiers suivants à %2$@ ?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/gl.lproj/Localizable.strings
+++ b/deltachat-ios/gl.lproj/Localizable.strings
@@ -57,7 +57,9 @@
 "media" = "Medios";
 "apps_and_media" = "Apps & Multimedia";
 "profile" = "Perfil";
+// deprecated
 "all_profiles" = "Todos os Perfís";
+// deprecated
 "current_profile" = "Perfil Actual";
 "main_menu" = "Menú principal";
 "start_chat" = "Inciar chat";
@@ -78,6 +80,7 @@
 "always" = "Sempre";
 "always_load_remote_images" = "Descargar sempre imaxes remotas";
 "once" = "Unha vez";
+// deprecated
 "show_warning" = "Mostrar aviso";
 "not_now" = "Agora non";
 "never" = "Nunca";
@@ -145,6 +148,7 @@
 "camera" = "Cámara";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Capturar";
+// Switch eg. from front to back camera
 "switch_camera" = "Cambiar de cámara";
 "toggle_fullscreen" = "Activar modo de pantalla completa";
 "location" = "Localización";
@@ -303,6 +307,7 @@
 "mute_for_one_day" = "Acalar durante 1 día";
 "mute_for_seven_days" = "Acalar durante 7 días";
 "mute_forever" = "Acalar para sempre";
+// deprecated
 "share_location_for_5_minutes" = "durante 5 min.";
 "share_location_for_30_minutes" = "durante 30 min.";
 "share_location_for_one_hour" = "durante 1 hora";
@@ -314,6 +319,7 @@
 "ask_leave_group" = "Tes a certeza de querer saír?";
 "ask_delete_named_chat" = "Eliminar a conversa \"%1$@\" en todos os teus dispositivos?";
 "ask_delete_message" = "Eliminar esta mensaxe en todos os teus dispositivos?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Reenviar mensaxes a %1$@?";
 "ask_forward_multiple" = "¿Reenviar mensaxes a %1$d conversas?";
 "ask_export_attachment" = "Exportar anexo? Ao exportar anexos outras aplicacións no dispositivo terán acceso a eles.\n\nGardar?";
@@ -576,6 +582,7 @@
 "pref_notifications_priority" = "Prioridade";
 "pref_notifications_explain" = "Activa as notificación para as novas mensaxes";
 "pref_show_notification_content" = "Motra o contido da mensaxe na notificación";
+// deprecated
 "pref_show_notification_content_explain" = "Mostra a remitente e as primeiras palabras da mensaxe na notificación";
 "pref_led_color" = "Cor LED";
 "pref_sound" = "Son";
@@ -614,12 +621,19 @@
 "pref_background" = "Fondo";
 "pref_background_btn_default" = "Usar imaxe por omisión";
 "pref_background_btn_gallery" = "Escoller na galería";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Se desactivas esta opción, asegúrate de que o servidor e os teus outros clientes están configurados de xeito acorde.\n\nSe non, algo podería fallar.";
+// deprecated
 "pref_auto_folder_moves" = "Mover automáticamente ao cartafol DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Obter só desde cartafol DeltaChat";
+// deprecated
 "pref_show_emails" = "Mostrar correos clásicos";
+// deprecated
 "pref_show_emails_no" = "Non, só conversas";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Para os contactos aceptados";
+// deprecated
 "pref_show_emails_all" = "Todos";
 "pref_experimental_features" = "Zona de probas";
 "pref_on_demand_location_streaming" = "Difusión da ubicación por solicitude";
@@ -659,12 +673,13 @@
 // automatically delete message
 "delete_old_messages" = "Eliminar mensaxes antigas";
 "autodel_device_title" = "Borrar mensaxes do dispositivo";
+// deprecated
 "autodel_server_title" = "Borrar mensaxes do servidor";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Queres borrar %1$d mensaxes agora e todas as novas mensaxes \"%2$@\" no futuro?\n\n• Esto inclúe todo o multimedia\n\n• As mensaxes borraranse fosen lidas ou non\n\n• As \"mensaxes gardadas\" non serán borradas do dispositivo.";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Desexas eliminar %1$d mensaxes e todas as \"%2$@\" novas mensaxes obtidas no futuro?\n\n⚠️ Esto inclúe emails, multimedia e \"Mensaxes gardadas\" en tódolos cartafoles do servidor\n\n⚠️ Non uses esta función se queres manter os datos gardados no servidor\n\n⚠️ Non uses esta función se estás a utilizar outro cliente de email ademáis de Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Esto inclúe emails, multimedia e \"Mensaxes gardadas\" en tódolos cartafoles do servidor. Non uses esta función se queres manter os datos gardados no servidor ou se estás a utilizar outro cliente de email ademáis de Delta Chat.";
 "autodel_confirm" = "Entendo, dalle e borra as mensaxes todas";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -741,7 +756,7 @@
 // %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name of the contact
 "ephemeral_timer_weeks_by_other" = "Temporizador de desaparición de mensaxes definido en %1$@ semanas por %2$@.";
 "devicemsg_self_deleted" = "Eliminaches o chat \"Mensaxes gardadas\".\n\nℹ️ Para usar \"Mensaxes gardadas\" de novo, crea un novo chat contigo mesmo.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ A almacenaxe do teu provedor vaise esgotar, xa utilizaches %1$@ %%.\n\nPode que non recibas mensaxes cando a almacenaxe chegue a 100%% utilizado.\n\n👉 Mira se podes eliminar datos antigos na interface web do teu provedor e pensa se debes activar \"Axustes / Eliminar Mensaxes Antigas\". Podes ver a almacenaxe actual utilizada en \"Axustes / Conectividade\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ A hora ou data no teu dispositivo poderían ser incorrectas (%1$@).\n\nAxusta o reloxio ⏰🔧 para asegurar que as túas mensaxes son recibidas correctamente.";

--- a/deltachat-ios/gl.lproj/Localizable.stringsdict
+++ b/deltachat-ios/gl.lproj/Localizable.stringsdict
@@ -157,9 +157,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Enviar o seguinte ficheiro a %s?</string>
+			<string>Enviar o seguinte ficheiro a %2$@?</string>
 			<key>other</key>
-			<string>Enviar os seguintes %d ficheiros a %s?</string>
+			<string>Enviar os seguintes %d ficheiros a %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/hr.lproj/Localizable.strings
+++ b/deltachat-ios/hr.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 // No need to translate "Wallpaper" literally. Chose what is common in your language for a "Wallpaper" or a "Background". Avoid adding the term "image" here, as the "Wallpaper" may also be just a single color.
 "pref_background" = "Pozadina";
 "pref_background_btn_gallery" = "Odaberi iz galerije";
+// deprecated
 "pref_show_emails_all" = "Sve";
 "pref_background_default" = "Zadana pozadina";
 "pref_background_default_color" = "Zadana boja";

--- a/deltachat-ios/hu.lproj/Localizable.strings
+++ b/deltachat-ios/hu.lproj/Localizable.strings
@@ -57,7 +57,9 @@
 "media" = "Média";
 "apps_and_media" = "Alkalmazások & média";
 "profile" = "Profil";
+// deprecated
 "all_profiles" = "Összes profil";
+// deprecated
 "current_profile" = "Jelenlegi profil";
 "main_menu" = "Főmenü";
 "start_chat" = "Csevegés indítása";
@@ -78,6 +80,7 @@
 "always" = "Mindig";
 "always_load_remote_images" = "Mindig töltse be a távoli képeket";
 "once" = "Azonnal";
+// deprecated
 "show_warning" = "Figyelmeztetés megjelenítése";
 "not_now" = "Most nem";
 "never" = "Soha";
@@ -146,6 +149,7 @@
 "camera" = "Kamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Rögzítés";
+// Switch eg. from front to back camera
 "switch_camera" = "Kameraváltás";
 "toggle_fullscreen" = "Váltás teljes képernyős módra";
 "location" = "Hely";
@@ -311,6 +315,7 @@
 "mute_for_one_day" = "Némítás 1 napra";
 "mute_for_seven_days" = "Némítás 7 napra";
 "mute_forever" = "Némítás örökre";
+// deprecated
 "share_location_for_5_minutes" = "5 percre";
 "share_location_for_30_minutes" = "30 percre";
 "share_location_for_one_hour" = "1 órára";
@@ -331,6 +336,7 @@
 "ask_leave_group" = "Biztosan elhagyja a csatornát?";
 "ask_delete_named_chat" = "Törli a(z) „%1$@” nevű csevegést az összes eszközén?";
 "ask_delete_message" = "Törli ezt az üzenetet az összes eszközén?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Továbbítja az üzenetet „%1$@” számára?";
 "ask_forward_multiple" = "Továbbítja az üzenetet a következő csevegésbe: %1$d?";
 "ask_export_attachment" = "A mellékletek exportálása lehetővé teszi, hogy más alkalmazások is hozzáférjenek azokhoz az eszközön.\n\nFolytatja?";
@@ -604,6 +610,7 @@
 "pref_notifications_priority" = "Prioritás";
 "pref_notifications_explain" = "Rendszerértesítések engedélyezése az új üzenetekről";
 "pref_show_notification_content" = "Üzenet tartalmának megjelenítése az értesítésben";
+// deprecated
 "pref_show_notification_content_explain" = "Az értesítésekben megjelenik az üzenet feladója és első szavai";
 "pref_led_color" = "Értesítésjelző-fény színe";
 "pref_sound" = "Hang";
@@ -644,12 +651,19 @@
 "pref_background" = "Háttérkép";
 "pref_background_btn_default" = "Alapértelemezett kép használata";
 "pref_background_btn_gallery" = "Kiválasztás a galériából";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Ha megváltoztatja ezt a beállítást, győződjön meg arról, hogy a kiszolgálója és a többi kliense is ennek megfelelően van beállítva.\n\nMáskülönben előfordulhat, hogy a dolgok egyáltalán nem fognak működni.";
+// deprecated
 "pref_auto_folder_moves" = "Automatikus áthelyezés a DeltaChat nevű mappába";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Csak a DeltaChat nevű mappából történjen lekérdezés";
+// deprecated
 "pref_show_emails" = "Klasszikus e-mailek megjelenítése";
+// deprecated
 "pref_show_emails_no" = "Nem, csak csevegések";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Elfogadott partnerek számára";
+// deprecated
 "pref_show_emails_all" = "Összes";
 "pref_experimental_features" = "Kísérleti funkciók";
 "pref_on_demand_location_streaming" = "On-Demand folyamatos helymegosztás";
@@ -693,14 +707,17 @@
 // automatically delete message
 "delete_old_messages" = "Régi üzenetek törlése";
 "autodel_device_title" = "Üzenetek törlése az eszközről a letöltést követően";
+// deprecated
 "autodel_server_title" = "Üzenetek törlése a kiszolgálóról a letöltést követően";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Szeretné törölni a %1$d üzenetet most és az összes újonnan érkező üzenetet a jövőben ekkor: „%2$@”?\n\n• Ez magában foglalja az összes médiát is\n\n• Az üzenetek törlésre kerülnek, akár látták őket, akár nem\n\n• A „Mentett üzenetek” nem kerülnek törlésre a helyi törlésből.";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Biztosan törölni szeretne %1$d üzenetet most, és a jövőben minden újonnan lekérdezett „%2$@” üzenetet?\n\n⚠️ Ez magába foglalja az e-maileket, a médiatartalmakat és a „Mentett üzeneteket” az összes kiszolgálómappában.\n\n⚠️ Ne használja ezt a funkciót, ha meg akarja tartani az adatokat a kiszolgálón, vagy ha klasszikus e-mail-klienseket is használ.";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Ez magába foglalja az e-maileket, a médiatartalmakat és a „Mentett üzeneteket” az összes kiszolgálómappában. Ne használja ezt a funkciót, ha meg akarja tartani az adatokat a kiszolgálón, vagy ha klasszikus e-mail-klienseket is használ.";
+// deprecated
 "autodel_server_warn_multi_device_title" = "A „Törlés a letöltés után azonnal” bekapcsolása";
+// deprecated
 "autodel_server_warn_multi_device" = "Ha a „Törlés a letöltés után azonnal” engedélyezve van, akkor nem használhatja ezt a profilt több eszközről.";
 "autodel_confirm" = "Értem, törölje ezeket az üzeneteket";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -787,7 +804,7 @@
 "invalid_unencrypted_explanation" = "A végpontok közötti titkosítás létrehozásához személyesen is találkozhat a partnereivel, és a QR-kódjukat beolvasva bemutathatja őket.";
 "learn_more" = "Tudjon meg többet";
 "devicemsg_self_deleted" = "Ön törölte a „Mentett üzenetek” csevegést.\n\nℹ️ A „Mentett üzenetek” funkció újbóli használatához hozzon létre egy új csevegést önmagával.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Az e-mail-szolgáltatójától kapott tárhelye hamarosan megtelik: %1$@%% már felhasználásra került.\n\n\nElképzelhető, hogy nem tud üzeneteket fogadni, ha a tárhelye megtelt.\n\n👉 Ellenőrizze, hogy a szolgáltatója webes felületén tudja-e törölni a DeltaChat-mappából az üzeneteket, és fontolja meg a „Beállítások / Csevegések és média / Üzenetek törlése a kiszolgálóról” engedélyezését. Az aktuális tárhelyhasználatot bármikor ellenőrizheti a „Beállítások / Tárhely” menüpontban.";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Az eszközén lévő dátum vagy idő pontatlannak tűnik (%1$@).\n\nJavítsa meg az órát ⏰🔧 az üzenetek helyes fogadásának biztosítása érdekében.";

--- a/deltachat-ios/hu.lproj/Localizable.stringsdict
+++ b/deltachat-ios/hu.lproj/Localizable.stringsdict
@@ -157,9 +157,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>A következő fájl elküldése neki: %s?</string>
+			<string>A következő fájl elküldése neki: %2$@?</string>
 			<key>other</key>
-			<string>A következő %d fájl elküldése „%s” számára?</string>
+			<string>A következő %d fájl elküldése „%2$@” számára?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/id.lproj/Localizable.strings
+++ b/deltachat-ios/id.lproj/Localizable.strings
@@ -57,6 +57,7 @@
 "load_remote_content" = "Memuat Gambar Jarak Jauh";
 "always" = "Selalu";
 "once" = "Sekali";
+// deprecated
 "show_warning" = "Tampilkan Peringatan";
 "not_now" = "Tidak sekarang";
 "never" = "Tidak pernah";
@@ -116,6 +117,7 @@
 "camera" = "Kamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Tangkap";
+// Switch eg. from front to back camera
 "switch_camera" = "Ganti kamera";
 "toggle_fullscreen" = "Beralih ke Mode Layar Penuh";
 "location" = "Lokasi";
@@ -224,12 +226,14 @@
 "mute_for_one_day" = "Diamkan untuk 1 hari";
 "mute_for_seven_days" = "Diamkan untuk 7 hari";
 "mute_forever" = "Diamkan seterusnya";
+// deprecated
 "share_location_for_5_minutes" = "untuk 5 menit";
 "share_location_for_30_minutes" = "untuk 30 menit";
 "share_location_for_one_hour" = "untuk 1 jam";
 "share_location_for_two_hours" = "untuk 2 jam";
 "share_location_for_six_hours" = "untuk 6 jam";
 "file_saved_to" = "Berkas disimpan ke \"%1$@\".";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Teruskan pesan ke %1$@?";
 "ask_export_attachment" = "Ekspor lampiran? Mengekspor lampiran akan membuat aplikasi lain di perangkat anda terakses.\n\nLanjut?";
 "ask_block_contact" = "Blokir kontak ini? Anda tak akan lagi menerima pesan dari kontak ini.";
@@ -350,6 +354,7 @@
 "pref_notifications" = "Notifikasi";
 "pref_notifications_show" = "Menunjukkan";
 "pref_notifications_priority" = "Prioritas";
+// deprecated
 "pref_show_notification_content_explain" = "Tampilkan pengirim dan kata-kata awal dari pesan di dalam notifikasi";
 "pref_led_color" = "Warna LED";
 "pref_sound" = "Suara";
@@ -381,10 +386,15 @@
 "pref_background" = "Latar belakang";
 "pref_background_btn_default" = "Menggunakan gambar default";
 "pref_background_btn_gallery" = "Pilih dari galeri";
+// deprecated
 "pref_auto_folder_moves" = "Perpindahan otomatis ke berkas DeltaChat";
+// deprecated
 "pref_show_emails" = "Tampilkan email klasik";
+// deprecated
 "pref_show_emails_no" = "Tidak, hanya obrolan saja";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Untuk kontak yang telah diterima";
+// deprecated
 "pref_show_emails_all" = "Semua";
 "pref_experimental_features" = "Fitur yang masih bersifat eksperimen";
 "pref_background_default" = "Latar belakang default";
@@ -403,6 +413,7 @@
 // automatically delete message
 "delete_old_messages" = "Hapus pesan-pesan lama";
 "autodel_device_title" = "Hapus pesarn dari perangkat";
+// deprecated
 "autodel_server_title" = "Hapus pesan dari server";
 "autodel_confirm" = "Saya mengerti, hapus semua pesan ini";
 // "At once" in the meaning of "Immediately", without any intervening time.

--- a/deltachat-ios/id.lproj/Localizable.stringsdict
+++ b/deltachat-ios/id.lproj/Localizable.stringsdict
@@ -125,7 +125,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>Kirimkan yang berikut ini %d berkas ke %s?</string>
+			<string>Kirimkan yang berikut ini %d berkas ke %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_messages</key>

--- a/deltachat-ios/it.lproj/Localizable.strings
+++ b/deltachat-ios/it.lproj/Localizable.strings
@@ -59,7 +59,9 @@
 "media" = "Media";
 "apps_and_media" = "Apps & Media";
 "profile" = "Profilo";
+// deprecated
 "all_profiles" = "Tutti i Profili";
+// deprecated
 "current_profile" = "Profilo Corrente";
 "main_menu" = "Menu Principale";
 "start_chat" = "Inizia Chat";
@@ -84,6 +86,7 @@
 "always" = "Sempre";
 "always_load_remote_images" = "Carica Sempre Immagini Remote";
 "once" = "Una Volta";
+// deprecated
 "show_warning" = "Mostra Avviso";
 "not_now" = "Non ora";
 "never" = "Mai";
@@ -160,6 +163,7 @@
 "camera" = "Fotocamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Cattura";
+// Switch eg. from front to back camera
 "switch_camera" = "Cambia Fotocamera";
 "toggle_fullscreen" = "Attiva/Disattiva Modalità Schermo Intero";
 "location" = "Posizione";
@@ -327,11 +331,13 @@
 "mute_for_one_day" = "Silenzia per 1 giorno";
 "mute_for_seven_days" = "Silenzia per 7 giorni";
 "mute_forever" = "Silenzia per sempre";
+// deprecated
 "share_location_for_5_minutes" = "Per 5 minuti";
 "share_location_for_30_minutes" = "Per 30 minuti";
 "share_location_for_one_hour" = "Per 1 ora";
 "share_location_for_two_hours" = "Per 2 ore";
 "share_location_for_six_hours" = "Per 6 ore";
+"share_location_for_24_hours" = "Per 24 ore";
 "file_saved_to" = "File salvato su \"%1$@\".";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "Chiama";
@@ -367,11 +373,16 @@
 "already_in_call" = "Già in chiamata";
 "call_answered_elsewhere" = "Chiamata risposta su un altro dispositivo";
 "call_requires_mic_permission" = "Per le chiamate è necessaria l\'autorizzazione per l\'utilizzo del microfono.";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "Chiama con %1$@";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "Chiamata %1$@…";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Sei sicuro di voler abbandonare?";
 "ask_delete_named_chat" = "Eliminare la chat \"%1$@\" su tutti i tuoi dispositivi?";
 "ask_delete_message" = "Vuoi eliminare questo messaggio da tutti i tuoi dispositivi?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Inoltrare messaggi a %1$@?";
 "ask_forward_multiple" = "Inoltra messaggi a %1$d chat?";
 "ask_export_attachment" = "Esportare allegati permetterà ad ogni altra app sul tuo dispositivo di accedervi.\n\nContinuare?";
@@ -442,8 +453,11 @@
 // search
 "search" = "Cerca";
 "search_in_chat" = "Cerca nella Chat";
+// Placeholder will be replaced by the chat name
+"search_in" = "Cerca in %1$@";
 "search_files" = "Cerca File";
 "search_explain" = "Cerca chat, contatti e messaggi";
+"search_result_for_x" = "Risultato per \"%1$@\"";
 "search_no_result_for_x" = "Nessun risultato trovato per \"%1$@\"";
 // Adjective, as in "Show Unread Messages"
 "search_unread" = "Non Letto";
@@ -455,6 +469,7 @@
 "group_create_button" = "Crea Gruppo";
 // deprecated, use please_enter_chat_name
 "group_please_enter_group_name" = "Per piacere inserisci un nome per il gruppo.";
+"please_enter_chat_name" = "Inserisci un nome.";
 "group_add_members" = "Aggiungi Membri";
 "group_self_not_in_group" = "Devi essere un membro del gruppo per fare questa azione.";
 "profile_encryption" = "Crittografia";
@@ -667,6 +682,7 @@
 "pref_notifications_priority" = "Priorità";
 "pref_notifications_explain" = "Abilita le notifiche di sistema per i nuovi messaggi";
 "pref_show_notification_content" = "Mostra il contenuto del messaggio nella notifica";
+// deprecated
 "pref_show_notification_content_explain" = "Mostra il mittente e le prime parole del messaggio nelle notifiche";
 "pref_led_color" = "Colore LED";
 "pref_sound" = "Suono";
@@ -685,6 +701,8 @@
 "pref_incognito_keyboard_explain" = "Richiedi alla tastiera di disattivare l\'apprendimento personalizzato";
 "pref_read_receipts" = "Ricevute di Lettura";
 "pref_read_receipts_explain" = "Se le conferme di lettura sono disattivate, non potrai vedere le conferme di lettura degli altri.";
+// Title above a list of contacts who read a message
+"read_by" = "Letto da";
 "pref_server" = "Server";
 "pref_encryption" = "Crittografia";
 "pref_manage_keys" = "Gestisci Chiavi";
@@ -707,16 +725,23 @@
 "pref_background" = "Sfondo";
 "pref_background_btn_default" = "Usa Immagine Predefinita";
 "pref_background_btn_gallery" = "Seleziona Dalla Galleria";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Se modifichi questa opzione, assicurati che il tuo server e gli altri client siano configurati di conseguenza.\n\nAltrimenti le cose potrebbero non funzionare affatto.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Modalità Multi-Dispositivo";
 "pref_multidevice_explain" = "Sincronizza i tuoi messaggi con gli altri dispositivi. Abilitazione automatica all\'aggiunta di un secondo dispositivo.";
 "pref_multidevice_change_warn" = "La Modalità Multi-Dispositivo deve essere abilitata quando si utilizza lo stesso profilo su più dispositivi. Disattivare questa impostazione solo se si è rimosso il profilo da tutti gli altri dispositivi.\n\nDisattivare la Modalità Multi-Dispositivo mentre si utilizza il profilo su più dispositivi causerà la perdita di messaggi e altri problemi.";
+// deprecated
 "pref_auto_folder_moves" = "Sposta nella Cartella DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Recupera dalla Cartella DeltaChat";
+// deprecated
 "pref_show_emails" = "Mostra E-mail Classiche";
+// deprecated
 "pref_show_emails_no" = "No, solo chat";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Per contatti accettati";
+// deprecated
 "pref_show_emails_all" = "Sì";
 "pref_experimental_features" = "Caratteristiche Sperimentali";
 "pref_experimental_features_explain" = "Queste funzionalità potrebbero essere instabili e potrebbero essere modificate o rimosse";
@@ -768,14 +793,17 @@
 // automatically delete message
 "delete_old_messages" = "Elimina Vecchi Messaggi";
 "autodel_device_title" = "Elimina Messaggi dal Dispositivo";
+// deprecated
 "autodel_server_title" = "Elimina Messaggi dal Server";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Vuoi eliminare %1$d messaggi ora e tutti i nuovi messaggi recuperati \"%2$@\" d\'ora in poi?\n\n• Questo include tutti i media\n\n• I messaggi verranno eliminati anche se non sono stati letti\n\n• I \"Messaggi salvati\" vengono preservati dalla cancellazione locale.";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Vuoi eliminare %1$d messaggi ora e tutti i messaggi non appena recuperati \"%2$@\" d\'ora in poi?\n\n⚠️ Ciò include e-mails, contenuti multimediali e \"Messaggi salvati\" in tutte le cartelle del server\n\n⚠️ Non utilizzare questa funzione se vuoi mantenere i dati sul server o se stai utilizzando anche altri client e-mail";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Questo include e-mail, media e \"Messaggi salvati\" in tutte le cartelle del server. Non utilizzare questa funzione se desideri mantenere i dati sul server o se stai utilizzando anche altri client e-mail";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Attiva l\'eliminazione immediata";
+// deprecated
 "autodel_server_warn_multi_device" = "Se abiliti l\'eliminazione immediata non potrai utilizzare questo profilo su più dispositivi.";
 "autodel_confirm" = "Ho capito, elimina tutti questi messaggi";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -793,9 +821,12 @@
 "group_name_changed_by_you" = "Hai cambiato il nome del gruppo da \"%1$@\" a \"%2$@\".";
 // %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action.
 "group_name_changed_by_other" = "Nome gruppo cambiato da \"%1$@\" a \"%2$@\" da %3$@.";
+// %1$s will be replaced by the old channel name, %2$s will be replaced by the new channel name
+"channel_name_changed" = "Il nome del canale è cambiato da \"%1$@\" a \"%2$@\".";
 "group_image_changed_by_you" = "Hai cambiato l\'immagine del gruppo.";
 // %1$s will be replaced by name of the contact who did the action
 "group_image_changed_by_other" = "Immagine del gruppo cambiata da %1$@.";
+"channel_image_changed" = "Immagine canale cambiata.";
 "chat_description_changed_by_you" = "Hai cambiato la descrizione della chat.";
 // %1$s will be replaced by name of the contact who did the action
 "chat_description_changed_by_other" = "Descrizione della chat modificata da %1$@.";
@@ -823,7 +854,7 @@
 "group_image_deleted_by_other" = "Immagine gruppo eliminata da %1$@.";
 "location_enabled_by_you" = "Hai abilitato la trasmissione della posizione.";
 // %1$s will be replaced by name of the contact
-"location_enabled_by_other" = "Trasmissione della posizione abilitato da %1$@.";
+"location_enabled_by_other" = "Trasmissione della posizione abilitata da %1$@.";
 "ephemeral_timer_disabled_by_you" = "Hai disabilitato il timer dei messaggi a scomparsa.";
 // %1$s will be replaced by name of the contact
 "ephemeral_timer_disabled_by_other" = "Timer messaggi a scomparsa disabilitato da %1$@.";
@@ -867,7 +898,7 @@
 "invalid_unencrypted_explanation" = "Per stabilire la crittografia end-to-end, potresti incontrare i contatti di persona e scansionare il loro Codice QR per verificarli.";
 "learn_more" = "Per Saperne di Più";
 "devicemsg_self_deleted" = "Hai eliminato la chat \"Messaggi salvati\".\n\nℹ️ Per utilizzare nuovamente la funzione \"Messaggi salvati\", crea una nuova chat con te stesso.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Lo spazio di archiviazione del tuo fornitore sta per esaurirsi:%1$@%% sono già utilizzati.\n\nPotresti non essere in grado di ricevere messaggi se lo spazio di archiviazione è pieno.\n\n👉 Per piacere controlla se puoi eliminare i vecchi dati nell\'interfaccia web del fornitore e considera di abilitare \"Impostazioni / Chat e Media / Elimina Vecchi Messaggi\". Puoi controllare l\'utilizzo attuale dello spazio di archiviazione in qualsiasi momento in \"Impostazioni / Connettività\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ La data o l\'ora del tuo dispositivo sembrano essere imprecise (%1$@).\n\nRegola l\'orologio ⏰🔧 per assicurarti che i tuoi messaggi vengano ricevuti correttamente.";
@@ -929,6 +960,8 @@
 // first placeholder is the name of the chat
 "confirm_replace_draft" = "%1$@ ha già una bozza di messaggio, vuoi sostituirla?";
 "mailto_link_could_not_be_decoded" = "Il collegamento mailto non può essere decodificato: %1$@";
+"remove_quote" = "Rimuovi citazione";
+"remove_attachment" = "Rimuovi allegato";
 // notifications
 "notify_reply_button" = "Rispondi";
 "notify_new_message" = "Nuovo messaggio";
@@ -944,6 +977,9 @@
 // Body text for a generic "New messages" notification. Shown if we do not have more information about a new messages. Note, that the string is also referenced at https://github.com/deltachat/notifiers
 "new_messages_body" = "Hai nuovi messaggi";
 "n_messages_in_m_chats" = "%1$d messaggi in %2$d chat";
+// location streaming
+"location_streaming_notification_text" = "Stai condividendo la tua posizione";
+"location_rationale" = "Per condividere la tua posizione in tempo reale con i membri della chat, consenti a Delta Chat di utilizzare i tuoi dati di geolocalizzazione.\n\nPer garantire il funzionamento continuo della geolocalizzazione in tempo reale, i dati di geolocalizzazione vengono utilizzati anche quando l\'app è chiusa o non in uso.";
 // permissions
 "perm_required_title" = "Autorizzazione richiesta";
 "perm_continue" = "Continua";
@@ -983,6 +1019,7 @@
 "global_menu_help_about_desktop" = "Informazioni Delta Chat";
 "global_menu_file_open_desktop" = "Apri Delta Chat";
 "global_menu_minimize_to_tray" = "Minimizza";
+"no_account_selected" = "Seleziona un profilo o creane uno nuovo";
 "no_chat_selected_suggestion_desktop" = "Seleziona una chat o crea una nuova chat";
 "write_message_desktop" = "Scrivi un messaggio";
 "encryption_info_title_desktop" = "Informazioni Cifratura";
@@ -1004,8 +1041,15 @@
 // deprecated, used on desktop although there is not spell checker
 "no_spellcheck_suggestions_found" = "Nessun suggerimento ortografico trovato.";
 "show_window" = "Mostra Finestra";
+"data_found_other_installation_message" = "I profili di un\'altra installazione di Delta Chat non sono accessibili: le diverse installazioni memorizzano i dati in posizioni separate.\n\nPer mantenere i profili esistenti:\n1. Esci ora\n2. Apri l\'altro Delta Chat; se necessario, reinstallalo da %1$@\n3. Esegui il backup di ciascun profilo in \"Impostazioni/Chat\"\n4. Riavvia questa versione\n5. Ripristina i backup utilizzando \"Ho già un profilo\"\n\nContinuare senza i profili precedenti?";
 // title of the "keybindings" dialog (for the keybindings names as such, where possible the normal command strings are used)
 "keybindings" = "Associazioni tasti";
+// subtitle in the "keybindings" dialog
+"navigation_shortcut_section" = "Navigazione";
+// subtitle in the "keybindings" dialog
+"message_input_shortcut_section" = "Scrivi Messaggio";
+// subtitle in the "keybindings" dialog
+"message_selected_shortcut_section" = "Messaggio Selezionato";
 "switch_between_chats" = "Passa da una Chat all\'altra";
 "scroll_messages" = "Scorri Messaggi";
 // command to put the cursor to the search input field

--- a/deltachat-ios/it.lproj/Localizable.stringsdict
+++ b/deltachat-ios/it.lproj/Localizable.stringsdict
@@ -211,11 +211,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Invia il seguente file a %s?</string>
+			<string>Invia il seguente file a %2$@?</string>
 			<key>many</key>
-			<string>Invia i seguenti %d files a %s?</string>
+			<string>Invia i seguenti %d files a %2$@?</string>
 			<key>other</key>
-			<string>Invia i seguenti %d files a %s?</string>
+			<string>Invia i seguenti %d files a %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/ja.lproj/Localizable.strings
+++ b/deltachat-ios/ja.lproj/Localizable.strings
@@ -101,6 +101,7 @@
 "camera" = "カメラ";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "撮影";
+// Switch eg. from front to back camera
 "switch_camera" = "カメラを切り替える";
 "toggle_fullscreen" = "フルスクリーン";
 "location" = "場所";
@@ -197,12 +198,14 @@
 "mute_for_one_day" = "24時間停止する";
 "mute_for_seven_days" = "7日間停止する";
 "mute_forever" = "無効";
+// deprecated
 "share_location_for_5_minutes" = "5分間";
 "share_location_for_30_minutes" = "30分間";
 "share_location_for_one_hour" = "1時間";
 "share_location_for_two_hours" = "2時間";
 "share_location_for_six_hours" = "6時間";
 "file_saved_to" = "%1$@に保存しました。";
+// deprecated, use ask_forward_messages
 "ask_forward" = "%1$@にメッセージを転送しますか？";
 "ask_forward_multiple" = "%1$dチャットにメッセージを転送しますか？";
 "ask_export_attachment" = "添付ファイルをエクスポートしますか？添付ファイルをエクスポートすると、他のアプリからもアクセスできるようになります。\n\nよろしいですか？";
@@ -345,6 +348,7 @@
 "pref_notifications_priority" = "優先度";
 "pref_notifications_explain" = "新着メッセージ通知を有効にします";
 "pref_show_notification_content" = "通知にメッセージの内容を表示します";
+// deprecated
 "pref_show_notification_content_explain" = "通知には、送信者と最初の単語を表示します";
 "pref_led_color" = "LED色";
 "pref_sound" = "通知音";
@@ -379,10 +383,15 @@
 "pref_background" = "背景";
 "pref_background_btn_default" = "デフォルトの画像を使う";
 "pref_background_btn_gallery" = "ギャラリーから選ぶ";
+// deprecated
 "pref_auto_folder_moves" = "DeltaChatフォルダに自動で移動する";
+// deprecated
 "pref_show_emails" = "一般的なメールを表示する";
+// deprecated
 "pref_show_emails_no" = "いいえ、チャットのみ";
+// deprecated
 "pref_show_emails_accepted_contacts" = "許可されたユーザーのみ";
+// deprecated
 "pref_show_emails_all" = "全部";
 "pref_experimental_features" = "実験的な機能";
 "pref_on_demand_location_streaming" = "オンデマンドの位置情報配信";
@@ -411,6 +420,7 @@
 // automatically delete message
 "delete_old_messages" = "古いメッセージの削除";
 "autodel_device_title" = "端末からメッセージを削除する";
+// deprecated
 "autodel_server_title" = "サーバーからメッセージを削除する";
 "autodel_confirm" = "分かりました。メッセージを削除していいです。";
 // "At once" in the meaning of "Immediately", without any intervening time.

--- a/deltachat-ios/ja.lproj/Localizable.stringsdict
+++ b/deltachat-ios/ja.lproj/Localizable.stringsdict
@@ -97,7 +97,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%sさんに%dつのファイルを送る？</string>
+			<string>%2$@さんに%dつのファイルを送る？</string>
 		</dict>
 	</dict>
 	<key>chat_archived</key>

--- a/deltachat-ios/kab.lproj/Localizable.strings
+++ b/deltachat-ios/kab.lproj/Localizable.strings
@@ -57,7 +57,9 @@
 "media" = "Amidya";
 "apps_and_media" = "Isnasen & Amidya";
 "profile" = "Amaɣnu";
+// deprecated
 "all_profiles" = "Akk imeɣna";
+// deprecated
 "current_profile" = "Amaɣnu amiran";
 "main_menu" = "Umuɣ agejdan";
 "start_chat" = "Bdu adiwinni";
@@ -80,6 +82,7 @@
 "always" = "Dima";
 "always_load_remote_images" = "Sali-d yal tikelt tugniwin n unmeggag";
 "once" = "Tikkelt";
+// deprecated
 "show_warning" = "Sken ulɣu";
 "not_now" = "Mačči tura";
 "never" = "Werǧin";
@@ -155,6 +158,7 @@
 "camera" = "Takamiṛat";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Tuṭṭfa ";
+// Switch eg. from front to back camera
 "switch_camera" = "Beddel takamiṛat ";
 "toggle_fullscreen" = "Ldi/Mdel askar n ugdil ačuran";
 "location" = "Adig";
@@ -320,6 +324,7 @@
 "mute_for_one_day" = "Sgugem i 1 wass";
 "mute_for_seven_days" = "Sgugem i 7 wussan";
 "mute_forever" = "Sgugem i lebda";
+// deprecated
 "share_location_for_5_minutes" = "I 5 n tisdatin";
 "share_location_for_30_minutes" = "I 30 n tisdatin";
 "share_location_for_one_hour" = "I 1 usrag";
@@ -363,6 +368,7 @@
 "ask_leave_group" = "Tetḥeqqeḍ tebɣiḍ ad truḥeḍ? ";
 "ask_delete_named_chat" = "Kkes adiwenni \"%1$@\"?";
 "ask_delete_message" = "Kkes izen-a?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Welleh iznan ɣer %1$@?";
 "ask_forward_multiple" = "Welleh iznan ɣer %1$d n yidiwenniyen?";
 "ask_export_attachment" = "Asifeḍ n imeddayen ad yeǧǧ isnasen-nniḍen deg yibenk-ik·im ad kecmen ɣur-sen.\n\nad tkemmleḍ?";
@@ -656,6 +662,7 @@
 "pref_notifications_priority" = "Tazwart";
 "pref_notifications_explain" = "Rmed ilɣa n unagraw i yiznan imaynuten";
 "pref_show_notification_content" = "Sken agbur n yizen deg ulɣu";
+// deprecated
 "pref_show_notification_content_explain" = "Sken-d amazan akked wawalen imezwura n yizen deg yilɣa";
 "pref_led_color" = "Ini LED";
 "pref_sound" = "Imesli";
@@ -696,16 +703,23 @@
 "pref_background" = "Tugniwin n ugilal";
 "pref_background_btn_default" = "Seqdec tugna tamezwert";
 "pref_background_btn_gallery" = "Fren seg timidelt";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Ma tbeddleḍ aɣewwaṛ-a, senqed aqeddac-ik·im d yimsaɣen-ik·im-nniḍen ad ttuswelen akken iwata.\n\nMa ulac, yezmer lḥal ur tteddunt ara akk tɣawsiwin.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Askar n tugett n yibenk";
 "pref_multidevice_explain" = "Mtawi iznan-ik·im akked ibenkan-nniḍen. Irmed s wudem awurman deg tmerna n yibenk wis sin";
 "pref_multidevice_change_warn" = "Askar aget-ibenk yessefk ad yettwarmed mi ara tesqedceḍ yiwen n umaɣnu deg ddeqs n yibenkan. Sens kan aɣewwaṛ-agi ma yella tekkseḍ amaɣnu-yagi seg yibenkan-ik·im nniḍen.\n\nAsens n usakar n waget-ibenk mi ara tesqedceḍ amaɣnu ɣef ddeqs n yibenkan ad d-yeglu s yiznan yettwazeglen akked wuguren-nniḍen.";
+// deprecated
 "pref_auto_folder_moves" = "Ddu s wudem awurman ɣer ukaram n DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Awi-d kan seg akaram n DeltaChat";
+// deprecated
 "pref_show_emails" = "Sken imaylen iklasanen";
+// deprecated
 "pref_show_emails_no" = "Ala, idiwenniyen kan";
+// deprecated
 "pref_show_emails_accepted_contacts" = "I yinermisen yettwaqeblen";
+// deprecated
 "pref_show_emails_all" = "Akk";
 "pref_experimental_features" = "Timahilin tirmitanin";
 "pref_experimental_features_explain" = "Timahilin-agi zemrent ad ilint ur rkident ara, daɣen zemrent ad ttwabeddlent neɣ ad ttwakksent";
@@ -757,14 +771,17 @@
 // automatically delete message
 "delete_old_messages" = "Kkes iznan iqbuṛen";
 "autodel_device_title" = "Kkes iznan seg yibenk";
+// deprecated
 "autodel_server_title" = "Kkes iznan seg uqeddac";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Tebɣiḍ ad tekkseḍ %1$d n iznan tura akk d yiznan imaynuten \"%2$@\" ɣer zdat?\n\n• Deg-s akk imidyaten\n\n• Iznan ad ttwakksen ma yella ttwalan neɣ ala\n\n• \"Iznan yettwaskelsen\" ad ttwazeglen seg tukksa tadigant";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Tebɣiḍ ad tekkseḍ %1$d n iznan tura akk d yiznan imaynuten \"%2$@\" ɣer zdat?\n\n⚠️ Ayagi yegber imaylen, imidyaten akked \" iznan yettwakelsen \" deg ikaramen meṛṛa n uqeddac\n\n⚠️ Ur sseqdac ara tawuri-a ma tebɣiḍ ad teǧǧeḍ isefka ɣef uqeddac neɣ ma tesqedceḍ imsaɣen n yimaylen iklasikiyen daɣen";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Ayagi yegber imaylen, imidyaten akked \" iznan yettwakelsen \" deg ikaramen meṛṛa n uqeddac. Ur sseqdac ara tawuri-a ma tebɣiḍ ad teǧǧeḍ isefka ɣef uqeddac neɣ ma tesqedceḍ imsaɣen n yimaylen iklasikiyen daɣen";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Rmed tukksa n dindin";
+// deprecated
 "autodel_server_warn_multi_device" = "Ma tremdeḍ tukksa n dindin ur tezmireḍ ara ad tesqedceḍ aṭas n yibenkan deg umaɣnu-a. ";
 "autodel_confirm" = "Fehmeɣ, kkes akk iznan-agi";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -856,7 +873,7 @@
 "invalid_unencrypted_explanation" = "Akken ad tesbeddeḍ awgelhen n yixef ɣer yixef, tzemreḍ ad temlileḍ inermisen s timmad-nsen u ad ḍummeḍ tangalt-nsen QR akken ad ten-id-tesmendeḍ.";
 "learn_more" = "Issin ugar";
 "devicemsg_self_deleted" = "Tekkseḍ adiwenni n \" iznan yettwakelsen \".\n\nℹ️ Akken ad tesqedceḍ tamahilt \" iznan yettwakelsen \", rnu adiwenni amaynut akked yiman-ik·im. ";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️Asaǧǧaw-ik·im n usekles qrib ad yaččar: %1$@%% yettwaseqdec yakan.\n\nAhat ur tezmireḍ ara ad d-remseḍ iznan ma yella asekles yeččur.\n\n 👉 Ttxil-k·m senqed ma yella tzemreḍ ad tekkseḍ isefka iqburen deg ugrudem n web n isaǧǧawen syin rmed \"Iɣewwaṛen / Idiwenniyen / Kkes iznan iqbuṛen\". Tzemreḍ ad tesneqdeḍ aseqdec n usekles-inek·inem amiran deg \"Iɣewwaṛen / tuqqna\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Azemz neɣ akud deg yibenk-ik·im yettban-d ur iṣeḥḥa ara (%1$@).\n\nṢeggem tamasragt-ik·im ⏰🔧Akken ad neḍmen d akken iznan-ik·im ad ttwaremsen akken iwata. ";

--- a/deltachat-ios/kab.lproj/Localizable.stringsdict
+++ b/deltachat-ios/kab.lproj/Localizable.stringsdict
@@ -189,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Azen afylu-agi ɣer %s?</string>
+			<string>Azen afylu-agi ɣer %2$@?</string>
 			<key>other</key>
-			<string>Azen %d ifuyla-agi ɣer %s?</string>
+			<string>Azen %d ifuyla-agi ɣer %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/ko.lproj/Localizable.strings
+++ b/deltachat-ios/ko.lproj/Localizable.strings
@@ -110,6 +110,7 @@
 "camera" = "카메라";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "캡쳐";
+// Switch eg. from front to back camera
 "switch_camera" = "카메라 전환";
 "toggle_fullscreen" = "전체 화면 모드 전환";
 "location" = "위치";
@@ -219,12 +220,14 @@
 "mute_for_one_day" = "1일 동안 알림 끄기";
 "mute_for_seven_days" = "7일 동안 알림 끄기";
 "mute_forever" = "영구히 음소거";
+// deprecated
 "share_location_for_5_minutes" = "5분 동안";
 "share_location_for_30_minutes" = "30분 동안";
 "share_location_for_one_hour" = "1시간 동안";
 "share_location_for_two_hours" = "2시간 동안";
 "share_location_for_six_hours" = "6시간 동안";
 "file_saved_to" = "파일 \"%1$@\"에 저장됨.";
+// deprecated, use ask_forward_messages
 "ask_forward" = "%1$@님에게 메시지를 전달할까요?";
 "ask_forward_multiple" = "%1$d 채팅으로 메시지를 전달하시겠습니까?";
 "ask_export_attachment" = "첨부 파일을 내보내면 단말기의 다른 앱에서 해당 첨부 파일에 액세스할 수 있습니다.\n\n계속하시겠습니까?";
@@ -396,6 +399,7 @@
 "pref_notifications_priority" = "우선순위";
 "pref_notifications_explain" = "새 메시지에 대한 시스템 알림 활성화";
 "pref_show_notification_content" = "알림에 메시지 내용 표시";
+// deprecated
 "pref_show_notification_content_explain" = "알림에서 메시지를 보낸 사람과 첫 번째 단어를 표시합니다.";
 "pref_led_color" = "LED 색상";
 "pref_sound" = "알림음";
@@ -430,11 +434,17 @@
 "pref_background" = "채팅방 배경화면";
 "pref_background_btn_default" = "기본 이미지 사용";
 "pref_background_btn_gallery" = "갤러리에서 선택됨";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "이 선택사항을 변경할 경우, 서버와 다른 클라이언트가 적절하게 구성되어 있는지 확인하십시오.\n\n그렇지 않으면 상황이 전혀 작동하지 않을 수 있습니다.";
+// deprecated
 "pref_auto_folder_moves" = "DeltaChat 폴더로 자동 이동";
+// deprecated
 "pref_only_fetch_mvbox_title" = "DeltaChat 폴더에서만 가져오기";
+// deprecated
 "pref_show_emails_no" = "아뇨, 오직 채팅만";
+// deprecated
 "pref_show_emails_accepted_contacts" = "승인된 연락처의 경우";
+// deprecated
 "pref_show_emails_all" = "전부";
 "pref_on_demand_location_streaming" = "주문형 위치 스트리밍";
 "pref_background_default" = "기본 배경";
@@ -463,10 +473,11 @@
 // automatically delete message
 "delete_old_messages" = "오래된 메시지 삭제";
 "autodel_device_title" = "기기에서 메시지 삭제";
+// deprecated
 "autodel_server_title" = "서버에서 메시지 삭제";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "%1$d 메시지와 새로 가져온 모든 메시지 \"%2$@\"를 나중에 삭제하시겠습니까?\n\n• 여기에는 모든 미디어가 포함됩니다.\n\n• 메시지가 표시되었는지 여부에 관계없이 삭제됩니다.\n\n• \"저장된 메시지\"는 로컬 삭제에서 건너뜁니다.";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "여기에는 모든 서버 폴더에 있는 전자 메일, 미디어 및 \"저장된 메시지\"가 포함됩니다. 서버에 데이터를 보관하거나 Delta Chat 외에 다른 이메일 클라이언트를 사용하는 경우 이 기능을 사용하지 마십시오.";
 "autodel_confirm" = "알겠습니다. 모든 메시지를 삭제하세요.";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -534,7 +545,7 @@
 // %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name of the contact
 "ephemeral_timer_weeks_by_other" = "%2$@가 사라지는 메시지 타이머를 %1$@주로 설정함.";
 "devicemsg_self_deleted" = "저장된 메시지 대화를 삭제했습니다.\n\nℹ️\"저장된 메시지\" 기능을 다시 사용하려면 자신과의 대화를 새로 만드십시오.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ 공급자의 저장공간이 곧 고갈될 예정입니다. %1$@%%가 이미 사용 중입니다.\n\n저장공간이 가득 찬 경우 메시지를 수신하지 못할 수 있습니다.\n\n👉 공급자의 웹 인터페이스에서 이전 데이터를 삭제할 수 있는지 확인하고 \"설정 / 이전 메시지 삭제\"를 활성화하는 것을 고려하십시오. \"설정/연결\"에서 언제든지 현재 저장공간 사용량을 확인할 수 있습니다.";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ 장치의 날짜 또는 시간이 정확하지 않은 것 같습니다(%1$@).\n\n메시지가 올바르게 수신되도록 시계 ⏰🔧를 조정하세요.";

--- a/deltachat-ios/ko.lproj/Localizable.stringsdict
+++ b/deltachat-ios/ko.lproj/Localizable.stringsdict
@@ -125,7 +125,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%s에게 %d파일을 보낼까요?</string>
+			<string>%2$@에게 %d파일을 보낼까요?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_messages</key>

--- a/deltachat-ios/lt.lproj/Localizable.strings
+++ b/deltachat-ios/lt.lproj/Localizable.strings
@@ -51,7 +51,9 @@
 "media" = "Medija";
 "apps_and_media" = "Programėlės ir medija";
 "profile" = "Profilis";
+// deprecated
 "all_profiles" = "Visi profiliai";
+// deprecated
 "current_profile" = "Dabartinis profilis";
 "main_menu" = "Pagrindinis meniu";
 "start_chat" = "Pradėti pokalbį";
@@ -66,6 +68,7 @@
 "always" = "Visada";
 "always_load_remote_images" = "Visada įkelti nuotolinius paveikslus";
 "once" = "Vieną kartą";
+// deprecated
 "show_warning" = "Rodyti įspėjimą";
 "not_now" = "Ne dabar";
 "never" = "Niekada";
@@ -132,6 +135,7 @@
 "documents" = "Dokumentai";
 "contact" = "Adresatas";
 "camera" = "Kamera";
+// Switch eg. from front to back camera
 "switch_camera" = "Perjungti kamerą";
 "toggle_fullscreen" = "Perjungti viso ekrano veikseną";
 "location" = "Vieta";
@@ -287,6 +291,7 @@
 "mute_for_one_day" = "Išjungti 1 dienai";
 "mute_for_seven_days" = "Išjungti 7 dienoms";
 "mute_forever" = "Išjungti visam laikui";
+// deprecated
 "share_location_for_5_minutes" = "5 minutėms";
 "share_location_for_30_minutes" = "30 minučių";
 "share_location_for_one_hour" = "1 valandai";
@@ -328,6 +333,7 @@
 "ask_leave_group" = "Ar tikrai norite išeiti?";
 "ask_delete_named_chat" = "Ištrinti pokalbį „%1$@“?";
 "ask_delete_message" = "Ištrinti šią žinutę visuose jūsų įrenginiuose?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Persiųsti žinutes %1$@?";
 "ask_export_attachment" = "Eksportuoti priedą? Priedų eksportavimas leis bet kurioms kitoms programėlėms jūsų įrenginyje turėti prieigą prie šių priedų.\n\nTęsti?";
 "ask_block_contact" = "Užblokuoti šį adresatą? Jūs daugiau nebegausite žinučių nuo šio adresato.";
@@ -580,6 +586,7 @@
 "pref_notifications_priority" = "Pirmenybė";
 "pref_notifications_explain" = "Įjungti sistemos pranešimus apie naujas žinutes";
 "pref_show_notification_content" = "Rodyti pranešime žinutės turinį";
+// deprecated
 "pref_show_notification_content_explain" = "Rodyti pranešimuose siuntėjo vardą ir pirmuosius žinutės žodžius";
 "pref_led_color" = "Šviesos diodo spalva";
 "pref_sound" = "Garsas";
@@ -619,14 +626,20 @@
 "pref_background" = "Fonas";
 "pref_background_btn_default" = "Naudoti numatytąjį paveikslą";
 "pref_background_btn_gallery" = "Pasirinkti iš galerijos";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Jeigu išjungiate šį parametrą, įsitikinkite, kad jūsų serveris ir kiti klientai yra sukonfigūruoti atitinkamai.\n\nPriešingu atveju, tai gali iš viso neveikti.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Kelių įrenginių veiksena";
 "pref_multidevice_explain" = "Sinchronizuoti jūsų žinutes su kitais įrenginiais. Automatiškai įjungta, kai pridėtas antrasis įrenginys";
+// deprecated
 "pref_auto_folder_moves" = "Automatiniai perkėlimai į DeltaChat aplanką";
+// deprecated
 "pref_show_emails" = "Rodyti klasikinius el. laiškus";
+// deprecated
 "pref_show_emails_no" = "Ne, tik pokalbius";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Iš priimtų adresatų";
+// deprecated
 "pref_show_emails_all" = "Iš visų";
 "pref_experimental_features" = "Eksperimentinės ypatybės";
 "pref_experimental_features_explain" = "Šios ypatybės gali būti nestabilios ir gali būti pakeistos ar pašalintos";
@@ -674,6 +687,7 @@
 // automatically delete message
 "delete_old_messages" = "Ištrinti senas žinutes";
 "autodel_device_title" = "Ištrinti žinutes iš įrenginio";
+// deprecated
 "autodel_server_title" = "Ištrinti žinutes iš serverio";
 "autodel_confirm" = "Aš suprantu, ištrinti visas šias žinutes";
 // "At once" in the meaning of "Immediately", without any intervening time.

--- a/deltachat-ios/nb.lproj/Localizable.strings
+++ b/deltachat-ios/nb.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 "downloading" = "Laster ned...";
 "open_attachment" = "Åpne vedlegg";
 "join" = "Bli med";
+"join_group" = "Bli med i gruppe";
+"join_channel" = "Bli med i kanal";
 "rejoin" = "Bli med igjen";
 "delete" = "Slett";
 "delete_for_me" = "Slett for meg";
@@ -57,7 +59,9 @@
 "media" = "Media";
 "apps_and_media" = "Apper & Media";
 "profile" = "Profil";
+// deprecated
 "all_profiles" = "Alle profiler";
+// deprecated
 "current_profile" = "Gjeldende profil";
 "main_menu" = "Hovedmeny";
 "start_chat" = "Start chat";
@@ -68,6 +72,10 @@
 "mark_as_read" = "Merk som lest";
 // Used beside an icon with very few space. Shortest text for "Mark as being read". In english, this could be "Read" (past tense of "to read"), in german, this could be "Gelesen".
 "mark_as_read_short" = "Lest";
+// Used as an menu entry or button
+"mark_as_unread" = "Merk som ulest";
+// Used beside an icon with very few space. Shortest text for "Mark as being unread". In english, this could be "Unread" (past tense of "to unread"), in german, this could be "Ungelesen".
+"mark_as_unread_short" = "Ulest";
 // Placeholder text when something is loading
 "loading" = "Laster...";
 "hide" = "Skjul";
@@ -78,6 +86,7 @@
 "always" = "Alltid";
 "always_load_remote_images" = "Last alltid eksterne bilder";
 "once" = "Én gang";
+// deprecated
 "show_warning" = "Vis advarsel";
 "not_now" = "Ikke nå";
 "never" = "Aldri";
@@ -87,6 +96,7 @@
 "offline" = "Avlogget";
 // For the next view or as "continue". Should be as short as possible.
 "next" = "Neste";
+"warning" = "Advarsel";
 "error" = "Feil";
 "error_x" = "Feil: %1$@";
 "no_app_to_handle_data" = "Kan ikke finne en app som kan handtere denne typen data.";
@@ -114,10 +124,14 @@
 // Refers to the time a contact was last seen. Shown below contact name in the profile. The placeholder will be replaced by a relative point in time as "3 minutes ago" (see https://momentjs.com for more examples and languages)
 "last_seen_relative" = "Sist sett %1$@";
 "last_seen_unknown" = "Sist sett: uvisst";
+// Call duration as shown in the call bubbles. There is some risk to mix with the sending time, so the word "Duration" may be helpful. Might also be "Duration: %d minutes", "%d-minute duration", "%d-minute length" or "%d-minute call"
+// Call duration as shown in the call bubbles in case the call is less than one minute. If the context is not clear enough, one may want to add the word "Duration".
+"call_duration_less_than_a_minute" = "Mindre enn 1 minutt";
 // Shown beside messages that are "N minutes old". Prefer short strings, or well-known abbreviations.
 // Shown beside messages that are "N hours old". Prefer short strings, or well-known abbreviations.
 // Short form for "N Items Selected"
 "selected_colon" = "Valgt:";
+"selected" = "Valgt";
 "self" = "Meg";
 "draft" = "Kladd";
 "image" = "Bilde";
@@ -131,6 +145,9 @@
 "add_stickers_instructions" = "For å legge til merker, trykk på \"Åpne merkemappe\", lag en undermappe for merkepakken, og dra bilder og merkefiler dit";
 // deprecated
 "open_sticker_folder" = "Åpne merkemappe";
+"ask_add_sticker_to_collection" = "Legg dette merket til samlingen din?";
+"ask_delete_sticker" = "Slett dette merket?";
+"sticker_picker_empty_hint" = "Trykk på et merke for å legge det til her.";
 "images" = "Bilder";
 // a noun, used for "Music" and other "Audio" files
 "audio" = "Lyd";
@@ -146,6 +163,7 @@
 "camera" = "Kamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Ta opp";
+// Switch eg. from front to back camera
 "switch_camera" = "Bytt kamera";
 "toggle_fullscreen" = "Vis fullskjerm";
 "location" = "Posisjon";
@@ -208,6 +226,7 @@
 "new_channel" = "Ny kanal";
 // consider keeping the term "channel" as in WhatsApp or Telegram
 "channel_name" = "Kanalnavn";
+// The number of times a message is shown in channels. Use what other messengers are using here, smth. as "N-times seen" or "1 Aufruf" (german) work as well, where "1 impression" or "1 hit" may sound too formal and may be more marketing slang.
 "email" = "E-post";
 // "New" as in "Create New Email"; shown together with "New Group" and "New Channel"
 "new_email" = "Ny e-post";
@@ -223,6 +242,7 @@
 "menu_add_attachment" = "Legg ved filer";
 "menu_leave_group" = "Forlat gruppe";
 "menu_leave_channel" = "Forlat kanal";
+"menu_leave_and_delete" = "Forlat & slett for meg";
 "menu_delete_chat" = "Slett chat";
 // Command to delete all messages in a chat. The chat itself will not be deleted but will be empty afterwards, so make sure to be different from "Delete Chat" here. "Clear" is a verb here, "Empty Chat" would also be fine (eg. in German "Chat leeren")
 "clear_chat" = "Tøm chat";
@@ -311,26 +331,58 @@
 "mute_for_one_day" = "Demp i 1 dag";
 "mute_for_seven_days" = "Demp i 7 dager";
 "mute_forever" = "Alltid dempet";
+// deprecated
 "share_location_for_5_minutes" = "i 5 minutter";
 "share_location_for_30_minutes" = "i 30 minutter";
 "share_location_for_one_hour" = "i 1 time";
 "share_location_for_two_hours" = "i 2 timer";
 "share_location_for_six_hours" = "i 6 timer";
+"share_location_for_24_hours" = "i 24 timer";
 "file_saved_to" = "Lagre fil til \"%1$@\".";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "Ring";
+// Menu item to start an audio call; verbs as "start" are probably superfluous in many translations
+"start_audio_call" = "Lydsamtale";
+// Menu item to start a video call; verbs as "start" are probably superfluous in many translations
+"start_video_call" = "Videosamtale";
 // the action "to answer" or to "accept" or to "pick up" a call. not: "the answer"
 "answer_call" = "Svar";
 // the action "to decline" a call, not: "the decline"
 "end_call" = "Avvis";
+// Used in call bubbles, summaries, notifications
+"audio_call" = "Lydsamtale";
+// Used in call bubbles, summaries, notifications
+"video_call" = "Videosamtale";
+"call_initializing" = "Initialiserer...";
+"call_incoming" = "Inkommende samtale";
+"call_ringing" = "Ringer...";
+"call_reconnecting" = "Gjenoppretter forbindelsen...";
+"call_ended" = "Samtale avsluttet";
+"call_failed" = "Samtale feilet";
+// deprecated, use "Audio call" instead
+"outgoing_audio_call" = "Utgående lydsamtale";
+// deprecated, use "Video call" instead
+"outgoing_video_call" = "Utgående videosamtale";
+// deprecated, use "Audio call" instead
+"incoming_audio_call" = "Inkommende lydsamtale";
+// deprecated, use "Video call" instead
+"incoming_video_call" = "Inkommende videosamtale";
 "declined_call" = "Avvist anrop";
 "canceled_call" = "Avbrutt anrop";
 "missed_call" = "Ubesvart anrop";
+"already_in_call" = "Allerede i en samtale";
+"call_answered_elsewhere" = "Samtale besvart på en annen enhet";
+"call_requires_mic_permission" = "Mikrofontillatelse er nødvendig for samtaler";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "Samtale med %1$@";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "Ringer %1$@...";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Er du sikker på at du vil forlate?";
 "ask_delete_named_chat" = "Slett chatten \"%1$@\" fra alle dine enheter?";
 "ask_delete_message" = "Slett denne meldingen fra alle dine enheter?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Videresend meldinger til %1$@?";
 "ask_forward_multiple" = "Videresend meldinger til %1$d chatter?";
 "ask_export_attachment" = "Eksporter vedlegg? Eksport av vedlegg vil gi andre apper på din enhet tilgang til dem\n\nFortsett?";
@@ -392,19 +444,61 @@
 "send_file_to" = "Send \"%1$@\" til…";
 // title shown above a list contacts where one should be selected (eg. when a webxdc attempts to send a message to a chat)
 "send_message_to" = "Send melding til…";
+// punycode warning / labeled links
+"puny_code_warning_header" = "Mistenkelig lenke oppdaget";
+// placeholder contains the hostname converted to ascii
+"puny_code_warning_question" = "Er du sikker på at du vil besøke %1$@?";
 // search
 "search" = "Søk";
+"search_in_chat" = "Søk i chat";
+// Placeholder will be replaced by the chat name
+"search_in" = "Søk i %1$@ ";
+"search_files" = "Søk i filer";
+"search_explain" = "Søk etter chatter, kontakter, og meldinger";
+"search_result_for_x" = "Resultat for \"%1$@\"";
+"search_no_result_for_x" = "Ingen resultater funnet for \"%1$@\"";
+// Adjective, as in "Show Unread Messages"
+"search_unread" = "Ulest";
 // create/edit groups, contact/group profile
 "group_name" = "Gruppenavn";
+"group_avatar" = "Gruppebilde";
+"remove_group_image" = "Fjern gruppebilde";
+"change_group_image" = "Endre gruppebilde";
 "group_create_button" = "Lag gruppe";
+// deprecated, use please_enter_chat_name
+"group_please_enter_group_name" = "Skriv inn et navn på gruppen.";
+"please_enter_chat_name" = "Skriv inn et navn.";
 "group_add_members" = "Legg til medlem";
+"group_self_not_in_group" = "Du må være medlem av gruppen for å utføre denne handlingen.";
 "profile_encryption" = "Kryptering";
 "profile_shared_chats" = "Delte chatter";
+// Separator between the list of actual members and past members
+"past_members" = "Tidligere medlemmer";
 "tab_contact" = "Kontakt";
 "tab_group" = "Gruppe";
 "tab_gallery" = "Galleri";
 "tab_docs" = "Dokumenter";
+"tab_links" = "Lenker";
+"tab_map" = "Kart";
+"tab_gallery_empty_hint" = "Bilder og videor tilknyttet denne chatten vil vises her.";
+"tab_docs_empty_hint" = "Dokumenter og andre filer tilknyttet denne chatten vil vises her.";
+"tab_image_empty_hint" = "Bilder tilknyttet denne chatten vil vises her.";
+"tab_video_empty_hint" = "Videoer tilknyttet denne chatten vil vises her.";
+"tab_audio_empty_hint" = "Lydfiler og talebeskjeder tilknyttet denne chatten vil vises her.";
+"tab_webxdc_empty_hint" = "Apper tilknyttet denne chatten vil vises her.";
+"tab_all_media_empty_hint" = "Media tilknyttet denne chatten vil vises her.";
+"all_files_empty_hint" = "Dokumenter og andre filer tilknyttet alle chatter vil vises her.";
+"all_apps_empty_hint" = "Apper tilknyttet alle chatter vil vises her.";
 "media_preview" = "Forhåndsvisning av medier";
+// option to show images in the gallery with the correct width/height aspect (instead of square); other gallery apps may be a source of inspiration for translation :)
+"aspect_ratio_grid" = "Rutenett for størrelsesforhold";
+// option to show images in the gallery as square (instead of using correct width/height)
+"square_grid" = "Kvadratisk rutenett";
+"send_message" = "Send melding";
+// Multi Device
+// "Second Device" can also be translated as "Another Device", if that is catchier in the destination language. However, make sure to use the term consistently.
+"multidevice_title" = "Legg til annen enhet";
+"multidevice_same_network_hint" = "Sørg for at begge enhetene er tilkoblet samme Wi-Fi eller nettverk";
 "login_title" = "Logg inn";
 "login_inbox" = "Innboks";
 "login_imap_login" = "IMAP-innloggingsnavn";

--- a/deltachat-ios/nb.lproj/Localizable.stringsdict
+++ b/deltachat-ios/nb.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>call_duration_minutes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@localized_format_key@</string>
+		<key>localized_format_key</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minutters varighet</string>
+			<key>other</key>
+			<string>%d minutters varighet</string>
+		</dict>
+	</dict>
 	<key>n_minutes</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -146,6 +162,22 @@
 			<string>%d valgte</string>
 		</dict>
 	</dict>
+	<key>n_views</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@localized_format_key@</string>
+		<key>localized_format_key</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d utsikt</string>
+			<key>other</key>
+			<string>%d visninger</string>
+		</dict>
+	</dict>
 	<key>ask_send_following_n_files_to</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -157,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Sende følgende fil til %s?</string>
+			<string>Sende følgende fil til %2$@?</string>
 			<key>other</key>
-			<string>Sende de følgende %d filene til %s?</string>
+			<string>Sende de følgende %d filene til %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/nl.lproj/Localizable.strings
+++ b/deltachat-ios/nl.lproj/Localizable.strings
@@ -59,7 +59,9 @@
 "media" = "Media";
 "apps_and_media" = "Apps en media";
 "profile" = "Profiel";
+// deprecated
 "all_profiles" = "Alle profielen";
+// deprecated
 "current_profile" = "Huidig profiel";
 "main_menu" = "Hoofdmenu";
 "start_chat" = "Gesprek beginnen";
@@ -84,6 +86,7 @@
 "always" = "Altijd";
 "always_load_remote_images" = "Externe afbeeldingen altijd laden";
 "once" = "Eenmalig";
+// deprecated
 "show_warning" = "Waarschuwing tonen";
 "not_now" = "Niet nu";
 "never" = "Nooit";
@@ -160,6 +163,7 @@
 "camera" = "Camera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Vastleggen";
+// Switch eg. from front to back camera
 "switch_camera" = "Andere camera";
 "toggle_fullscreen" = "Schermvullende weergave aan/uit";
 "location" = "Locatie";
@@ -327,11 +331,13 @@
 "mute_for_one_day" = "1 dag lang uitschakelen";
 "mute_for_seven_days" = "7 dagen lang uitschakelen";
 "mute_forever" = "Permanent uitschakelen";
+// deprecated
 "share_location_for_5_minutes" = "5 minuten lang";
 "share_location_for_30_minutes" = "30 minuten lang";
 "share_location_for_one_hour" = "1 uur lang";
 "share_location_for_two_hours" = "2 uur lang";
 "share_location_for_six_hours" = "6 uur lang";
+"share_location_for_24_hours" = "24 uur lang";
 "file_saved_to" = "Het bestand is opgeslagen in ‘%1$@’.";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "Bellen";
@@ -367,11 +373,16 @@
 "already_in_call" = "Reeds in gesprek";
 "call_answered_elsewhere" = "Er is opgenomen op een ander apparaat";
 "call_requires_mic_permission" = "Microfoontoegang is vereist om te kunnen bellen";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "Bellen met %1$@";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "Aan het bellen met %1$@…";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Weet je zeker dat je dit kanaal wilt verlaten?";
 "ask_delete_named_chat" = "Wil je ‘%1$@’ verwijderen?";
 "ask_delete_message" = "Wil je dit bericht verwijderen?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Wil je de berichten doorsturen aan %1$@?";
 "ask_forward_multiple" = "Wil je de berichten doorsturen naar %1$d gesprekken?";
 "ask_export_attachment" = "Als je de bijlage exporteert, geef je andere apps op je apparaat toegang om hem uit te lezen.\n\nWil je doorgaan?";
@@ -671,6 +682,7 @@
 "pref_notifications_priority" = "Prioriteit";
 "pref_notifications_explain" = "Systeemmeldingen tonen bij nieuwe berichten";
 "pref_show_notification_content" = "Berichtinhoud tonen op meldingen";
+// deprecated
 "pref_show_notification_content_explain" = "Toont de afzender en eerste regel van berichten op meldingen";
 "pref_led_color" = "Ledkleur";
 "pref_sound" = "Geluid";
@@ -713,16 +725,23 @@
 "pref_background" = "Achtergrond";
 "pref_background_btn_default" = "Standaardafbeelding gebruiken";
 "pref_background_btn_gallery" = "Kiezen uit galerij";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Als je deze optie uitschakelt, zorg er dan voor dat je server en overige clients goed ingesteld zijn.\n\nAls dat niet zo is, dan werkt het misschien helemaal niet.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Meerdere apparaten";
 "pref_multidevice_explain" = "Synchroniseer berichten met andere apparaten. Dit wordt automatisch ingeschakeld na het toevoegen van een secundair apparaat.";
 "pref_multidevice_change_warn" = "Let op: deze modus moet op alle apparaten worden ingeschakeld op hetzelfde profiel. Schakel deze instelling alleen uit als je je profiel van alle andere apparaten hebt verwijderd.\n\nDoor deze modus uit te schakelen terwijl het profiel nog gebruikt wordt, gaan er berichten verloren en kunnen er andere problemen ontstaan.";
+// deprecated
 "pref_auto_folder_moves" = "Automatisch verplaatsen naar DeltaChat-map";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Alleen DeltaChat-map controleren";
+// deprecated
 "pref_show_emails" = "Klassieke e-mails tonen";
+// deprecated
 "pref_show_emails_no" = "Nee, alleen gesprekken";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Van goedgekeurde contactpersonen";
+// deprecated
 "pref_show_emails_all" = "Alles";
 "pref_experimental_features" = "Experimentele functies";
 "pref_experimental_features_explain" = "Let op: deze functies zijn experimenteel en kunnen te allen tijde worden aangepast of verwijderd";
@@ -774,14 +793,17 @@
 // automatically delete message
 "delete_old_messages" = "Oude berichten verwijderen";
 "autodel_device_title" = "Berichten verwijderen van apparaat";
+// deprecated
 "autodel_server_title" = "Berichten verwijderen van server";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Wil je nu %1$d berichten verwijderen en toekomstige berichten ‘%2$@’?\n\n• Dit omvat alle media\n\n• Berichten worden verwijderd, ongeacht of ze bekeken zijn\n\n• Het gesprek ‘Bewaarde berichten’ wordt overgeslagen.";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Wil je nu %1$d berichten verwijderen en toekomstige berichten ‘%2$@’,?\n\n⚠️ Dit omvat alle berichten, media en het gesprek ‘Bewaarde berichten’.\n\n⚠️ Gebruik deze functie niet als je je gegevens wilt bewaren op de server\n\n⚠️ Gebruik deze functie niet als je ook andere e-mailclients gebruikt";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Dit omvat alle berichten, media en het gesprek ‘Bewaarde berichten’. Gebruik deze functie niet als je je gegevens wilt bewaren op de server of als je ook andere e-mailclients gebruikt.";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Onmiddellijke verwijdering inschakelen";
+// deprecated
 "autodel_server_warn_multi_device" = "Let op: als je deze optie inschakelt, dan kun je geen meerdere apparaten tegelijk meer gebruiken met dit profiel.";
 "autodel_confirm" = "Ik begrijp het; verwijder alle berichten";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -876,7 +898,7 @@
 "invalid_unencrypted_explanation" = "Spreek met elkaar af en scan elkaars QR-code om eind-tot-eindversleuteling op te zetten.";
 "learn_more" = "Meer informatie";
 "devicemsg_self_deleted" = "Je hebt het gesprek ‘Bewaarde berichten’ verwijderd.\n\nℹ️ Als je weer gebruik wilt maken van deze functie, begin dan een nieuw gesprek met jezelf.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ De opslagruimte die je provider biedt is bijna overschreden. Momenteel heb je %1$@%% ervan in gebruik.\n\nAls je geen ruimte meer hebt, kun je mogelijk geen berichten meer ontvangen.\n\n👉 Kijk of je oude gegevens kunt verwijderen in de webclient van je provider. Overweeg ook ‘Instellingen → Oude berichten verwijderen’ in te schakelen. Je kunt je huidige gebruik te allen tijde bekijken via ‘Instellingen → Verbindingen’.";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ De datum en tijd van je apparaat lijken niet te kloppen (%1$@).\n\nVerzet je klok ⏰🔧 om er zeker van te zijn dat je berichten kunt ontvangen.";
@@ -956,8 +978,6 @@
 "new_messages_body" = "Je hebt nieuwe berichten";
 "n_messages_in_m_chats" = "%1$d berichten in %2$d gesprekken";
 // location streaming
-"location_streaming_channel_desc" = "Kanaal voor locatie delen op verzoek";
-"location_streaming_notification_title" = "Locatiedeling";
 "location_streaming_notification_text" = "Je deelt op dit moment je locatie";
 "location_rationale" = "Om je locatie live te kunnen blijven doorgeven aan andere deelnemers, is locatietoegang vereist.\n\nHiervoor is het ook nodig om je locatie op de achtergrond door te geven.";
 // permissions
@@ -1048,6 +1068,8 @@
 "a11y_message_context_menu_btn_label" = "Berichtacties";
 "a11y_background_preview_label" = "Achtergrondvoorbeeld";
 "a11y_disappearing_messages_activated" = "Verdwijnende berichten zijn ingeschakeld";
+// The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility.
+"open_link" = "‘%1$@’ openen";
 // iOS specific strings, developers: please take care to remove strings that are no longer used!
 "stop_sharing_location" = "Stop locatiedeling";
 "a11y_voice_message_hint_ios" = "Dubbeltik op de opname om hem te versturen. Veeg met twee vingers van links naar rechts om de opname af te breken.";

--- a/deltachat-ios/nl.lproj/Localizable.stringsdict
+++ b/deltachat-ios/nl.lproj/Localizable.stringsdict
@@ -189,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Wil je het volgende bestand versturen aan %s?</string>
+			<string>Wil je het volgende bestand versturen aan %2$@?</string>
 			<key>other</key>
-			<string>Wil je de volgende %d bestanden versturen aan %s?</string>
+			<string>Wil je de volgende %d bestanden versturen aan %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/pl.lproj/Localizable.strings
+++ b/deltachat-ios/pl.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 "downloading" = "Pobieranie…";
 "open_attachment" = "Otwórz załącznik";
 "join" = "Dołącz";
+"join_group" = "Dołącz do grupy";
+"join_channel" = "Dołącz do kanału";
 "rejoin" = "Dołącz ponownie";
 "delete" = "Usuń";
 "delete_for_me" = "Usuń u mnie";
@@ -57,7 +59,9 @@
 "media" = "Multimedia";
 "apps_and_media" = "Aplikacje i multimedia";
 "profile" = "Profil";
+// deprecated
 "all_profiles" = "Wszystkie profile";
+// deprecated
 "current_profile" = "Aktualny profil";
 "main_menu" = "Menu główne";
 "start_chat" = "Rozpocznij czat";
@@ -68,6 +72,8 @@
 "mark_as_read" = "Oznacz jako przeczytane";
 // Used beside an icon with very few space. Shortest text for "Mark as being read". In english, this could be "Read" (past tense of "to read"), in german, this could be "Gelesen".
 "mark_as_read_short" = "Przeczytane";
+// Used as an menu entry or button
+"mark_as_unread" = "Oznacz jako nieprzeczytane";
 // Used beside an icon with very few space. Shortest text for "Mark as being unread". In english, this could be "Unread" (past tense of "to unread"), in german, this could be "Ungelesen".
 "mark_as_unread_short" = "Nieprzeczytane";
 // Placeholder text when something is loading
@@ -80,6 +86,7 @@
 "always" = "Zawsze";
 "always_load_remote_images" = "Zawsze wczytuj zdalne obrazy";
 "once" = "Jeden raz";
+// deprecated
 "show_warning" = "Pokaż ostrzeżenie";
 "not_now" = "Nie teraz";
 "never" = "Nigdy";
@@ -89,6 +96,7 @@
 "offline" = "Offline";
 // For the next view or as "continue". Should be as short as possible.
 "next" = "Dalej";
+"warning" = "Ostrzeżenie";
 "error" = "Błąd";
 "error_x" = "Błąd: %1$@";
 "no_app_to_handle_data" = "Nie można znaleźć aplikacji do obsługi tego typu danych.";
@@ -155,6 +163,7 @@
 "camera" = "Kamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Zrób to";
+// Switch eg. from front to back camera
 "switch_camera" = "Przełącz kamerę";
 "toggle_fullscreen" = "Przełącz na tryb pełnoekranowy";
 "location" = "Lokalizacja";
@@ -322,11 +331,13 @@
 "mute_for_one_day" = "Wyłącz na 1 dzień";
 "mute_for_seven_days" = "Wyłącz na 7 dni";
 "mute_forever" = "Wyłącz na zawsze";
+// deprecated
 "share_location_for_5_minutes" = "na 5 minut";
 "share_location_for_30_minutes" = "na 30 mninut";
 "share_location_for_one_hour" = "na 1 godzinę";
 "share_location_for_two_hours" = "na 2 godziny";
 "share_location_for_six_hours" = "na 6 godzin";
+"share_location_for_24_hours" = "na 24 godziny";
 "file_saved_to" = "Plik zapisany w „%1$@";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "Zadzwoń";
@@ -360,11 +371,18 @@
 "canceled_call" = "Połączenie anulowane";
 "missed_call" = "Połączenie anulowane";
 "already_in_call" = "Już w trakcie rozmowy";
+"call_answered_elsewhere" = "Połączenie odebrane na innym urządzeniu";
+"call_requires_mic_permission" = "Do połączeń wymagane jest zezwolenie na korzystanie z mikrofonu";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "Rozmowa z %1$@";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "Dzwonię do %1$@…";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Na pewno chcesz opuścić?";
 "ask_delete_named_chat" = "Usunąć czat „%1$@”?";
 "ask_delete_message" = "Usunąć tę wiadomość?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Przekazać wiadomości do użytkownika %1$@?";
 "ask_forward_multiple" = "Przekazać wiadomości do %1$d czatów?";
 "ask_export_attachment" = "Eksportować załącznik? Eksportowanie załączników umożliwi dostęp do nich innym aplikacjom na urządzeniu.\n\nKontynuować?";
@@ -435,8 +453,11 @@
 // search
 "search" = "Szukaj";
 "search_in_chat" = "Wyszukaj w czacie";
+// Placeholder will be replaced by the chat name
+"search_in" = "Wyszukaj w %1$@";
 "search_files" = "Szukaj plików";
 "search_explain" = "Wyszukaj czaty, kontakty i wiadomości";
+"search_result_for_x" = "Wynik dla „%1$@”";
 "search_no_result_for_x" = "Nie znaleziono wyników dla „%1$@";
 // Adjective, as in "Show Unread Messages"
 "search_unread" = "Nieprzeczytane";
@@ -448,6 +469,7 @@
 "group_create_button" = "Utwórz grupę";
 // deprecated, use please_enter_chat_name
 "group_please_enter_group_name" = "Podaj nazwę dla grupy";
+"please_enter_chat_name" = "Wpisz nazwę.";
 "group_add_members" = "Dodaj członków";
 "group_self_not_in_group" = "Musisz być członkiem grupy, aby wykonać tę czynność.";
 "profile_encryption" = "Szyfrowanie";
@@ -632,10 +654,10 @@
 "pref_profile_photo" = "Zdjęcie profilowe";
 "pref_blocked_contacts" = "Zablokowane kontakty";
 "blocked_empty_hint" = "Zablokowane kontakty, zostaną pokazane tutaj.";
-"pref_who_can_see_profile_explain" = "Twoje zdjęcie profilowe, nazwa i biografia będą wyświetlane wraz z wiadomościami podczas komunikacji z innymi użytkownikami. Już wysłanych informacji nie można skasować ani usunąć.";
+"pref_who_can_see_profile_explain" = "Twoje zdjęcie profilowe, nazwa i biografia zostaną wysłane razem z wiadomościami, podczas komunikacji z innymi użytkownikami.";
 "pref_your_name" = "Twoja nazwa";
 // Label of the Bio/Signature/Status/Motto field
-"pref_default_status_label" = "Tekst podpisu";
+"pref_default_status_label" = "Biografia";
 "chat_description" = "Opis";
 // Option name for changing behaviour of the "Enter key" to sending out a message directly (instead of adding new line). If in doubt, please refer to a similar option in other messengers.
 "pref_enter_sends" = "Enter wysyła";
@@ -660,6 +682,7 @@
 "pref_notifications_priority" = "Priorytet";
 "pref_notifications_explain" = "Włącz powiadomienia systemowe o nowych wiadomościach";
 "pref_show_notification_content" = "Pokaż treść wiadomości w powiadomieniu";
+// deprecated
 "pref_show_notification_content_explain" = "Pokaż nadawcę i pierwsze słowa wiadomości w powiadomieniach";
 "pref_led_color" = "Kolor LED-a";
 "pref_sound" = "Dźwięk";
@@ -678,6 +701,8 @@
 "pref_incognito_keyboard_explain" = "Poproś klawiaturę o wyłączenie spersonalizowanej nauki";
 "pref_read_receipts" = "Potwierdzenie odczytu";
 "pref_read_receipts_explain" = "Jeśli potwierdzenia odczytu zostaną wyłączone, nie będzie można zobaczyć potwierdzeń odczytu od innych osób.";
+// Title above a list of contacts who read a message
+"read_by" = "Przeczytana przez";
 "pref_server" = "Serwer";
 "pref_encryption" = "Szyfrowanie";
 "pref_manage_keys" = "Zarządzaj prywatnymi kluczami";
@@ -700,20 +725,27 @@
 "pref_background" = "Tło";
 "pref_background_btn_default" = "Użyj domyślnego obrazu";
 "pref_background_btn_gallery" = "Wybierz z galerii";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Jeśli zmienisz tę opcję, upewnij się, że twój serwer i inni klienci są odpowiednio skonfigurowani.\n\nW przeciwnym razie wszystko może w ogóle nie działać.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Tryb wielu urządzeń";
 "pref_multidevice_explain" = "Synchronizuj swoje wiadomości z innymi swoimi urządzeniami. Włączane automatycznie po dodaniu drugiego urządzenia";
 "pref_multidevice_change_warn" = "Tryb wielu urządzeń musi być włączony podczas korzystania z tego samego profilu na wielu urządzeniach. Wyłącz to ustawienie tylko wtedy, gdy usuniesz ten profil ze wszystkich pozostałych urządzeń.\n\nWyłączenie trybu wielu urządzeń podczas korzystania z profilu na wielu urządzeniach spowoduje pominięcie wiadomości i inne problemy.";
+// deprecated
 "pref_auto_folder_moves" = "Automatyczne przenoszenie do folderu DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Pobieraj tylko z folderu DeltaChat";
+// deprecated
 "pref_show_emails" = "Pokaż klasyczne e-maile";
+// deprecated
 "pref_show_emails_no" = "Nie, tylko czaty";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Dla zaakceptowanych kontaktów";
+// deprecated
 "pref_show_emails_all" = "Wszystkie";
 "pref_experimental_features" = "Funkcje eksperymentalne";
 "pref_experimental_features_explain" = "Te funkcje mogą być niestabilne i mogą zostać zmienione lub usunięte";
-"pref_on_demand_location_streaming" = "Przesyłanie strumieniowe lokalizacji na żądanie";
+"pref_on_demand_location_streaming" = "Strumieniowanie lokalizacji";
 "pref_background_default" = "Domyślne tło";
 "pref_background_default_color" = "Domyślny kolor";
 "pref_background_custom_image" = "Własny obraz";
@@ -761,14 +793,17 @@
 // automatically delete message
 "delete_old_messages" = "Usuwanie starych wiadomości";
 "autodel_device_title" = "Usuń wiadomości z urządzenia";
+// deprecated
 "autodel_server_title" = "Usuń wiadomości z serwera";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Czy chcesz teraz usunąć %1$d wiadomości i wszystkie nowo pobrane wiadomości w przyszłości „%2$@”?\n\n• Obejmuje to wszystkie multimedia\n\n• Wiadomości zostaną usunięte niezależnie od tego, czy były widoczne, czy nie\n\n• „Zapisane wiadomości” zostaną pominięte podczas lokalnego usuwania";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Czy chcesz teraz usunąć %1$d wiadomości i wszystkie nowo pobrane wiadomości w przyszłości „%2$@”?\n\n⚠️ Obejmuje to e-maile, multimedia i „Zapisane wiadomości” we wszystkich folderach na serwerze.\n\n⚠️ Nie używaj tej funkcji, jeśli chcesz zachować dane na serwerze\n\n⚠️ Nie używaj tej funkcji, jeśli chcesz zachować dane na serwerze lub korzystasz także z klasycznych klientów poczty e-mail";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Obejmuje to e-maile, multimedia i „Zapisane wiadomości” we wszystkich folderach na serwerze. Nie używaj tej funkcji, jeśli chcesz zachować dane na serwerze lub jeśli używasz klasycznych klientów poczty e-mail";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Włącz natychmiastowe usuwanie";
+// deprecated
 "autodel_server_warn_multi_device" = "Jeśli włączysz natychmiastowe usuwanie, nie będzie można używać wielu urządzeń w tym profilu.";
 "autodel_confirm" = "Rozumiem, usuń te wszystkie wiadomości";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -786,9 +821,12 @@
 "group_name_changed_by_you" = "Zmieniono nazwę grupy z „%1$@“ na „%2$@“.";
 // %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action.
 "group_name_changed_by_other" = "Nazwa grupy zmieniona z „%1$@“ na „%2$@“ przez %3$@.";
+// %1$s will be replaced by the old channel name, %2$s will be replaced by the new channel name
+"channel_name_changed" = "Zmieniono nazwę kanału z „%1$@” na „%2$@”.";
 "group_image_changed_by_you" = "Zmieniono obraz grupy.";
 // %1$s will be replaced by name of the contact who did the action
 "group_image_changed_by_other" = "Obraz grupy zmieniony przez %1$@.";
+"channel_image_changed" = "Zmieniono obraz kanału.";
 "chat_description_changed_by_you" = "Zmieniono opis czatu.";
 // %1$s will be replaced by name of the contact who did the action
 "chat_description_changed_by_other" = "Opis czatu zmieniony przez %1$@.";
@@ -860,7 +898,7 @@
 "invalid_unencrypted_explanation" = "Aby ustanowić szyfrowanie end-to-end, możesz spotkać się z kontaktami osobiście i zeskanować ich kod QR, żeby ich zweryfikować.";
 "learn_more" = "Czytaj więcej";
 "devicemsg_self_deleted" = "Usunięto czat „Zapisane wiadomości”.\n\nℹ️ Aby ponownie użyć funkcji „Zapisane wiadomości”, utwórz nowy czat ze sobą.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Limit pamięci u twojego dostawcy wkrótce zostanie przekroczony, wykorzystano już %1$@%%.\n\nMożesz nie być w stanie otrzymywać wiadomości, gdy pamięć jest pełna.\n\n👉 Sprawdzić, czy możesz usunąć stare dane w interfejsie internetowym dostawcy i rozważyć włączenie opcji \"Ustawienia » Czaty » Usuwanie starych wiadomości\". W dowolnym momencie możesz sprawdzić swoje bieżące wykorzystanie pamięci w \"Ustawienia » Łączność\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Data lub godzina urządzenia wydaje się być niedokładna (%1$@).\n\nDostosuj zegar ⏰🔧, aby upewnić się, że wiadomości są prawidłowo odbierane.";
@@ -922,6 +960,8 @@
 // first placeholder is the name of the chat
 "confirm_replace_draft" = "Na czacie %1$@ jest już wersja robocza wiadomości, czy chcesz ją zastąpić?";
 "mailto_link_could_not_be_decoded" = "link mailto nie mógł zostać odszyfrowany: %1$@";
+"remove_quote" = "Usuń cytat";
+"remove_attachment" = "Usuń załącznik";
 // notifications
 "notify_reply_button" = "Odpowiedz";
 "notify_new_message" = "Nowa wiadomość";
@@ -937,6 +977,9 @@
 // Body text for a generic "New messages" notification. Shown if we do not have more information about a new messages. Note, that the string is also referenced at https://github.com/deltachat/notifiers
 "new_messages_body" = "Masz nowe wiadomości";
 "n_messages_in_m_chats" = "%1$d wiadomości w %2$d czatach";
+// location streaming
+"location_streaming_notification_text" = "Udostępniasz swoją lokalizację";
+"location_rationale" = "Aby udostępnić swoją lokalizację na żywo członkom czatu, zezwól aplikacji Delta Chat na korzystanie z danych o twojej lokalizacji.\n\nAby funkcja lokalizacji na żywo działała bez przerw, dane o lokalizacji są używane nawet wtedy, gdy aplikacja jest zamknięta lub nieużywana.";
 // permissions
 "perm_required_title" = "Wymagane zezwolenie";
 "perm_continue" = "Kontynuuj";
@@ -976,6 +1019,7 @@
 "global_menu_help_about_desktop" = "O Delta Chat";
 "global_menu_file_open_desktop" = "Otwórz Delta Chat";
 "global_menu_minimize_to_tray" = "Minimalizuj";
+"no_account_selected" = "Wybierz profil lub utwórz nowy profil";
 "no_chat_selected_suggestion_desktop" = "Wybierz czat lub utwórz nowy czat";
 "write_message_desktop" = "Napisz wiadomość";
 "encryption_info_title_desktop" = "Informacje o szyfrowaniu";
@@ -997,8 +1041,15 @@
 // deprecated, used on desktop although there is not spell checker
 "no_spellcheck_suggestions_found" = "Nie znaleziono propozycji pisowni.";
 "show_window" = "Pokaż okno";
+"data_found_other_installation_message" = "Twoje profile z innej instalacji Delta Chat nie są dostępne – różne instalacje przechowują swoje dane w oddzielnych lokalizacjach.\n\nAby zachować istniejące profile:\n1. Zamknij teraz.\n2. Otwórz inny Delta Chat – w razie potrzeby zainstaluj go ponownie z %1$@\n3. Utwórz kopię zapasową każdego profilu w „Ustawienia/Czaty”.\n4. Uruchom ponownie tę wersję.\n5. Przywróć kopie zapasowe, naciskając „Mam już profil”.\n\nCzy kontynuować bez poprzednich profili?";
 // title of the "keybindings" dialog (for the keybindings names as such, where possible the normal command strings are used)
 "keybindings" = "Przypisanie klawiszy";
+// subtitle in the "keybindings" dialog
+"navigation_shortcut_section" = "Nawigacja";
+// subtitle in the "keybindings" dialog
+"message_input_shortcut_section" = "Wprowadzanie wiadomości";
+// subtitle in the "keybindings" dialog
+"message_selected_shortcut_section" = "Zaznaczona wiadomość";
 "switch_between_chats" = "Przełącz się między czatami";
 "scroll_messages" = "Przewiń wiadomości";
 // command to put the cursor to the search input field
@@ -1017,6 +1068,8 @@
 "a11y_message_context_menu_btn_label" = "Działania na wiadomości";
 "a11y_background_preview_label" = "Podgląd tła";
 "a11y_disappearing_messages_activated" = "Aktywowano znikające wiadomości";
+// The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility.
+"open_link" = "Otwórz %1$@";
 // iOS specific strings, developers: please take care to remove strings that are no longer used!
 "stop_sharing_location" = "Zatrzymaj udostępnianie lokalizacji";
 "a11y_voice_message_hint_ios" = "Po nagraniu dotknij dwukrotnie, aby wysłać. Aby odrzucić nagranie, przeciągnij dwoma palcami.";

--- a/deltachat-ios/pl.lproj/Localizable.stringsdict
+++ b/deltachat-ios/pl.lproj/Localizable.stringsdict
@@ -233,13 +233,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Wysłać plik do %s?</string>
+			<string>Wysłać plik do %2$@?</string>
 			<key>few</key>
-			<string>Wysłać %d pliki do %s?</string>
+			<string>Wysłać %d pliki do %2$@?</string>
 			<key>many</key>
-			<string>Wysłać %d plików do %s?</string>
+			<string>Wysłać %d plików do %2$@?</string>
 			<key>other</key>
-			<string>Wysłać %d pliku do %s?</string>
+			<string>Wysłać %d pliku do %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/pt-BR.lproj/Localizable.strings
+++ b/deltachat-ios/pt-BR.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "always" = "Sempre";
 "always_load_remote_images" = "Sempre Carregar Imagens Remotas";
 "once" = "Uma vez";
+// deprecated
 "show_warning" = "Mostrar Aviso";
 "not_now" = "Mais tarde";
 "never" = "Nunca";
@@ -124,6 +125,7 @@
 "camera" = "Câmera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Capturar";
+// Switch eg. from front to back camera
 "switch_camera" = "Trocar câmera";
 "toggle_fullscreen" = "Ativar modo tela cheia";
 "location" = "Localização";
@@ -237,12 +239,14 @@
 "mute_for_one_day" = "Silenciar por 1 dia";
 "mute_for_seven_days" = "Silenciar por 7 dias";
 "mute_forever" = "Silenciar para sempre";
+// deprecated
 "share_location_for_5_minutes" = "por 5 minutos";
 "share_location_for_30_minutes" = "por 30 minutos";
 "share_location_for_one_hour" = "por 1 hora";
 "share_location_for_two_hours" = "por 2 horas";
 "share_location_for_six_hours" = "por 6 horas";
 "file_saved_to" = "Arquivo salvo em \"%1$@\".";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Encaminhar mensagens para %1$@?";
 "ask_forward_multiple" = "Encaminhar mensagens para 1%1$d conversas?";
 "ask_export_attachment" = "Exportar o anexo? Anexos exportados poderão ser acessados por outros aplicativos.\n\nContinuar?";
@@ -446,6 +450,7 @@
 "pref_notifications_priority" = "Prioridade";
 "pref_notifications_explain" = "Ativar notificações do sistema para novas mensagens";
 "pref_show_notification_content" = "Mostrar o conteúdo da mensagem na notificação";
+// deprecated
 "pref_show_notification_content_explain" = "Mostra o remetente e as primeiras palavras da mensagem nas notificações";
 "pref_led_color" = "Cor do LED";
 "pref_sound" = "Som";
@@ -480,12 +485,19 @@
 "pref_background" = "Papel de parede";
 "pref_background_btn_default" = "Usar imagem padrão";
 "pref_background_btn_gallery" = "Selecionar da galeria";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Se você mudar esta opção, certifique-se de que seu servidor e demais aplicativos estejam configurados de acordo.\n\nDo contrário, funcionalidades podem não funcionar.";
+// deprecated
 "pref_auto_folder_moves" = "Mover automaticamente para a pasta DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Apenas pegar da pasta DeltaChat";
+// deprecated
 "pref_show_emails" = "Exibir e-mails normais";
+// deprecated
 "pref_show_emails_no" = "Não, somente conversas";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Para contatos aceitos";
+// deprecated
 "pref_show_emails_all" = "Todos";
 "pref_experimental_features" = "Recursos experimentais";
 "pref_on_demand_location_streaming" = "Streaming de localização sob demanda";
@@ -520,12 +532,13 @@
 // automatically delete message
 "delete_old_messages" = "Apagar mensagens antigas";
 "autodel_device_title" = "Apagar mensagens do dispositivo";
+// deprecated
 "autodel_server_title" = "Apagar mensagens do servidor";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Você quer apagar %1$d mensagens agora e todas as mensagens recém-obtidas \"%2$@\" no futuro?\n\n• Isso inclui todas as mídias\n\n• As mensagens serão excluídas independentemente de serem sido vistas ou não\n\n• \"Mensagens salvas\" serão ignoradas da exclusão local";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Você quer apagar %1$d mensagens agora e todas as mensagens recém-obtidas \"%2$@\" no futuro?\n\n⚠️ Isso inclui e-mails, mídia e \"Mensagens salvas\" em todas as pastas do servidor\n\n⚠️ Não use esta função se quiser manter os dados no servidor\n\n⚠️ Não use esta função se estiver usando outros clientes de e-mail além do Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Isso inclui e-mails, mídia e \"Mensagens salvas\" em todas as pastas do servidor. Não use esta função se quiser manter os dados no servidor ou se estiver usando outros clientes de e-mail além do Delta Chat.";
 "autodel_confirm" = "Eu entendo, apague todas essas mensagens";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -597,7 +610,7 @@
 // %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name of the contact
 "ephemeral_timer_weeks_by_other" = "Temporizador de desaparecimento de mensagens definido para %1$@ semanas por %2$@.";
 "devicemsg_self_deleted" = "Você excluiu o bate-papo \"Mensagens salvas\".\n\nℹ️ Para usar o recurso \"Mensagens salvas\" novamente, crie um novo bate-papo com você mesmo. ";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ O armazenamento em seu provedor está prestes a terminar, %1$@%% já foram utilizados\n\nVocê pode não conseguir receber mensagens quando o armazenamento estiver 100 %% utilizado.\n\n👉 Verifique se você pode excluir dados antigos através da interface da web do provedor e considere habilitar \"Configurações / Excluir Mensagens Antigas\". Você pode verificar o uso de armazenamento atual a qualquer momento em \"Configurações / Conectividade\". ";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ A data ou hora do seu dispositivo parecem imprecisas (%1$@).\n\nAjuste o relógio ⏰🔧 para garantir que suas mensagens sejam recebidas corretamente.";

--- a/deltachat-ios/pt-BR.lproj/Localizable.stringsdict
+++ b/deltachat-ios/pt-BR.lproj/Localizable.stringsdict
@@ -157,11 +157,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Enviar o seguinte arquivo para %s?</string>
+			<string>Enviar o seguinte arquivo para %2$@?</string>
 			<key>many</key>
-			<string>Enviar os seguintes arquivos %d para %s?</string>
+			<string>Enviar os seguintes arquivos %d para %2$@?</string>
 			<key>other</key>
-			<string>Enviar os seguintes arquivos %d para %s?</string>
+			<string>Enviar os seguintes arquivos %d para %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_messages</key>

--- a/deltachat-ios/pt-PT.lproj/Localizable.strings
+++ b/deltachat-ios/pt-PT.lproj/Localizable.strings
@@ -48,7 +48,9 @@
 "save" = "Guardar";
 "chat" = "Conversa";
 "profile" = "Perfil";
+// deprecated
 "all_profiles" = "Todos os Perfis";
+// deprecated
 "current_profile" = "Perfil Actual";
 "main_menu" = "Menu Principal";
 "show_full_message" = "Mostrar mensagem completa...";
@@ -192,11 +194,13 @@
 "mute_for_one_day" = "Calado por 1 dia";
 "mute_for_seven_days" = "Calado por 7 dias";
 "mute_forever" = "Silenciar para sempre";
+// deprecated
 "share_location_for_5_minutes" = "por 5 min";
 "share_location_for_30_minutes" = "por 30 min";
 "share_location_for_one_hour" = "por 1 hora";
 "share_location_for_two_hours" = "por 2 horas";
 "share_location_for_six_hours" = "por 6 horas";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Reencaminhar mensages para %1$@?";
 "ask_forward_multiple" = "Reencaminhar mensagens para %1$d conversas?";
 "ask_export_attachment" = "Exportar anexo? A exportação de anexos permitirá o seu acesso a qualquer outra aplicação no seu dispositivo.\n\nContinuar?";
@@ -333,10 +337,15 @@
 "pref_backup_written_to_x" = "Backup escrito com sucesso em %1$@";
 // No need to translate "Wallpaper" literally. Chose what is common in your language for a "Wallpaper" or a "Background". Avoid adding the term "image" here, as the "Wallpaper" may also be just a single color.
 "pref_background" = "Fundo";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Se desabilitar esta opção, verifique se seu servidor e seus outros clientes estão configurados adequadamente. \n\ncaso contrário, as coisas podem não funcionar.";
+// deprecated
 "pref_auto_folder_moves" = "Mover pasta automaticamente para o Delta Chat";
+// deprecated
 "pref_show_emails" = "Exibir e-mails comuns";
+// deprecated
 "pref_show_emails_no" = "Não, apenas conversas";
+// deprecated
 "pref_show_emails_all" = "Tudo";
 // %1$s will be replaced by the old group name, %2$s will be replaced by the new group name
 "group_name_changed_by_you" = "O nome do grupo mudou de \"%1$@\" para \"%2$@\" por mim.";

--- a/deltachat-ios/pt-PT.lproj/Localizable.stringsdict
+++ b/deltachat-ios/pt-PT.lproj/Localizable.stringsdict
@@ -103,11 +103,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Enviar o ficheiro para %s?</string>
+			<string>Enviar o ficheiro para %2$@?</string>
 			<key>many</key>
-			<string>Enviar %d ficheiros para %s?</string>
+			<string>Enviar %d ficheiros para %2$@?</string>
 			<key>other</key>
-			<string>Enviar %d ficheiros para %s?</string>
+			<string>Enviar %d ficheiros para %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_messages</key>

--- a/deltachat-ios/ro.lproj/Localizable.strings
+++ b/deltachat-ios/ro.lproj/Localizable.strings
@@ -59,6 +59,7 @@
 "always" = "Întotdeauna";
 "always_load_remote_images" = "Încărcați întotdeauna imagini la distanță";
 "once" = "Odată ce";
+// deprecated
 "show_warning" = "Afișați avertismentul";
 "not_now" = "Nu acum";
 "never" = "Niciodata";
@@ -116,6 +117,7 @@
 "camera" = "Cameră";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Captură";
+// Switch eg. from front to back camera
 "switch_camera" = "Comutați camera";
 "toggle_fullscreen" = "Comutarea modului ecran complet";
 "location" = "Locație";
@@ -227,12 +229,14 @@
 "mute_for_one_day" = "Silențios pentru 1 zi";
 "mute_for_seven_days" = "Silențios timp de 7 zile";
 "mute_forever" = "Silențios pentru totdeauna";
+// deprecated
 "share_location_for_5_minutes" = "Timp de 5 minute";
 "share_location_for_30_minutes" = "Timp de 30 de minute";
 "share_location_for_one_hour" = "Timp de 1 oră";
 "share_location_for_two_hours" = "Timp de 2 ore";
 "share_location_for_six_hours" = "Timp de 6 ore";
 "file_saved_to" = "Fișier salvat la \"%1$@\".";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Transmiteți mesajele către %1$@?";
 "ask_forward_multiple" = "Transmiteți mesajele către %1$d chat-uri?";
 "ask_export_attachment" = "Exportul atașamentelor va permite altor aplicații de pe dispozitivul dumneavoastră să le acceseze them.\n\nContinue?";
@@ -431,6 +435,7 @@
 "pref_notifications_priority" = "Prioritate";
 "pref_notifications_explain" = "Activați notificările de sistem pentru mesajele noi";
 "pref_show_notification_content" = "Afișați conținutul mesajului în notificare";
+// deprecated
 "pref_show_notification_content_explain" = "Afișează expeditorul și primele cuvinte ale mesajului în notificări";
 "pref_led_color" = "Culoare LED";
 "pref_sound" = "Sunet";

--- a/deltachat-ios/ro.lproj/Localizable.stringsdict
+++ b/deltachat-ios/ro.lproj/Localizable.stringsdict
@@ -157,11 +157,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Trimiteți următorul fișier la %s?</string>
+			<string>Trimiteți următorul fișier la %2$@?</string>
 			<key>few</key>
-			<string>Trimiteți următoarele %d fișiere la %s?</string>
+			<string>Trimiteți următoarele %d fișiere la %2$@?</string>
 			<key>other</key>
-			<string>Trimiteți următoarele %d de fișiere la %s?</string>
+			<string>Trimiteți următoarele %d de fișiere la %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_messages</key>

--- a/deltachat-ios/ru.lproj/Localizable.strings
+++ b/deltachat-ios/ru.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "off" = "Выкл.";
 "def" = "По умолчанию";
 "default_value" = "По умолчанию (%1$@)";
-"custom" = "Персональная настройка";
+"custom" = "Свой вариант";
 "none" = "Не задано";
 "automatic" = "Автоматически";
 "strict" = "Строгий";
@@ -23,6 +23,8 @@
 "downloading" = "Загрузка…";
 "open_attachment" = "Открыть вложение";
 "join" = "Присоединиться";
+"join_group" = "Вступить в группу";
+"join_channel" = "Присоединиться к каналу";
 "rejoin" = "Присоединиться снова";
 "delete" = "Удалить";
 "delete_for_me" = "Удалить для меня";
@@ -51,13 +53,15 @@
 // Adjective "smth is muted". used to describe a muted or silenced chat, that e.g. does not make noise or cause notifications
 "muted" = "Беззвучный";
 "ephemeral_messages" = "Исчезающие сообщения";
-"ephemeral_messages_hint" = "Применяется ко всем участникам этого чата, но они по-прежнему могут копировать, сохранять и пересылать сообщения.";
+"ephemeral_messages_hint" = "Настройка распространяется на всех участников; однако сообщения всё ещё можно копировать, сохранять и пересылать";
 "save" = "Сохранить";
 "chat" = "Чат";
 "media" = "Медиафайлы";
 "apps_and_media" = "Приложения и медиафайлы";
 "profile" = "Профиль";
+// deprecated
 "all_profiles" = "Все профили";
+// deprecated
 "current_profile" = "Текущий профиль";
 "main_menu" = "Главное меню";
 "start_chat" = "Начать чат";
@@ -68,6 +72,8 @@
 "mark_as_read" = "Отметить как прочитанное";
 // Used beside an icon with very few space. Shortest text for "Mark as being read". In english, this could be "Read" (past tense of "to read"), in german, this could be "Gelesen".
 "mark_as_read_short" = "Прочитано";
+// Used as an menu entry or button
+"mark_as_unread" = "Отметить как непрочитанное";
 // Used beside an icon with very few space. Shortest text for "Mark as being unread". In english, this could be "Unread" (past tense of "to unread"), in german, this could be "Ungelesen".
 "mark_as_unread_short" = "Не прочитано";
 // Placeholder text when something is loading
@@ -80,6 +86,7 @@
 "always" = "Всегда";
 "always_load_remote_images" = "Всегда загружать изображения из внешних источников";
 "once" = "Только сейчас";
+// deprecated
 "show_warning" = "Показать предупреждение";
 "not_now" = "Не сейчас";
 "never" = "Никогда";
@@ -89,6 +96,7 @@
 "offline" = "Не в сети";
 // For the next view or as "continue". Should be as short as possible.
 "next" = "Далее";
+"warning" = "Предупреждение";
 "error" = "Ошибка";
 "error_x" = "Ошибка: %1$@";
 "no_app_to_handle_data" = "Не удалось найти приложение для обработки этого типа данных.";
@@ -154,7 +162,8 @@
 "bot" = "Бот";
 "camera" = "Камера";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
-"capture" = "Захват";
+"capture" = "Снять";
+// Switch eg. from front to back camera
 "switch_camera" = "Переключить камеру";
 "toggle_fullscreen" = "Полноэкранный режим";
 "location" = "Местоположение";
@@ -300,7 +309,7 @@
 "device_talk" = "Сообщения устройства";
 "device_talk_subtitle" = "Сообщения, созданные устройством";
 "device_talk_explain" = "Сообщения в этом чате генерируются локально на вашем устройстве чтобы информировать об обновлениях и проблемах при использовании приложения.";
-"device_talk_welcome_message2" = "Оставайтесь на связи!\n\n🙌 Нажмите \"QR-код\" на главном экране обоих устройств. На одном устройстве выберите \"Сканировать QR-код\" и направьте камеру на другое устройство.\n\n🌍 Если устройства находятся в разных местах, отсканируйте код с помощью видеозвонка или поделитесь ссылкой-приглашением из раздела \"Сканировать QR-код\"\n\nЗатем: Наслаждайтесь децентрализованным мессенджером. В отличие от других популярных приложений, он не имеет центра управления и не отслеживает ваши действия, а также не продаёт данные о вас, ваших друзьях, коллегах или членах семьи крупным организациям.";
+"device_talk_welcome_message2" = "Оставайтесь на связи!\n\n🙌 Нажмите \"QR-код\" на главном экране обоих устройств. На одном устройстве выберите \"Сканировать QR-код\" и направьте камеру на другое устройство.\n\n🌍 Если устройства находятся в разных местах, отсканируйте код с помощью видеозвонка или поделитесь ссылкой-приглашением из раздела \"Сканировать QR-код\"\n\nЗатем: Пользуйтесь преимуществами децентрализованного мессенджера. В отличие от других популярных приложений, он не имеет центрального узла управления, не следит за вами и не продает ваши данные, данные о ваших друзьях, коллегах или членах семьи крупным организациям.";
 "edit_contact" = "Редактировать контакт";
 // Verb "to pin", making something sticky, not a noun or abbreviation for "pin number".
 "pin_chat" = "Закрепить чат";
@@ -322,11 +331,13 @@
 "mute_for_one_day" = "На 1 день";
 "mute_for_seven_days" = "На 7 дней";
 "mute_forever" = "Постоянно";
+// deprecated
 "share_location_for_5_minutes" = "5 минут";
 "share_location_for_30_minutes" = "30 минут";
 "share_location_for_one_hour" = "1 час";
 "share_location_for_two_hours" = "2 часа";
 "share_location_for_six_hours" = "6 часов";
+"share_location_for_24_hours" = "В течение 24 часов";
 "file_saved_to" = "Файл сохранён в \"%1$@\".";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "Позвонить";
@@ -360,12 +371,19 @@
 "canceled_call" = "Отменённый звонок";
 "missed_call" = "Пропущенный звонок";
 "already_in_call" = "Вызов уже идёт";
+"call_answered_elsewhere" = "Звонок отвечен на другом устройстве";
+"call_requires_mic_permission" = "Для совершения звонков требуется разрешение на использование микрофона";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "Звонок от %1$@";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "Вызов %1$@…";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Вы действительно хотите выйти?";
 "ask_delete_named_chat" = "Удалить чат \"%1$@\"?";
 "ask_delete_message" = "Удалить это сообщение?";
-"ask_forward" = "Переслать сообщения для %1$@?";
+// deprecated, use ask_forward_messages
+"ask_forward" = "Переслать сообщения %1$@?";
 "ask_forward_multiple" = "Переслать сообщения в %1$d чата(ов)?";
 "ask_export_attachment" = "Экспорт вложений позволит другим приложениям на вашем устройстве получить к ним доступ.\n\nПродолжить?";
 "ask_block_contact" = "Заблокировать этот контакт?\n\nЗаблокированные контакты не будут показаны в личных сообщениях или группах, созданных ими.\n\nВ других группах сообщения заблокированных контактов, по-прежнему будут видны.";
@@ -431,12 +449,15 @@
 // placeholder contains the hostname converted to ascii
 "puny_code_warning_question" = "Вы уверены, что хотите посетить %1$@?";
 // this message is shown whenever a link with non-latin characters is clicked. first placeholder is original hostname with special chars, second placeholder is hostname encoded in ascii
-"puny_code_warning_description" = "Эта ссылка может искажать символы, заменяя их похожими символами из других алфавитов. Переход по ссылке отмеченной %1$@ приведет к %2$@, что является нормальным для нелатинских символов. Если вы не ожидали увидеть такие символы, эта ссылка может быть опасной.";
+"puny_code_warning_description" = "Эта ссылка может использовать визуально похожие символы из разных алфавитов. Переход по ссылке отмеченной %1$@ приведет к %2$@, что является нормальным для нелатинских символов. Если вы не ожидали увидеть такие символы, эта ссылка может быть опасной.";
 // search
 "search" = "Поиск";
 "search_in_chat" = "Поиск в чате";
+// Placeholder will be replaced by the chat name
+"search_in" = "Поиск в %1$@";
 "search_files" = "Поиск файлов";
 "search_explain" = "Поиск чатов, контактов и сообщений";
+"search_result_for_x" = "Результат по запросу \"%1$@\"";
 "search_no_result_for_x" = "Ничего не найдено по запросу \"%1$@\"";
 // Adjective, as in "Show Unread Messages"
 "search_unread" = "Не прочитано";
@@ -448,6 +469,7 @@
 "group_create_button" = "Создать группу";
 // deprecated, use please_enter_chat_name
 "group_please_enter_group_name" = "Введите название группы";
+"please_enter_chat_name" = "Пожалуйста, введите имя.";
 "group_add_members" = "Добавить участников";
 "group_self_not_in_group" = "Вы должны быть участником группы, чтобы выполнить это действие.";
 "profile_encryption" = "Шифрование";
@@ -614,7 +636,7 @@
 "delete_account_explain_with_name" = "Все данные профиля \"%1$@\" на этом устройстве будут безвозвратно удалены, включая настройки сквозного шифрования, контакты, чаты, сообщения и медиафайлы. Это действие не может быть отменено.";
 "unconfigured_account" = "Не настроенный профиль";
 "unconfigured_account_hint" = "Откройте профиль чтобы настроить его.";
-"try_connect_now" = "Попробуйте подключиться сейчас";
+"try_connect_now" = "Попробовать подключиться сейчас";
 "sync_all" = "Синхронизировать все";
 // Translations: %1$s will be replaced by a more detailed error message
 "configuration_failed_with_error" = "Ошибка конфигурации. Ошибка: %1$@";
@@ -643,7 +665,7 @@
 "pref_outgoing_media_quality" = "Качество отправляемых медиафайлов";
 "pref_outgoing_media_quality_hint" = "Чтобы отправить файлы в исходном качестве, прикрепляйте их как \"Файл\". Это потребует больше трафика для вас и ваших получателей.";
 "pref_outgoing_balanced" = "Сбалансированное";
-"pref_outgoing_worse" = "Низкое качество, малый размер";
+"pref_outgoing_worse" = "Низкое качество, экономия данных";
 "pref_vibrate" = "Вибрация";
 "pref_screen_security" = "Безопасность экрана";
 // Translators: Must indicate that there is no guarantee as the system may not honor our request.
@@ -655,11 +677,12 @@
 // Title for the "Calls" notification setting. This is a plural noun, not a verb.
 "pref_calls" = "Звонки";
 // Details about what the "Calls" notification setting does
-"pref_calls_explain" = "Показывать экран входящего вызова";
+"pref_calls_explain" = "Показывать экран вызова для принятых контактов";
 "pref_notifications_show" = "Показывать";
 "pref_notifications_priority" = "Приоритет";
 "pref_notifications_explain" = "Включить системные уведомления для новых сообщений";
 "pref_show_notification_content" = "Показывать содержимое сообщения в уведомлении";
+// deprecated
 "pref_show_notification_content_explain" = "Показать отправителя и текст сообщения в уведомлениях";
 "pref_led_color" = "Цвет светодиода ";
 "pref_sound" = "Звук";
@@ -678,6 +701,8 @@
 "pref_incognito_keyboard_explain" = "Запрос клавиатуре на отключение персонализированного обучения";
 "pref_read_receipts" = "Уведомления о прочтении";
 "pref_read_receipts_explain" = "Если уведомления о прочтении отключены, вы не будете видеть подтверждения прочтения сообщений другими пользователями.";
+// Title above a list of contacts who read a message
+"read_by" = "Прочитано";
 "pref_server" = "Сервер";
 "pref_encryption" = "Шифрование";
 "pref_manage_keys" = "Управление ключами";
@@ -700,20 +725,27 @@
 "pref_background" = "Обои для чатов";
 "pref_background_btn_default" = "Использовать изображение по умолчанию";
 "pref_background_btn_gallery" = "Выбрать из галереи";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Если вы измените этот параметр, убедитесь, что ваш сервер и другие клиенты настроены соответствующим образом.\n\nВ противном случае, всё может перестать работать.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Режим нескольких устройств";
 "pref_multidevice_explain" = "Синхронизируйте свои сообщения с другими устройствами. Функция включается автоматически при добавлении второго устройства";
 "pref_multidevice_change_warn" = "Режим нескольких устройств должен быть включен, если вы используете один и тот же профиль на нескольких устройствах. Отключайте эту настройку, только если вы удалили этот профиль со всех остальных устройств.\n\nОтключение режима нескольких устройств при использовании профиля на нескольких устройствах приведет к потере сообщений и возникновению других проблем.";
+// deprecated
 "pref_auto_folder_moves" = "Автоперемещение в папку DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Загружать только из папки DeltaChat";
+// deprecated
 "pref_show_emails" = "Показывать обычную почту";
+// deprecated
 "pref_show_emails_no" = "Нет, только чаты";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Для принятых контактов";
+// deprecated
 "pref_show_emails_all" = "Все";
 "pref_experimental_features" = "Экспериментальные функции";
 "pref_experimental_features_explain" = "Эти функции могут быть нестабильными и могут быть изменены или удалены";
-"pref_on_demand_location_streaming" = "Трансляция местоположения по запросу";
+"pref_on_demand_location_streaming" = "Трансляция местоположения";
 "pref_background_default" = "Изображение по умолчанию";
 "pref_background_default_color" = "Цвет по умолчанию";
 "pref_background_custom_image" = "Персональное изображение";
@@ -761,14 +793,17 @@
 // automatically delete message
 "delete_old_messages" = "Удалить старые сообщения";
 "autodel_device_title" = "Удалять сообщения с устройства";
+// deprecated
 "autodel_server_title" = "Удалять сообщения с сервера";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Вы хотите удалить %1$d сообщений сейчас и все новые сообщения \"%2$@\" в дальнейшем?\n\n• Это действие затронет все медиафайлы\n\n• Сообщения будут удалены, независимо от того, были ли они прочитаны или нет.\n\n• \"Сохранённые сообщения\" не будут удалены с устройства";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Вы хотите удалить %1$d сообщений сейчас и все новые сообщения \"%2$@\" в дальнейшем?\n\n⚠️ Это относится ко всем электронным письмам, медиафайлам и \"Сохранённым сообщениям\" во всех папках на сервере.\n\n⚠️ Не используйте эту функцию, если хотите сохранить данные на сервере или если вы используете обычные клиенты электронной почты";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Это относится ко всем электронным письмам, медиафайлам и \"Сохранённым сообщениям\" во всех папках на сервере. Не используйте эту функцию, если хотите сохранить данные на сервере или если вы используете обычные клиенты электронной почты";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Включить удаление без запроса";
+// deprecated
 "autodel_server_warn_multi_device" = "Если включить удаление без запроса, вы не сможете использовать этот профиль на нескольких устройствах.";
 "autodel_confirm" = "Я понимаю, удалить все эти сообщения";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -786,9 +821,12 @@
 "group_name_changed_by_you" = "Вы изменили название группы с \"%1$@\" на \"%2$@\".";
 // %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action.
 "group_name_changed_by_other" = "%3$@ меняет название группы с \"%1$@\" на \"%2$@\".";
+// %1$s will be replaced by the old channel name, %2$s will be replaced by the new channel name
+"channel_name_changed" = "Название канала изменено с \"%1$@\" на \"%2$@\".";
 "group_image_changed_by_you" = "Вы изменили изображение группы.";
 // %1$s will be replaced by name of the contact who did the action
 "group_image_changed_by_other" = "%1$@ меняет изображение группы.";
+"channel_image_changed" = "Изображение канала изменено.";
 "chat_description_changed_by_you" = "Вы изменили описание чата.";
 // %1$s will be replaced by name of the contact who did the action
 "chat_description_changed_by_other" = "Описание чата изменено пользователем %1$@.";
@@ -860,7 +898,7 @@
 "invalid_unencrypted_explanation" = "Чтобы установить сквозное шифрование, вы можете встретиться с контактами лично и отсканировать их QR-код, чтобы подтвердить их личность.";
 "learn_more" = "Узнать больше";
 "devicemsg_self_deleted" = "Вы удалили чат \"Сохраненные сообщения\".\n\nℹ️ Чтобы снова использовать функцию \"Сохраненные сообщения\", создайте новый чат с собой.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Место на сервере вашего провайдера скоро закончится, уже использовано: %1$@%%.\n\nЕсли место на сервере будет полностью заполнено, вы не сможете получать сообщения.\n\n👉 Проверьте, можно ли удалить старые данные через веб-интерфейс вашего провайдера, и подумайте о включении опции \"Настройки / Чаты / Удалить старые сообщения\". Вы всегда можете проверить текущее использование места на сервере в разделе \"Настройки / Соединение\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Вероятно, дата или время на вашем устройстве установлены неверно (%1$@).\n\nНастройте часы ⏰🔧 чтобы ваши сообщения доставлялись правильно.";
@@ -922,6 +960,8 @@
 // first placeholder is the name of the chat
 "confirm_replace_draft" = "%1$@ уже имеет черновик, вы хотите его заменить?";
 "mailto_link_could_not_be_decoded" = "ссылка mailto не может быть обработана: %1$@";
+"remove_quote" = "Удалить цитату";
+"remove_attachment" = "Удалить вложение";
 // notifications
 "notify_reply_button" = "Ответить";
 "notify_new_message" = "Новое сообщение";
@@ -937,6 +977,9 @@
 // Body text for a generic "New messages" notification. Shown if we do not have more information about a new messages. Note, that the string is also referenced at https://github.com/deltachat/notifiers
 "new_messages_body" = "Есть новые сообщения";
 "n_messages_in_m_chats" = "%1$d сообщений в %2$d чатах";
+// location streaming
+"location_streaming_notification_text" = "Вы делитесь своим местоположением";
+"location_rationale" = "Чтобы поделиться своим местоположением в реальном времени с участниками чата, разрешите Delta Chat использовать данные о вашем местоположении.\n\nДля обеспечения бесперебойной работы функции передачи геопозиции данные используются даже тогда, когда приложение закрыто или не активно.";
 // permissions
 "perm_required_title" = "Требуется разрешение";
 "perm_continue" = "Продолжить";
@@ -976,7 +1019,8 @@
 "global_menu_help_about_desktop" = "О Delta Chat";
 "global_menu_file_open_desktop" = "Открыть Delta Chat";
 "global_menu_minimize_to_tray" = "Свернуть";
-"no_chat_selected_suggestion_desktop" = "Выберите чат или создайте новый";
+"no_account_selected" = "Выберите или создайте новый профиль";
+"no_chat_selected_suggestion_desktop" = "Выберите или создайте новый чат";
 "write_message_desktop" = "Напишите сообщение";
 "encryption_info_title_desktop" = "Информация о шифровании";
 "delete_message_desktop" = "Удалить сообщение";
@@ -997,8 +1041,15 @@
 // deprecated, used on desktop although there is not spell checker
 "no_spellcheck_suggestions_found" = "Не найдены варианты исправления орфографии.";
 "show_window" = "Показать окно";
+"data_found_other_installation_message" = "Профили из другой установки Delta Chat недоступны - разные экземпляры приложения хранят данные в отдельных папках.\n\nЧтобы сохранить существующие профили:\n1. Выйдите сейчас.\n2. Откройте другую установку Delta Chat - если потребуется, переустановите её из %1$@\n3. Создайте резервные копии каждого профиля в разделе \"Настройки/Чаты\"\n4. Запустите текущую версию приложения\n5. Восстановите данные из резервных копий, выбрав \"У меня уже есть профиль\"\n\nПродолжить без предыдущих профилей?";
 // title of the "keybindings" dialog (for the keybindings names as such, where possible the normal command strings are used)
 "keybindings" = "Горячие клавиши";
+// subtitle in the "keybindings" dialog
+"navigation_shortcut_section" = "Навигация";
+// subtitle in the "keybindings" dialog
+"message_input_shortcut_section" = "Поле ввода сообщения";
+// subtitle in the "keybindings" dialog
+"message_selected_shortcut_section" = "Выбранное сообщение";
 "switch_between_chats" = "Переключение между чатами";
 "scroll_messages" = "Прокрутка сообщений";
 // command to put the cursor to the search input field
@@ -1017,6 +1068,8 @@
 "a11y_message_context_menu_btn_label" = "Действия с сообщением";
 "a11y_background_preview_label" = "Предпросмотр";
 "a11y_disappearing_messages_activated" = "Исчезающие сообщения включены";
+// The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility.
+"open_link" = "Открыть %1$@";
 // iOS specific strings, developers: please take care to remove strings that are no longer used!
 "stop_sharing_location" = "Прекратить делиться местоположением";
 "a11y_voice_message_hint_ios" = "После записи дважды нажмите, чтобы отправить. Чтобы отменить запись, проведите двумя пальцами.";

--- a/deltachat-ios/ru.lproj/Localizable.stringsdict
+++ b/deltachat-ios/ru.lproj/Localizable.stringsdict
@@ -233,13 +233,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Отправить следующий файл %s?</string>
+			<string>Отправить следующий файл %2$@?</string>
 			<key>few</key>
-			<string>Отправить следующие %d файла(ов) %s?</string>
+			<string>Отправить следующие %d файла(ов) %2$@?</string>
 			<key>many</key>
-			<string>Отправить следующие %d файлы(ов) %s?</string>
+			<string>Отправить следующие %d файлы(ов) %2$@?</string>
 			<key>other</key>
-			<string>Отправить следующие %d файлы(ов) %s?</string>
+			<string>Отправить следующие %d файлы(ов) %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/sc.lproj/Localizable.strings
+++ b/deltachat-ios/sc.lproj/Localizable.strings
@@ -162,12 +162,14 @@
 "mute_for_one_day" = "A sa muda pro 1 die";
 "mute_for_seven_days" = "A sa muda pro 7 dies";
 "mute_forever" = "A sa muda pro semper";
+// deprecated
 "share_location_for_5_minutes" = "pro 5 minutos";
 "share_location_for_30_minutes" = "pro 30 minutos";
 "share_location_for_one_hour" = "pro 1 ora";
 "share_location_for_two_hours" = "pro 2 oras";
 "share_location_for_six_hours" = "pro 6 oras";
 "file_saved_to" = "Documentu sarvadu in \"%1$@\".";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Inoltrare su messàgiu a %1$@?";
 "ask_forward_multiple" = "Inoltrare messàgios a %1$d tzarradas?";
 "ask_export_attachment" = "Esportare sos allegados? S\'esportatzione de sos allegados at a permìtere a cale si siat àtera aplicatzione in su dispositivu tuo de b\'atzèdere.\n\nSighire?";
@@ -326,11 +328,17 @@
 "pref_background" = "Isfundu";
 "pref_background_btn_default" = "Imprea s\'immàgine predefinida";
 "pref_background_btn_gallery" = "Ischerta dae sa galleria";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Si disabìlitas custa opztione assegura·ti chi su serbidore tuo e totu sos àteros clientes siant cunfigurados in sa matessi manera\n\nSi nono sas cosas diant pòdere non funtzionare pro nudda.";
+// deprecated
 "pref_auto_folder_moves" = "Tramudòngios automàticos a sa cartella DeltaChat";
+// deprecated
 "pref_show_emails" = "Ammustra sas lìteras traditzionales";
+// deprecated
 "pref_show_emails_no" = "Nono, tzarradas ebbia";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Pro sos cuntatos atzetados";
+// deprecated
 "pref_show_emails_all" = "Totus";
 "pref_experimental_features" = "Funtzionalidades isperimentales";
 "pref_on_demand_location_streaming" = "Trasmissione de sa positzione suta dimanda";
@@ -348,6 +356,7 @@
 // automatically delete message
 "delete_old_messages" = "Iscantzella sos messàgios betzos";
 "autodel_device_title" = "Iscantzella sos messàgios dae su dispositivu";
+// deprecated
 "autodel_server_title" = "Iscantzella sos messàgios dae su servidore";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Cheres iscantzellare%1$d messàgios como e totu sos messàgios arribados \"%2$@\" in su tempus benidore?\n\n• Custu at a incluire totu sos documentos multimediales\n\n• Sos messàgios ant a èssere iscantzellados fintzas si no ant a èssere istados lèghidos\n\n• Sos \"Messàgios sarvados\" ant a èssere esclùdidos dae s\'iscantzellamentu locale";

--- a/deltachat-ios/sk.lproj/Localizable.strings
+++ b/deltachat-ios/sk.lproj/Localizable.strings
@@ -54,7 +54,9 @@
 "media" = "Médiá";
 "apps_and_media" = "Aplikácie a médiá";
 "profile" = "Účet";
+// deprecated
 "all_profiles" = "Všetky účty";
+// deprecated
 "current_profile" = "Aktuálny účet";
 "main_menu" = "Hlavné menu";
 "start_chat" = "Začať konverzáciu";
@@ -74,6 +76,7 @@
 "load_remote_content_ask" = "Na sledovanie vás možno použiť obrázky nadiaľku.\n\nToto nastavenie tiež umožňuje načítať písma a ďalší obsah. Aj keď je vypnutá, stále sa vám môžu zobrazovať vložené alebo uložené obrázky.\n\nNačítať vzdialené obrázky?";
 "always" = "Vždy";
 "once" = "Raz";
+// deprecated
 "show_warning" = "Zobraziť varovanie";
 "not_now" = "Teraz nie";
 "never" = "Nikdy";
@@ -142,6 +145,7 @@
 "camera" = "Fotoaparát";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Zachytiť";
+// Switch eg. from front to back camera
 "switch_camera" = "Prepnúť fotoaparát";
 "toggle_fullscreen" = "Prepnúť režim zobrazenia na celú obrazovku";
 "location" = "Poloha";
@@ -291,6 +295,7 @@
 "mute_for_one_day" = "Stíšiť na 1 deň";
 "mute_for_seven_days" = "Stíšiť na 7 dní";
 "mute_forever" = "Stlmiť navždy";
+// deprecated
 "share_location_for_5_minutes" = "po dobu 5 minút";
 "share_location_for_30_minutes" = "po dobu 30 minút";
 "share_location_for_one_hour" = "po dobu 1 hodiny";
@@ -299,6 +304,7 @@
 "file_saved_to" = "Súbor bol uložený do priečinka %1$@";
 "ask_delete_named_chat" = "Odstrániť konverzáciu \"%1$@\" zo všetkých vašich zariadení?";
 "ask_delete_message" = "Odstrániť túto správu zo všetkých vašich zariadení?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Preposielať správy na %1$@?";
 "ask_forward_multiple" = "Preposielať správy do %1$d konverzácií?";
 "ask_export_attachment" = "Exportovať prílohu? Exportovanie príloh umožní prístup k nim všetkým ďalším aplikáciám na vašom zariadení.\n\nChcete pokračovať?";
@@ -538,6 +544,7 @@
 "pref_notifications_priority" = "Priorita";
 "pref_notifications_explain" = "Povoliť systémové upozornenia na nové správy";
 "pref_show_notification_content" = "Zobraziť obsah správy v upozornení";
+// deprecated
 "pref_show_notification_content_explain" = "V oznámeniach sa zobrazuje odosielateľ a prvé slová správy";
 "pref_led_color" = "Farba LED";
 "pref_sound" = "Zvuk";
@@ -577,12 +584,19 @@
 "pref_background" = "Pozadie";
 "pref_background_btn_default" = "Použiť predvolený obrázok";
 "pref_background_btn_gallery" = "Vyberte z galérie";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Ak túto možnosť zakážete, uistite sa, že váš server a ostatní klienti sú zodpovedajúcim spôsobom nakonfigurovaní.\n\nV opačnom prípade nemusí fungovať vôbec.";
+// deprecated
 "pref_auto_folder_moves" = "Automaticky presúvať do priečinka DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Prijímať iba z priečinka DeltaChat";
+// deprecated
 "pref_show_emails" = "Zobraziť klasické e-maily";
+// deprecated
 "pref_show_emails_no" = "Nie, iba konverzácie";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Pre prijaté kontakty";
+// deprecated
 "pref_show_emails_all" = "Všetky";
 "pref_experimental_features" = "Experimentálne vlastnosti";
 "pref_on_demand_location_streaming" = "Vysielanie polohy na požiadanie";
@@ -626,12 +640,13 @@
 // automatically delete message
 "delete_old_messages" = "Odstraňovať staré správy";
 "autodel_device_title" = "Odstráňte správy zo zariadenia";
+// deprecated
 "autodel_server_title" = "Odstraňovať správy zo servera";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Chcete odstrániť %1$d správy a všetky novo načítané správy %2$@ v budúcnosti?\n\n• Zahŕňa to všetky médiá\n\n• Správy budú odstránené bez ohľadu na to, či boli alebo neboli videné\n\n• „Uložené správy \"bude preskočené z lokálneho mazania";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Chcete odstrániť %1$d správy a všetky novo načítané správy %2$@ v budúcnosti?\n\n⚠️ Zahŕňa to e-maily, médiá a uložené správy vo všetkých priečinkoch servera\n\n⚠️ Túto funkciu nepoužívajte, ak chcete uchovanie údajov na serveri\n\n⚠️ Túto funkciu nepoužívajte, ak okrem Delta Chatu používate aj iných e-mailových klientov";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Patria sem e-maily, médiá a „Uložené správy“ vo všetkých priečinkoch servera. Túto funkciu nepoužívajte, ak chcete uchovať údaje na serveri alebo ak okrem Delta Chatu používate aj iných e-mailových klientov.";
 "autodel_confirm" = "Rozumiem, vymazať všetky tieto správy";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -705,7 +720,7 @@
 "chat_protection_enabled_tap_to_learn_more" = "Správy sú šifrované. Ťuknite pre viac informácií.";
 "learn_more" = "Zistiť viac";
 "devicemsg_self_deleted" = "Odstránili ste konverzáciu \"Uložené správy\".\n\nℹ️ Aby ste využili funkciu \"Uložené správy\" znova, vytvorte novú konverzáciu so sebou.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Úložisko vašeho poskytovateľa čoskoro prekročí limit, už%1$@%% sú využité.\n\n Je možné, že nebudete môcť prijímať správy, ak bude úložisko 100 %% využité.\n\n👉 Prosím skontrolujte, či môžete vo webovom rozhraní poskytovateľa vymazať staré údaje, a zvážte aktiváciu „Nastavenia / Odstrániť Staré Správy“. Aktuálne využitie úložiska si môžete kedykoľvek skontrolovať v časti „Nastavenia / Pripojenie“. ";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "Zdá sa, že dátum alebo čas vášho zariadenia je nepresný (%1$@).\n\nUpravte si hodiny ⏰🔧, aby ste zaistili správne prijímanie správ. ";

--- a/deltachat-ios/sk.lproj/Localizable.stringsdict
+++ b/deltachat-ios/sk.lproj/Localizable.stringsdict
@@ -193,13 +193,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Odoslať nasledujúci súbor %s používateľovi?</string>
+			<string>Odoslať nasledujúci súbor %2$@ používateľovi?</string>
 			<key>few</key>
-			<string>Odoslať nasledujúce %d súbory %s používateľovi?</string>
+			<string>Odoslať nasledujúce %d súbory %2$@ používateľovi?</string>
 			<key>many</key>
-			<string>Odoslať nasledujúce %d súbory %s používateľovi?</string>
+			<string>Odoslať nasledujúce %d súbory %2$@ používateľovi?</string>
 			<key>other</key>
-			<string>Odoslať nasledujúce %d súbory %s používateľovi?</string>
+			<string>Odoslať nasledujúce %d súbory %2$@ používateľovi?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/sq.lproj/Localizable.strings
+++ b/deltachat-ios/sq.lproj/Localizable.strings
@@ -58,7 +58,9 @@
 "media" = "Media";
 "apps_and_media" = "Aplikacione & Media";
 "profile" = "Profil";
+// deprecated
 "all_profiles" = "Krejt Profilet";
+// deprecated
 "current_profile" = "Profili i Tanishëm";
 "main_menu" = "Menuja Kryesore";
 "start_chat" = "Nisni Fjalosje";
@@ -81,6 +83,7 @@
 "always" = "Përherë";
 "always_load_remote_images" = "Ngarko Përherë Figura të Largëta";
 "once" = "Vetëm një herë";
+// deprecated
 "show_warning" = "Shfaq Sinjalizim";
 "not_now" = "Jo tani";
 "never" = "Kurrë";
@@ -154,6 +157,7 @@
 "contact" = "Kontakt";
 "bot" = "Robot";
 "camera" = "Kamerë";
+// Switch eg. from front to back camera
 "switch_camera" = "Ndërro Kamera";
 "toggle_fullscreen" = "Kalo në / Dil nga mënyra “Sa krejt ekrani”";
 "location" = "Vendndodhje";
@@ -321,11 +325,13 @@
 "mute_for_one_day" = "Heshtoji për 1 ditë";
 "mute_for_seven_days" = "Heshtoji për 7 ditë";
 "mute_forever" = "Heshtoje përgjithmonë";
+// deprecated
 "share_location_for_5_minutes" = "Për 5 minuta";
 "share_location_for_30_minutes" = "Për 30 minuta";
 "share_location_for_one_hour" = "Për 1 orë";
 "share_location_for_two_hours" = "Për 2 orë";
 "share_location_for_six_hours" = "Për 6 orë";
+"share_location_for_24_hours" = "Për 24 orë";
 "file_saved_to" = "Kartela u ruajt te “%1$@”.";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "Thirreni";
@@ -361,11 +367,16 @@
 "already_in_call" = "Tashmë në një thirrje";
 "call_answered_elsewhere" = "Thirrje që ka marrë përgjigje në pajisje tjetër";
 "call_requires_mic_permission" = "Leja mbi mikrofonin është e domosdoshme për thirrje";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "Thirrje me %1$@";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "Po thirret %1$@";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Jeni i sigurt se doni të largoheni?";
 "ask_delete_named_chat" = "Të fshihet fjalosja “%1$@” në krejt pajisjet tuaja?";
 "ask_delete_message" = "Të fshihet ky mesazh në krejt pajisjet tuaja?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Të përcillen mesazhet te %1$@?";
 "ask_forward_multiple" = "Të përcillen mesazhet te %1$d fjalosje?";
 "ask_export_attachment" = "Eksportimi i bashkëngjitjeve do t\’u lejojë aplikacioneve të tjerë në pajisjen tuaj t\’i përdorin ato.\n\nTë vazhdohet?";
@@ -665,6 +676,7 @@
 "pref_notifications_priority" = "Përparësi";
 "pref_notifications_explain" = "Aktivizoni njoftime sistemi për mesazhe të reja";
 "pref_show_notification_content" = "Shfaq lëndë mesazhi në njoftim";
+// deprecated
 "pref_show_notification_content_explain" = "Shfaq te njoftimet dërguesin dhe fjalët e para të mesazhit";
 "pref_led_color" = "Ngjyrë LED-i";
 "pref_sound" = "Tingull";
@@ -707,16 +719,23 @@
 "pref_background" = "Sfond";
 "pref_background_btn_default" = "Përdor Figurën Parazgjedhje";
 "pref_background_btn_gallery" = "Përzgjidhni Nga Galeri";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Nëse e ndryshoni këtë mundësi, garantoni që shërbyesi juaj dhe klientët tuaj të tjerët të jenë formësuar për këtë.\n\nPërndryshe gjërat mund të mos punojnë fare.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Mënyra Shumë-Pajisje";
 "pref_multidevice_explain" = "Njëkohësoni mesazhet tuaj në pajisje tuajat të tjera. E aktivizuar automatikisht gjatë shtimit të një pajisjeje të dytë";
 "pref_multidevice_change_warn" = "Mënyra Shumë-Pajisje duhet aktivizuar, kur përdoret i njëjti profil në disa pajisje. Çaktivizojeni këtë rregullim vetëm në se e keni hequr këtë profil nga krejt pajisjet tuaja të tjera.\n\nÇaktivizimi i Mënyrës Shumë-Pajisje, teksa përdoret profili në disa pajisje, do të sjellë mesazhe të humbura dhe probleme të tjera.";
+// deprecated
 "pref_auto_folder_moves" = "Kaloji vetvetiu te Dosja DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Sill Vetëm nga Dosje DeltaChat";
+// deprecated
 "pref_show_emails" = "Shfaq Email-e Klasikë";
+// deprecated
 "pref_show_emails_no" = "Jo, vetëm fjalosje";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Për kontakte të pranuar";
+// deprecated
 "pref_show_emails_all" = "Krejt";
 "pref_experimental_features" = "Veçori Eksperimentale";
 "pref_experimental_features_explain" = "Këto veçori mund të jenë të paqëndrueshme dhe mund të ndryshohen, ose hiqen";
@@ -767,14 +786,17 @@
 // automatically delete message
 "delete_old_messages" = "Fshiji Mesazhet e Vjetër";
 "autodel_device_title" = "Fshiji Mesazhet prej Pajisjes";
+// deprecated
 "autodel_server_title" = "Fshiji Mesazhe prej Shërbyesi";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Doni të fshihen %1$d mesazhe tani dhe krejt mesazhet e prurë rishtazi “%2$@” në të ardhmen?\n\n• Kjo përfshin krejt mediat\n\n• Mesazhi do të fshihet, qoftë kur është parë, qoftë kur s’është parë\n\n• “Mesazhe të ruajtur” do të anashkalohen nga fshirja vendore";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Doni të fshihen tani %1$d mesazhe dhe krejt mesazhet e prurë rishtas “%2$@” më vonë në të ardhmen?\n\n⚠️ Kjo përfshin email-et, media dhe “Mesazhe të ruajtur” në krejt dosjet e shërbyesit\n\n⚠️ Mos e përdorni këtë funksion, nëse doni të mbani të dhënat në shërbyes, apo nëse përdorni klientë klasikë email-i";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Kjo përfshin email-et, media dhe “Mesazhe të ruajtur” në krejt dosjet e shërbyesit. Mos e përdorni këtë funksion, nëse doni të mbani të dhënat te shërbyesi ose nëse përdorni klientë klasikë email-i";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Aktivizoni fshirje të menjëhershme";
+// deprecated
 "autodel_server_warn_multi_device" = "Nëse aktivizoni fshirje të menjëhershme, s’mund të përdorni pajisje të shumta në këtë profil.";
 "autodel_confirm" = "E kuptoj, fshiji krejt këto mesazhe";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -869,7 +891,7 @@
 "invalid_unencrypted_explanation" = "Për të vendosur fshehtëzim skaj-më-skaj, mund të takoheni personalisht me kontaktet dhe të skanoni kodin e tyre QR, për t’i pranuar.";
 "learn_more" = "Mësoni Më Tepër";
 "devicemsg_self_deleted" = "Fshitë fjalosjen “Mesazhe të ruajtur”.\n\nℹ️ Që të përdorni sërish veçorinë “Mesazhe të ruajtur”, krijoni një fjalosje të re me veten tuaj.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Po mbaron depozita e shërbimit tuaj: përdoren tashmë %1$@%%.\n\nNëse depozita është plot, mund të mos jeni në gjendje të merrni mesazhe.\n\n👉 Ju lutemi, shihni se mos mund të fshini të dhëna të vjetra që nga ndërfaqja web e furnizuesit të shërbimit dhe shihni mundësinë të aktivizoni “Rregullime / Fjalosje dje Media / Fshi Mesazhe të Vjetër”. Se sa depozitë është aktualisht e përdorur mund ta kontrolloni kurdo, që nga \"Rregullime / Lidhje\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Data ose koha në pajisjen tuaj duket të jetë e pasaktë (%1$@).\n\nRregulloni sahatin tuaj ⏰🔧 që të garantohet se mesazhet tuaj merren saktë.";
@@ -948,7 +970,9 @@
 // Body text for a generic "New messages" notification. Shown if we do not have more information about a new messages. Note, that the string is also referenced at https://github.com/deltachat/notifiers
 "new_messages_body" = "Keni mesazhe të rinj";
 "n_messages_in_m_chats" = "%1$d mesazhe në %2$d fjalosje";
+// location streaming
 "location_streaming_notification_text" = "Po tregoni vendndodhjen tuaj";
+"location_rationale" = "Që të jepni vendndodhjen aty për aty për anëtarë të fjalosjes, lejojeni Delta Chat-in të përdorë të dhëna të vendndodhjes suaj.\n\nPër ta bërë vendndodhjen e atypëratyshme të funksionojë rrjedhshëm, përdoren të dhëna edhe kur aplikacioni është i mbyllur, ose jo në përdorim.";
 // permissions
 "perm_required_title" = "Lypset leje";
 "perm_continue" = "Vazhdo";
@@ -1010,6 +1034,7 @@
 // deprecated, used on desktop although there is not spell checker
 "no_spellcheck_suggestions_found" = "S’u gjetën sugjerimi drejtshkrimi.";
 "show_window" = "Shfaq Dritare";
+"data_found_other_installation_message" = "Profilet tuaja nga instalim tjetër i Delta Chat-it s’mund të përdoren - instalime të ndryshme i depozitojnë të dhënat e veta në vendndodhje të ndryshme:\n1. Mbylle tani\n2. Hap Delta Chat-in tjetër - në u dashtë, riinstaloje nga %1$@\n3. Kopjeruaje secilin profil te “Rregullime/Fjalosje”4. Rinis këtë version\n5. Riktheni kopjeruajtje duke përdorur “Kam tashmë një profil”\n\nTë vazhdohet pa profilet tuaj të mëparshëm?";
 // title of the "keybindings" dialog (for the keybindings names as such, where possible the normal command strings are used)
 "keybindings" = "Kombinim tastesh";
 // subtitle in the "keybindings" dialog
@@ -1036,6 +1061,8 @@
 "a11y_message_context_menu_btn_label" = "Veprime mesazhesh";
 "a11y_background_preview_label" = "Paraparje sfondi";
 "a11y_disappearing_messages_activated" = "Zhdukja e mesazheve është e aktivizuar";
+// The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility.
+"open_link" = "Hap %1$@";
 // iOS specific strings, developers: please take care to remove strings that are no longer used!
 "stop_sharing_location" = "Ndale tregimin e vendndodhjes";
 "a11y_voice_message_hint_ios" = "Pas regjistrimit, prekeni dy herë që të dërgohet. Për ta hedhur regjistrimin tej, fërkojeni majtas-djathtas me dy gishta.";

--- a/deltachat-ios/sq.lproj/Localizable.stringsdict
+++ b/deltachat-ios/sq.lproj/Localizable.stringsdict
@@ -189,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Të dërgohet kartela vijuese te %s?</string>
+			<string>Të dërgohet kartela vijuese te %2$@?</string>
 			<key>other</key>
-			<string>Të dërgohen %d kartelat vijuese te %s?</string>
+			<string>Të dërgohen %d kartelat vijuese te %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/sr.lproj/Localizable.strings
+++ b/deltachat-ios/sr.lproj/Localizable.strings
@@ -50,6 +50,7 @@
 "chat" = "Ћаскање";
 "media" = "Медији";
 "profile" = "Профил";
+// deprecated
 "all_profiles" = "Сви профили";
 "main_menu" = "Главни мени";
 "start_chat" = "Започните ћаскање";
@@ -70,6 +71,7 @@
 "always" = "Увек";
 "always_load_remote_images" = "Увек учитај слике са сервера";
 "once" = "Само једном";
+// deprecated
 "show_warning" = "Прикажи упозорење";
 "not_now" = "Не сада";
 "never" = "Никад";
@@ -132,6 +134,7 @@
 "camera" = "Камера";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Сними";
+// Switch eg. from front to back camera
 "switch_camera" = "Промени камеру";
 "toggle_fullscreen" = "Обрће режим пуног екрана";
 "location" = "Локација";
@@ -250,6 +253,7 @@
 "mute_for_one_day" = "Утишај на 1 дан";
 "mute_for_seven_days" = "Утишај на 7 дана";
 "mute_forever" = "Утишај заувек";
+// deprecated
 "share_location_for_5_minutes" = "на 5 минута";
 "share_location_for_30_minutes" = "За 30 минута";
 "share_location_for_one_hour" = "За 1 сат";
@@ -265,6 +269,7 @@
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Да ли сте сигурни да желите да напустите?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Да ли желите да проследите поруке %1$@?";
 "ask_forward_multiple" = "Да ли желите да проследим поруке за %1$dћаскања?";
 "ask_export_attachment" = "Извоз прилога ће омогућити другим апликацијама на вашем уређају да им приступе.\n\nДа ли желите ли да наставите?";
@@ -446,6 +451,7 @@
 "pref_notifications_priority" = "Приоритет";
 "pref_notifications_explain" = "Дозволи обавештења за нове поруке преко оперативног система";
 "pref_show_notification_content" = "Прикажи садржај поруке у обавештењима.";
+// deprecated
 "pref_show_notification_content_explain" = "Прикажи пошиљаоца и првих пар речи поруке у обавештењима";
 "pref_led_color" = "Боја ЛЕД светла";
 "pref_sound" = "Звук";
@@ -480,12 +486,19 @@
 "pref_background" = "Позадина";
 "pref_background_btn_default" = "Користи дату слику";
 "pref_background_btn_gallery" = "Изабери из галерије";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Ако промените ову опцију, морате проверити да су ваш сервер и ваши други клијенти конфигурисани у складу са тим.\n\nУ супротном апликација можда уопште неће функционисати.";
+// deprecated
 "pref_auto_folder_moves" = "Аутоматски премести у DeltaChat директоријум";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Примај поруке само из DeltaChat директоријума";
+// deprecated
 "pref_show_emails" = "Прикажи обичне поруке е-поште";
+// deprecated
 "pref_show_emails_no" = "Не, само ћаскања";
+// deprecated
 "pref_show_emails_accepted_contacts" = "За прихваћене контакте";
+// deprecated
 "pref_show_emails_all" = "Сви";
 "pref_experimental_features" = "Експерименталне могућности";
 "pref_on_demand_location_streaming" = "Проток положаја на захтев";
@@ -520,12 +533,13 @@
 // automatically delete message
 "delete_old_messages" = "Избриши старе поруке";
 "autodel_device_title" = "Избриши поруке са уређаја";
+// deprecated
 "autodel_server_title" = "Избриши поруке са сервера";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Да ли желите да избришете %1$d поруке сада и све новопреузете поруке „%2$@“ у будућности?\n\n• Ово укључује све медије\n\n• Поруке ће бити избрисане без обзира да ли су виђене или не\n\n• \"Сачуване поруке\" неће бити избрисане на уређају";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Да ли желите да избришете %1$d поруке сада и све новопреузете поруке „%2$@“ у будућности?\n\n⚠️ Ово укључује све поруке е-поште, медије и „Сачуване поруке“ у свим директоријумима на серверу\n\n⚠️ Немојте користити ову функцију ако користите било које друге клијенте е-поште осим Delta Chat-а";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Ово укључује све поруке е-поште, медије и „Сачуване поруке“ у свим директоријумима на серверу. Немојте користити ову функцију ако користите било које друге клијенте е-поште осим Delta Chat-а.";
 "autodel_confirm" = "Разумем и желим да избришем све ове поруке";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -597,7 +611,7 @@
 // %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name of the contact
 "ephemeral_timer_weeks_by_other" = "%2$@ је подесио хронометар за нестајуће поруке на %1$@ недеље.";
 "devicemsg_self_deleted" = "Обрисали сте ћаскање „Сачуване поруке“.\n\nℹ️ Ако желите да користите „Сачуване поруке“ могућност поново, направите ново ћаскање са самим собом.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Складишни простор вашег имејл провајдера ће ускоро да понестане: %1$@%% већ се користи.\n\nМожда нећете моћи да примате поруке ако је складиште пунo.\n\n👉 Проверите да ли можете да избришете старе податке у веб интерфејсу провајдера и размислите да омогућите „Подешавања / Избриши старе поруке“ опцију. Можете да проверите тренутну употребу меморијског простора у било ком тренутку у „Подешавања / Повезивање“.";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Изгледа да датум или време на вашем уређају нису тачни (%1$@).\n\nПодесите сат ⏰🔧 да бисте били сигурни да ће ваше поруке бити правилно примљене.";

--- a/deltachat-ios/sr.lproj/Localizable.stringsdict
+++ b/deltachat-ios/sr.lproj/Localizable.stringsdict
@@ -157,11 +157,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Пошаљи датотеку %s?</string>
+			<string>Пошаљи датотеку %2$@?</string>
 			<key>few</key>
-			<string>Пошаљи %d датотеке %s?</string>
+			<string>Пошаљи %d датотеке %2$@?</string>
 			<key>other</key>
-			<string>Пошаљи %d датотеке %s?</string>
+			<string>Пошаљи %d датотеке %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_messages</key>

--- a/deltachat-ios/sv.lproj/Localizable.strings
+++ b/deltachat-ios/sv.lproj/Localizable.strings
@@ -57,7 +57,9 @@
 "media" = "Media";
 "apps_and_media" = "Appar & Media";
 "profile" = "Profil";
+// deprecated
 "all_profiles" = "Alla profiler";
+// deprecated
 "current_profile" = "Aktuell profil";
 "main_menu" = "Huvudmeny";
 "start_chat" = "Starta chatt";
@@ -78,6 +80,7 @@
 "always" = "Alltid";
 "always_load_remote_images" = "Läs alltid in fjärrbilder";
 "once" = "en gång";
+// deprecated
 "show_warning" = "Visa varning";
 "not_now" = "Inte nu";
 "never" = "Aldrig";
@@ -152,6 +155,7 @@
 "camera" = "Kamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Fånga";
+// Switch eg. from front to back camera
 "switch_camera" = "Växla kamera";
 "toggle_fullscreen" = "Växla fullskärm";
 "location" = "Plats";
@@ -319,6 +323,7 @@
 "mute_for_one_day" = "Tysta 1 dag";
 "mute_for_seven_days" = "Tysta 7 dagar";
 "mute_forever" = "Tysta för evigt";
+// deprecated
 "share_location_for_5_minutes" = "i 5 minuter";
 "share_location_for_30_minutes" = "i 30 minuter";
 "share_location_for_one_hour" = "i 1 timma";
@@ -355,6 +360,7 @@
 "ask_leave_group" = "Vill du verkligen lämna?";
 "ask_delete_named_chat" = "Vill du ta bort chatten\"%1$@\"?";
 "ask_delete_message" = "Vill du ta bort detta meddelande?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Vill du vidarebefordra meddelanden till %1$@?";
 "ask_forward_multiple" = "Vill du vidarebefordra meddelanden till %1$d chattar?";
 "ask_export_attachment" = "Vill du exportera bilagor? Exporterade bilagor tillåter andra appar på din enhet att komma åt dem.\n\nVill du fortsätta?";
@@ -643,6 +649,7 @@
 "pref_notifications_priority" = "Prioritet";
 "pref_notifications_explain" = "Aktivera systemavisering för nya meddelanden";
 "pref_show_notification_content" = "Visa meddelandeinnehåll i avisering";
+// deprecated
 "pref_show_notification_content_explain" = "Visar avsändare och de första orden i meddelandet, i aviseringen.";
 "pref_led_color" = "Färg på ljusindikator";
 "pref_sound" = "Ljud";
@@ -683,16 +690,23 @@
 "pref_background" = "Bakgrund";
 "pref_background_btn_default" = "Använd standardbild";
 "pref_background_btn_gallery" = "Välj från galleriet";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Om du inaktiverar det här alternativet, tillse att servern och dina andra klienter är konfigurerade i enlighet med detta.\n\nAnnars kanske saker och ting inte fungerar alls.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Flerenhetsläge";
 "pref_multidevice_explain" = "Synkronisera dina meddelanden med dina andra enheter. Aktiveras automatiskt när du lägger till en andra enhet";
 "pref_multidevice_change_warn" = "Flerenhetsläge måste vara aktiverat när du använder samma profil på flera enheter. Inaktivera endast den här inställningen om du har tagit bort profilen från alla andra enheter.\n\nInaktiverar du flerenhetsläget när du använder profilen på flera enheter kommer du att missa meddelanden och få andra problem.";
+// deprecated
 "pref_auto_folder_moves" = "Flyttas automatiskt till DeltaChat-mappen";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Hämta endast från DeltaChat-mappen";
+// deprecated
 "pref_show_emails" = "Visa vanliga e-postmeddelanden";
+// deprecated
 "pref_show_emails_no" = "Nej, bara chattar";
+// deprecated
 "pref_show_emails_accepted_contacts" = "För godkända kontakter";
+// deprecated
 "pref_show_emails_all" = "Alla";
 "pref_experimental_features" = "Experimentella funktioner";
 "pref_experimental_features_explain" = "Dessa funktioner kan vara instabila och kan ändras eller tas bort";
@@ -744,14 +758,17 @@
 // automatically delete message
 "delete_old_messages" = "Ta bort gamla meddelanden";
 "autodel_device_title" = "Ta bort meddelanden från enheten";
+// deprecated
 "autodel_server_title" = "Ta bort meddelanden från servern";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Vill du ta bort %1$d meddelanden nu och alla kommande meddelanden \"%2$@\" i framtiden?\n\n• Detta inkluderar all mediafiler.\n\n• Meddelanden kommer att tas bort oavsett om de har lästs eller inte.\n\n• \"Sparade meddelanden\" undantas från lokal borttagning.";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Vill du ta bort %1$d meddelanden nu och alla nyligen hämtade meddelanden \"%2$@\" i framtiden?\n\n⚠️ Detta inkluderar e-post, media och \"Sparade meddelanden\" i alla servermappar\n\n⚠️ Använd inte den här funktionen om du vill behålla data på servern\n\n⚠️ Använd inte den här funktionen om du använder andra e-postklienter än Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Detta inkluderar e-post, media och \"Sparade meddelanden\" i alla servermappar. Använd inte den här funktionen om du vill spara data på servern eller om du använder andra e-postklienter än Delta Chat.";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Slå på direktborttagning";
+// deprecated
 "autodel_server_warn_multi_device" = "Om du aktiverar direktborttagning kan du inte använda flera enheter på den här profilen.";
 "autodel_confirm" = "Jag förstår! Ta bort alla dessa meddelanden.";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -842,7 +859,7 @@
 "invalid_unencrypted_explanation" = "För att skapa totalsträckskryptering kan du träffa kontakter personligen och skanna deras QR-kod för att introducera dem.";
 "learn_more" = "Lär dig mer";
 "devicemsg_self_deleted" = "Du har tagit bort chatten \"Sparade meddelanden\".\n\nℹ️ Om du vill använda funktionen \"Sparade meddelanden\" igen skapar du en ny chatt med dig själv.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Din leverantörs lagringsutrymme är snart slut: %1$@%% är redan använt.\n\nDu kanske inte kan ta emot meddelanden om lagringsutrymmet är fullt.\n\n👉 Kontrollera om du kan radera gammal data i leverantörens webbgränssnitt och överväg att aktivera \"Inställningar / Chattar och media / Ta bort gamla meddelanden\". Du kan kontrollera din aktuella lagringsanvändning när som helst under \"Inställningar / Anslutning\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Datum eller tid på din enhet verkar vara felaktigt (%1$@).\n\nJustera din klocka ⏰🔧 för att säkerställa att dina meddelanden tas emot korrekt.";

--- a/deltachat-ios/sv.lproj/Localizable.stringsdict
+++ b/deltachat-ios/sv.lproj/Localizable.stringsdict
@@ -189,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Skicka följande fil till %s?</string>
+			<string>Skicka följande fil till %2$@?</string>
 			<key>other</key>
-			<string>Vill du skicka följande %d filer till %s ?</string>
+			<string>Vill du skicka följande %d filer till %2$@ ?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/ta.lproj/Localizable.strings
+++ b/deltachat-ios/ta.lproj/Localizable.strings
@@ -113,11 +113,13 @@
 "mute_for_one_day" = "1 நாள் இதற்காக ஊமையாக்கு";
 "mute_for_seven_days" = "7 நாட்கள் இதற்காக ஊமையாக்கு";
 "mute_forever" = "எப்போதுமே ஊமையாக்கு";
+// deprecated
 "share_location_for_5_minutes" = "5 நிமிடங்கள் ";
 "share_location_for_30_minutes" = "30 நிமிடங்கள் ";
 "share_location_for_one_hour" = "1 மணி";
 "share_location_for_two_hours" = "2 மணிகள்";
 "share_location_for_six_hours" = "6 மணிகள்";
+// deprecated, use ask_forward_messages
 "ask_forward" = "தேர்வு செய்யப்பட்ட செய்திகளை இவற்றுக்கு %1$@ முன்னோக்கி அனுப்பவா ?";
 "ask_block_contact" = "இந்த தொடர்பை முடக்கவா ?";
 // contact list

--- a/deltachat-ios/te.lproj/Localizable.strings
+++ b/deltachat-ios/te.lproj/Localizable.strings
@@ -116,6 +116,7 @@
 "mute_for_eight_hours" = "8 గంటలు నిశబ్దంగా ఉంచు";
 "mute_for_one_day" = "1 రోజు నిశబ్దంగా ఉంచు";
 "mute_for_seven_days" = "7 రోజులు నిశబ్దంగా ఉంచు";
+// deprecated, use ask_forward_messages
 "ask_forward" = "సందేశాలు %1$@ ఫార్వర్డ్ చేయాలా?";
 "ask_block_contact" = "మీరు ఈ పరిచయాన్ని రద్దుచేయాలని నిర్ణయించుకున్నారా?";
 // contact list

--- a/deltachat-ios/tr.lproj/Localizable.strings
+++ b/deltachat-ios/tr.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 "downloading" = "İndiriliyor…";
 "open_attachment" = "İlişiği Aç";
 "join" = "Katıl";
+"join_group" = "Gruba Katıl";
+"join_channel" = "Kanala Katıl";
 "rejoin" = "Yeniden Katıl";
 "delete" = "Sil";
 "delete_for_me" = "Benim için Sil";
@@ -57,7 +59,9 @@
 "media" = "Ortam";
 "apps_and_media" = "Uygulamalar ve Ortamlar";
 "profile" = "Profil";
+// deprecated
 "all_profiles" = "Tüm Profiller";
+// deprecated
 "current_profile" = "Şu Anki Profil";
 "main_menu" = "Ana Menü";
 "start_chat" = "Sohbet Başlat";
@@ -68,6 +72,8 @@
 "mark_as_read" = "Okundu Olarak İmle";
 // Used beside an icon with very few space. Shortest text for "Mark as being read". In english, this could be "Read" (past tense of "to read"), in german, this could be "Gelesen".
 "mark_as_read_short" = "Okundu İmi";
+// Used as an menu entry or button
+"mark_as_unread" = "Okunmadı Olarak İmle";
 // Used beside an icon with very few space. Shortest text for "Mark as being unread". In english, this could be "Unread" (past tense of "to unread"), in german, this could be "Ungelesen".
 "mark_as_unread_short" = "Okunmayan";
 // Placeholder text when something is loading
@@ -80,6 +86,7 @@
 "always" = "Her zaman";
 "always_load_remote_images" = "Her Zaman Uzak Görselleri Yükle";
 "once" = "Bir kez";
+// deprecated
 "show_warning" = "Uyarı Göster";
 "not_now" = "Şimdi değil";
 "never" = "Hiçbir zaman";
@@ -89,6 +96,7 @@
 "offline" = "Çevrimdışı";
 // For the next view or as "continue". Should be as short as possible.
 "next" = "Sonraki";
+"warning" = "Uyarı";
 "error" = "Hata";
 "error_x" = "Hata: %1$@";
 "no_app_to_handle_data" = "Bu veri türünü işleyen bir uygulama bulunamıyor.";
@@ -155,6 +163,7 @@
 "camera" = "Kamera";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Yakala";
+// Switch eg. from front to back camera
 "switch_camera" = "Kamerayı Değiştir";
 "toggle_fullscreen" = "Tam Ekran Moduna Geç";
 "location" = "Konum";
@@ -322,6 +331,7 @@
 "mute_for_one_day" = "1 günlüğüne sessize al";
 "mute_for_seven_days" = "7 günlüğüne sessize al";
 "mute_forever" = "Sonsuza dek sessize al";
+// deprecated
 "share_location_for_5_minutes" = "5 dakikalığına";
 "share_location_for_30_minutes" = "30 dakikalığına";
 "share_location_for_one_hour" = "1 saatliğine";
@@ -360,11 +370,14 @@
 "canceled_call" = "İptal edilen arama";
 "missed_call" = "Yanıtlanmayan arama";
 "already_in_call" = "Zaten bir aramada";
+"call_answered_elsewhere" = "Arama başka bir aygıtta yanıtlandı";
+"call_requires_mic_permission" = "Mikrofon izni aramalar için gereklidir";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "Ayrılmak istediğinizden emin misiniz?";
 "ask_delete_named_chat" = "“%1$@” sohbeti silinsin mi?";
 "ask_delete_message" = "Bu ileti silinsin mi?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "İletiler %1$@ kişisine iletilsin mi?";
 "ask_forward_multiple" = "İletiler %1$d sohbete iletilsin mi?";
 "ask_export_attachment" = "İlişikleri dışa aktarmak, aygıtınızdaki diğer uygulamaların onlara erişmesine izin verir.\n\nSürdürülsün mü?";
@@ -435,8 +448,11 @@
 // search
 "search" = "Ara";
 "search_in_chat" = "Sohbette Ara";
+// Placeholder will be replaced by the chat name
+"search_in" = "%1$@ içinde ara";
 "search_files" = "Dosyalar Ara";
 "search_explain" = "Sohbetleri, kişileri ve iletileri ara";
+"search_result_for_x" = "“%1$@” için sonuç";
 "search_no_result_for_x" = "“%1$@” için sonuç bulunamadı";
 // Adjective, as in "Show Unread Messages"
 "search_unread" = "Okunmayan";
@@ -448,6 +464,7 @@
 "group_create_button" = "Grup Oluştur";
 // deprecated, use please_enter_chat_name
 "group_please_enter_group_name" = "Lütfen grup için bir ad girin.";
+"please_enter_chat_name" = "Lütfen bir ad girin.";
 "group_add_members" = "Üyeler Ekle";
 "group_self_not_in_group" = "Bu eylemi gerçekleştirmek için grubun bir üyesi olmalısınız.";
 "profile_encryption" = "Şifreleme";
@@ -660,6 +677,7 @@
 "pref_notifications_priority" = "Öncelik";
 "pref_notifications_explain" = "Yeni iletiler için sistem bildirimlerini etkinleştir";
 "pref_show_notification_content" = "Bildirimde ileti içeriğini göster";
+// deprecated
 "pref_show_notification_content_explain" = "Bildirimlerde iletinin gönderenini ve ilk sözcüklerini gösterir";
 "pref_led_color" = "LED Rengi";
 "pref_sound" = "Ses";
@@ -678,6 +696,8 @@
 "pref_incognito_keyboard_explain" = "Kişiselleştirilen öğrenmeyi etkisizleştirmek için klavye iste";
 "pref_read_receipts" = "Okundu Onayları";
 "pref_read_receipts_explain" = "Okundu onayları etkisizleştirilirse, diğerlerinden gelen okundu onaylarını göremeyeceksiniz.";
+// Title above a list of contacts who read a message
+"read_by" = "Okuyanlar";
 "pref_server" = "Sunucu";
 "pref_encryption" = "Şifreleme";
 "pref_manage_keys" = "Anahtarları Yönet";
@@ -700,16 +720,23 @@
 "pref_background" = "Duvar Kâğıdı";
 "pref_background_btn_default" = "Varsayılan Görseli Kullan";
 "pref_background_btn_gallery" = "Galeriden Seç";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Bu seçeneği değiştirirseniz, sunucunuzun ve diğer istemcilerinizin uygun olarak yapılandırıldığından emin olun.\n\nDeğilse özellikler hiç çalışmayabilir.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Çoklu Aygıt Modu";
 "pref_multidevice_explain" = "İletilerinizi diğer aygıtlarınızla eşzamanlayın. İkinci bir aygıt eklendiğinde otomatik olarak etkinleştirilir";
 "pref_multidevice_change_warn" = "Aynı profili birden fazla aygıtta kullanırken Çoklu Aygıt Modu etkinleştirilmelidir. Bu ayarı yalnızca bu profili diğer tüm aygıtlarınızdan kaldırdıysanız etkisizleştirin.\n\nProfili birden fazla aygıtta kullanırken Çoklu Aygıt Modu\'nu etkisizleştirmek, iletilerin kaçırılmasına ve diğer sorunlara neden olur.";
+// deprecated
 "pref_auto_folder_moves" = "DeltaChat Klasörüne Otomatik Olarak Taşı";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Yalnızca DeltaChat Klasöründen Getir";
+// deprecated
 "pref_show_emails" = "Klasik E-Postaları Göster";
+// deprecated
 "pref_show_emails_no" = "Hayır, yalnızca sohbetler";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Kabul edilen kişiler için";
+// deprecated
 "pref_show_emails_all" = "Tümü";
 "pref_experimental_features" = "Deneysel Özellikler";
 "pref_experimental_features_explain" = "Bu özellikler, kararsız olabilir ve değiştirilebilir ya da kaldırılabilir";
@@ -761,14 +788,17 @@
 // automatically delete message
 "delete_old_messages" = "Eski İletileri Sil";
 "autodel_device_title" = "İletileri Aygıttan Sil";
+// deprecated
 "autodel_server_title" = "İletileri Sunucudan Sil";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "%1$d iletiyi şimdi ve gelecekte yeni getirilen tüm iletileri “%2$@” silmek istiyor musunuz?\n\n• Bu, tüm ortamları kapsar\n\n• İletiler görülse de görülmese de silinecek\n\n• “Kaydedilen İletiler” yerel silmeden atlanacak";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "%1$d iletiyi şimdi ve gelecekte yeni getirilen tüm iletileri “%2$@” silmek istiyor musunuz?\n\n⚠️ Bu, tüm sunucu klasörlerindeki e-postaları, ortamları ve “Kaydedilen İletiler”i kapsar\n\n⚠️ Verileri sunucuda tutmak istiyorsanız ya da klasik e-posta istemcilerini de kullanıyorsanız bu işlevi kullanmayın";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Bu, tüm sunucu klasörlerindeki e-postaları, ortamları ve “Kaydedilen İletiler”i kapsar. Verileri sunucuda tutmak istiyorsanız ya da klasik e-posta istemcilerini de kullanıyorsanız bu işlevi kullanmayın";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Bir kerede silmeyi aç";
+// deprecated
 "autodel_server_warn_multi_device" = "Bir kerede silmeyi etkinleştirirseniz, bu profilde çoklu aygıtları kullanamazsınız.";
 "autodel_confirm" = "Anladım, tüm bu iletileri sil";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -786,9 +816,12 @@
 "group_name_changed_by_you" = "“%1$@” grup adını “%2$@” olarak değiştirdiniz.";
 // %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action.
 "group_name_changed_by_other" = "%3$@ tarafından “%1$@” grup adı “%2$@” olarak değiştirildi.";
+// %1$s will be replaced by the old channel name, %2$s will be replaced by the new channel name
+"channel_name_changed" = "“%1$@” kanal adı “%2$@” olarak değiştirildi.";
 "group_image_changed_by_you" = "Grup görselini değiştirdiniz.";
 // %1$s will be replaced by name of the contact who did the action
 "group_image_changed_by_other" = "%1$@ tarafından grup görseli değiştirildi.";
+"channel_image_changed" = "Kanal görseli değiştirildi.";
 "chat_description_changed_by_you" = "Sohbet açıklamasını değiştirdiniz.";
 // %1$s will be replaced by name of the contact who did the action
 "chat_description_changed_by_other" = "%1$@ tarafından sohbet açıklaması değiştirildi.";
@@ -860,7 +893,7 @@
 "invalid_unencrypted_explanation" = "Uçtan uca şifrelemeyi kurmak için kişilerle kişisel olarak tanışabilir ve onları tanıtmak için onların QR kodunu tarayabilirsiniz.";
 "learn_more" = "Daha Fazlasını Öğrenin";
 "devicemsg_self_deleted" = "“Kaydedilen İletiler” sohbetini sildiniz.\n\nℹ️ “Kaydedilen İletiler” özelliğini yeniden kullanmak için kendinizle yeni bir sohbet oluşturun.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Sağlayıcınızın depolaması dolmak üzere: %1$@%% zaten kullanımda.\n\nDepolama tam dolduğunda iletileri alamayabilirsiniz.\n\n👉 Lütfen sağlayıcınızın web arabiriminden eski verileri silip silemeyeceğinizi denetleyin ve “Ayarlar / Sohbetler / Eski İletileri Sil”i etkinleştirmeyi düşünün. Herhangi bir zamanda şu anki depolama kullanımınızı “Ayarlar / Bağlanabilirlik”ten denetleyebilirsiniz.";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Aygıtınızdaki tarih ya da saat yanlış görünüyor (%1$@).\n\nİletilerinizin doğru şekilde alınmasını sağlamak için saatinizi ⏰🔧 ayarlayın.";
@@ -922,6 +955,8 @@
 // first placeholder is the name of the chat
 "confirm_replace_draft" = "%1$@ zaten bir taslak ileti; onu değiştirmek istiyor musunuz?";
 "mailto_link_could_not_be_decoded" = "mailto bağlantısının kodu çözülemedi: %1$@";
+"remove_quote" = "Alıntıyı kaldır";
+"remove_attachment" = "İlişiği kaldır";
 // notifications
 "notify_reply_button" = "Yanıtla";
 "notify_new_message" = "Yeni ileti";
@@ -937,6 +972,9 @@
 // Body text for a generic "New messages" notification. Shown if we do not have more information about a new messages. Note, that the string is also referenced at https://github.com/deltachat/notifiers
 "new_messages_body" = "Yeni iletileriniz var";
 "n_messages_in_m_chats" = "%2$d sohbette %1$d ileti";
+// location streaming
+"location_streaming_notification_text" = "Konumunuzu paylaşıyorsunuz";
+"location_rationale" = "Sohbet üyeleriyle canlı konumunuzu paylaşmak için Delta Chat\'in konum verilerinizi kullanmasına izin verin.\n\nCanlı konumun çalışmasını kesintisiz yapmak için konum verileri, uygulama kapatıldığında ya da kullanımda değilken bile kullanılır.";
 // permissions
 "perm_required_title" = "İzin gerekli";
 "perm_continue" = "Sürdür";
@@ -976,6 +1014,7 @@
 "global_menu_help_about_desktop" = "Delta Chat hakkında";
 "global_menu_file_open_desktop" = "Delta Chat\'i Aç";
 "global_menu_minimize_to_tray" = "Küçült";
+"no_account_selected" = "Bir profil seçin ya da yeni bir profil oluşturun";
 "no_chat_selected_suggestion_desktop" = "Bir sohbet seçin ya da yeni bir sohbet oluşturun";
 "write_message_desktop" = "Bir ileti yazın";
 "encryption_info_title_desktop" = "Şifreleme Bilgisi";
@@ -997,8 +1036,15 @@
 // deprecated, used on desktop although there is not spell checker
 "no_spellcheck_suggestions_found" = "Yazım önerileri bulunamadı.";
 "show_window" = "Pencereyi Göster";
+"data_found_other_installation_message" = "Başka bir Delta Chat kurulumundan gelen profilleriniz erişilebilir değildir - farklı kurulumlar, verilerini ayrı konumlarda saklar.\n\nVarolan profilleri tutmak için:\n1. Şimdi çıkın\n2. Diğer Delta Chat\'i açın - gerekirse, onu %1$@ üzerinden yeniden kurun\n3. Her profili “Ayarlar/Sohbetler”den yedekleyin\n4. Bu sürümü yeniden başlatın\n5. Yedekleri “Zaten bir profilim var”dan geri yükleyin\n\nÖnceki profilleriniz olmadan sürdürülsün mü?";
 // title of the "keybindings" dialog (for the keybindings names as such, where possible the normal command strings are used)
 "keybindings" = "Tuş Bağları";
+// subtitle in the "keybindings" dialog
+"navigation_shortcut_section" = "Gezinti";
+// subtitle in the "keybindings" dialog
+"message_input_shortcut_section" = "İleti Girişi";
+// subtitle in the "keybindings" dialog
+"message_selected_shortcut_section" = "Seçilen İleti";
 "switch_between_chats" = "Sohbetler Arasında Geçiş Yap";
 "scroll_messages" = "İletileri Kaydır";
 // command to put the cursor to the search input field

--- a/deltachat-ios/tr.lproj/Localizable.stringsdict
+++ b/deltachat-ios/tr.lproj/Localizable.stringsdict
@@ -189,9 +189,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Aşağıdaki dosya %s kişisine gönderilsin mi?</string>
+			<string>Aşağıdaki dosya %2$@ kişisine gönderilsin mi?</string>
 			<key>other</key>
-			<string>Aşağıdaki %d dosya %s kişisine gönderilsin mi?</string>
+			<string>Aşağıdaki %d dosya %2$@ kişisine gönderilsin mi?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/uk.lproj/Localizable.strings
+++ b/deltachat-ios/uk.lproj/Localizable.strings
@@ -57,7 +57,9 @@
 "media" = "Медіа";
 "apps_and_media" = "Додатки й медіа";
 "profile" = "Профіль";
+// deprecated
 "all_profiles" = "Усі профілі";
+// deprecated
 "current_profile" = "Поточний Профіль";
 "main_menu" = "Головне меню";
 "start_chat" = "Почати розмову";
@@ -80,6 +82,7 @@
 "always" = "Завжди";
 "always_load_remote_images" = "Завжди завантажувати віддалені зображення";
 "once" = "Один раз";
+// deprecated
 "show_warning" = "Показати попередження";
 "not_now" = "Не зараз";
 "never" = "Ніколи";
@@ -155,6 +158,7 @@
 "camera" = "Камера";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Захопити";
+// Switch eg. from front to back camera
 "switch_camera" = "Перемкнути камеру";
 "toggle_fullscreen" = "Перейти в повноекранний режим";
 "location" = "Розташування";
@@ -322,6 +326,7 @@
 "mute_for_one_day" = "Вимкнути сповіщення на добу";
 "mute_for_seven_days" = "Вимкнути сповіщення на 7 днів";
 "mute_forever" = "Вимкнути сповіщення назавжди";
+// deprecated
 "share_location_for_5_minutes" = "на 5 хвилин";
 "share_location_for_30_minutes" = "на 30 хвилин";
 "share_location_for_one_hour" = "на 1 годину";
@@ -365,6 +370,7 @@
 "ask_leave_group" = "Ви впевнені, що хочете піти?";
 "ask_delete_named_chat" = "Видалити чат \"%1$@\" на всіх ваших пристроях?";
 "ask_delete_message" = "Видалити це повідомлення?";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Переслати повідомлення %1$@?";
 "ask_forward_multiple" = "Переслати повідомлення в %1$d?";
 "ask_export_attachment" = "Якщо експортувати вкладені файли, інші програми на вашому пристрої отримають до них доступ.\n\nПродовжити?";
@@ -660,6 +666,7 @@
 "pref_notifications_priority" = "Пріоритет";
 "pref_notifications_explain" = "Увімкнути системні сповіщення для нових повідомлень";
 "pref_show_notification_content" = "Відображати вміст повідомлення у сповіщенні";
+// deprecated
 "pref_show_notification_content_explain" = "Відображає відправника та перші слова повідомлення в сповіщеннях";
 "pref_led_color" = "Колір світлодіоду";
 "pref_sound" = "Звук";
@@ -700,16 +707,23 @@
 "pref_background" = "Фон";
 "pref_background_btn_default" = "Використовувати тло за замовчуванням";
 "pref_background_btn_gallery" = "Вибрати з галереї";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Якщо ви змінюєте цей параметр, переконайтеся, що Ваш сервер та інші Ваші клієнти налаштовані відповідним чином.\n\nІнакше щось може взагалі не працювати.";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "Режим роботи з декількома пристроями";
 "pref_multidevice_explain" = "Синхронізуйте свої повідомлення з іншими пристроями. Автоматично вмикається після додавання іншими пристроями";
 "pref_multidevice_change_warn" = "Режим декількох пристроїв має бути увімкнений, якщо ви використовуєте один і той самий профіль на декількох пристроях. Вимикайте цей параметр, лише якщо ви видалили цей профіль з усіх інших пристроїв.\n\nВимкнення режиму декількох пристроїв під час використання профілю на декількох пристроях призведе до пропусків повідомлення та інших проблем.";
+// deprecated
 "pref_auto_folder_moves" = "Автоматично пересувати до папки DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Збирати лише з теки DeltaChat.";
+// deprecated
 "pref_show_emails" = "Показувати звичайну пошту";
+// deprecated
 "pref_show_emails_no" = "Ні, лише чати";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Для прийнятих контактів";
+// deprecated
 "pref_show_emails_all" = "Всі";
 "pref_experimental_features" = "Експериментальні функції";
 "pref_experimental_features_explain" = "Ці функції можуть бути нестабільними і можуть бути змінені або видалені";
@@ -761,14 +775,17 @@
 // automatically delete message
 "delete_old_messages" = "Видалити старі повідомлення";
 "autodel_device_title" = "Видалити повідомлення з пристрою";
+// deprecated
 "autodel_server_title" = "Видалити повідомлення з сервера";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Ви хочете видалити %1$d повідомлень зараз і всі нові повідомлення \"%2$@\" у майбутньому?\n\n- Це включає всі медіа\n\n- Повідомлення буде видалено незалежно від того, чи були вони переглянуті чи ні\n\n- \"Збережені повідомлення\" буде пропущено при локальному видаленні";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Ви хочете видалити %1$d повідмолень зараз і всі нові повідомлення \"%2$@\" в майбутньому?\n\n⚠️ Сюди входять електронні листи, медіа та \"Збережені повідомлення\" у всіх теках сервера\n\n⚠️ Не використовуйте цю функцію, якщо ви хочете зберегти дані на сервері або якщо ви також використовуєте класичні поштові клієнти";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Сюди входять електронні листи, медіафайли та \"Збережені повідомлення\" у всіх папках сервера. Не використовуйте цю функцію, якщо ви хочете зберігати дані на сервері або якщо ви використовуєте класичні поштові клієнти";
+// deprecated
 "autodel_server_warn_multi_device_title" = "Увімкнути одномоментне видалення";
+// deprecated
 "autodel_server_warn_multi_device" = "Якщо ви ввімкнули одномоментне видалення, ви не зможете використовувати кілька пристроїв у цьому профілі.";
 "autodel_confirm" = "Я розумію, видалити всі ці повідомлення";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -860,7 +877,7 @@
 "invalid_unencrypted_explanation" = "Щоб встановити наскрізне шифрування, Ви можете зустрітися з контактами особисто та відсканувати їх QR-код.";
 "learn_more" = "Дізнатися більше";
 "devicemsg_self_deleted" = "Ви видалили чат \"Збережені повідомлення\".\n\nℹ️ Аби використовувати функцію \"Збережені повідомлення\" знову, створіть новий чат самі із собою.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Сховище вашого провайдера електронної пошти майже заповнено, уже використовується %1$@%%.\n\nМожливо, Ви не зможете отримувати повідомлення, коли сховище буде заповнене.\n\n👉 Перевірте, чи можна видалити старі дані у веб-інтерфейсі провайдера та ввімкніть \"Налаштування / Чати / Видалити старі повідомлення\". Ви можете будь-коли перевірити своє поточне використання сховища в \"Налаштування / Зʼєднання\". ";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Дата й час на вашому пристрої видаються неточними (%1$@).\n\nНалаштуйте свій годинник ⏰🔧 для правильного отримання повідомлень.";

--- a/deltachat-ios/uk.lproj/Localizable.stringsdict
+++ b/deltachat-ios/uk.lproj/Localizable.stringsdict
@@ -233,13 +233,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Надіслати цей файл → %s?</string>
+			<string>Надіслати цей файл → %2$@?</string>
 			<key>few</key>
-			<string>Надіслати ці %d файли → %s?</string>
+			<string>Надіслати ці %d файли → %2$@?</string>
 			<key>many</key>
-			<string>Надіслати ці %d файлів → %s?</string>
+			<string>Надіслати ці %d файлів → %2$@?</string>
 			<key>other</key>
-			<string>Надіслати ці %d файлів → %s?</string>
+			<string>Надіслати ці %d файлів → %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/vi.lproj/Localizable.strings
+++ b/deltachat-ios/vi.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "always" = "Luôn luôn";
 "always_load_remote_images" = "Luôn tải hình ảnh từ xa";
 "once" = "Một lần";
+// deprecated
 "show_warning" = "Hiển thị cảnh báo";
 "not_now" = "Không phải bây giờ";
 "never" = "Không bao giờ";
@@ -126,6 +127,7 @@
 "camera" = "Máy ảnh";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "Chụp";
+// Switch eg. from front to back camera
 "switch_camera" = "Chuyển đổi máy ảnh";
 "toggle_fullscreen" = "Chuyển đổi Chế độ toàn màn hình";
 "location" = "Vị trí";
@@ -245,12 +247,14 @@
 "mute_for_one_day" = "Tắt tiếng trong 1 ngày";
 "mute_for_seven_days" = "Tắt tiếng trong 7 ngày";
 "mute_forever" = "Tắt tiếng vĩnh viễn";
+// deprecated
 "share_location_for_5_minutes" = "Trong 5 phút";
 "share_location_for_30_minutes" = "Trong 30 phút";
 "share_location_for_one_hour" = "Trong 1 giờ";
 "share_location_for_two_hours" = "Trong 2 giờ";
 "share_location_for_six_hours" = "Trong 6 giờ";
 "file_saved_to" = "Tệp đã được lưu vào \"%1$@\".";
+// deprecated, use ask_forward_messages
 "ask_forward" = "Chuyển tiếp tin nhắn tới %1$@?";
 "ask_forward_multiple" = "Chuyển tiếp tin nhắn tới %1$d cuộc trò chuyện?";
 "ask_export_attachment" = "Xuất tệp đính kèm sẽ cho phép các ứng dụng khác trên thiết bị của bạn truy cập chúng.\n\nTiếp tục?";
@@ -460,6 +464,7 @@
 "pref_notifications_priority" = "Ưu tiên";
 "pref_notifications_explain" = "Bật thông báo hệ thống cho tin nhắn mới";
 "pref_show_notification_content" = "Hiển thị nội dung tin nhắn trong thông báo";
+// deprecated
 "pref_show_notification_content_explain" = "Hiển thị người gửi và từ đầu tiên của tin nhắn trong thông báo";
 "pref_led_color" = "Màu LED";
 "pref_sound" = "Âm thanh";
@@ -496,12 +501,19 @@
 "pref_background" = "Hình nền";
 "pref_background_btn_default" = "Sử dụng hình ảnh mặc định";
 "pref_background_btn_gallery" = "Chọn từ thư viện";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "Nếu bạn thay đổi tùy chọn này, hãy đảm bảo rằng máy chủ và các máy khách khác của bạn được cấu hình tương ứng.\n\nNếu không, mọi thứ có thể không hoạt động.";
+// deprecated
 "pref_auto_folder_moves" = "Tự động di chuyển đến Thư mục DeltaChat";
+// deprecated
 "pref_only_fetch_mvbox_title" = "Chỉ tìm nạp từ thư mục DeltaChat";
+// deprecated
 "pref_show_emails" = "Hiển thị E-mail cổ điển";
+// deprecated
 "pref_show_emails_no" = "Không, chỉ trò chuyện";
+// deprecated
 "pref_show_emails_accepted_contacts" = "Đối với các liên hệ được chấp nhận";
+// deprecated
 "pref_show_emails_all" = "Tất cả";
 "pref_experimental_features" = "Tính năng thử nghiệm";
 "pref_on_demand_location_streaming" = "Truyền phát vị trí theo yêu cầu";
@@ -538,12 +550,13 @@
 // automatically delete message
 "delete_old_messages" = "Xóa tin nhắn cũ";
 "autodel_device_title" = "Xóa tin nhắn khỏi thiết bị";
+// deprecated
 "autodel_server_title" = "Xóa tin nhắn khỏi máy chủ";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "Bạn có muốn xóa %1$d tin nhắn ngay bây giờ và tất cả các tin nhắn mới được tìm nạp \"%2$@\" trong tương lai không?\n\n• Điều này bao gồm tất cả phương tiện\n\n• Tin nhắn sẽ bị xóa dù chúng có được nhìn thấy hay không\n\n• \"Tin nhắn đã lưu\" sẽ bị bỏ qua khỏi quá trình xóa cục bộ";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "Bạn có muốn xóa %1$d tin nhắn ngay bây giờ và tất cả các tin nhắn mới được tìm nạp \"%2$@\" trong tương lai không?\n\n⚠️ Điều này bao gồm e-mail, phương tiện và \"Tin nhắn đã lưu\" trong tất cả máy chủ thư mục\n\n⚠️ Không sử dụng chức năng này nếu bạn muốn giữ dữ liệu trên máy chủ\n\n⚠️ Không sử dụng chức năng này nếu bạn đang sử dụng các ứng dụng e-mail khác ngoài Delta Chat";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "Điều này bao gồm e-mail, phương tiện và \"Tin nhắn đã lưu\" trong tất cả các thư mục máy chủ. Không sử dụng chức năng này nếu bạn muốn giữ dữ liệu trên máy chủ hoặc nếu bạn đang sử dụng các ứng dụng e-mail khác ngoài Delta Chat.";
 "autodel_confirm" = "Tôi hiểu, hãy xóa tất cả những tin nhắn này";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -618,7 +631,7 @@
 "chat_protection_enabled_explanation" = "Hiện tại, chúng tôi đảm bảo rằng tất cả tin nhắn trong cuộc trò chuyện này đều được mã hóa hai đầu.\n\nMã hóa hai đầu giúp giữ tin nhắn giữa bạn và đối tác trò chuyện của bạn ở chế độ riêng tư. Ngay cả nhà cung cấp email của bạn cũng không thể đọc được chúng.";
 "learn_more" = "Tìm hiểu thêm";
 "devicemsg_self_deleted" = "Bạn đã xóa cuộc trò chuyện \"Tin nhắn đã lưu\".\n\nℹ️ Để sử dụng lại tính năng \"Tin nhắn đã lưu\", hãy tạo một cuộc trò chuyện mới với chính bạn.";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ Bộ nhớ nhà cung cấp của bạn sắp hết: %1$@%% đã được sử dụng.\n\nBạn có thể không nhận được tin nhắn nếu bộ nhớ đầy.\n\n 👉 Vui lòng kiểm tra xem bạn có thể xóa không dữ liệu cũ trong giao diện web của nhà cung cấp và cân nhắc bật \"Cài đặt / Xóa tin nhắn cũ\". Bạn có thể kiểm tra mức sử dụng bộ nhớ hiện tại của mình bất kỳ lúc nào tại \"Cài đặt / Kết nối\".";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ Ngày hoặc giờ trên thiết bị của bạn có vẻ không chính xác (%1$@).\n\nĐiều chỉnh đồng hồ của bạn ⏰🔧 để đảm bảo tin nhắn của bạn được nhận chính xác.";

--- a/deltachat-ios/vi.lproj/Localizable.stringsdict
+++ b/deltachat-ios/vi.lproj/Localizable.stringsdict
@@ -125,7 +125,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>Gửi tập tin sau tới %s?</string>
+			<string>Gửi tập tin sau tới %2$@?</string>
 		</dict>
 	</dict>
 	<key>ask_delete_messages</key>

--- a/deltachat-ios/zh-Hans.lproj/Localizable.strings
+++ b/deltachat-ios/zh-Hans.lproj/Localizable.strings
@@ -59,7 +59,9 @@
 "media" = "媒体";
 "apps_and_media" = "应用和媒体";
 "profile" = "账号";
+// deprecated
 "all_profiles" = "所有账号";
+// deprecated
 "current_profile" = "当前账号";
 "main_menu" = "主菜单";
 "start_chat" = "开始聊天";
@@ -84,6 +86,7 @@
 "always" = "总是";
 "always_load_remote_images" = "始终加载远程图像";
 "once" = "仅一次";
+// deprecated
 "show_warning" = "显示警告";
 "not_now" = "现在不";
 "never" = "从不";
@@ -160,6 +163,7 @@
 "camera" = "相机";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "捕获";
+// Switch eg. from front to back camera
 "switch_camera" = "切换摄像头";
 "toggle_fullscreen" = "切换全屏模式";
 "location" = "位置";
@@ -327,11 +331,13 @@
 "mute_for_one_day" = "静音 1 天";
 "mute_for_seven_days" = "静音 7 天";
 "mute_forever" = "永久静音";
+// deprecated
 "share_location_for_5_minutes" = "5 分钟";
 "share_location_for_30_minutes" = "30 分钟";
 "share_location_for_one_hour" = "1 小时";
 "share_location_for_two_hours" = "2 小时";
 "share_location_for_six_hours" = "6 小时";
+"share_location_for_24_hours" = "24 小时";
 "file_saved_to" = "文件已保存到 “%1$@”。";
 // the action "to call someone", used as a tooltip for the "phone" icon. not: "the call"
 "start_call" = "呼叫";
@@ -367,11 +373,16 @@
 "already_in_call" = "已在通话中";
 "call_answered_elsewhere" = "通话已在其他设备上接听";
 "call_requires_mic_permission" = "通话需要麦克风权限";
+// Used e.g. in a notifications to describe an ongoing call. "Call" is a noun here, in the meaning of "This is the call with ..." where the placeholder is replaced by the name of the contact.
+"call_with" = "与 %1$@ 的通话";
+// Use e.g. in a notifications during ringing. Placeholder is relaced by the name of the contact being called.
+"calling_person" = "正在呼叫 %1$@…";
 // get confirmations
 // confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well
 "ask_leave_group" = "是否确定要离开？";
 "ask_delete_named_chat" = "删除聊天“%1$@”？";
 "ask_delete_message" = "删除此消息？";
+// deprecated, use ask_forward_messages
 "ask_forward" = "将消息转发给 %1$@？";
 "ask_forward_multiple" = "转发消息到 %1$d 个聊天？";
 "ask_export_attachment" = "导出附件将允许您设备上的其他应用访问这些附件。\n\n是否继续？";
@@ -654,7 +665,7 @@
 "pref_outgoing_media_quality" = "发出媒体质量";
 "pref_outgoing_media_quality_hint" = "如需发送原始质量的媒体，请将媒体以“文件”形式附加。此方式会消耗您和接收者更多的数据使用量。";
 "pref_outgoing_balanced" = "平衡";
-"pref_outgoing_worse" = "体积小，但质量更差";
+"pref_outgoing_worse" = "质量较差，节省数据";
 "pref_vibrate" = "振动";
 "pref_screen_security" = "屏幕安全";
 // Translators: Must indicate that there is no guarantee as the system may not honor our request.
@@ -666,11 +677,12 @@
 // Title for the "Calls" notification setting. This is a plural noun, not a verb.
 "pref_calls" = "通话";
 // Details about what the "Calls" notification setting does
-"pref_calls_explain" = "来电时显示通话屏幕";
+"pref_calls_explain" = "显示已接听联系人的通话屏幕";
 "pref_notifications_show" = "显示";
 "pref_notifications_priority" = "优先级";
 "pref_notifications_explain" = "为新消息启用系统通知";
 "pref_show_notification_content" = "在通知中显示消息内容";
+// deprecated
 "pref_show_notification_content_explain" = "在通知中显示发送者和消息开头部分";
 "pref_led_color" = "LED 颜色";
 "pref_sound" = "声音";
@@ -713,20 +725,27 @@
 "pref_background" = "背景";
 "pref_background_btn_default" = "使用默认图像";
 "pref_background_btn_gallery" = "从图库中选择";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "若要更改此选项，请您务必调整服务器以及其他客户端的相应设置。\n\n否则软件可能无法正常工作。";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "多设备模式";
 "pref_multidevice_explain" = "将您的消息与其他设备同步。添加第二台设备时自动启用";
 "pref_multidevice_change_warn" = "在多个设备上使用同一账号时，必须启用多设备模式。仅当您已从所有其他设备中移除此账号后，才能禁用此设置。\n\n在多个设备上使用该账号时禁用多设备模式会导致错过消息和其他问题。";
+// deprecated
 "pref_auto_folder_moves" = "自动移动至 DeltaChat 文件夹";
+// deprecated
 "pref_only_fetch_mvbox_title" = "只从 DeltaChat 文件夹获取";
+// deprecated
 "pref_show_emails" = "显示传统电子邮件";
+// deprecated
 "pref_show_emails_no" = "不显示，仅聊天";
+// deprecated
 "pref_show_emails_accepted_contacts" = "已接受的联系人";
+// deprecated
 "pref_show_emails_all" = "全部";
 "pref_experimental_features" = "实验性功能";
 "pref_experimental_features_explain" = "这些功能可能不稳定，可能会更改或移除";
-"pref_on_demand_location_streaming" = "按需位置流";
+"pref_on_demand_location_streaming" = "位置流";
 "pref_background_default" = "默认背景";
 "pref_background_default_color" = "默认颜色";
 "pref_background_custom_image" = "自定义图像";
@@ -774,14 +793,17 @@
 // automatically delete message
 "delete_old_messages" = "删除旧消息";
 "autodel_device_title" = "从设备删除消息";
+// deprecated
 "autodel_server_title" = "从服务器删除消息";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "您是否要立即删除 %1$d 条消息，并在之后于消息收到 %2$@ 删除它们？\n\n• 这包括所有媒体文件\n\n• 无论消息是否被浏览过，它们都将被删除\n\n• 在本地删除中，“保存的消息”将被跳过";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "您是否要立即删除 %1$d 条消息，并在之后于消息收到 %2$@ 删除它们？\n\n⚠️ 这包括服务器所有文件夹中的电子邮件、媒体和“保存的消息”\n\n⚠️ 如果您想在服务器上保留数据或使用传统电子邮件客户端，请勿使用此功能";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "这包括所有服务器文件夹中的电子邮件、媒体和“保存的消息”。如果您想在服务器上保留数据，或者也使用传统电子邮件客户端，请勿使用此功能";
+// deprecated
 "autodel_server_warn_multi_device_title" = "开启一次性删除";
+// deprecated
 "autodel_server_warn_multi_device" = "如果您启用一次删除，则无法在此配置文件中使用多台设备。";
 "autodel_confirm" = "我了解，将这些消息全部删除";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -876,7 +898,7 @@
 "invalid_unencrypted_explanation" = "要建立端到端加密，您可以亲自和联系人碰面并扫描联系人的二维码。";
 "learn_more" = "了解更多";
 "devicemsg_self_deleted" = "您已删除“保存的消息”聊天。\n\nℹ️ 要再次使用“保存的消息”功能，请创建一个与自己的新聊天。";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ 您的服务提供者存储空间即将用完：已使用 %1$@%%。\n\n如果存储空间已满，您可能无法接收消息。\n\n👉 请检查您是否可以在服务提供者的网页界面中删除旧数据，并考虑启用“设置/聊天/删除旧消息”。您可以随时在“设置/连接”中查看当前的存储空间使用情况。";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ 设备的日期或时间似乎不准确 （%1$@）。\n\n请调整时钟 ⏰🔧 以确保能够正确接收消息。";
@@ -956,8 +978,6 @@
 "new_messages_body" = "你有新消息";
 "n_messages_in_m_chats" = "%1$d 条消息，位于 %2$d 个聊天内";
 // location streaming
-"location_streaming_channel_desc" = "按需位置流频道";
-"location_streaming_notification_title" = "位置流";
 "location_streaming_notification_text" = "您正在共享您的位置";
 "location_rationale" = "要与聊天成员共享您的实时位置，请允许 Delta Chat 使用您的位置数据。\n\n为了确保实时位置无缝工作，即使应用已关闭或未使用，也会使用位置数据。";
 // permissions
@@ -1048,6 +1068,8 @@
 "a11y_message_context_menu_btn_label" = "消息操作";
 "a11y_background_preview_label" = "背景预览";
 "a11y_disappearing_messages_activated" = "消息定时销毁已激活";
+// The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility.
+"open_link" = "打开 %1$@";
 // iOS specific strings, developers: please take care to remove strings that are no longer used!
 "stop_sharing_location" = "停止共享位置";
 "a11y_voice_message_hint_ios" = "录制后，点按两次即可发送。如需舍弃录制内容，请双指滑动。";

--- a/deltachat-ios/zh-Hans.lproj/Localizable.stringsdict
+++ b/deltachat-ios/zh-Hans.lproj/Localizable.stringsdict
@@ -167,7 +167,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>将以下 %d 个文件发送给 %s？</string>
+			<string>将以下 %d 个文件发送给 %2$@？</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/deltachat-ios/zh-Hant.lproj/Localizable.strings
+++ b/deltachat-ios/zh-Hant.lproj/Localizable.strings
@@ -57,7 +57,9 @@
 "media" = "多媒體";
 "apps_and_media" = "應用程式和媒體";
 "profile" = "賬戶";
+// deprecated
 "all_profiles" = "所有賬戶";
+// deprecated
 "current_profile" = "當前賬戶";
 "main_menu" = "主選單";
 "start_chat" = "開始聊天";
@@ -78,6 +80,7 @@
 "always" = "永遠";
 "always_load_remote_images" = "總是載入遠端圖片";
 "once" = "僅一次";
+// deprecated
 "show_warning" = "顯示警告";
 "not_now" = "現在不要";
 "never" = "永遠不要";
@@ -153,6 +156,7 @@
 "camera" = "相機";
 // As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras
 "capture" = "拍攝";
+// Switch eg. from front to back camera
 "switch_camera" = "切換相機";
 "toggle_fullscreen" = "切換全螢幕模式";
 "location" = "地點";
@@ -320,6 +324,7 @@
 "mute_for_one_day" = "靜音1天";
 "mute_for_seven_days" = "靜音7天";
 "mute_forever" = "永遠靜音";
+// deprecated
 "share_location_for_5_minutes" = "5分鐘";
 "share_location_for_30_minutes" = "30分鐘";
 "share_location_for_one_hour" = "1小時";
@@ -362,6 +367,7 @@
 "ask_leave_group" = "確定要離開？";
 "ask_delete_named_chat" = "刪除您所有設備上的“%1$@”聊天 ？";
 "ask_delete_message" = "在您的所有裝置上刪除此訊息？";
+// deprecated, use ask_forward_messages
 "ask_forward" = "轉發訊息給%1$@？";
 "ask_forward_multiple" = "轉發訊息到%1$d個聊天？";
 "ask_export_attachment" = "要匯出附件嗎？匯出的附件可以用裝置上的其它應用程式打開。\n\n要繼續嗎？";
@@ -655,6 +661,7 @@
 "pref_notifications_priority" = "通知優先權";
 "pref_notifications_explain" = "為新訊息啟用系統通知";
 "pref_show_notification_content" = "在通知中顯示訊息內容";
+// deprecated
 "pref_show_notification_content_explain" = "顯示通知中訊息的寄件人和開頭部分";
 "pref_led_color" = "LED顏色";
 "pref_sound" = "音效";
@@ -695,16 +702,23 @@
 "pref_background" = "背景";
 "pref_background_btn_default" = "使用預設圖案";
 "pref_background_btn_gallery" = "從相簿中挑選";
+// deprecated
 "pref_imap_folder_warn_disable_defaults" = "如果關閉本選項的話，請務必確定你的伺服器和其它客戶端應用程式都使用相同的設定，否則很可能不能運作。";
 // No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help
 "pref_multidevice" = "多裝置模式";
 "pref_multidevice_explain" = "將您的訊息與其他裝置同步。新增第二個裝置時自動啟用";
 "pref_multidevice_change_warn" = "在多個裝置上使用同一的帳戶時，必須啟用多裝置模式。只有在您已從所有其他設備移除此帳戶後，才可以禁用此設定。\n\n在多個裝置上使用該帳戶時禁用多裝置模式將導致漏接訊息及其他問題。";
+// deprecated
 "pref_auto_folder_moves" = "自動搬移到 DeltaChat 資料夾";
+// deprecated
 "pref_only_fetch_mvbox_title" = "僅從 DeltaChat 資料夾中獲取";
+// deprecated
 "pref_show_emails" = "顯示傳統email";
+// deprecated
 "pref_show_emails_no" = "只顯示對話";
+// deprecated
 "pref_show_emails_accepted_contacts" = "顯示已接受的聯絡人";
+// deprecated
 "pref_show_emails_all" = "所有郵件";
 "pref_experimental_features" = "實驗性功能";
 "pref_experimental_features_explain" = "這些功能可能不穩定，並且可能會被更改或移除";
@@ -756,14 +770,17 @@
 // automatically delete message
 "delete_old_messages" = "刪除舊訊息";
 "autodel_device_title" = "從裝置中刪除訊息";
+// deprecated
 "autodel_server_title" = "從伺服器中刪除訊息";
 // %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
 "autodel_device_ask" = "您是否要立即刪除%1$d條消息，之後在收到消息「%2$@」后刪除它們？ \n\n⚠️ 這包括伺服器所有媒體\n\n•這包括所有媒體\n\n• 無論消息是否被看到都將被刪除\n\n• “已保存的郵件”將不會被本地刪除";
-// %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option.
+// deprecated
 "autodel_server_ask" = "您是否要立即刪除%1$d條訊息，之後在訊息收到「%2$@」后刪除它們？ \n\n⚠️ 這包括伺服器所有資料夾中的電子郵件、媒體和“保存的消息”\n\n⚠️ 如果您想在伺服器上保留數據，請不要使用此功能\n\n⚠️ 如果您正在使用 Delta Chat 之外的電子郵件用戶端，請不要使用此功能";
-// shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact
+// deprecated
 "autodel_server_enabled_hint" = "這包括所有伺服器資料夾中的電子郵件、媒體和「保存的訊息」。如果您想將數據保留在伺服器上，或者您正在使用 Delta Chat 以外的其他電子郵件用戶端，請不要使用此功能。";
+// deprecated
 "autodel_server_warn_multi_device_title" = "啟用一次性刪除";
+// deprecated
 "autodel_server_warn_multi_device" = "如果啟用一次性刪除，則您無法使用多個裝置登入該賬戶。";
 "autodel_confirm" = "我已知曉，刪除所有這些消息";
 // "At once" in the meaning of "Immediately", without any intervening time.
@@ -854,7 +871,7 @@
 "invalid_unencrypted_explanation" = "要建立端到端加密，您可以當面掃描聯絡人的QR碼。";
 "learn_more" = "瞭解更多";
 "devicemsg_self_deleted" = "您刪除了「已保存的訊息」聊天。\n\nℹ️要再次使用「已保存的訊息」功能，請與自己創建新聊天。";
-// %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %%
+// deprecated
 "devicemsg_storage_exceeding" = "⚠️ 您的供應商的存儲空間即將用完：已使用%1$@%%。\n\n如果存儲空間已滿，您可能無法接收訊息。\n\n👉請檢查您是否可以在提供商的網頁介面中刪除舊數據，並考慮啟用「設定/聊天和媒體/刪除舊訊息」。您可以隨時在「設定/連接」 中檢查您目前的儲存使用方式。";
 // %1%s will be replaced by date and time in some human-readable format
 "devicemsg_bad_time" = "⚠️ 您裝置上的日期或時間似乎不準確 （%1$@）。\n\n調整您的時鐘⏰🔧以確保您的訊息被正確接收。";

--- a/deltachat-ios/zh-Hant.lproj/Localizable.stringsdict
+++ b/deltachat-ios/zh-Hant.lproj/Localizable.stringsdict
@@ -167,7 +167,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>要將%d個檔案傳送給%s？</string>
+			<string>要將%d個檔案傳送給%2$@？</string>
 		</dict>
 	</dict>
 	<key>ask_delete_chat</key>

--- a/scripts/convert_translations.py
+++ b/scripts/convert_translations.py
@@ -61,8 +61,9 @@ def generate_stringsdict(plurals: list, xml: TextIO) -> None:
         for quantity in ["zero", "one", "two", "few", "many", "other"]:
             item = elem.find(f'item[@quantity="{quantity}"]')
             if item is not None:
+                text = normalize_plurals_text(item.text)
                 xml.write(f"\t\t\t<key>{quantity}</key>\n")
-                xml.write(f"\t\t\t<string>{item.text}</string>\n")
+                xml.write(f"\t\t\t<string>{text}</string>\n")
         xml.write("\t\t</dict>\n")
         xml.write("\t</dict>\n")
     xml.write("</dict>\n")
@@ -82,6 +83,15 @@ def normalize_text(original: str) -> str:
     text = text.replace("$s", "$@")
     return text.replace("%s", "%1$@")
 
+def normalize_plurals_text(original: str) -> str:
+    text = re.sub(r"[ \t]*[\r\n]+[ \t]*", " ", original) # real newlines -> space
+    if text != original:
+        logging.warning(f"Superfluous plurals lineend detected: {original}")
+
+    # plurals is in an html context, no need for entitiy conversion
+    text = text.replace("$s", "$@")
+    text = text.replace("%1$d", "%d") # "d" hard-referenced as <key>NSStringFormatValueTypeKey</key><string>d</string>
+    return text.replace("%s", "%2$@") # non-indexed string is the second parameter
 
 def get_resources(paths: list[Path]):
     for path in paths:


### PR DESCRIPTION
> for review, only the first two small commits are interesting, the third big one is the output of `convert_translations.py`

this PR shows the message count when forwarding messages and uses the new string, see https://github.com/deltachat/deltachat-android/pull/4427

to make this possible `convert_translations.py` needed to be changed to allow plural strings as `Forward COUNT messages to CHAT" - this is still a bit clumsy, however, no need to support all possible cases for plurals and placeholders, we adapt as needed instead. android eg. anyway does not support more than one plural value per string.

#skip-changelog as this is a minor change only

<img width=320 src="https://github.com/user-attachments/assets/f56c4139-b176-4b7c-ae0a-5a5fb1ed190a" />
