### PR TITLE
use system buttons more eagerly

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1487,7 +1487,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             if let appSettings = URL(string: UIApplication.openSettingsURLString) {
                 alert.addAction(UIAlertAction(title: String.localized("open_settings"), style: .default, handler: { _ in
                     UIApplication.shared.open(appSettings, options: [:], completionHandler: nil)}))
-                alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .destructive, handler: nil))
+                alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
             }
             self?.present(alert, animated: true, completion: nil)
         }

--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -20,7 +20,7 @@ class BackupTransferViewController: UIViewController {
     private var isFinishing = false
 
     private var cancelButton: UIBarButtonItem {
-        return UIBarButtonItem(title: String.localized("cancel"), style: .plain, target: self, action: #selector(cancelButtonPressed))
+        return UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed))
     }
 
     private let statusLine: UILabel

--- a/deltachat-ios/Controller/EphemeralMessagesViewController.swift
+++ b/deltachat-ios/Controller/EphemeralMessagesViewController.swift
@@ -11,12 +11,12 @@ class EphemeralMessagesViewController: UITableViewController {
     }()
 
     private lazy var cancelButton: UIBarButtonItem = {
-        let button =  UIBarButtonItem(title: String.localized("cancel"), style: .plain, target: self, action: #selector(cancelButtonPressed))
+        let button =  UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed))
         return button
     }()
 
     private lazy var okButton: UIBarButtonItem = {
-        let button =  UIBarButtonItem(title: String.localized("ok"), style: .done, target: self, action: #selector(okButtonPressed))
+        let button =  UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(okButtonPressed))
         return button
     }()
 

--- a/deltachat-ios/Controller/HelpViewController.swift
+++ b/deltachat-ios/Controller/HelpViewController.swift
@@ -17,7 +17,7 @@ class HelpViewController: WebViewViewController {
     }
 
     private lazy var doneButton: UIBarButtonItem = {
-        return UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonPressed))
+        return UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(doneButtonPressed))
     }()
 
     private lazy var prevPageButton: UIBarButtonItem = {

--- a/deltachat-ios/Controller/ProfileSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/ProfileSetup/WelcomeViewController.swift
@@ -41,7 +41,7 @@ class WelcomeViewController: UIViewController {
     }()
 
     private lazy var cancelButton: UIBarButtonItem = {
-        return UIBarButtonItem(title: String.localized("cancel"), style: .plain, target: self, action: #selector(cancelAccountCreation))
+        return UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelAccountCreation))
     }()
 
     private lazy var mediaPicker: MediaPicker? = {

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -159,7 +159,7 @@ class QrCodeReaderController: UIViewController {
             if let appSettings = URL(string: UIApplication.openSettingsURLString) {
                 alert.addAction(UIAlertAction(title: String.localized("open_settings"), style: .default, handler: { _ in
                         UIApplication.shared.open(appSettings, options: [:], completionHandler: nil)}))
-                alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .destructive, handler: nil))
+                alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
             }
             self?.present(alert, animated: true, completion: nil)
         }

--- a/deltachat-ios/Controller/Settings/AutodelOptionsViewController.swift
+++ b/deltachat-ios/Controller/Settings/AutodelOptionsViewController.swift
@@ -28,12 +28,12 @@ class AutodelOptionsViewController: UITableViewController {
     var currVal: Int
 
     private var cancelButton: UIBarButtonItem {
-        let button =  UIBarButtonItem(title: String.localized("cancel"), style: .plain, target: self, action: #selector(cancelButtonPressed))
+        let button =  UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed))
         return button
     }
 
     private var okButton: UIBarButtonItem {
-        let button =  UIBarButtonItem(title: String.localized("ok"), style: .done, target: self, action: #selector(okButtonPressed))
+        let button =  UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(okButtonPressed))
         return button
     }
 

--- a/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
+++ b/deltachat-ios/Controller/Settings/Transports/EditTransportViewController.swift
@@ -236,12 +236,12 @@ class EditTransportViewController: UITableViewController {
     }()
 
     private var cancelButton: UIBarButtonItem {
-        let button =  UIBarButtonItem(title: String.localized("cancel"), style: .plain, target: self, action: #selector(cancelButtonPressed))
+        let button =  UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed))
         return button
     }
 
     private lazy var loginButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: String.localized("login_title"), style: .done, target: self, action: #selector(loginButtonPressed))
+        let button = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(loginButtonPressed))
         button.isEnabled = !dcContext.isConfigured()
         return button
     }()

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -388,7 +388,7 @@ class AppCoordinator: NSObject {
             let name = dcContext.getContact(id: qrParsed.id).displayName
             let msg = String.localizedStringWithFormat(String.localized(state==DC_QR_ADDR ? "ask_start_chat_with" : "qrshow_x_verified"), name)
             let alert = UIAlertController(title: msg, message: nil, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .default, handler: nil))
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
             alert.addAction(UIAlertAction(title: String.localized("start_chat"), style: .default, handler: { [weak self] _ in
                 let chatId = dcContext.createChatByContactId(contactId: qrParsed.id)
                 self?.showChat(chatId: chatId)
@@ -446,7 +446,7 @@ class AppCoordinator: NSObject {
         case DC_QR_WITHDRAW_VERIFYCONTACT:
             let alert = UIAlertController(title: String.localized("withdraw_verifycontact_explain"),
                                           message: nil, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .default))
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
             alert.addAction(UIAlertAction(title: String.localized("withdraw_qr_code"), style: .destructive, handler: { _ in
                 _ = dcContext.setConfigFromQR(qrCode: code)
             }))
@@ -455,7 +455,7 @@ class AppCoordinator: NSObject {
         case DC_QR_REVIVE_VERIFYCONTACT, DC_QR_REVIVE_VERIFYGROUP, DC_QR_REVIVE_JOINBROADCAST:
             let alert = UIAlertController(title: String.localized("revive_verifycontact_explain"),
                                           message: nil, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .default))
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
             alert.addAction(UIAlertAction(title: String.localized("revive_qr_code"), style: .default, handler: { _ in
                 _ = dcContext.setConfigFromQR(qrCode: code)
             }))
@@ -465,7 +465,7 @@ class AppCoordinator: NSObject {
             guard let name = qrParsed.text1 else { return }
             let msg = String.localizedStringWithFormat(String.localized(state == DC_QR_WITHDRAW_JOINBROADCAST ? "withdraw_joinbroadcast_explain" : "withdraw_verifygroup_explain"), name)
             let alert = UIAlertController(title: msg, message: nil, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .default))
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel))
             alert.addAction(UIAlertAction(title: String.localized("withdraw_qr_code"), style: .destructive, handler: { _ in
                 _ = dcContext.setConfigFromQR(qrCode: code)
             }))


### PR DESCRIPTION
for non-liquid-glass, there is no visible change, but for liquid-glass, it makes a differerence as controls familar and consistent to the system are used.
    
as a side effect, this forces to use more semantics, which may also help for accessibility, without adding any code - and be even shorter.

#skip-changelog as initial liquid glass is not released yet, and it otherwise does not make a big difference