### PR TITLE
move 'mark all as read' up

### DIFF
--- a/deltachat-ios/Controller/ProfileSwitchViewController.swift
+++ b/deltachat-ios/Controller/ProfileSwitchViewController.swift
@@ -102,14 +102,13 @@ class ProfileSwitchViewController: UITableViewController {
             previewProvider: nil,
             actionProvider: { [weak self] _ in
                 guard let self else { return nil }
-                var children: [UIMenuElement] = [
-                    UIAction.menuAction(localizationKey: muteTitle, systemImageName: muteImage, with: indexPath, action: toggleMute),
-                    UIAction.menuAction(localizationKey: "profile_tag", systemImageName: "tag", with: indexPath, action: setProfileTag),
-                    UIAction.menuAction(localizationKey: "move_to_top", systemImageName: "arrow.up", with: indexPath, action: moveToTop),
-                ]
+                var children: [UIMenuElement] = []
+                children.append(UIAction.menuAction(localizationKey: muteTitle, systemImageName: muteImage, with: indexPath, action: toggleMute))
                 if hasUnreadMessages {
                     children.append(UIAction.menuAction(localizationKey: "mark_all_as_read", systemImageName: checkmarkImage, with: indexPath, action: markAllAsRead))
                 }
+                children.append(UIAction.menuAction(localizationKey: "profile_tag", systemImageName: "tag", with: indexPath, action: setProfileTag))
+                children.append(UIAction.menuAction(localizationKey: "move_to_top", systemImageName: "arrow.up", with: indexPath, action: moveToTop))
                 children.append(UIAction.menuAction(localizationKey: "delete", attributes: [.destructive], systemImageName: "trash", with: indexPath, action: deleteAccount))
                 return UIMenu(children: children)
             }


### PR DESCRIPTION
'mark all as read' is a function that might be used on a regular base, similar to 'mute for some time'.
in contrast to profile label, ordering, delete, which is typically used much more rare.

therefore, move the option up.
this is also more consistent with desktop/android.

follow-up of #3099

#skip-changelog as there is already an entry and there was no release in between