### PR TITLE
Cache thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add outgoing ringing sound and call status
 - Fix: Tapping "Me" in reactions overview would open the wrong contact on anything other than your first profile
+- Fix: Video and PDF thumbnails are now cached for smoother scrolling
+
 
 ## v2.52.0
 2026-06

--- a/DcCore/DcCore/Helper/DcUtils.swift
+++ b/DcCore/DcCore/Helper/DcUtils.swift
@@ -70,55 +70,6 @@ public struct DcUtils {
         return "application/octet-stream"
     }
 
-    public static func generateThumbnailFromVideo(url: URL?) -> UIImage? {
-		guard let url = url else {
-			return nil
-		}
-		do {
-			let asset = AVURLAsset(url: url)
-			let imageGenerator = AVAssetImageGenerator(asset: asset)
-			imageGenerator.appliesPreferredTrackTransform = true
-			let cgImage = try imageGenerator.copyCGImage(at: .zero, actualTime: nil)
-			return UIImage(cgImage: cgImage)
-		} catch {
-			print(error.localizedDescription)
-			return nil
-		}
-	}
-
-	public static func thumbnailFromPdf(withUrl url: URL, pageNumber: Int = 1, width: CGFloat = 240) -> UIImage? {
-		guard let pdf = CGPDFDocument(url as CFURL),
-			let page = pdf.page(at: pageNumber)
-			else {
-				return nil
-		}
-
-		var pageRect = page.getBoxRect(.mediaBox)
-		let pdfScale = width / pageRect.size.width
-		pageRect.size = CGSize(width: pageRect.size.width*pdfScale, height: pageRect.size.height*pdfScale)
-		pageRect.origin = .zero
-
-		UIGraphicsBeginImageContext(pageRect.size)
-		let context = UIGraphicsGetCurrentContext()!
-
-		// White BG
-		context.setFillColor(UIColor.white.cgColor)
-		context.fill(pageRect)
-		context.saveGState()
-
-		// Next 3 lines makes the rotations so that the page look in the right direction
-		context.translateBy(x: 0.0, y: pageRect.size.height)
-		context.scaleBy(x: 1.0, y: -1.0)
-		context.concatenate(page.getDrawingTransform(.mediaBox, rect: pageRect, rotate: 0, preserveAspectRatio: true))
-
-		context.drawPDFPage(page)
-		context.restoreGState()
-
-		let image = UIGraphicsGetImageFromCurrentImageContext()
-		UIGraphicsEndImageContext()
-		return image
-	}
-
     public static func getConnectivityString(dcContext: DcContext, connectedString: String) -> String {
         let connectivity = dcContext.getConnectivity()
         if connectivity >= DC_CONNECTIVITY_CONNECTED {

--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		5F153E9A2CC38BAA00871ABE /* GiveBackMyFirstResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F153E992CC38BAA00871ABE /* GiveBackMyFirstResponder.swift */; };
 		5F4945AB2D315E7000DCD50A /* UIPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */; };
 		5F785F6E2CB9344F003FFFB9 /* ReusableCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */; };
+		640C769B2FDD378F00F6BC8A /* Thumbnails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640C769A2FDD378F00F6BC8A /* Thumbnails.swift */; };
 		641620FC2ECFCDC70076CFA3 /* CallUIToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641620FB2ECFCDC70076CFA3 /* CallUIToggleButton.swift */; };
 		641620FE2ECFFA880076CFA3 /* WebRTC+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641620FD2ECFFA880076CFA3 /* WebRTC+Extensions.swift */; };
 		6430531D2DF0668600E26D1F /* NSItemProvider+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6430531C2DF0668600E26D1F /* NSItemProvider+Extensions.swift */; };
