### PR TITLE
update relay list when modified on other devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - You can now click on the Location streaming info message to bring up the map
 - Fix: Reactions could go to the wrong message if a new message was received while long pressing
+- Fix: update relay list when modified on other devices
+
 
 ## v2.51.1
 2026-06

--- a/DcCore/DcCore/DC/events.swift
+++ b/DcCore/DcCore/DC/events.swift
@@ -22,6 +22,7 @@ public enum Event {
     public static let configurationProgress = Notification.Name(rawValue: "configurationProgress")
 
     public static let connectivityChanged = Notification.Name(rawValue: "connectivityChanged")
+    public static let transportsModified = Notification.Name(rawValue: "transportsModified")
 
     // Webxdc
     public static let webxdcStatusUpdate = Notification.Name(rawValue: "webxdcStatusUpdate")
@@ -185,6 +186,10 @@ public class DcEventHandler {
         case DC_EVENT_CONNECTIVITY_CHANGED:
             logger.info("📡[\(accountId)] connectivity changed")
             NotificationCenter.default.post(name: Event.connectivityChanged, object: nil, userInfo: ["account_id": Int(accountId)])
+
+        case DC_EVENT_TRANSPORTS_MODIFIED:
+            logger.info("📡[\(accountId)] transports modified")
+            NotificationCenter.default.post(name: Event.transportsModified, object: nil, userInfo: ["account_id": Int(accountId)])
 
         case DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE:
             if let sem = dcAccounts.fetchSemaphore {

--- a/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
@@ -44,10 +44,6 @@ class TransportListViewController: UITableViewController {
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     @objc private func handleTransportsModified(_ notification: Notification) {
         guard dcContext.id == notification.userInfo?["account_id"] as? Int else { return }
         DispatchQueue.main.async { [weak self] in

--- a/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/TransportListViewController.swift
@@ -38,9 +38,22 @@ class TransportListViewController: UITableViewController {
                 self?.addFromQrCode(continueQrScan)
             }
         }
+
+         NotificationCenter.default.addObserver(self, selector: #selector(handleTransportsModified(_:)), name: Event.transportsModified, object: nil)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func handleTransportsModified(_ notification: Notification) {
+        guard dcContext.id == notification.userInfo?["account_id"] as? Int else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.reloadTransports()
+        }
+    }
 
     private func reloadTransports() {
         transports = dcContext.listTransportsEx()


### PR DESCRIPTION
this PR adds the even "transports modified" and let the relay view controller listen to it.

once received, the relay list is updated.

this reflects changes done on the relay settings of other devices immediately also on iOS.

closes #2970