### PR TITLE
Smaller liquid glass input bar size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- Fix: smaller input bar size for new liquid glass design.
+
 ## v2.53.0
 2026-06
 

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -12,7 +12,7 @@ struct InputBarView: View {
     var updateIntrinsicContentSize: () -> Void
 
     var buttonSize: CGFloat {
-        isLiquidGlassEnabled ? 54 : 36
+        isLiquidGlassEnabled ? 42 : 36
     }
 
     var body: some View {
@@ -57,6 +57,7 @@ struct InputBarView: View {
                         }
                     }
                     .padding(.horizontal, 10)
+                    .padding(.vertical, -6)
                     .modifier { glassEffect(view: $0, minHeight: buttonSize, interactive: true) }
                     .frame(maxHeight: 150, alignment: .center)
                     .onTapGesture {

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -45,7 +45,7 @@ struct InputBarView: View {
                         .renderingMode(.template)
                         .resizable()
                         .scaledToFit()
-                        .padding(4)
+                        .padding(2)
                 }).frame(height: buttonSize)
                 InputBarTextView(text: $draft.text, imagePasteDelegate: chatViewController)
                     .focused($textEditorFocus)
@@ -57,8 +57,7 @@ struct InputBarView: View {
                         }
                     }
                     .padding(.horizontal, 10)
-                    .padding(.vertical, -6)
-                    .modifier { glassEffect(view: $0, minHeight: buttonSize, interactive: true) }
+                    .modifier { glassEffect(view: $0, padding: 2, minHeight: buttonSize, interactive: true) }
                     .frame(maxHeight: 150, alignment: .center)
                     .onTapGesture {
                         textEditorFocus = true
@@ -71,7 +70,7 @@ struct InputBarView: View {
                         .renderingMode(.template)
                         .resizable()
                         .scaledToFit()
-                        .padding(4)
+                        .padding(2)
                 })
                 .frame(height: buttonSize)
                 .disabled(!draft.canSend())
@@ -169,10 +168,10 @@ struct InputBarView: View {
         }
     }
 
-    @ViewBuilder func glassEffect<V: View>(view: V, minHeight: CGFloat? = nil, interactive: Bool) -> some View {
+    @ViewBuilder func glassEffect<V: View>(view: V, padding: CGFloat = 8, minHeight: CGFloat? = nil, interactive: Bool) -> some View {
         if #available(iOS 26.0, *) {
-            view.padding(8)
-                .frame(minHeight: minHeight)
+            view.padding(padding)
+                .frame(minHeight: minHeight, alignment: .center)
                 .glassEffect(.regular.interactive(interactive), in: .rect(cornerRadius: buttonSize / 2, style: .continuous))
         } else {
             view


### PR DESCRIPTION
Thanks for #3104! It really makes the app feel more modern 😄. However, I think the input bar is currently a bit large in the new design. For reference, here are telegram, element, imessage:
<img width="250"  alt="IMG_9372" src="https://github.com/user-attachments/assets/c4b4407e-0411-418f-a864-32992d390752" /><img width="250"  alt="IMG_9373" src="https://github.com/user-attachments/assets/327bc42c-1e3a-4fa1-856b-10b9c0da2e68" /><img width="250"  alt="IMG_9374" src="https://github.com/user-attachments/assets/71f891b2-6480-4f32-b35b-8454799cde55" />


  I believe this may have been chosen due to the native UITextView content size, but this is easily circumvented with a negative vertical padding.   
  
### Preview (Old / New)

<img width="250" alt="IMG_9376" src="https://github.com/user-attachments/assets/3044df95-9b47-4456-8585-0246ce145c5f" /><img width="250" alt="IMG_9369" src="https://github.com/user-attachments/assets/6d44b7b6-094b-426a-8dc4-d499d65ad536" />

<img width="250" alt="IMG_9375" src="https://github.com/user-attachments/assets/60b455de-97da-48bd-9c01-ec76a9843ce1" /><img width="250" alt="IMG_9371" src="https://github.com/user-attachments/assets/313c8ccc-ed27-4002-a5b1-156aeda7fea1" />
