### PR TITLE
add custom fade effects for chat edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Allow voice and audio messages to continue playing in the background
+- Improve message fading behind the input bar on iOS 26
 
 
 ## v2.53.0

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -583,7 +583,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         edgeEffectDimmingGradients.top.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
         edgeEffectDimmingGradients.top.startPoint = CGPoint(x: 0.5, y: 0)
         edgeEffectDimmingGradients.top.endPoint = CGPoint(x: 0.5, y: 1)
-        edgeEffectDimmingGradients.top.colors = [0.65, 0.30, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
+        edgeEffectDimmingGradients.top.colors = [0.70, 0.55, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
         edgeEffectDimmingGradients.top.locations = [0, 0.6, 1]
 
         let fadeEnd = min(height / bounds.height, 1)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -49,6 +49,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }()
 
     private lazy var tableViewContainer: UIView = UIView()
+    private let readabilityFadeExtension: CGFloat = 24
+    private let readabilityDimmingGradients = (top: CAGradientLayer(), bottom: CAGradientLayer())
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.delegate = self
@@ -87,7 +89,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         didSet {
             guard toolbarHeight != oldValue else { return }
             setTableViewContentInset()
-            updateTableViewContainerMask()
+            updateEdgeEffects()
         }
     }
 
@@ -309,6 +311,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         if #available(iOS 26.0, *) {
             tableView.topEdgeEffect.isHidden = true
             tableView.bottomEdgeEffect.isHidden = true
+            view.layer.addSublayer(readabilityDimmingGradients.top)
+            view.layer.addSublayer(readabilityDimmingGradients.bottom)
         }
         view.addSubview(contextMenuPreviewContainer)
         contextMenuPreviewContainer.fillSuperview()
@@ -502,14 +506,13 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         toolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
-        updateTableViewContainerMask()
+        updateEdgeEffects()
     }
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         setTableViewContentInset()
-
-        updateTableViewContainerMask()
+        updateEdgeEffects()
     }
 
     override func didMove(toParent parent: UIViewController?) {
@@ -534,7 +537,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
     }
 
-    private func updateTableViewContainerMask() {
+    private func updateEdgeEffects() {
         let bounds = tableViewContainer.bounds
         guard bounds.height > 0 else { return }
 
@@ -553,27 +556,13 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
 
         if #available(iOS 26, *), view.safeAreaInsets.top > 0 {
-            // Custom tableView.topEdgeEffect.
-            let topFadeEnd = min(view.safeAreaInsets.top / bounds.height, 1)
-            appendStop(location: 0, alpha: 0)
-            appendStop(location: topFadeEnd * 0.6, alpha: 0.3)
-            appendStop(location: topFadeEnd, alpha: 1)
+            updateTopEdgeEffect(bounds: bounds, appendStop: appendStop)
         } else {
             appendStop(location: 0, alpha: 1)
         }
 
         if #available(iOS 26, *) {
-            // Custom tableView.bottomEdgeEffect
-            let bottomCoveredHeight = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom)
-            if bottomCoveredHeight > 0 {
-                let bottomFadeStart = max((bounds.height - bottomCoveredHeight) / bounds.height, 0)
-                let bottomFadeMid = bottomFadeStart + ((1 - bottomFadeStart) * 0.4)
-                appendStop(location: bottomFadeStart, alpha: 1)
-                appendStop(location: bottomFadeMid, alpha: 0.3)
-                appendStop(location: 1, alpha: 0.1)
-            } else {
-                appendStop(location: 1, alpha: 1)
-            }
+            updateBottomEdgeEffect(bounds: bounds, appendStop: appendStop)
         } else {
             appendStop(location: 1, alpha: 1)
         }
@@ -581,6 +570,40 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         mask.colors = stops.map { UIColor(white: 1, alpha: $0.alpha).cgColor }
         mask.locations = stops.map { NSNumber(value: Float($0.location)) }
         tableViewContainer.layer.mask = mask
+    }
+
+    private func updateTopEdgeEffect(bounds: CGRect, appendStop: (CGFloat, CGFloat) -> Void) {
+        let height = view.safeAreaInsets.top + readabilityFadeExtension
+        readabilityDimmingGradients.top.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
+        readabilityDimmingGradients.top.startPoint = CGPoint(x: 0.5, y: 0)
+        readabilityDimmingGradients.top.endPoint = CGPoint(x: 0.5, y: 1)
+        readabilityDimmingGradients.top.colors = [0.65, 0.30, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
+        readabilityDimmingGradients.top.locations = [0, 0.6, 1]
+
+        let fadeEnd = min(height / bounds.height, 1)
+        appendStop(0, 0)
+        appendStop(fadeEnd * 0.7, 0.15)
+        appendStop(fadeEnd, 0.9)
+    }
+
+    private func updateBottomEdgeEffect(bounds: CGRect, appendStop: (CGFloat, CGFloat) -> Void) {
+        let height = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom) + readabilityFadeExtension / 2
+        readabilityDimmingGradients.bottom.frame = CGRect(
+            x: 0,
+            y: view.bounds.height - height,
+            width: view.bounds.width,
+            height: height
+        )
+        readabilityDimmingGradients.bottom.startPoint = CGPoint(x: 0.5, y: 0)
+        readabilityDimmingGradients.bottom.endPoint = CGPoint(x: 0.5, y: 1)
+        readabilityDimmingGradients.bottom.colors = [0, 0.30, 0.65].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
+        readabilityDimmingGradients.bottom.locations = [0, 0.4, 1]
+
+        let fadeStart = max((bounds.height - height) / bounds.height, 0)
+        let fadeMid = fadeStart + ((1 - fadeStart) * 0.4)
+        appendStop(fadeStart, 1)
+        appendStop(fadeMid, 0.3)
+        appendStop(1, 0.1)
     }
 
     // MARK: - Notifications
@@ -999,6 +1022,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         if UserDefaults.standard.string(forKey: Constants.Keys.backgroundImageName) == nil {
             backgroundContainer.image = UIImage(named: traitCollection.userInterfaceStyle == .light ? "background_light" : "background_dark")
         }
+        updateEdgeEffects()
     }
 
     private func configureMessageStyle(for message: DcMsg, at indexPath: IndexPath) -> UIRectCorner {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -563,6 +563,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
 
         if #available(iOS 26, *) {
+            // Custom tableView.bottomEdgeEffect
             let bottomCoveredHeight = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom)
             if bottomCoveredHeight > 0 {
                 let bottomFadeStart = max((bounds.height - bottomCoveredHeight) / bounds.height, 0)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -49,6 +49,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }()
 
     private lazy var tableViewContainer: UIView = UIView()
