### PR TITLE
Fix reactions going to wrong message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- Fix: Reactions could go to the wrong message if a new message was received while long pressing
+
 ## v2.51.1
 2026-06
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1897,8 +1897,7 @@ extension ChatViewController {
         return preview
     }
 
-    private func appendReactionItems(to menuElements: inout [UIMenuElement], indexPath: IndexPath) {
-        let messageId = messages[indexPath.row].id
+    private func appendReactionItems(to menuElements: inout [UIMenuElement], messageId: Int) {
         let myReactions = getMyReactions(messageId: messageId)
         var myReactionChecked = false
 
@@ -1982,11 +1981,11 @@ extension ChatViewController {
 
                 if canReply(to: message) {
                     if #available(iOS 16.0, *) {
-                        appendReactionItems(to: &children, indexPath: indexPath)
+                        appendReactionItems(to: &children, messageId: messageId)
                         preferredElementSizeSmall = true
                     } else {
                         var items: [UIMenuElement] = []
-                        appendReactionItems(to: &items, indexPath: indexPath)
+                        appendReactionItems(to: &items, messageId: messageId)
                         children.append(UIMenu(title: String.localized("react"), image: UIImage(systemName: "face.smiling"), children: items))
                     }
                     children.append(


### PR DESCRIPTION
Previously if you received a message while long pressing to open the context menu, a reaction could go to the wrong message.

After this change this desync can only happen to "Copy link" action and "Select more" which are way lower priority.