### PR TITLE
Improve audio recorder session routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: Improve voice message recording with Bluetooth and car audio systems
 - Allow voice and audio messages to continue playing in the background
 
 

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -21,7 +21,13 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     private let bitrate: Int
 
     // Private variables
-    var oldSessionCategory: AVAudioSession.Category?
+    private struct AudioSessionConfiguration {
+        let category: AVAudioSession.Category
+        let mode: AVAudioSession.Mode
+        let options: AVAudioSession.CategoryOptions
+    }
+
+    private var previousAudioSessionConfiguration: AudioSessionConfiguration?
     var wasIdleTimerDisabled: Bool = false
 
     var recordingFilePath: String = ""
@@ -141,10 +147,10 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
         audioRecorder?.stop()
+        endRecordingSession()
         stopUpdatingMeter()
-        UIApplication.shared.isIdleTimerDisabled = wasIdleTimerDisabled
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -182,20 +188,27 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     @objc func startRecording() {
         AudioController.stopBackgroundPlayback()
         do {
-            self.setToolbarItems([pauseButton], animated: true)
-            doneButton.isEnabled = true
             if FileManager.default.fileExists(atPath: recordingFilePath) {
                 try FileManager.default.removeItem(atPath: recordingFilePath)
             }
-            let session = AVAudioSession.sharedInstance()
-            oldSessionCategory = session.category
-            try session.setCategory(AVAudioSession.Category.record)
+            try configureAudioSessionForRecording()
             UIApplication.shared.isIdleTimerDisabled = true
-            guard let audioRecorder, audioRecorder.prepareToRecord() else { logger.error("prepareToRecord() failed"); return }
+            guard let audioRecorder, audioRecorder.prepareToRecord() else {
+                logger.error("prepareToRecord() failed")
+                endRecordingSession()
+                return
+            }
             isRecordingPaused = false
-            guard audioRecorder.record() else { logger.error("record() failed"); return }
+            guard audioRecorder.record() else {
+                logger.error("record() failed")
+                endRecordingSession()
+                return
+            }
+            self.setToolbarItems([pauseButton], animated: true)
+            doneButton.isEnabled = true
         } catch {
             logger.error("Cannot start recording: \(error)")
+            endRecordingSession()
         }
     }
 
@@ -214,6 +227,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
 
     @objc func cancelAction() {
         audioRecorder?.stop()
+        endRecordingSession()
         do {
             try FileManager.default.removeItem(atPath: recordingFilePath)
         } catch {
@@ -238,13 +252,12 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     }
 
     func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        defer {
+            endRecordingSession()
+        }
         do {
             if flag {
                 self.setToolbarItems([startRecordingButton], animated: true)
-                if let oldSessionCategory = oldSessionCategory {
-                    try AVAudioSession.sharedInstance().setCategory(oldSessionCategory)
-                    UIApplication.shared.isIdleTimerDisabled = wasIdleTimerDisabled
-                }
             } else {
                 try FileManager.default.removeItem(at: URL(fileURLWithPath: recordingFilePath))
             }
@@ -256,6 +269,35 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
 
     func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
         logger.error("audio recording failed: \(error?.localizedDescription ?? "unknown")")
+        endRecordingSession()
+    }
+
+    private func configureAudioSessionForRecording() throws {
+        let session = AVAudioSession.sharedInstance()
+        if previousAudioSessionConfiguration == nil {
+            previousAudioSessionConfiguration = AudioSessionConfiguration(category: session.category,
+                                                                         mode: session.mode,
+                                                                         options: session.categoryOptions)
+        }
+        try session.setCategory(.playAndRecord, mode: .default, options: [.allowBluetoothHFP])
+        try session.setActive(true)
+    }
+
+    private func endRecordingSession() {
+        restoreAudioSession()
+        UIApplication.shared.isIdleTimerDisabled = wasIdleTimerDisabled
+    }
+
+    private func restoreAudioSession() {
+        guard let configuration = previousAudioSessionConfiguration else { return }
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setActive(false, options: .notifyOthersOnDeactivation)
+            try session.setCategory(configuration.category, mode: configuration.mode, options: configuration.options)
+            previousAudioSessionConfiguration = nil
+        } catch {
+            logger.error("Cannot restore audio session: \(error)")
+        }
     }
 
     func validateMicrophoneAccess() {
@@ -265,7 +307,7 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
                 if let self {
                     self.noRecordingPermissionView.isHidden = granted
                     self.waveFormView.isHidden = !granted
-                    self.doneButton.isEnabled = granted
+                    self.doneButton.isEnabled = false
 
                     if self.isFirstUsage {
                         if !granted {

--- a/deltachat-ios/Controller/AudioRecorderController.swift
+++ b/deltachat-ios/Controller/AudioRecorderController.swift
@@ -275,9 +275,11 @@ class AudioRecorderController: UIViewController, AVAudioRecorderDelegate {
     private func configureAudioSessionForRecording() throws {
         let session = AVAudioSession.sharedInstance()
         if previousAudioSessionConfiguration == nil {
-            previousAudioSessionConfiguration = AudioSessionConfiguration(category: session.category,
-                                                                         mode: session.mode,
-                                                                         options: session.categoryOptions)
+            previousAudioSessionConfiguration = AudioSessionConfiguration(
+                category: session.category,
+                mode: session.mode,
+                options: session.categoryOptions
+            )
         }
         try session.setCategory(.playAndRecord, mode: .default, options: [.allowBluetoothHFP])
         try session.setActive(true)


### PR DESCRIPTION
## Summary

- Configure the audio recorder session as `playAndRecord` with Bluetooth input support and explicitly activate it before starting `AVAudioRecorder`.
- Preserve and restore the previous audio session category, mode, and options when recording ends or fails.
- Restore the idle timer and remove the matching background notification observer during recorder teardown.
- Add an `Unreleased` changelog entry for the end-user-facing recording fix.

## Why

The voice-message recorder only switched the shared `AVAudioSession` to `.record`. On routes such as Bluetooth hands-free or car audio, iOS can fail to select the expected external microphone unless the session is active and configured for recording plus playback-style routing. Using `.playAndRecord` with `.allowBluetooth` lets iOS use HFP microphone routes while keeping the change scoped to the recorder lifecycle.

## Validation

- `git diff --check`
- `xcodebuild -list -workspace deltachat-ios.xcworkspace`
- `xcodebuild -workspace deltachat-ios.xcworkspace -scheme deltachat-ios -destination "generic/platform=iOS Simulator" build`