+    /// Reused for custom edge fades to avoid allocating a new mask layer on every layout pass.
     private let edgeEffectMask = CAGradientLayer()
     private let edgeEffectFadeExtension: CGFloat = 24
     private let edgeEffectDimmingGradients = (top: CAGradientLayer(), bottom: CAGradientLayer())
@@ -507,6 +508,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         let newToolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
+        // Avoid updating edge effects twice when toolbarHeight.didSet already handles the change.
         if toolbarHeight != newToolbarHeight {
             toolbarHeight = newToolbarHeight
         } else {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -49,8 +49,9 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }()
 
     private lazy var tableViewContainer: UIView = UIView()
-    private let readabilityFadeExtension: CGFloat = 24
-    private let readabilityDimmingGradients = (top: CAGradientLayer(), bottom: CAGradientLayer())
+    private let edgeEffectMask = CAGradientLayer()
+    private let edgeEffectFadeExtension: CGFloat = 24
+    private let edgeEffectDimmingGradients = (top: CAGradientLayer(), bottom: CAGradientLayer())
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.delegate = self
@@ -311,8 +312,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         if #available(iOS 26.0, *) {
             tableView.topEdgeEffect.isHidden = true
             tableView.bottomEdgeEffect.isHidden = true
-            view.layer.addSublayer(readabilityDimmingGradients.top)
-            view.layer.addSublayer(readabilityDimmingGradients.bottom)
+            view.layer.addSublayer(edgeEffectDimmingGradients.top)
+            view.layer.addSublayer(edgeEffectDimmingGradients.bottom)
         }
         view.addSubview(contextMenuPreviewContainer)
         contextMenuPreviewContainer.fillSuperview()
@@ -505,8 +506,12 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        toolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
-        updateEdgeEffects()
+        let newToolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
+        if toolbarHeight != newToolbarHeight {
+            toolbarHeight = newToolbarHeight
+        } else {
+            updateEdgeEffects()
+        }
     }
 
     override func viewSafeAreaInsetsDidChange() {
@@ -541,10 +546,9 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         let bounds = tableViewContainer.bounds
         guard bounds.height > 0 else { return }
 
-        let mask = CAGradientLayer()
-        mask.frame = bounds
-        mask.startPoint = CGPoint(x: 0.5, y: 0)
-        mask.endPoint = CGPoint(x: 0.5, y: 1)
+        edgeEffectMask.frame = bounds
+        edgeEffectMask.startPoint = CGPoint(x: 0.5, y: 0)
+        edgeEffectMask.endPoint = CGPoint(x: 0.5, y: 1)
 
         var stops: [(location: CGFloat, alpha: CGFloat)] = []
         func appendStop(location: CGFloat, alpha: CGFloat) {
@@ -567,18 +571,20 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             appendStop(location: 1, alpha: 1)
         }
 
-        mask.colors = stops.map { UIColor(white: 1, alpha: $0.alpha).cgColor }
-        mask.locations = stops.map { NSNumber(value: Float($0.location)) }
-        tableViewContainer.layer.mask = mask
+        edgeEffectMask.colors = stops.map { UIColor(white: 1, alpha: $0.alpha).cgColor }
+        edgeEffectMask.locations = stops.map { NSNumber(value: Float($0.location)) }
+        if tableViewContainer.layer.mask !== edgeEffectMask {
+            tableViewContainer.layer.mask = edgeEffectMask
+        }
     }
 
     private func updateTopEdgeEffect(bounds: CGRect, appendStop: (CGFloat, CGFloat) -> Void) {
-        let height = view.safeAreaInsets.top + readabilityFadeExtension
-        readabilityDimmingGradients.top.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
-        readabilityDimmingGradients.top.startPoint = CGPoint(x: 0.5, y: 0)
-        readabilityDimmingGradients.top.endPoint = CGPoint(x: 0.5, y: 1)
-        readabilityDimmingGradients.top.colors = [0.65, 0.30, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
-        readabilityDimmingGradients.top.locations = [0, 0.6, 1]
+        let height = view.safeAreaInsets.top + edgeEffectFadeExtension
+        edgeEffectDimmingGradients.top.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
+        edgeEffectDimmingGradients.top.startPoint = CGPoint(x: 0.5, y: 0)
+        edgeEffectDimmingGradients.top.endPoint = CGPoint(x: 0.5, y: 1)
+        edgeEffectDimmingGradients.top.colors = [0.65, 0.30, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
+        edgeEffectDimmingGradients.top.locations = [0, 0.6, 1]
 
         let fadeEnd = min(height / bounds.height, 1)
         appendStop(0, 0)
@@ -587,17 +593,17 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     private func updateBottomEdgeEffect(bounds: CGRect, appendStop: (CGFloat, CGFloat) -> Void) {
-        let height = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom) + readabilityFadeExtension / 2
-        readabilityDimmingGradients.bottom.frame = CGRect(
+        let height = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom) + edgeEffectFadeExtension / 2
+        edgeEffectDimmingGradients.bottom.frame = CGRect(
             x: 0,
             y: view.bounds.height - height,
             width: view.bounds.width,
             height: height
         )
-        readabilityDimmingGradients.bottom.startPoint = CGPoint(x: 0.5, y: 0)
-        readabilityDimmingGradients.bottom.endPoint = CGPoint(x: 0.5, y: 1)
-        readabilityDimmingGradients.bottom.colors = [0, 0.30, 0.65].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
-        readabilityDimmingGradients.bottom.locations = [0, 0.4, 1]
+        edgeEffectDimmingGradients.bottom.startPoint = CGPoint(x: 0.5, y: 0)
+        edgeEffectDimmingGradients.bottom.endPoint = CGPoint(x: 0.5, y: 1)
+        edgeEffectDimmingGradients.bottom.colors = [0, 0.30, 0.65].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
+        edgeEffectDimmingGradients.bottom.locations = [0, 0.4, 1]
 
         let fadeStart = max((bounds.height - height) / bounds.height, 0)
         let fadeMid = fadeStart + ((1 - fadeStart) * 0.4)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -87,6 +87,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         didSet {
             guard toolbarHeight != oldValue else { return }
             setTableViewContentInset()
+            updateTableViewContainerMask()
         }
     }
 
@@ -501,25 +502,14 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         toolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
+        updateTableViewContainerMask()
     }
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         setTableViewContentInset()
 
-        if #available(iOS 26, *) {
-            // Custom tableView.topEdgeEffect
-            let mask = CAGradientLayer()
-            mask.frame = view.frame
-            mask.colors = [
-                UIColor(white: 1, alpha: 0).cgColor,
-                UIColor(white: 1, alpha: 0.3).cgColor,
-                UIColor(white: 1, alpha: 1).cgColor,
-            ]
-            mask.startPoint = CGPoint(x: 0.5, y: 0)
-            mask.endPoint = CGPoint(x: 0.5, y: view.safeAreaInsets.top / view.frame.height)
-            tableViewContainer.layer.mask = mask
-        }
+        updateTableViewContainerMask()
     }
 
     override func didMove(toParent parent: UIViewController?) {
@@ -542,6 +532,54 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             }
             tableView.contentInset.top = topInset
         }
