### PR TITLE
docs: Add documentation to ReusableCell protocol

### DIFF
--- a/deltachat-ios/Chat/Views/Cells/ReusableCellProtocol.swift
+++ b/deltachat-ios/Chat/Views/Cells/ReusableCellProtocol.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+/// Protocol for reusable table view cells, defining a static reuse identifier for consistent cell dequeuing in table views.
 protocol ReusableCell: UITableViewCell {
     static var reuseIdentifier: String { get }
 }


### PR DESCRIPTION
### 问题背景
公共协议 `ReusableCell` 缺少文档注释，这降低了代码的可读性和维护性。作为开源项目的一部分，良好的文档注释有助于新贡献者和维护者快速理解代码意图。

### 修改内容
- **修改了什么**：在 `ReusableCellProtocol.swift` 文件中，为 `ReusableCell` 协议添加了文档注释。
- **为什么这样改**：通过提供清晰的协议描述，提升代码的可读性和维护性。注释说明了协议用于可重用的表格视图单元格，定义静态重用标识符以确保一致的单元格出列。
- **对代码质量的提升**：增强了代码的自文档化，减少了理解代码所需的时间。

### 验证方式
- 由于这是一个纯文档更改，不影响代码功能，所有现有测试应继续通过。
- 可以手动检查代码是否符合项目的文档风格和编码标准。

### 其他信息
- 没有 breaking changes。
- 不需要更新额外的文档。
- 没有已知限制。