### PR TITLE
New messages marker now takes daymarkers into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minimum system version is iOS 15.6 now (all iOS 14 devices can upgrade to iOS 15.6)
 - Remove explict tab bar icon bounce and leave animation up to the system
 - Fix: Improve voice message recording with Bluetooth and car audio systems
+- Fix: "x new messages" is now in the intended place even if there was a new day marker
 - Allow voice and audio messages to continue playing in the background
 
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1143,8 +1143,16 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         var msgs = dcContext.getChatMsgsAndTimestamps(chatId: chatId, flags: DC_GCM_ADDDAYMARKER)
         let freshMsgsCount = self.dcContext.getUnreadMessages(chatId: self.chatId)
         if freshMsgsCount > 0 && msgs.count >= freshMsgsCount {
-            let index = msgs.count - freshMsgsCount
-            msgs.insert((Int(DC_MSG_ID_MARKER1), 0), at: index)
+            /// Fresh count including daymarkers
+            var freshCount = freshMsgsCount
+            var i = 0
+            while i < freshCount {
+                i += 1
+                if msgs.count > freshCount, msgs[msgs.count - freshCount].0 == DC_MSG_ID_DAYMARKER {
+                    freshCount += 1
+                }
+            }
+            msgs.insert((Int(DC_MSG_ID_MARKER1), 0), at: msgs.count - freshCount)
         }
         self.messages = msgs.reversed()
         self.showEmptyStateView(self.messages.isEmpty)


### PR DESCRIPTION

Previously:
```
- msg
- fresh msg
- new msgs marker
- daymarker
- fresh msg
```

Now:
```
- msg
- new msgs marker
- fresh msg
- daymarker
- fresh msg