### PR TITLE
Match UIToolbar appearance by adding divider and padding

### DIFF
--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -110,6 +110,8 @@ struct InputBarView: View {
                 }
             } else {
                 view.background(Material.bar, ignoresSafeAreaEdges: .bottom)
+                    .overlay(alignment: .top, content: Divider.init)
+                    .padding(.top, 8)
             }
         }
     }


### PR DESCRIPTION
This is only for pre liquid glass