### PR TITLE
feat: show imap folder in relay settings, if set

### DIFF
--- a/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
@@ -37,6 +37,7 @@ class EditTransportViewController: UITableViewController {
         imapUserCell,
         imapServerCell,
         imapPortCell,
+        imapFolderCell,
         smtpSecurityCell,
         smtpUserCell,
         smtpPasswordCell,
@@ -134,6 +135,16 @@ class EditTransportViewController: UITableViewController {
             delegate: self)
         cell.textField.tag = tagTextFieldImapPort
         cell.textField.keyboardType = .numberPad
+        return cell
+    }()
+
+    lazy var imapFolderCell: TextFieldCell = {
+        let cell = TextFieldCell(
+            description: "IMAP Folder",
+            placeholder: String.localized("automatic"),
+            delegate: self)
+        cell.textField.isUserInteractionEnabled = false
+        cell.textField.textColor = .gray
         return cell
     }()
 
@@ -277,6 +288,7 @@ class EditTransportViewController: UITableViewController {
         imapUserCell.setText(text: loginParam?.imapUser)
         imapServerCell.setText(text: loginParam?.imapServer)
         imapPortCell.setText(text: editablePort(port: loginParam?.imapPort))
+        imapFolderCell.setText(text: loginParam?.imapFolder)
         imapSecurityValue.value = loginParam?.imapSecurity ?? "automatic"
         smtpUserCell.setText(text: loginParam?.smtpUser)
         smtpPasswordCell.setText(text: loginParam?.smtpPassword)
@@ -424,6 +436,7 @@ class EditTransportViewController: UITableViewController {
         var loginParam = DcEnteredLoginParam(addr: emailAddress, password: passwordCell.getText() ?? "")
         loginParam.imapServer = imapServerCell.getText()
         loginParam.imapPort = imapPortCell.getText().flatMap { Int($0) }
+        loginParam.imapFolder = imapFolderCell.getText()
         loginParam.imapUser = imapUserCell.getText()
         loginParam.imapSecurity = imapSecurityValue.value
         loginParam.smtpServer = smtpServerCell.getText()

--- a/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
@@ -282,6 +282,10 @@ class EditTransportViewController: UITableViewController {
             }
         }
 
+        if loginParam?.imapFolder == nil {
+            advancedSectionCells.removeAll { $0 === imapFolderCell }
+        }
+
         // init text cells (selections are initialized at viewWillAppear)
         emailCell.setText(text: loginParam?.addr)
         passwordCell.setText(text: loginParam?.password)

--- a/deltachat-ios/DC/DcEnteredLoginParam.swift
+++ b/deltachat-ios/DC/DcEnteredLoginParam.swift
@@ -7,6 +7,7 @@ public struct DcEnteredLoginParam: Codable {
     public var imapSecurity: String?
     public var imapServer: String?
     public var imapUser: String?
+    public var imapFolder: String?
     public var oauth2: Bool?
     public var password: String
     public var smtpPassword: String?


### PR DESCRIPTION
the imap folder is not editable,
and could only be set if migrating from old setups that were using "Only fetch from Delta Chat folder",
which is for shared usage, which is no longer supported.

still, on reconfiguration, the imap folder needs to be preserved, and the easiest way to do that is to have an disabled text field. this also has the nice side effect
that the user has a change to get aware that not INBOX is used.

the string itself is not translated on purpose, it is a super-special cornercase we're in here, and we do not want that to be used in the future at all. it would be hard to explain to translators what this string is for, alone the discussions are not worth the time :)

closes #3121 

#skip-changelog as there is already an entry about removed "Only fetch from Delta Chat folder" and that it is preserved

<img width="350" src="https://github.com/user-attachments/assets/d8f8d394-0532-4584-bba0-de6b3bfc9fbf" />
