### PR TITLE
remove now mostly superfluous tabbar animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove explict tab bar icon bounce and leave animation up to the system
 - Fix: Improve voice message recording with Bluetooth and car audio systems
 - Allow voice and audio messages to continue playing in the background
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Support LiquidGlass UI language on systems that support that
+- Minimum system version is iOS 15.6 now (all iOS 14 devices can upgrade to iOS 15.6)
 - Remove explict tab bar icon bounce and leave animation up to the system
 - Fix: Improve voice message recording with Bluetooth and car audio systems
 - Allow voice and audio messages to continue playing in the background

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -613,52 +613,10 @@ extension AppCoordinator: UITabBarControllerDelegate {
             }
         }
 
-        // animate only on re-tap (same tab) — UIKit won't interfere here
-        if viewController == tabBarController.selectedViewController {
-            if let viewControllers = tabBarController.viewControllers,
-               let index = viewControllers.firstIndex(of: viewController) {
-                animateTabBarItem(at: index, in: tabBarController.tabBar)
-            }
-        }
-
         return true
     }
 
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
         appStateRestorer.tabBarController(tabBarController, didSelect: viewController)
-
-        // animate on tab switch — by this point UIKit has finished updating selection state
-        if let viewControllers = tabBarController.viewControllers,
-           let index = viewControllers.firstIndex(of: viewController) {
-            animateTabBarItem(at: index, in: tabBarController.tabBar)
-        }
-    }
-
-    private func animateTabBarItem(at index: Int, in tabBar: UITabBar) {
-        guard !UIAccessibility.isReduceMotionEnabled else { return }
-
-        let tabBarButtons = tabBar.subviews
-            .filter { String(describing: type(of: $0)).contains("UITabBarButton") }
-            .sorted { $0.frame.minX < $1.frame.minX }
-        guard index < tabBarButtons.count,
-              let iconView = findFirstImageView(in: tabBarButtons[index]) else { return }
-
-        let bounce = CAKeyframeAnimation(keyPath: "transform.scale")
-        bounce.values = [1.0, 0.9, 1.08, 1.0]
-        bounce.keyTimes = [0, 0.35, 0.7, 1.0]
-        bounce.duration = 0.4
-        iconView.layer.add(bounce, forKey: "tabBounce")
-    }
-
-    private func findFirstImageView(in view: UIView) -> UIImageView? {
-        for subview in view.subviews {
-            if let imageView = subview as? UIImageView {
-                return imageView
-            }
-            if let imageView = findFirstImageView(in: subview) {
-                return imageView
-            }
-        }
-        return nil
     }
 }


### PR DESCRIPTION
with LiquidGlass, the animation introduced at https://github.com/deltachat/deltachat-ios/pull/3014 becomes superfluous as there is now enough visual feedback from the system.

for older systems, we remove the animation as well, it was not there for all the years beside the last months, and, while we support old systems,
we do not want to maintain code paths for them if we can avoid that.

let's just leave that up to the system again.

targets https://github.com/deltachat/deltachat-ios/issues/3157