### PR TITLE
feat: add option to process unencrypted messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Allow otherwise invalid TLS connections if the key is unchanged
 - Do not show "non delivered" notifications in broadcast channels
 - Adapt quota warning to automatic cleanup.
+- Add an option to process unencrypted messages to "Advanced / Relays / Edit / More Options". By default, only encrypted messages can be sent or received
 - Fix: Your own video now shows as mirrored in a call
 - Fix: Improve detection of stickers
 - Fix: Allow animated stickers

--- a/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
@@ -43,6 +43,7 @@ class EditTransportViewController: UITableViewController {
         smtpServerCell,
         smtpPortCell,
         certCheckCell,
+        forceE2eeCell,
         viewLogCell
     ]
     private let editAddr: String?
@@ -209,6 +210,10 @@ class EditTransportViewController: UITableViewController {
         cell.tag = tagCertCheckCell
         cell.accessoryType = .disclosureIndicator
         return cell
+    }()
+
+    lazy var forceE2eeCell: SwitchCell = {
+        return SwitchCell(textLabel: String.localized("enforce_e2ee"), on: dcContext.getConfigBool("force_encryption"))
     }()
 
     lazy var viewLogCell: UITableViewCell = {
@@ -429,6 +434,7 @@ class EditTransportViewController: UITableViewController {
         loginParam.certificateChecks = certValue
 
         do {
+            dcContext.setConfigBool("force_encryption", forceE2eeCell.isOn)
             _ = try dcContext.addOrUpdateTransport(param: loginParam)
         } catch {
             progressAlertHandler.updateProgressAlert(error: error.localizedDescription)


### PR DESCRIPTION
this PR adds the new option to allow processing of unencrypted messages. 

this requires an account that can process these messages. for new profiles, "force encryption" is the default, for existing profile it depends on the most recent messages, however, the option can be changed at any time.

counterpart of https://github.com/deltachat/deltachat-android/pull/4431 and https://github.com/deltachat/deltachat-desktop/pull/6410

closes https://github.com/deltachat/deltachat-ios/issues/3117

<img width="320" src="https://github.com/user-attachments/assets/92fa5e83-efb2-4b85-9aeb-ef47a1ad4c34" />
