### PR TITLE
Tap on location streaming info message to open map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- You can now click on the Location streaming info message to bring up the map
 - Fix: Reactions could go to the wrong message if a new message was received while long pressing
 
 ## v2.51.1

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -850,6 +850,9 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             showInvalidUnencryptedDialog()
         case (_, DC_INFO_GROUP_DESCRIPTION_CHANGED):
             navigationController?.pushViewController(ProfileViewController(dcContext, chatId: chatId), animated: true)
+        case (_, DC_INFO_LOCATIONSTREAMING_ENABLED),
+            (_, DC_INFO_UNKNOWN) where message.isInfo && message.text == "Location streaming disabled.":
+            navigationController?.pushViewController(MapViewController(dcContext: dcContext, chatId: chatId), animated: true)
         default:
             if let contactId = message.infoContactId, contactId != DC_CONTACT_ID_SELF {
                 navigationController?.pushViewController(ProfileViewController(dcContext, contactId: contactId), animated: true)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -850,8 +850,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             showInvalidUnencryptedDialog()
         case (_, DC_INFO_GROUP_DESCRIPTION_CHANGED):
             navigationController?.pushViewController(ProfileViewController(dcContext, chatId: chatId), animated: true)
-        case (_, DC_INFO_LOCATIONSTREAMING_ENABLED),
-            (_, DC_INFO_UNKNOWN) where message.isInfo && message.text == "Location streaming disabled.":
+        case (_, DC_INFO_LOCATIONSTREAMING_ENABLED):
             navigationController?.pushViewController(MapViewController(dcContext: dcContext, chatId: chatId), animated: true)
         default:
             if let contactId = message.infoContactId, contactId != DC_CONTACT_ID_SELF {


### PR DESCRIPTION
QoL for location streaming because user feedback was that they could not find where to see the location that was being streamed.

Note: It would be nicer if core exposed a DC_INFO_LOCATIONSTREAMING_DISABLED (or TOGGLED) but that's not the case.