### PR TITLE
Fix sharing files to a chat in a different profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Show notifications when app is in foreground and the respective chat is not on screen
+- Fix: sharing files to a chat in a different profile no longer sends empty files
 
 
 ## v2.53.1 Testflight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Show in title if an app is still in draft mode
 - Style buttons on welcome screen according to LiquidGlass
 - Fix: Hide 'Show in Chat' and 'Use as widget' from app drafts
+- Fix: sharing files to a chat in a different profile no longer sends empty files
 
 
 ## v2.53.1 Testflight

--- a/DcCore/DcCore/Helper/CodableNSItemProvider.swift
+++ b/DcCore/DcCore/Helper/CodableNSItemProvider.swift
@@ -10,7 +10,14 @@ public var shareExtensionDirectory = FileManager.default
 public enum CodableNSItemProvider: Codable {
     case contentsAt(url: URL, viewType: Int32)
     case text(text: String)
-    
+
+    public var viewType: Int32 {
+        switch self {
+        case .contentsAt(_, let viewType): return viewType
+        case .text: return DC_MSG_TEXT
+        }
+    }
+
     public func itemProvider() -> NSItemProvider? {
         switch self {
         case .contentsAt(let url, _):

--- a/DcTests/DcTests.swift
+++ b/DcTests/DcTests.swift
@@ -4,7 +4,7 @@ import DcCore
 @testable import deltachat_ios
 import UIKit
 
-class DcTests {
+@Suite(.serialized) class DcTests {
     lazy var context = DcTestContext.newOfflineAccount()
     deinit { DcTestContext.cleanup() }
     
@@ -27,6 +27,44 @@ class DcTests {
         #expect(webxdcVC != nil)
         await webxdcVC!.dismiss(animated: false)
         #expect(webxdcVC == nil)
+    }
+
+    @Test @MainActor func shareAttachmentToDifferentProfileKeepsFileBytes() async throws {
+        let aContext = DcTestContext.newOfflineAccount()
+        let aId = aContext.id
+
+        let bId = DcAccounts.shared.add()
+        let bContext = DcAccounts.shared.get(id: bId)
+        bContext.setConfig("displayname", "Unit Test Account B")
+        bContext.setConfig("addr", "ios.test.b@delta.chat")
+        bContext.setConfig("configured_addr", "ios.test.b@delta.chat")
+        bContext.setConfig("configured_mail_pw", "abcd")
+        bContext.setConfigBool("ui.ios.test_account", true)
+        bContext.setConfigBool("configured", true)
+
+        #expect(DcAccounts.shared.getSelected().id == aId)
+
+        try? FileManager.default.removeItem(at: shareExtensionDirectory)
+        try FileManager.default.createDirectory(at: shareExtensionDirectory, withIntermediateDirectories: true)
+        let fileURL = shareExtensionDirectory.appendingPathComponent("shared-file.txt")
+        let sharedBytes = Data([0x44, 0x65, 0x6c, 0x74, 0x61])
+        try sharedBytes.write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: shareExtensionDirectory) }
+
+        let provider = CodableNSItemProvider.contentsAt(url: fileURL, viewType: DC_MSG_FILE)
+        RelayHelper.shared.setShareItems(items: [provider])
+
+        #expect(DcAccounts.shared.select(id: bId))
+        let selectedBContext = DcAccounts.shared.get(id: bId)
+        let chatB = selectedBContext.createChatByContactId(contactId: Int(DC_CONTACT_ID_SELF))
+        RelayHelper.shared.shareAndFinishRelaying(to: chatB)
+
+        let ids = selectedBContext.getChatMsgs(chatId: chatB, flags: 0)
+        #expect(!ids.isEmpty)
+        guard let lastId = ids.last else { return }
+        let msg = selectedBContext.getMessage(id: lastId)
+        #expect(msg.type == DC_MSG_FILE)
+        #expect(msg.filesize > 0)
     }
 }
 

--- a/DcTests/DcTests.swift
+++ b/DcTests/DcTests.swift
@@ -5,9 +5,15 @@ import DcCore
 import UIKit
 
 @Suite(.serialized) class DcTests {
-    lazy var context = DcTestContext.newOfflineAccount()
-    deinit { DcTestContext.cleanup() }
-    
+    lazy var context = DcTestContext.newOfflineAccount(named: "Main")
+    lazy var secondaryContext = DcTestContext.newOfflineAccount(named: "Secondary")
+    init() {
+        #expect(DcAccounts.shared.select(id: context.id))
+    }
+    deinit {
+        DcTestContext.cleanup()
+    }
+
     @Test @MainActor func webxdcShouldNotLeak() async throws {
         // send a webxdc message
         let selfChat = context.createChatByContactId(contactId: Int(DC_CONTACT_ID_SELF))
@@ -30,19 +36,7 @@ import UIKit
     }
 
     @Test @MainActor func shareAttachmentToDifferentProfileKeepsFileBytes() async throws {
-        let aContext = DcTestContext.newOfflineAccount()
-        let aId = aContext.id
-
-        let bId = DcAccounts.shared.add()
-        let bContext = DcAccounts.shared.get(id: bId)
-        bContext.setConfig("displayname", "Unit Test Account B")
-        bContext.setConfig("addr", "ios.test.b@delta.chat")
-        bContext.setConfig("configured_addr", "ios.test.b@delta.chat")
-        bContext.setConfig("configured_mail_pw", "abcd")
-        bContext.setConfigBool("ui.ios.test_account", true)
-        bContext.setConfigBool("configured", true)
-
-        #expect(DcAccounts.shared.getSelected().id == aId)
+        #expect(DcAccounts.shared.getSelected().id == context.id)
 
         try? FileManager.default.removeItem(at: shareExtensionDirectory)
         try FileManager.default.createDirectory(at: shareExtensionDirectory, withIntermediateDirectories: true)
@@ -54,17 +48,18 @@ import UIKit
         let provider = CodableNSItemProvider.contentsAt(url: fileURL, viewType: DC_MSG_FILE)
         RelayHelper.shared.setShareItems(items: [provider])
 
-        #expect(DcAccounts.shared.select(id: bId))
-        let selectedBContext = DcAccounts.shared.get(id: bId)
-        let chatB = selectedBContext.createChatByContactId(contactId: Int(DC_CONTACT_ID_SELF))
+        #expect(DcAccounts.shared.select(id: secondaryContext.id))
+        let chatB = secondaryContext.createChatByContactId(contactId: Int(DC_CONTACT_ID_SELF))
         RelayHelper.shared.shareAndFinishRelaying(to: chatB)
 
-        let ids = selectedBContext.getChatMsgs(chatId: chatB, flags: 0)
+        let ids = secondaryContext.getChatMsgs(chatId: chatB, flags: 0)
         #expect(!ids.isEmpty)
-        guard let lastId = ids.last else { return }
-        let msg = selectedBContext.getMessage(id: lastId)
-        #expect(msg.type == DC_MSG_FILE)
-        #expect(msg.filesize > 0)
+        if let lastId = ids.last {
+            let msg = secondaryContext.getMessage(id: lastId)
+            #expect(msg.type == DC_MSG_FILE)
+            #expect(msg.filesize > 0)
+        }
+        #expect(DcAccounts.shared.select(id: context.id))
     }
 }
 
@@ -77,18 +72,16 @@ struct DcTestContext {
         }
     }
     
-    static func newOfflineAccount() -> DcContext {
-        cleanup()
+    static func newOfflineAccount(named name: String) -> DcContext {
         let newAccountId = DcAccounts.shared.add()
         let newAccount = DcAccounts.shared.get(id: newAccountId)
-        newAccount.setConfig("displayname", "Unit Test Account")
-        newAccount.setConfig("addr", "ios.test@delta.chat")
-        newAccount.setConfig("configured_addr", "ios.test@delta.chat")
+        newAccount.setConfig("displayname", "Unit Test Account \(name)")
+        newAccount.setConfig("addr", "ios.test.\(name)@delta.chat")
+        newAccount.setConfig("configured_addr", "ios.test.\(name)@delta.chat")
         newAccount.setConfig("configured_mail_pw", "abcd")
         newAccount.setConfigBool("bcc_self", false)
         newAccount.setConfigBool("ui.ios.test_account", true)
         newAccount.setConfigBool("configured", true)
-        assert(DcAccounts.shared.select(id: newAccountId))
         return newAccount
     }
 }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -462,7 +462,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             draft.text = draftText ?? draft.text
             RelayHelper.shared.finishRelaying()
         case .share(let items):
-            let description = Dictionary(items.map { ($0.type, 1) }, uniquingKeysWith: +)
+            let description = Dictionary(items.map { ($0.viewType, 1) }, uniquingKeysWith: +)
                 .compactMap { viewType, count in
                     switch viewType { // TODO: Localize
                     case DC_MSG_GIF: "\(count) GIF(s)"

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -230,21 +230,6 @@ class AppCoordinator: NSObject {
             }
         }
         
-        // Create messages
-        let dcContext = dcAccounts.getSelected()
-        let messages = providers.map {
-            switch $0 {
-            case let .contentsAt(url, viewType):
-                let msg = dcContext.newMessage(viewType: viewType)
-                msg.setFile(filepath: url.relativePath)
-                return msg
-            case .text(let text):
-                let msg = dcContext.newMessage(viewType: DC_MSG_TEXT)
-                msg.text = text
-                return msg
-            }
-        }
-        
         // Ask for sending messages
         if let chatId = parameters["chatId"].flatMap(Int.init) {
             showChat(chatId: chatId)
@@ -253,7 +238,7 @@ class AppCoordinator: NSObject {
             let nvc = tabBarController.selectedViewController as? UINavigationController
             nvc?.popToRootViewController(animated: false)
         }
-        RelayHelper.shared.setShareMessages(messages: messages)
+        RelayHelper.shared.setShareItems(items: providers)
 
         return true
     }

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -6,7 +6,7 @@ enum RelayData {
     case forwardMessage(text: String?, fileData: Data?, fileName: String?)
     case forwardVCard(Data)
     case mailto(address: String, draft: String?)
-    case share([DcMsg])
+    case share([CodableNSItemProvider])
 }
 
 class RelayHelper {
@@ -38,10 +38,10 @@ class RelayHelper {
         self.data = .forwardMessages(srcContextId: DcAccounts.shared.getSelected().id, ids: messageIds)
     }
     
-    func setShareMessages(messages: [DcMsg]) {
+    func setShareItems(items: [CodableNSItemProvider]) {
         finishRelaying()
         self.dialogTitle = String.localized("chat_share_with_title")
-        self.data = .share(messages)
+        self.data = .share(items)
     }
 
     func isForwarding() -> Bool {
@@ -56,9 +56,18 @@ class RelayHelper {
     }
     
     func shareAndFinishRelaying(to chatId: Int) {
-        if case .share(let messages) = data {
+        if case .share(let items) = data {
             let dcContext = DcAccounts.shared.getSelected()
-            for msg in messages {
+            for item in items {
+                let msg: DcMsg
+                switch item {
+                case let .contentsAt(url, viewType):
+                    msg = dcContext.newMessage(viewType: viewType)
+                    msg.setFile(filepath: url.relativePath)
+                case .text(let text):
+                    msg = dcContext.newMessage(viewType: DC_MSG_TEXT)
+                    msg.text = text
+                }
                 dcContext.sendMessage(chatId: chatId, message: msg)
             }
             DcUtils.donateSendMessageIntent(


### PR DESCRIPTION
## Summary

Sharing a file from the iOS share sheet into a chat that belongs to a **different profile** than the one selected when the share sheet opened now sends the real attachment instead of an empty (0-byte) file.

## Why this matters

The regression was introduced in #3017. When the app is opened from the share sheet, `AppCoordinator.handleShareDeeplink(url:)` decoded the payload and immediately built `DcMsg` objects against the *currently selected* `dcContext`, calling `setFile(filepath:)` which copies each attachment into that profile's blobdir. The messages were then stashed in `RelayHelper`.

If the user subsequently picked a chat in another profile, `shareAndFinishRelaying(to:)` sent those pre-built messages against the now-selected destination account. The messages and their copied blob files still belonged to the originating account's database, so they could not be resolved from the destination account and the sent attachments arrived empty.

## Changes

- `RelayHelper` now carries the raw `[CodableNSItemProvider]` payload instead of pre-built `[DcMsg]`. The `DcMsg` objects are constructed inside `shareAndFinishRelaying(to:)` against the destination chat's context, so `setFile` copies attachments into the correct profile's blobdir. The same-profile path is unchanged in behavior.
- No change to where the share extension stores files: they already live in the shared app-group container (`shareExtensionDirectory`), reachable by the main app for any account.
- `CodableNSItemProvider` gains a `viewType` accessor so the share-confirmation summary in `ChatViewController` can report item types without a materialized message.

## Testing

Added a regression test (`DcTests.shareAttachmentToDifferentProfileKeepsFileBytes`) that stages a shared file while profile A is selected, switches to profile B, relays to a chat in B, and asserts the resulting message resolves to a non-empty file. The test suite is marked `.serialized` because the new case mutates the globally selected account and shared `RelayHelper` state.

Fixes #3101