@@ -498,6 +499,7 @@
 		5F153E992CC38BAA00871ABE /* GiveBackMyFirstResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiveBackMyFirstResponder.swift; sourceTree = "<group>"; };
 		5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPasteboard.swift; sourceTree = "<group>"; };
 		5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableCellProtocol.swift; sourceTree = "<group>"; };
+		640C769A2FDD378F00F6BC8A /* Thumbnails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnails.swift; sourceTree = "<group>"; };
 		641620FB2ECFCDC70076CFA3 /* CallUIToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallUIToggleButton.swift; sourceTree = "<group>"; };
 		641620FD2ECFFA880076CFA3 /* WebRTC+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebRTC+Extensions.swift"; sourceTree = "<group>"; };
 		6430531C2DF0668600E26D1F /* NSItemProvider+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSItemProvider+Extensions.swift"; sourceTree = "<group>"; };
@@ -1156,6 +1158,7 @@
 		AE851AC2227C695000ED86F0 /* Helper */ = {
 			isa = PBXGroup;
 			children = (
+				640C769A2FDD378F00F6BC8A /* Thumbnails.swift */,
 				30238CFE28A5554C00EF14AC /* FileHelper.swift */,
 				3067AAC52667F3FE00525036 /* ImageFormat.swift */,
 				305702A024C6453700D84EFC /* TypeAlias.swift */,
@@ -1804,6 +1807,7 @@
 				30AAD71B2762869600DE3DC1 /* SelectableCell.swift in Sources */,
 				AE9DAF0F22C278C6004C9591 /* ChatTitleView.swift in Sources */,
 				AE4AEE3522B1030D000AA495 /* PreviewController.swift in Sources */,
+				640C769B2FDD378F00F6BC8A /* Thumbnails.swift in Sources */,
 				64AFC0802F0EB9E900F44416 /* NSLayoutConstraints+activateWithPriority.swift in Sources */,
 				D84AED272B566C0700D753F6 /* ReactionsOverviewTableViewCell.swift in Sources */,
 				7070FB9B2101ECBB000DC258 /* NewGroupController.swift in Sources */,

--- a/deltachat-ios/Helper/Thumbnails.swift
+++ b/deltachat-ios/Helper/Thumbnails.swift
@@ -1,0 +1,69 @@
+import AVFoundation
+import DcCore
+import SDWebImage
+
+extension DcUtils {
+    public static func generateThumbnailFromVideo(url: URL?) -> UIImage? {
+        guard let url = url else { return nil }
+        do {
+            if let image = cachedThumbnail(for: url) {
+                return image
+            }
+            let asset = AVURLAsset(url: url)
+            let imageGenerator = AVAssetImageGenerator(asset: asset)
+            imageGenerator.appliesPreferredTrackTransform = true
+            let cgImage = try imageGenerator.copyCGImage(at: .zero, actualTime: nil)
+            let image = UIImage(cgImage: cgImage)
+            cacheThumbnail(image, for: url)
+            return image
+        } catch {
+            logger.error(error.localizedDescription)
+            return nil
+        }
+    }
+
+    public static func thumbnailFromPdf(withUrl url: URL, pageNumber: Int = 1, width: CGFloat = 240) -> UIImage? {
+        if let image = cachedThumbnail(for: url) {
+            return image
+        }
+        guard let pdf = CGPDFDocument(url as CFURL),
+              let page = pdf.page(at: pageNumber)
+        else {
+            return nil
+        }
+
+        var pageRect = page.getBoxRect(.mediaBox)
+        let pdfScale = width / pageRect.size.width
+        pageRect.size = CGSize(width: pageRect.size.width*pdfScale, height: pageRect.size.height*pdfScale)
+        pageRect.origin = .zero
+
+        UIGraphicsBeginImageContext(pageRect.size)
+        let context = UIGraphicsGetCurrentContext()!
+
+        // White BG
+        context.setFillColor(UIColor.white.cgColor)
+        context.fill(pageRect)
+        context.saveGState()
+
+        // Next 3 lines makes the rotations so that the page look in the right direction
+        context.translateBy(x: 0.0, y: pageRect.size.height)
+        context.scaleBy(x: 1.0, y: -1.0)
+        context.concatenate(page.getDrawingTransform(.mediaBox, rect: pageRect, rotate: 0, preserveAspectRatio: true))
+
+        context.drawPDFPage(page)
+        context.restoreGState()
+
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        cacheThumbnail(image, for: url)
+        return image
+    }
+
+    private static func cachedThumbnail(for url: URL) -> UIImage? {
+        SDImageCache.shared.imageFromCache(forKey: url.absoluteString + "-thumbnail")
+    }
+
+    private static func cacheThumbnail(_ thumbnail: UIImage?, for url: URL) {
+        SDImageCache.shared.store(thumbnail, forKey: url.absoluteString + "-thumbnail")
+    }
+}


### PR DESCRIPTION
This prevents repeated frame drops when scrolling because we no longer generate the thumbnails every time a cell comes into view. 

I tried to use URLCache for this but it did not save to disk so I opted for the SDImageCache which we already depend on anyway. This did mean the caching can't be done in DcCore module because it does not depend on SDImage so I moved the thumbnail generation out of DcCore.

The initial thumbnail can still take a while and it would probably be better to do this async but that means we need to reload the tableview after generating the thumbnail because thumbnail will give the cell a different height. This PR is already a big improvement.