+    }
+
+    private func updateTableViewContainerMask() {
+        let bounds = tableViewContainer.bounds
+        guard bounds.height > 0 else { return }
+
+        let mask = CAGradientLayer()
+        mask.frame = bounds
+        mask.startPoint = CGPoint(x: 0.5, y: 0)
+        mask.endPoint = CGPoint(x: 0.5, y: 1)
+
+        var stops: [(location: CGFloat, alpha: CGFloat)] = []
+        func appendStop(location: CGFloat, alpha: CGFloat) {
+            let clampedLocation = min(max(location, 0), 1)
+            if let lastLocation = stops.last?.location, clampedLocation < lastLocation {
+                return
+            }
+            stops.append((clampedLocation, alpha))
+        }
+
+        if #available(iOS 26, *), view.safeAreaInsets.top > 0 {
+            // Custom tableView.topEdgeEffect.
+            let topFadeEnd = min(view.safeAreaInsets.top / bounds.height, 1)
+            appendStop(location: 0, alpha: 0)
+            appendStop(location: topFadeEnd * 0.6, alpha: 0.3)
+            appendStop(location: topFadeEnd, alpha: 1)
+        } else {
+            appendStop(location: 0, alpha: 1)
+        }
+
+        if #available(iOS 26, *) {
+            let bottomCoveredHeight = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom)
+            if bottomCoveredHeight > 0 {
+                let bottomFadeStart = max((bounds.height - bottomCoveredHeight) / bounds.height, 0)
+                let bottomFadeMid = bottomFadeStart + ((1 - bottomFadeStart) * 0.4)
+                appendStop(location: bottomFadeStart, alpha: 1)
+                appendStop(location: bottomFadeMid, alpha: 0.3)
+                appendStop(location: 1, alpha: 0.1)
+            } else {
+                appendStop(location: 1, alpha: 1)
+            }
+        } else {
+            appendStop(location: 1, alpha: 1)
+        }
+
+        mask.colors = stops.map { UIColor(white: 1, alpha: $0.alpha).cgColor }
+        mask.locations = stops.map { NSNumber(value: Float($0.location)) }
+        tableViewContainer.layer.mask = mask
     }
 
     // MARK: - Notifications

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -595,6 +595,13 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     private func updateEdgeEffectAppearance() {
         guard #available(iOS 26.0, *) else { return }
 
+        let tintColor = traitCollection.userInterfaceStyle == .dark
+            ? UIColor.black.withAlphaComponent(0.65)
+            : UIColor.clear
+        [edgeEffectBlurViews.top, edgeEffectBlurViews.bottom].forEach {
+            $0.contentView.backgroundColor = tintColor
+        }
+
         let blurMaskColor = UIColor(white: 0, alpha: edgeEffectBlurStrength).cgColor
         edgeEffectBlurMasks.top.colors = [blurMaskColor, blurMaskColor, UIColor.clear.cgColor]
         edgeEffectBlurMasks.bottom.colors = [UIColor.clear.cgColor, blurMaskColor, blurMaskColor]

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -596,7 +596,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         guard #available(iOS 26.0, *) else { return }
 
         let tintColor = traitCollection.userInterfaceStyle == .dark
-            ? UIColor.black.withAlphaComponent(0.65)
+            ? UIColor.black.withAlphaComponent(0.67)
             : UIColor.clear
         [edgeEffectBlurViews.top, edgeEffectBlurViews.bottom].forEach {
             $0.contentView.backgroundColor = tintColor

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -50,8 +50,9 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }()
 
     private lazy var tableViewContainer: UIView = UIView()
-    private let readabilityFadeExtension: CGFloat = 24
-    private let readabilityDimmingGradients = (top: CAGradientLayer(), bottom: CAGradientLayer())
+    private let edgeEffectMask = CAGradientLayer()
+    private let edgeEffectFadeExtension: CGFloat = 24
+    private let edgeEffectDimmingGradients = (top: CAGradientLayer(), bottom: CAGradientLayer())
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.delegate = self
@@ -345,8 +346,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         if #available(iOS 26.0, *) {
             tableView.topEdgeEffect.isHidden = true
             tableView.bottomEdgeEffect.isHidden = true
-            view.layer.addSublayer(readabilityDimmingGradients.top)
-            view.layer.addSublayer(readabilityDimmingGradients.bottom)
+            view.layer.addSublayer(edgeEffectDimmingGradients.top)
+            view.layer.addSublayer(edgeEffectDimmingGradients.bottom)
         }
         view.addSubview(contextMenuPreviewContainer)
         contextMenuPreviewContainer.fillSuperview()
