### PR TITLE
Show summary in liquid glass input bar quote view

### DIFF
--- a/deltachat-ios/Chat/Views/QuoteViewSwiftUI.swift
+++ b/deltachat-ios/Chat/Views/QuoteViewSwiftUI.swift
@@ -26,7 +26,7 @@ struct QuoteViewSwiftUI: View {
                         .foregroundColor(color)
                         .font(.preferredFont(for: .caption1, weight: .semibold))
                 }
-                if let text = msg.text {
+                if let text = msg.summary(chars: 1000) {
                     Text(text)
                         .font(.preferredFont(for: .subheadline, weight: .regular))
                         .lineLimit(3)


### PR DESCRIPTION
Instead of quote text being empty, it now shows eg "📷 Image" that comes from core summary