### PR TITLE
webxdc drafts: show state in title, hide options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Show notifications when app is in foreground and the respective chat is not on screen
+- Show in title if an app is still in draft mode
+- Fix: Hide 'Show in Chat' and 'Use as widget' from app drafts
 
 
 ## v2.53.1 Testflight

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -15,6 +15,7 @@ class WebxdcViewController: WebViewViewController {
     let INTERNALSCHEMA = "webxdc"
     
     var messageId: Int
+    var isDraft: Bool = false
     var href: String?
     var webxdcName: String = ""
     var sourceCodeUrl: String?
@@ -309,7 +310,13 @@ class WebxdcViewController: WebViewViewController {
         let chatName = dcContext.getChat(chatId: msg.chatId).name
         self.allowInternet = dict["internet_access"] as? Bool ?? false
 
-        self.title = document.isEmpty ? "\(webxdcName) – \(chatName)" : "\(document) – \(chatName)"
+        isDraft = msg.state == DC_STATE_OUT_DRAFT
+        if isDraft {
+            title = String.localized("draft")
+        } else {
+            title = document.isEmpty ? "\(webxdcName) – \(chatName)" : "\(document) – \(chatName)"
+        }
+
         if let sourceCode = dict["source_code_url"] as? String,
            !sourceCode.isEmpty {
             sourceCodeUrl = sourceCode
@@ -431,32 +438,35 @@ class WebxdcViewController: WebViewViewController {
         let actions: () -> [UIMenuElement] = { [weak self] in
             guard let self else { return [] }
             var actions = [UIMenuElement]()
-            actions.append(UIAction(title: String.localized("show_in_chat"), image: UIImage(systemName: "doc.text.magnifyingglass")) { [weak self] _ in
-                guard let self, let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-                let message = dcContext.getMessage(id: self.messageId)
-                DispatchQueue.main.async {
-                    appDelegate.appCoordinator.showChat(chatId: message.chatId, msgId: message.id, animated: true, clearViewControllerStack: true)
-                }
-            })
 
-            if #available(iOS 17.0, *), let userDefaults = UserDefaults.shared {
-                let appsInWidgetsMessageIds = userDefaults.getAppWidgetEntries().compactMap { entry in
-                    switch entry.type {
-                    case .app(let messageId): return messageId
-                    case .chat: return nil
+            if !isDraft {
+                actions.append(UIAction(title: String.localized("show_in_chat"), image: UIImage(systemName: "doc.text.magnifyingglass")) { [weak self] _ in
+                    guard let self, let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+                    let message = dcContext.getMessage(id: self.messageId)
+                    DispatchQueue.main.async {
+                        appDelegate.appCoordinator.showChat(chatId: message.chatId, msgId: message.id, animated: true, clearViewControllerStack: true)
                     }
-                }
-                let isOnHomescreen = appsInWidgetsMessageIds.contains(messageId)
-                if isOnHomescreen {
-                    actions.append(UIAction(title: String.localized("remove_from_widget"), image: UIImage(systemName: "minus.square")) { [weak self] _ in
-                        guard let self else { return }
-                        userDefaults.removeWebxdcFromHomescreen(accountId: dcContext.id, messageId: messageId)
-                    })
-                } else {
-                    actions.append(UIAction(title: String.localized("add_to_widget"), image: UIImage(systemName: "plus.square")) { [weak self] _ in
-                        guard let self else { return }
-                        userDefaults.addWebxdcToHomescreenWidget(accountId: dcContext.id, messageId: messageId)
-                    })
+                })
+
+                if #available(iOS 17.0, *), let userDefaults = UserDefaults.shared {
+                    let appsInWidgetsMessageIds = userDefaults.getAppWidgetEntries().compactMap { entry in
+                        switch entry.type {
+                        case .app(let messageId): return messageId
+                        case .chat: return nil
+                        }
+                    }
+                    let isOnHomescreen = appsInWidgetsMessageIds.contains(messageId)
+                    if isOnHomescreen {
+                        actions.append(UIAction(title: String.localized("remove_from_widget"), image: UIImage(systemName: "minus.square")) { [weak self] _ in
+                            guard let self else { return }
+                            userDefaults.removeWebxdcFromHomescreen(accountId: dcContext.id, messageId: messageId)
+                        })
+                    } else {
+                        actions.append(UIAction(title: String.localized("add_to_widget"), image: UIImage(systemName: "plus.square")) { [weak self] _ in
+                            guard let self else { return }
+                            userDefaults.addWebxdcToHomescreenWidget(accountId: dcContext.id, messageId: messageId)
+                        })
+                    }
                 }
             }
 


### PR DESCRIPTION
- hide the options 'show in chat' and 'add as widget' if the webxdc is a draft; they cannot work reliably as we do not have a final message id, and also would not make much sense

- moreover, show draft state already in title. we got reports that some ppl are not aware they have to send an app for collaboration, to mitigate that, we set the subtitle to "tap 'send' to share". showing 'draft' when enlarged makes additionally clear that this is not sent out yet. moreover, it removes clutter - the title and the chat is not really needed as the conext is very much clear (more than eg. opening an app by icon from the media view)

for review: better hide whitespace

counterpart of https://github.com/deltachat/deltachat-android/pull/4506

<img width="1218" height="563" alt="IMG_2066" src="https://github.com/user-attachments/assets/77370068-60a1-4f29-8e04-6875ecabe40c" />