@@ -541,8 +542,12 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        toolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
-        updateEdgeEffects()
+        let newToolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
+        if toolbarHeight != newToolbarHeight {
+            toolbarHeight = newToolbarHeight
+        } else {
+            updateEdgeEffects()
+        }
     }
 
     override func viewSafeAreaInsetsDidChange() {
@@ -577,10 +582,9 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         let bounds = tableViewContainer.bounds
         guard bounds.height > 0 else { return }
 
-        let mask = CAGradientLayer()
-        mask.frame = bounds
-        mask.startPoint = CGPoint(x: 0.5, y: 0)
-        mask.endPoint = CGPoint(x: 0.5, y: 1)
+        edgeEffectMask.frame = bounds
+        edgeEffectMask.startPoint = CGPoint(x: 0.5, y: 0)
+        edgeEffectMask.endPoint = CGPoint(x: 0.5, y: 1)
 
         var stops: [(location: CGFloat, alpha: CGFloat)] = []
         func appendStop(location: CGFloat, alpha: CGFloat) {
@@ -603,18 +607,20 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             appendStop(location: 1, alpha: 1)
         }
 
-        mask.colors = stops.map { UIColor(white: 1, alpha: $0.alpha).cgColor }
-        mask.locations = stops.map { NSNumber(value: Float($0.location)) }
-        tableViewContainer.layer.mask = mask
+        edgeEffectMask.colors = stops.map { UIColor(white: 1, alpha: $0.alpha).cgColor }
+        edgeEffectMask.locations = stops.map { NSNumber(value: Float($0.location)) }
+        if tableViewContainer.layer.mask !== edgeEffectMask {
+            tableViewContainer.layer.mask = edgeEffectMask
+        }
     }
 
     private func updateTopEdgeEffect(bounds: CGRect, appendStop: (CGFloat, CGFloat) -> Void) {
-        let height = view.safeAreaInsets.top + readabilityFadeExtension
-        readabilityDimmingGradients.top.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
-        readabilityDimmingGradients.top.startPoint = CGPoint(x: 0.5, y: 0)
-        readabilityDimmingGradients.top.endPoint = CGPoint(x: 0.5, y: 1)
-        readabilityDimmingGradients.top.colors = [0.65, 0.30, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
-        readabilityDimmingGradients.top.locations = [0, 0.6, 1]
+        let height = view.safeAreaInsets.top + edgeEffectFadeExtension
+        edgeEffectDimmingGradients.top.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
+        edgeEffectDimmingGradients.top.startPoint = CGPoint(x: 0.5, y: 0)
+        edgeEffectDimmingGradients.top.endPoint = CGPoint(x: 0.5, y: 1)
+        edgeEffectDimmingGradients.top.colors = [0.65, 0.30, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
+        edgeEffectDimmingGradients.top.locations = [0, 0.6, 1]
 
         let fadeEnd = min(height / bounds.height, 1)
         appendStop(0, 0)
@@ -623,17 +629,17 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     private func updateBottomEdgeEffect(bounds: CGRect, appendStop: (CGFloat, CGFloat) -> Void) {
-        let height = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom) + readabilityFadeExtension / 2
-        readabilityDimmingGradients.bottom.frame = CGRect(
+        let height = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom) + edgeEffectFadeExtension / 2
+        edgeEffectDimmingGradients.bottom.frame = CGRect(
             x: 0,
             y: view.bounds.height - height,
             width: view.bounds.width,
             height: height
         )
-        readabilityDimmingGradients.bottom.startPoint = CGPoint(x: 0.5, y: 0)
-        readabilityDimmingGradients.bottom.endPoint = CGPoint(x: 0.5, y: 1)
-        readabilityDimmingGradients.bottom.colors = [0, 0.30, 0.65].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
-        readabilityDimmingGradients.bottom.locations = [0, 0.4, 1]
+        edgeEffectDimmingGradients.bottom.startPoint = CGPoint(x: 0.5, y: 0)
+        edgeEffectDimmingGradients.bottom.endPoint = CGPoint(x: 0.5, y: 1)
+        edgeEffectDimmingGradients.bottom.colors = [0, 0.30, 0.65].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
+        edgeEffectDimmingGradients.bottom.locations = [0, 0.4, 1]
 
         let fadeStart = max((bounds.height - height) / bounds.height, 0)
         let fadeMid = fadeStart + ((1 - fadeStart) * 0.4)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -619,7 +619,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         edgeEffectDimmingGradients.top.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
         edgeEffectDimmingGradients.top.startPoint = CGPoint(x: 0.5, y: 0)
         edgeEffectDimmingGradients.top.endPoint = CGPoint(x: 0.5, y: 1)
-        edgeEffectDimmingGradients.top.colors = [0.65, 0.30, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
+        edgeEffectDimmingGradients.top.colors = [0.70, 0.55, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
         edgeEffectDimmingGradients.top.locations = [0, 0.6, 1]
 
         let fadeEnd = min(height / bounds.height, 1)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -50,10 +50,14 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }()
 
     private lazy var tableViewContainer: UIView = UIView()
-    /// Reused for custom edge fades to avoid allocating a new mask layer on every layout pass.
-    private let edgeEffectMask = CAGradientLayer()
-    private let edgeEffectFadeExtension: CGFloat = 24
-    private let edgeEffectDimmingGradients = (top: CAGradientLayer(), bottom: CAGradientLayer())
+    private let edgeEffectExtension = (top: CGFloat(12), bottom: CGFloat(8))
+    private let edgeEffectBlurStrength = (light: CGFloat(0.85), dark: CGFloat(0.62))
+    private let edgeEffectBlurTransition: Float = 0.5
+    private let edgeEffectBlurViews = (
+        top: UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial)),
+        bottom: UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
+    )
+    private let edgeEffectBlurMasks = (top: CAGradientLayer(), bottom: CAGradientLayer())
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.delegate = self
@@ -92,7 +96,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         didSet {
             guard toolbarHeight != oldValue else { return }
             setTableViewContentInset()
-            updateEdgeEffects()
         }
     }
 
@@ -347,8 +350,17 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         if #available(iOS 26.0, *) {
             tableView.topEdgeEffect.isHidden = true
             tableView.bottomEdgeEffect.isHidden = true
-            view.layer.addSublayer(edgeEffectDimmingGradients.top)
-            view.layer.addSublayer(edgeEffectDimmingGradients.bottom)
+
+            edgeEffectBlurMasks.top.locations = [0, NSNumber(value: 1 - edgeEffectBlurTransition), 1]
+            edgeEffectBlurMasks.bottom.locations = [0, NSNumber(value: edgeEffectBlurTransition), 1]
+            updateEdgeEffectAppearance()
+
+            edgeEffectBlurViews.top.layer.mask = edgeEffectBlurMasks.top
+            edgeEffectBlurViews.bottom.layer.mask = edgeEffectBlurMasks.bottom
+            [edgeEffectBlurViews.top, edgeEffectBlurViews.bottom].forEach {
+                $0.isUserInteractionEnabled = false
+                view.addSubview($0)
+            }
         }
         view.addSubview(contextMenuPreviewContainer)
         contextMenuPreviewContainer.fillSuperview()
