### PR TITLE
add and use helpers to style UIButton according to liquid glass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Show notifications when app is in foreground and the respective chat is not on screen
 - Show in title if an app is still in draft mode
+- Style buttons on welcome screen according to LiquidGlass
 - Fix: Hide 'Show in Chat' and 'Use as widget' from app drafts
 
 

--- a/DcCore/DcCore.xcodeproj/project.pbxproj
+++ b/DcCore/DcCore.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		64E7AA642EBE43E400DB88B7 /* CallKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E7AA632EBE43DE00DB88B7 /* CallKit.swift */; };
 		78072F172A040ED800EB7C98 /* libdeltachat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78072F162A040ED800EB7C98 /* libdeltachat.a */; };
 		7871729629BA495200F110DC /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7871729529BA495200F110DC /* SystemConfiguration.framework */; };
+		B20992892FFBCFBE004CBFD8 /* UIButton+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20992882FFBCFB4004CBFD8 /* UIButton+Extensions.swift */; };
 		B2526A222DEA12A000EB90CC /* DcEnteredLoginParam.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2526A212DEA12A000EB90CC /* DcEnteredLoginParam.swift */; };
 		B2A830392F6D8C75006D1C8D /* DcTransportListEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A830382F6D8C75006D1C8D /* DcTransportListEntry.swift */; };
 		B2F691252C0790140010D9B1 /* DcVcard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F691242C0790140010D9B1 /* DcVcard.swift */; };
@@ -80,6 +81,7 @@
 		7827C8882A04089900B8470D /* libraries */ = {isa = PBXFileReference; lastKnownFileType = folder; name = libraries; path = "../deltachat-ios/libraries"; sourceTree = "<group>"; };
 		7827C88A2A0408A700B8470D /* libdeltachat.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdeltachat.a; path = "../deltachat-ios/libraries/deltachat-core-rust/libdeltachat.a"; sourceTree = "<group>"; };
 		7871729529BA495200F110DC /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		B20992882FFBCFB4004CBFD8 /* UIButton+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extensions.swift"; sourceTree = "<group>"; };
 		B2526A212DEA12A000EB90CC /* DcEnteredLoginParam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DcEnteredLoginParam.swift; sourceTree = "<group>"; };
 		B2A830382F6D8C75006D1C8D /* DcTransportListEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DcTransportListEntry.swift; sourceTree = "<group>"; };
 		B2F691242C0790140010D9B1 /* DcVcard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DcVcard.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				3042195F243E257100516852 /* UIColor+Extensions.swift */,
 				30421963243F0B8400516852 /* String+Extensions.swift */,
 				30E8F2472449C98600CE2C90 /* UIView+Extensions.swift */,
+				B20992882FFBCFB4004CBFD8 /* UIButton+Extensions.swift */,
 				304F5E40244F2F3200462538 /* UIImage+Extensions.swift */,
 				308198AA24866229003BE20D /* UserDefaults+Extensions.swift */,
 				3057028524C5C60000D84EFC /* UITableView+Extensions.swift */,
@@ -327,6 +330,7 @@
 				D8BBF0092B57D92E008C96FD /* DcEvent.swift in Sources */,
 				640BC0472DCC941D0049B475 /* DarwinNotificationCenter.swift in Sources */,
 				30E8F2212447357500CE2C90 /* DatabaseHelper.swift in Sources */,
+				B20992892FFBCFBE004CBFD8 /* UIButton+Extensions.swift in Sources */,
 				64E7AA642EBE43E400DB88B7 /* CallKit.swift in Sources */,
 				D8BBF01B2B57D9BE008C96FD /* DcReaction.swift in Sources */,
 				3042195D243E23F100516852 /* DcUtils.swift in Sources */,

--- a/DcCore/DcCore/Extensions/UIButton+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UIButton+Extensions.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+public extension UIButton {
+    private func applyStyle(_ config: UIButton.Configuration) {
+        var config = config
+        config.cornerStyle = .capsule
+        config.buttonSize = .large
+        configuration = config
+    }
+
+    func primaryCapsule() {
+        let config = UIButton.Configuration.filled()
+        applyStyle(config)
+    }
+
+    func secondaryCapsule() {
+        let config = UIButton.Configuration.bordered()
+        applyStyle(config)
+    }
+}

--- a/deltachat-ios/Controller/ProfileSetup/WelcomeViewController.swift
+++ b/deltachat-ios/Controller/ProfileSetup/WelcomeViewController.swift
@@ -357,25 +357,17 @@ class WelcomeContentView: UIView {
 
     private lazy var signUpButton: UIButton = {
         let button = UIButton(type: .roundedRect)
-        let title = String.localized("onboarding_create_instant_account")
-        button.setTitle(title, for: .normal)
-        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
-        button.setTitleColor(.white, for: .normal)
-        button.backgroundColor = .systemBlue
-        button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 15, bottom: 8, right: 15)
-        button.layer.cornerRadius = 5
-        button.clipsToBounds = true
+        button.setTitle(String.localized("onboarding_create_instant_account"), for: .normal)
         button.addTarget(self, action: #selector(signUpButtonPressed(_:)), for: .touchUpInside)
+        button.primaryCapsule()
         return button
     }()
 
     private lazy var logInButton: UIButton = {
         let button = UIButton()
-        let title = String.localized("onboarding_alternative_logins")
-        button.setTitleColor(UIColor.systemBlue, for: .normal)
-        button.setTitle(title, for: .normal)
-        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+        button.setTitle(String.localized("onboarding_alternative_logins"), for: .normal)
         button.addTarget(self, action: #selector(logInButtonPressed(_:)), for: .touchUpInside)
+        button.secondaryCapsule()
         return button
     }()
 


### PR DESCRIPTION
this PR adds to small helper functions used to style primary and secondary liquid glass style buttons.

that way, `UIButton` look the same as `UIBarButtonItem` buttons used eg. for the "accept" or "block" buttons. i was wondering, why this is needed at all, i thought, that style should just be the default, but after short call with @Amzd , the configuration roundtrip seems really to be needed.

in subsequent PR, these helper function should also be used for "instant onboarding" and "wallpaper" view controller, but they need some additional love (https://github.com/deltachat/deltachat-ios/issues/3183 ,  https://github.com/deltachat/deltachat-ios/issues/3157) before to not make things worse by styling.

targets https://github.com/deltachat/deltachat-ios/issues/3157

before / after:


<img width="320" src="https://github.com/user-attachments/assets/5aa656f1-8977-40a7-9caa-2e18103c09bf" /> <img width="320" src="https://github.com/user-attachments/assets/7537706f-0d08-4897-ae98-14f29ee4aa19" />

<details>
<summary>using `.large` is too large :)</summary>
<img width="320" src="https://github.com/user-attachments/assets/ee7a92e5-132a-4852-9c70-205d77d88928" /> <img width="320" src="https://github.com/user-attachments/assets/39b95bd6-672f-4138-b97a-cf028362518f" />
</details>