### PR TITLE
Center input bar textfield on pre-liquid glass with regular text size

### DIFF
--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -54,12 +54,13 @@ struct InputBarView: View {
                         .scaledToFit()
                         .padding(2)
                 }).frame(height: buttonSize)
-                InputBarTextView(
-                    text: $draft.text,
-                    imagePasteDelegate: chatViewController,
-                    textContainerInset: UIEdgeInsets(top: 4, left: 12, bottom: 4, right: 12),
-                    maxHeight: 150
-                )
+                VStack {
+                    InputBarTextView(
+                        text: $draft.text,
+                        imagePasteDelegate: chatViewController,
+                        textContainerInset: UIEdgeInsets(top: 4, left: 12, bottom: 4, right: 12),
+                        maxHeight: 150
+                    )
                     .focused($textEditorFocus)
                     .overlay(alignment: .leading) {
                         if draft.text.isEmpty && !textEditorFocus {
@@ -74,6 +75,7 @@ struct InputBarView: View {
                         textEditorFocus = true
                     }
                     .accessibilityLabel(String.localized("write_message_desktop"))
+                }.frame(maxHeight: .infinity)
                 Button(action: {
                     draft.send()
                 }, label: {


### PR DESCRIPTION
The HStack aligns items to the bottom so when text field grows, the send and attach button stick to the bottom. However when the Input bar is smaller it should stay centered instead of be at the bottom. The VStack wrapper is required because resizing the InputBarTextView itself with a min-height does not center the cursor inside it.

Before and after:

<img width="200" alt="IMG_4751" src="https://github.com/user-attachments/assets/ad115913-0d5f-49e5-b0e6-d6e339243aa2" />
<img width="200" alt="IMG_4752" src="https://github.com/user-attachments/assets/9b117816-2069-495b-a2b4-24f1c9475d31" />


The red box is the text view. The added VStack expands to the full height.
