### PR TITLE
Added webxdc.isAppSender and webxdc.isBroadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - You can now click on the Location streaming info message to bring up the map
+- Add new webxdc.isAppSender and webxdc.isBroadcast APIs for mini-apps
 - Fix: Reactions could go to the wrong message if a new message was received while long pressing
 - Fix: update relay list when modified on other devices
 

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -16,12 +16,7 @@ class WebxdcViewController: WebViewViewController {
     
     var messageId: Int
     var href: String?
-    var webxdcName: String = ""
-    var sourceCodeUrl: String?
-    var selfAddr: String = ""
-    var sendUpdateInterval: Int = 0
-    var sendUpdateMaxSize: Int = 0
-    private var allowInternet: Bool = false
+    var info: WebxdcInfo?
 
     private lazy var moreButton: UIBarButtonItem = {
         let image = UIImage(systemName: "ellipsis.circle")
@@ -51,7 +46,7 @@ class WebxdcViewController: WebViewViewController {
     """
     
     lazy var webxdcbridge: String = {
-        let addr = selfAddr
+        let addr = info?.selfAddr
             .addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
         let displayname = (dcContext.displayname ?? dcContext.addr)?
             .addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
@@ -118,13 +113,12 @@ class WebxdcViewController: WebViewViewController {
         }
 
           return {
-            selfAddr: decodeURI("\((addr ?? "unknown"))"),
-        
-            selfName: decodeURI("\((displayname ?? "unknown"))"),
-
-            sendUpdateInterval: \(sendUpdateInterval),
-
-            sendUpdateMaxSize: \(sendUpdateMaxSize),
+            selfAddr: decodeURI("\((addr?.nilIfEmpty ?? "ErrAddr"))"),
+            selfName: decodeURI("\((displayname?.nilIfEmpty ?? "ErrName"))"),
+            sendUpdateInterval: \(info?.sendUpdateInterval ?? 0),
+            sendUpdateMaxSize: \(info?.sendUpdateMaxSize ?? 0),
+            isAppSender: \(info?.isAppSender == true),
+            isBroadcast: \(info?.isBroadcast == true),
 
             joinRealtimeChannel: () => {
               realtimeChannel = createRealtimeChannel();
@@ -299,21 +293,18 @@ class WebxdcViewController: WebViewViewController {
 
     func refreshWebxdcInfo() {
         let msg = dcContext.getMessage(id: messageId)
-        let dict = msg.getWebxdcInfoDict()
-
-        let document = dict["document"] as? String ?? ""
-        webxdcName = dict["name"] as? String ?? "ErrName" // name should not be empty
-        selfAddr = dict["self_addr"] as? String ?? "ErrAddr"
-        sendUpdateInterval = dict["send_update_interval"] as? Int ?? 0
-        sendUpdateMaxSize = dict["send_update_max_size"] as? Int ?? 0
-        let chatName = dcContext.getChat(chatId: msg.chatId).name
-        self.allowInternet = dict["internet_access"] as? Bool ?? false
-
-        self.title = document.isEmpty ? "\(webxdcName) – \(chatName)" : "\(document) – \(chatName)"
-        if let sourceCode = dict["source_code_url"] as? String,
-           !sourceCode.isEmpty {
-            sourceCodeUrl = sourceCode
+        let json = msg.getWebxdcInfoJson()
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        info = try? decoder.decode(WebxdcInfo.self, from: json.data(using: .utf8) ?? Data())
+        if info == nil {
+            logger.error("Failed to decode WebxdcInfo from \(json)")
+            assertionFailure()
         }
+
+        let chatName = dcContext.getChat(chatId: msg.chatId).name
+
+        self.title = "\(info?.document?.nilIfEmpty ?? info?.name.nilIfEmpty ?? "ErrName") – \(chatName)"
     }
 
     // MARK: - Notifications
@@ -387,7 +378,7 @@ class WebxdcViewController: WebViewViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if allowInternet {
+        if info?.internetAccess == true {
             loadHtml()
         } else {
             loadRestrictedHtml()
@@ -466,7 +457,7 @@ class WebxdcViewController: WebViewViewController {
             helpActions.append(UIAction(title: String.localized("what_is_webxdc"), image: UIImage(systemName: "questionmark.circle")) { [weak self] _ in
                 self?.openHelp(fragment: "#webxdc")
             })
-            if sourceCodeUrl != nil {
+            if let url = info?.sourceCodeUrl, !url.isEmpty {
                 helpActions.append(UIAction(title: String.localized("source_code"), image: UIImage(systemName: "arrow.up.right")) { [weak self] _ in
                     self?.openSourceCodeUrl()
                 })
@@ -491,8 +482,7 @@ class WebxdcViewController: WebViewViewController {
     }
 
     private func openSourceCodeUrl() {
-        if let sourceCodeUrl,
-           let url = URL(string: sourceCodeUrl) {
+        if let url = URL(string: info?.sourceCodeUrl ?? "") {
             UIApplication.shared.open(url)
         }
     }
@@ -605,7 +595,7 @@ extension WebxdcViewController: WKURLSchemeHandler {
                 "Content-Length": "\(data.count)",
             ]
 
-            if !self.allowInternet {
+            if self.info?.internetAccess != true {
                 headerFields["Content-Security-Policy"] = """
                     default-src 'self';
                     style-src 'self' 'unsafe-inline' blob: ;
@@ -674,5 +664,27 @@ extension WKWebViewConfiguration {
         func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
             urlSchemeHandler?.webView(webView, stop: urlSchemeTask)
         }
+    }
+}
+
+struct WebxdcInfo: Decodable {
+    let name: String
+    let icon: String
+    let document: String?
+    let summary: String?
+    /// Note that core sends an empty string as default which is not a valid URL so we can't use URL decoding
+    let sourceCodeUrl: String?
+    let internetAccess: Bool
+    let selfAddr: String
+    let isAppSender: Bool
+    let isBroadcast: Bool
+    let sendUpdateInterval: Int
+    let sendUpdateMaxSize: Int
+}
+
+
+extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }


### PR DESCRIPTION
Webxdc info decoding changed from dict to Codable. The Swift type does not strictly follow the core type because I did not get a resounding "yes this can never be NULL" in dev channels so for safety, a couple properties are optional. 

https://github.com/deltachat/deltachat-android/pull/4366
https://github.com/chatmail/core/pull/8138