### PR TITLE
unify "done" buttons

### DIFF
--- a/deltachat-ios/Controller/EditContactController.swift
+++ b/deltachat-ios/Controller/EditContactController.swift
@@ -23,7 +23,7 @@ class EditContactController: UITableViewController {
         nameCell.placeholder = String.localizedStringWithFormat(String.localized("edit_name_placeholder"), authNameOrAddr)
 
         title = String.localized("menu_edit_name")
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(saveButtonPressed))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(saveButtonPressed))
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed))
     }
 

--- a/deltachat-ios/Controller/EditGroupViewController.swift
+++ b/deltachat-ios/Controller/EditGroupViewController.swift
@@ -40,7 +40,7 @@ class EditGroupViewController: UITableViewController, MediaPickerDelegate {
     }()
 
     lazy var doneButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(saveContactButtonPressed))
+        let button = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(saveContactButtonPressed))
         button.isEnabled = false
         return button
     }()


### PR DESCRIPTION
at other places, we're using .done instead of .save - in the past, this was not much of a difference,
but with LiquidGlass, .done is a nicely styled, visually outstanding checkbox, while .save is a text only.

as .done is semantically totally fine here as well, let's stay with that.

this is also more aligned with android, showing a checkmark there as well.

#skip-changelog as this is a minor