@@ -543,13 +555,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        let newToolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
-        // Avoid updating edge effects twice when toolbarHeight.didSet already handles the change.
-        if toolbarHeight != newToolbarHeight {
-            toolbarHeight = newToolbarHeight
-        } else {
-            updateEdgeEffects()
-        }
+        toolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
+        updateEdgeEffects()
     }
 
     override func viewSafeAreaInsetsDidChange() {
@@ -581,73 +588,31 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     private func updateEdgeEffects() {
-        let bounds = tableViewContainer.bounds
-        guard bounds.height > 0 else { return }
+        guard #available(iOS 26.0, *) else { return }
 
-        edgeEffectMask.frame = bounds
-        edgeEffectMask.startPoint = CGPoint(x: 0.5, y: 0)
-        edgeEffectMask.endPoint = CGPoint(x: 0.5, y: 1)
+        let topHeight = view.safeAreaInsets.top + edgeEffectExtension.top
+        edgeEffectBlurViews.top.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: topHeight)
+        edgeEffectBlurMasks.top.frame = edgeEffectBlurViews.top.bounds
 
-        var stops: [(location: CGFloat, alpha: CGFloat)] = []
-        func appendStop(location: CGFloat, alpha: CGFloat) {
-            let clampedLocation = min(max(location, 0), 1)
-            if let lastLocation = stops.last?.location, clampedLocation < lastLocation {
-                return
-            }
-            stops.append((clampedLocation, alpha))
-        }
-
-        if #available(iOS 26, *), view.safeAreaInsets.top > 0 {
-            updateTopEdgeEffect(bounds: bounds, appendStop: appendStop)
-        } else {
-            appendStop(location: 0, alpha: 1)
-        }
-
-        if #available(iOS 26, *) {
-            updateBottomEdgeEffect(bounds: bounds, appendStop: appendStop)
-        } else {
-            appendStop(location: 1, alpha: 1)
-        }
-
-        edgeEffectMask.colors = stops.map { UIColor(white: 1, alpha: $0.alpha).cgColor }
-        edgeEffectMask.locations = stops.map { NSNumber(value: Float($0.location)) }
-        if tableViewContainer.layer.mask !== edgeEffectMask {
-            tableViewContainer.layer.mask = edgeEffectMask
-        }
-    }
-
-    private func updateTopEdgeEffect(bounds: CGRect, appendStop: (CGFloat, CGFloat) -> Void) {
-        let height = view.safeAreaInsets.top + edgeEffectFadeExtension
-        edgeEffectDimmingGradients.top.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
-        edgeEffectDimmingGradients.top.startPoint = CGPoint(x: 0.5, y: 0)
-        edgeEffectDimmingGradients.top.endPoint = CGPoint(x: 0.5, y: 1)
-        edgeEffectDimmingGradients.top.colors = [0.70, 0.55, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
-        edgeEffectDimmingGradients.top.locations = [0, 0.6, 1]
-
-        let fadeEnd = min(height / bounds.height, 1)
-        appendStop(0, 0)
-        appendStop(fadeEnd * 0.7, 0.15)
-        appendStop(fadeEnd, 0.9)
-    }
-
-    private func updateBottomEdgeEffect(bounds: CGRect, appendStop: (CGFloat, CGFloat) -> Void) {
-        let height = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom) + edgeEffectFadeExtension / 2
-        edgeEffectDimmingGradients.bottom.frame = CGRect(
+        let bottomHeight = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom) + edgeEffectExtension.bottom
+        edgeEffectBlurViews.bottom.frame = CGRect(
             x: 0,
-            y: view.bounds.height - height,
+            y: view.bounds.height - bottomHeight,
             width: view.bounds.width,
-            height: height
+            height: bottomHeight
         )
-        edgeEffectDimmingGradients.bottom.startPoint = CGPoint(x: 0.5, y: 0)
-        edgeEffectDimmingGradients.bottom.endPoint = CGPoint(x: 0.5, y: 1)
-        edgeEffectDimmingGradients.bottom.colors = [0, 0.30, 0.65].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
-        edgeEffectDimmingGradients.bottom.locations = [0, 0.4, 1]
+        edgeEffectBlurMasks.bottom.frame = edgeEffectBlurViews.bottom.bounds
+    }
 
-        let fadeStart = max((bounds.height - height) / bounds.height, 0)
-        let fadeMid = fadeStart + ((1 - fadeStart) * 0.4)
-        appendStop(fadeStart, 1)
-        appendStop(fadeMid, 0.3)
-        appendStop(1, 0.1)
+    private func updateEdgeEffectAppearance() {
+        guard #available(iOS 26.0, *) else { return }
+
+        let strength = traitCollection.userInterfaceStyle == .dark
+            ? edgeEffectBlurStrength.dark
+            : edgeEffectBlurStrength.light
+        let blurMaskColor = UIColor(white: 0, alpha: strength).cgColor
+        edgeEffectBlurMasks.top.colors = [blurMaskColor, blurMaskColor, UIColor.clear.cgColor]
+        edgeEffectBlurMasks.bottom.colors = [UIColor.clear.cgColor, blurMaskColor, blurMaskColor]
     }
 
     // MARK: - Notifications
@@ -1095,7 +1060,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         if UserDefaults.standard.string(forKey: Constants.Keys.backgroundImageName) == nil {
             backgroundContainer.image = UIImage(named: traitCollection.userInterfaceStyle == .light ? "background_light" : "background_dark")
         }
-        updateEdgeEffects()
+        updateEdgeEffectAppearance()
     }
 
     private func configureMessageStyle(for message: DcMsg, at indexPath: IndexPath) -> UIRectCorner {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -51,7 +51,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     private lazy var tableViewContainer: UIView = UIView()
     private let edgeEffectExtension = (top: CGFloat(12), bottom: CGFloat(8))
-    private let edgeEffectBlurStrength = (light: CGFloat(0.85), dark: CGFloat(0.62))
+    private let edgeEffectBlurStrength = (light: CGFloat(0.70), dark: CGFloat(0.85))
     private let edgeEffectBlurTransition: Float = 0.5
     private let edgeEffectBlurViews = (
         top: UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial)),

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -50,6 +50,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }()
 
     private lazy var tableViewContainer: UIView = UIView()
