### PR TITLE
Fix Liquid Glass input bar layout jump

### DIFF
--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarTextView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarTextView.swift
@@ -22,6 +22,8 @@ private struct _InputBarTextView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> ChatInputTextView {
         let textView = ChatInputTextView()
+        textView.text = text
+        textView.imagePasteDelegate = imagePasteDelegate
         textView.keyboardDismissMode = .none
         textView.delegate = context.coordinator
         textView.adjustsFontForContentSizeCategory = true

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -94,7 +94,11 @@ struct InputBarView: View {
             if draft.isFieldFocused != $0 {
                 draft.isFieldFocused = $0
             }
-            _updateIntrinsicContentSize(())
+            if isLiquidGlassEnabled || textEditorFocus {
+                // Only update when the size could grow otherwise
+                // kb dismiss animation is choppy on older phones
+                _updateIntrinsicContentSize(())
+            }
         }
         .onAppear {
             textEditorFocus = draft.isFieldFocused

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -94,6 +94,7 @@ struct InputBarView: View {
             if draft.isFieldFocused != $0 {
                 draft.isFieldFocused = $0
             }
+            _updateIntrinsicContentSize(())
         }
         .onAppear {
             textEditorFocus = draft.isFieldFocused

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -65,7 +65,7 @@ struct InputBarView: View {
                     }
                     .padding(.horizontal, 10)
                     .modifier { glassEffect(view: $0, padding: 2, minHeight: buttonSize, interactive: true) }
-                    .frame(maxHeight: 150, alignment: .center)
+                    .frame(maxHeight: draft.text.isEmpty && !textEditorFocus ? buttonSize : 150, alignment: .center)
                     .onTapGesture {
                         textEditorFocus = true
                     }
@@ -97,6 +97,7 @@ struct InputBarView: View {
         }
         .onAppear {
             textEditorFocus = draft.isFieldFocused
+            _updateIntrinsicContentSize(())
         }
         .modifier { view in
             if #available(iOS 26.0, *) {


### PR DESCRIPTION
The layout jump happened when you have set a bigger text size (or when using smaller device).

This PR

- removes the jump by doing an extra layout call in onAppear
- limits the height of the input bar to the button size unless there is a draft or it is focused