### PR TITLE
Fix incorrect contact is me check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add outgoing ringing sound and call status
-
+- Fix: Tapping "Me" in reactions overview would open the wrong contact on anything other than your first profile
 
 ## v2.52.0
 2026-06

--- a/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
+++ b/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
@@ -85,9 +85,7 @@ extension ReactionsOverviewViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let contactId = contactIds[indexPath.row]
-
-        let isMe = (context.id == contactId)
-        if isMe == false {
+        if contactId != DC_CONTACT_ID_SELF {
             delegate?.showContact(self, with: contactId)
         }
     }


### PR DESCRIPTION
Fixes #3133

This only happened on profiles that have an account id that's not the same as DC_CONTACT_ID_SELF