### PR TITLE
Reduce padding on the input field

### DIFF
--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarTextView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarTextView.swift
@@ -5,13 +5,16 @@ struct InputBarTextView: View {
     @Binding var text: String
     @State private var contentSize: CGSize = .zero
     weak var imagePasteDelegate: ChatInputTextViewPasteDelegate?
+    var textContainerInset: UIEdgeInsets
+    var maxHeight: CGFloat
 
     var body: some View {
         _InputBarTextView(
             text: $text,
             contentSize: $contentSize,
-            imagePasteDelegate: imagePasteDelegate
-        ).frame(idealHeight: contentSize.height, alignment: .center)
+            imagePasteDelegate: imagePasteDelegate,
+            textContainerInset: textContainerInset
+        ).frame(height: min(maxHeight, contentSize.height), alignment: .center)
     }
 }
 
@@ -19,9 +22,11 @@ private struct _InputBarTextView: UIViewRepresentable {
     @Binding var text: String
     @Binding var contentSize: CGSize
     weak var imagePasteDelegate: ChatInputTextViewPasteDelegate?
+    var textContainerInset: UIEdgeInsets
 
     func makeUIView(context: Context) -> ChatInputTextView {
         let textView = ChatInputTextView()
+        textView.textContainerInset = textContainerInset
         textView.keyboardDismissMode = .none
         textView.delegate = context.coordinator
         textView.adjustsFontForContentSizeCategory = true
@@ -37,6 +42,7 @@ private struct _InputBarTextView: UIViewRepresentable {
     func updateUIView(_ uiView: ChatInputTextView, context: Context) {
         uiView.text = text
         uiView.imagePasteDelegate = imagePasteDelegate
+        uiView.textContainerInset = textContainerInset
     }
 
     func makeCoordinator() -> Coordinator {

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -54,18 +54,22 @@ struct InputBarView: View {
                         .scaledToFit()
                         .padding(2)
                 }).frame(height: buttonSize)
-                InputBarTextView(text: $draft.text, imagePasteDelegate: chatViewController)
+                InputBarTextView(
+                    text: $draft.text,
+                    imagePasteDelegate: chatViewController,
+                    textContainerInset: UIEdgeInsets(top: 4, left: 12, bottom: 4, right: 12),
+                    maxHeight: 150
+                )
                     .focused($textEditorFocus)
                     .overlay(alignment: .leading) {
                         if draft.text.isEmpty && !textEditorFocus {
                             Text(String.localized("chat_input_placeholder"))
                                 .foregroundColor(Color(uiColor: DcColors.placeholderColor))
                                 .accessibilityHidden(true)
+                                .padding(.horizontal, 12)
                         }
                     }
-                    .padding(.horizontal, 10)
-                    .modifier { glassEffect(view: $0, padding: 2, minHeight: buttonSize, interactive: true) }
-                    .frame(maxHeight: 150, alignment: .center)
+                    .modifier { glassEffect(view: $0, padding: 0, minHeight: buttonSize, interactive: true) }
                     .onTapGesture {
                         textEditorFocus = true
                     }


### PR DESCRIPTION
Replaces #3176 

This reduces the padding on the input field and fixes the field being misaligned when text size is smaller.

Below the largest text size (without "Larger Accessibility Sizes" turned on) and the default text size.

<img width="200" alt="Simulator Screenshot - iPhone Air - 2026-07-01 at 14 09 51" src="https://github.com/user-attachments/assets/fee19cd7-5152-4895-98e7-c8270d364262" />

<img width="200" alt="Simulator Screenshot - iPhone Air - 2026-07-01 at 14 10 07" src="https://github.com/user-attachments/assets/b42bae3d-5919-4dcb-b576-3fd39212fdeb" />

Jumping still happens when you use "Larger Accessibility Sizes"
