### PR TITLE
remove remainings of isChatmail

### DIFF
--- a/deltachat-ios/Controller/NewChatViewController.swift
+++ b/deltachat-ios/Controller/NewChatViewController.swift
@@ -63,7 +63,7 @@ class NewChatViewController: UITableViewController {
 
         var newOptions: [NewOption]
         newOptions = [.scanQRCode, .newGroup, .newBroadcastList]
-        if self.dcContext.isChatmail == false {
+        if self.dcContext.forceEncryption == false {
             newOptions.append(.newEmail)
         }
         self.newOptions = newOptions

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -97,7 +97,7 @@ class QrPageController: UIPageViewController {
         actions.append(UIAction(title: String.localized("paste_from_clipboard"), image: UIImage(systemName: "doc.on.clipboard")) { [weak self] _ in
             self?.pasteFromClipboard()
         })
-        if dcContext.isChatmail == false {
+        if dcContext.forceEncryption == false {
             actions.append(UIAction(title: String.localized("menu_new_classic_contact"), image: UIImage(systemName: "highlighter")) { [weak self] _ in
                 guard let self else { return }
                 self.navigationController?.pushViewController(NewContactController(dcContext: self.dcContext), animated: true)

--- a/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
@@ -224,7 +224,7 @@ class EditTransportViewController: UITableViewController {
     }()
 
     lazy var forceE2eeCell: SwitchCell = {
-        return SwitchCell(textLabel: String.localized("enforce_e2ee"), on: dcContext.getConfigBool("force_encryption"))
+        return SwitchCell(textLabel: String.localized("enforce_e2ee"), on: dcContext.forceEncryption)
     }()
 
     lazy var viewLogCell: UITableViewCell = {
@@ -451,7 +451,7 @@ class EditTransportViewController: UITableViewController {
         loginParam.certificateChecks = certValue
 
         do {
-            dcContext.setConfigBool("force_encryption", forceE2eeCell.isOn)
+            dcContext.forceEncryption = forceE2eeCell.isOn
             _ = try dcContext.addOrUpdateTransport(param: loginParam)
         } catch {
             progressAlertHandler.updateProgressAlert(error: error.localizedDescription)

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -789,8 +789,9 @@ public class DcContext {
         set { setConfigBool("mdns_enabled", newValue) }
     }
 
-    public var isChatmail: Bool {
-        return getConfigInt("is_chatmail") == 1
+    public var forceEncryption: Bool {
+        get { return getConfigBool("force_encryption") }
+        set { setConfigBool("force_encryption", newValue) }
     }
 
     public var isProxyEnabled: Bool {


### PR DESCRIPTION
instead, forceEncryption is checked now,
and this only for for option "New Chat -> New Email".

this also fixes the bug that, for classic relays, by default "force encryption" is set but we still show "new email"

counterpart of https://github.com/deltachat/deltachat-android/pull/4480