+    private let readabilityFadeExtension: CGFloat = 24
+    private let readabilityDimmingGradients = (top: CAGradientLayer(), bottom: CAGradientLayer())
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.delegate = self
@@ -88,7 +90,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         didSet {
             guard toolbarHeight != oldValue else { return }
             setTableViewContentInset()
-            updateTableViewContainerMask()
+            updateEdgeEffects()
         }
     }
 
@@ -343,6 +345,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         if #available(iOS 26.0, *) {
             tableView.topEdgeEffect.isHidden = true
             tableView.bottomEdgeEffect.isHidden = true
+            view.layer.addSublayer(readabilityDimmingGradients.top)
+            view.layer.addSublayer(readabilityDimmingGradients.bottom)
         }
         view.addSubview(contextMenuPreviewContainer)
         contextMenuPreviewContainer.fillSuperview()
@@ -538,14 +542,13 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         toolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
-        updateTableViewContainerMask()
+        updateEdgeEffects()
     }
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         setTableViewContentInset()
-
-        updateTableViewContainerMask()
+        updateEdgeEffects()
     }
 
     override func didMove(toParent parent: UIViewController?) {
@@ -570,7 +573,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
     }
 
-    private func updateTableViewContainerMask() {
+    private func updateEdgeEffects() {
         let bounds = tableViewContainer.bounds
         guard bounds.height > 0 else { return }
 
@@ -589,27 +592,13 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
 
         if #available(iOS 26, *), view.safeAreaInsets.top > 0 {
-            // Custom tableView.topEdgeEffect.
-            let topFadeEnd = min(view.safeAreaInsets.top / bounds.height, 1)
-            appendStop(location: 0, alpha: 0)
-            appendStop(location: topFadeEnd * 0.6, alpha: 0.3)
-            appendStop(location: topFadeEnd, alpha: 1)
+            updateTopEdgeEffect(bounds: bounds, appendStop: appendStop)
         } else {
             appendStop(location: 0, alpha: 1)
         }
 
         if #available(iOS 26, *) {
-            // Custom tableView.bottomEdgeEffect
-            let bottomCoveredHeight = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom)
-            if bottomCoveredHeight > 0 {
-                let bottomFadeStart = max((bounds.height - bottomCoveredHeight) / bounds.height, 0)
-                let bottomFadeMid = bottomFadeStart + ((1 - bottomFadeStart) * 0.4)
-                appendStop(location: bottomFadeStart, alpha: 1)
-                appendStop(location: bottomFadeMid, alpha: 0.3)
-                appendStop(location: 1, alpha: 0.1)
-            } else {
-                appendStop(location: 1, alpha: 1)
-            }
+            updateBottomEdgeEffect(bounds: bounds, appendStop: appendStop)
         } else {
             appendStop(location: 1, alpha: 1)
         }
@@ -617,6 +606,40 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         mask.colors = stops.map { UIColor(white: 1, alpha: $0.alpha).cgColor }
         mask.locations = stops.map { NSNumber(value: Float($0.location)) }
         tableViewContainer.layer.mask = mask
+    }
+
+    private func updateTopEdgeEffect(bounds: CGRect, appendStop: (CGFloat, CGFloat) -> Void) {
+        let height = view.safeAreaInsets.top + readabilityFadeExtension
+        readabilityDimmingGradients.top.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
+        readabilityDimmingGradients.top.startPoint = CGPoint(x: 0.5, y: 0)
+        readabilityDimmingGradients.top.endPoint = CGPoint(x: 0.5, y: 1)
+        readabilityDimmingGradients.top.colors = [0.65, 0.30, 0].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
+        readabilityDimmingGradients.top.locations = [0, 0.6, 1]
+
+        let fadeEnd = min(height / bounds.height, 1)
+        appendStop(0, 0)
+        appendStop(fadeEnd * 0.7, 0.15)
+        appendStop(fadeEnd, 0.9)
+    }
+
+    private func updateBottomEdgeEffect(bounds: CGRect, appendStop: (CGFloat, CGFloat) -> Void) {
+        let height = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom) + readabilityFadeExtension / 2
+        readabilityDimmingGradients.bottom.frame = CGRect(
+            x: 0,
+            y: view.bounds.height - height,
+            width: view.bounds.width,
+            height: height
+        )
+        readabilityDimmingGradients.bottom.startPoint = CGPoint(x: 0.5, y: 0)
+        readabilityDimmingGradients.bottom.endPoint = CGPoint(x: 0.5, y: 1)
+        readabilityDimmingGradients.bottom.colors = [0, 0.30, 0.65].map { UIColor.systemBackground.withAlphaComponent($0).cgColor }
+        readabilityDimmingGradients.bottom.locations = [0, 0.4, 1]
+
+        let fadeStart = max((bounds.height - height) / bounds.height, 0)
+        let fadeMid = fadeStart + ((1 - fadeStart) * 0.4)
+        appendStop(fadeStart, 1)
+        appendStop(fadeMid, 0.3)
+        appendStop(1, 0.1)
     }
 
     // MARK: - Notifications
@@ -1064,6 +1087,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         if UserDefaults.standard.string(forKey: Constants.Keys.backgroundImageName) == nil {
             backgroundContainer.image = UIImage(named: traitCollection.userInterfaceStyle == .light ? "background_light" : "background_dark")
         }
+        updateEdgeEffects()
     }
 
     private func configureMessageStyle(for message: DcMsg, at indexPath: IndexPath) -> UIRectCorner {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -88,6 +88,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         didSet {
             guard toolbarHeight != oldValue else { return }
             setTableViewContentInset()
+            updateTableViewContainerMask()
         }
     }
 
@@ -537,25 +538,14 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         toolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
+        updateTableViewContainerMask()
     }
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         setTableViewContentInset()
 
-        if #available(iOS 26, *) {
-            // Custom tableView.topEdgeEffect
-            let mask = CAGradientLayer()
-            mask.frame = view.frame
-            mask.colors = [
-                UIColor(white: 1, alpha: 0).cgColor,
-                UIColor(white: 1, alpha: 0.3).cgColor,
-                UIColor(white: 1, alpha: 1).cgColor,
-            ]
-            mask.startPoint = CGPoint(x: 0.5, y: 0)
-            mask.endPoint = CGPoint(x: 0.5, y: view.safeAreaInsets.top / view.frame.height)
-            tableViewContainer.layer.mask = mask
-        }
+        updateTableViewContainerMask()
     }
 
     override func didMove(toParent parent: UIViewController?) {
@@ -578,6 +568,54 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             }
             tableView.contentInset.top = topInset
         }
+    }
+
+    private func updateTableViewContainerMask() {
+        let bounds = tableViewContainer.bounds
+        guard bounds.height > 0 else { return }
+
+        let mask = CAGradientLayer()
+        mask.frame = bounds
+        mask.startPoint = CGPoint(x: 0.5, y: 0)
+        mask.endPoint = CGPoint(x: 0.5, y: 1)
+
+        var stops: [(location: CGFloat, alpha: CGFloat)] = []
+        func appendStop(location: CGFloat, alpha: CGFloat) {
+            let clampedLocation = min(max(location, 0), 1)
+            if let lastLocation = stops.last?.location, clampedLocation < lastLocation {
+                return
+            }
+            stops.append((clampedLocation, alpha))
+        }
+
+        if #available(iOS 26, *), view.safeAreaInsets.top > 0 {
+            // Custom tableView.topEdgeEffect.
+            let topFadeEnd = min(view.safeAreaInsets.top / bounds.height, 1)
+            appendStop(location: 0, alpha: 0)
+            appendStop(location: topFadeEnd * 0.6, alpha: 0.3)
+            appendStop(location: topFadeEnd, alpha: 1)
+        } else {
+            appendStop(location: 0, alpha: 1)
+        }
+
+        if #available(iOS 26, *) {
+            let bottomCoveredHeight = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom)
+            if bottomCoveredHeight > 0 {
+                let bottomFadeStart = max((bounds.height - bottomCoveredHeight) / bounds.height, 0)
+                let bottomFadeMid = bottomFadeStart + ((1 - bottomFadeStart) * 0.4)
+                appendStop(location: bottomFadeStart, alpha: 1)
+                appendStop(location: bottomFadeMid, alpha: 0.3)
+                appendStop(location: 1, alpha: 0.1)
+            } else {
+                appendStop(location: 1, alpha: 1)
+            }
+        } else {
+            appendStop(location: 1, alpha: 1)
+        }
+
+        mask.colors = stops.map { UIColor(white: 1, alpha: $0.alpha).cgColor }
+        mask.locations = stops.map { NSNumber(value: Float($0.location)) }
+        tableViewContainer.layer.mask = mask
     }
 
     // MARK: - Notifications

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1120,6 +1120,10 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             
             var rightBarButtonItems = [UIBarButtonItem]()
 
+            let button = UIBarButtonItem(image: UIImage(systemName: "square.grid.2x2"), style: .plain, target: self, action: #selector(appsAndMediaPressed))
+            button.accessibilityLabel = String.localized("apps_and_media")
+            rightBarButtonItems.append(button)
+
             if let image = dcChat.profileImage {
                 titleView.initialsBadge.setImage(image)
             } else {
@@ -1356,6 +1360,10 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
                 self?.searchPressed()
             }
         }
+    }
+
+    @objc private func appsAndMediaPressed() {
+        navigationController?.pushViewController(AllMediaViewController(dcContext: dcContext, chatId: chatId), animated: true)
     }
 
     var isLocationStreaming: Bool {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -50,8 +50,8 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }()
 
     private lazy var tableViewContainer: UIView = UIView()
-    private let edgeEffectExtension = (top: CGFloat(12), bottom: CGFloat(8))
-    private let edgeEffectBlurStrength = (light: CGFloat(0.70), dark: CGFloat(0.85))
+    private let edgeEffectExtension = (top: CGFloat(16), bottom: CGFloat(8))
+    private let edgeEffectBlurStrength = CGFloat(0.72)
     private let edgeEffectBlurTransition: Float = 0.5
     private let edgeEffectBlurViews = (
         top: UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial)),
@@ -607,10 +607,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     private func updateEdgeEffectAppearance() {
         guard #available(iOS 26.0, *) else { return }
 
-        let strength = traitCollection.userInterfaceStyle == .dark
-            ? edgeEffectBlurStrength.dark
-            : edgeEffectBlurStrength.light
-        let blurMaskColor = UIColor(white: 0, alpha: strength).cgColor
+        let blurMaskColor = UIColor(white: 0, alpha: edgeEffectBlurStrength).cgColor
         edgeEffectBlurMasks.top.colors = [blurMaskColor, blurMaskColor, UIColor.clear.cgColor]
         edgeEffectBlurMasks.bottom.colors = [UIColor.clear.cgColor, blurMaskColor, blurMaskColor]
     }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -238,10 +238,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         return panGestureRecognizer
     }()
 
-    private lazy var navBarTap: UITapGestureRecognizer = {
-        UITapGestureRecognizer(target: self, action: #selector(chatProfilePressed))
-    }()
-
     private lazy var cancelButton: UIBarButtonItem = {
         UIBarButtonItem.init(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel, target: self, action: #selector(onCancelPressed))
     }()
@@ -341,6 +337,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        titleView.addTarget(self, action: #selector(chatProfilePressed), for: .primaryActionTriggered)
         view.addSubview(backgroundContainer)
         backgroundContainer.fillSuperview()
         view.addSubview(tableViewContainer)
@@ -450,8 +447,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     var isInitialViewWillAppear = true
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        // this will be removed in viewWillDisappear
-        navigationController?.navigationBar.addGestureRecognizer(navBarTap)
         updateTitle()
 
         if activateSearch {
@@ -535,13 +530,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             // so we disable it in the chat view.
             navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
         }
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        // the navigationController will be used when chatDetail is pushed, so we have to remove that gestureRecognizer
-        navigationController?.navigationBar.removeGestureRecognizer(navBarTap)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -1125,10 +1113,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             
             var rightBarButtonItems = [UIBarButtonItem]()
 
-            let button = UIBarButtonItem(image: UIImage(systemName: "square.grid.2x2"), style: .plain, target: self, action: #selector(appsAndMediaPressed))
-            button.accessibilityLabel = String.localized("apps_and_media")
-            rightBarButtonItems.append(button)
-
             if let image = dcChat.profileImage {
                 titleView.initialsBadge.setImage(image)
             } else {
@@ -1365,10 +1349,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
                 self?.searchPressed()
             }
         }
-    }
-
-    @objc private func appsAndMediaPressed() {
-        navigationController?.pushViewController(AllMediaViewController(dcContext: dcContext, chatId: chatId), animated: true)
     }
 
     var isLocationStreaming: Bool {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -50,6 +50,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }()
 
     private lazy var tableViewContainer: UIView = UIView()
+    /// Reused for custom edge fades to avoid allocating a new mask layer on every layout pass.
     private let edgeEffectMask = CAGradientLayer()
     private let edgeEffectFadeExtension: CGFloat = 24
     private let edgeEffectDimmingGradients = (top: CAGradientLayer(), bottom: CAGradientLayer())
@@ -543,6 +544,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         let newToolbarHeight = toolbarContainerView.frame.height - view.keyboardLayoutGuide.layoutFrame.height
+        // Avoid updating edge effects twice when toolbarHeight.didSet already handles the change.
         if toolbarHeight != newToolbarHeight {
             toolbarHeight = newToolbarHeight
         } else {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -599,6 +599,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
 
         if #available(iOS 26, *) {
+            // Custom tableView.bottomEdgeEffect
             let bottomCoveredHeight = max(toolbarContainerView.frame.height, view.safeAreaInsets.bottom)
             if bottomCoveredHeight > 0 {
                 let bottomFadeStart = max((bounds.height - bottomCoveredHeight) / bounds.height, 0)

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -268,6 +268,7 @@ class ChatListViewController: UITableViewController {
     }
 
     private func updateNextScreensBackButton(accountId: Int? = nil, chatId: Int? = nil) {
+        navigationItem.backButtonDisplayMode = .minimal
         let numberOfUnreadMessages = DcAccounts.shared.getFreshMessagesCount()
 
         if isArchive {

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -85,7 +85,7 @@ class ChatTitleView: UIButton {
             configuration = .glass()
         }
 
-        layoutMargins = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
+        layoutMargins = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
         isAccessibilityElement = true
 
         addSubview(contentStack)

--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import DcCore
 
-class ChatTitleView: UIStackView {
+class ChatTitleView: UIButton {
 
     lazy var initialsBadge: InitialsBadge = {
         let badge: InitialsBadge
@@ -10,7 +10,7 @@ class ChatTitleView: UIStackView {
         return badge
     }()
 
-    private lazy var titleLabel: UILabel = {
+    private lazy var chatTitleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.backgroundColor = UIColor.clear
@@ -44,7 +44,7 @@ class ChatTitleView: UIStackView {
     }()
 
     private lazy var titleContainer: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, muteView, ephemeralView, locationView])
+        let stackView = UIStackView(arrangedSubviews: [chatTitleLabel, muteView, ephemeralView, locationView])
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.spacing = 3
@@ -52,7 +52,7 @@ class ChatTitleView: UIStackView {
         return stackView
     }()
 
-    private lazy var subtitleLabel: UILabel = {
+    private lazy var chatSubtitleLabel: UILabel = {
         let subtitleLabel = UILabel()
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         subtitleLabel.font = UIFont.systemFont(ofSize: 12)
@@ -61,47 +61,77 @@ class ChatTitleView: UIStackView {
     }()
 
     private lazy var textsContainer: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [titleContainer, subtitleLabel])
+        let stackView = UIStackView(arrangedSubviews: [titleContainer, chatSubtitleLabel])
         stackView.axis = .vertical
         stackView.alignment = .leading
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
 
+    private lazy var contentStack: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [initialsBadge, textsContainer])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 5
+        stackView.isUserInteractionEnabled = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
     init() {
         super.init(frame: .zero)
-        
+
+        if #available(iOS 26.0, *) {
+            configuration = .glass()
+        }
+
+        layoutMargins = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
         isAccessibilityElement = true
-        axis = .horizontal
-        alignment = .center
-        spacing = 5
-        addArrangedSubview(initialsBadge)
-        addArrangedSubview(textsContainer)
+
+        addSubview(contentStack)
+        NSLayoutConstraint.activate([
+            contentStack.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            contentStack.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
+        ])
     }
 
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override var intrinsicContentSize: CGSize {
+        let size = contentStack.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        return CGSize(
+            width: size.width + layoutMargins.left + layoutMargins.right,
+            height: size.height + layoutMargins.top + layoutMargins.bottom
+        )
+    }
+
     func updateTitleView(title: String, subtitle: String?, isMuted: Bool, isEphemeral: Bool, isSendingLocations: Bool) {
-        titleLabel.text = title
-        titleLabel.textColor = DcColors.defaultTextColor
+        chatTitleLabel.text = title
+        chatTitleLabel.textColor = DcColors.defaultTextColor
         muteView.isHidden = !isMuted
         ephemeralView.isHidden = !isEphemeral
         locationView.isHidden = !isSendingLocations
 
         if let subtitle {
-            subtitleLabel.text = subtitle
-            subtitleLabel.textColor = DcColors.defaultTextColor.withAlphaComponent(0.95)
-            subtitleLabel.isHidden = false
+            chatSubtitleLabel.text = subtitle
+            chatSubtitleLabel.textColor = DcColors.defaultTextColor.withAlphaComponent(0.95)
+            chatSubtitleLabel.isHidden = false
         } else {
-            subtitleLabel.isHidden = true
+            chatSubtitleLabel.isHidden = true
         }
+
+        accessibilityLabel = [title, subtitle].compactMap { $0 }.joined(separator: ", ")
+        invalidateIntrinsicContentSize()
     }
 
     func setEnabled(_ enabled: Bool) {
-        titleLabel.isEnabled = enabled
-        subtitleLabel.isEnabled = enabled
+        isEnabled = enabled
+        chatTitleLabel.isEnabled = enabled
+        chatSubtitleLabel.isEnabled = enabled
         muteView.alpha = enabled ? 1 : 0.4
         ephemeralView.alpha = enabled ? 1 : 0.4
         locationView.alpha = enabled ? 1 : 0.4


### PR DESCRIPTION
add a fade effect at the bottom of the chat behind the message input bar. Without it, the input bar feels a bit visually unpleasant

_before_:

<details>
<summary>Details</summary>

<img width="1028" height="1914" alt="image" src="https://github.com/user-attachments/assets/682ec5d9-eb41-4be9-838e-6c9f6224086d" />


</details>

_after_:

<details>
<summary>Details</summary>

<img width="1028" height="1914" alt="image" src="https://github.com/user-attachments/assets/b9b8475d-0d33-48ff-86be-13d9c6daa70d" />


</details>