### PR TITLE
Fix: Attaching live photos as file so they aren't compressed did not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Style buttons on welcome screen according to LiquidGlass
 - Fix: Hide 'Show in Chat' and 'Use as widget' from app drafts
 - Fix: sharing files to a chat in a different profile no longer sends empty files
+- Fix: Attaching live photos as file so they aren't compressed did not work
 
 
 ## v2.53.1 Testflight

--- a/DcCore/DcCore/Helper/CodableNSItemProvider.swift
+++ b/DcCore/DcCore/Helper/CodableNSItemProvider.swift
@@ -31,7 +31,7 @@ public enum CodableNSItemProvider: Codable {
         }
     }
     
-    public init(from provider: NSItemProvider) async throws {
+    public init(from provider: NSItemProvider, in directory: URL) async throws {
         self = try await withCheckedThrowingContinuation { continuation in
             switch provider.hasItemConformingToTypeIdentifier {
             case UTType.gif.identifier: loadFile(forType: .gif, DC_MSG_GIF, plistToImage: true)
@@ -54,7 +54,7 @@ public enum CodableNSItemProvider: Codable {
                 _ = provider.loadObject(ofClass: URL.self) { url, error in
                     if let url {
                         do {
-                            let tempFile = shareExtensionDirectory.appendingPathComponent(url.lastPathComponent)
+                            let tempFile = directory.appendingPathComponent(url.lastPathComponent)
                             try FileManager.default.copyItem(at: url, to: tempFile)
                             let viewType = url.pathExtension == "xdc" ? DC_MSG_WEBXDC : DC_MSG_FILE
                             return continuation.resume(returning: .contentsAt(url: tempFile, viewType: viewType))
@@ -75,7 +75,7 @@ public enum CodableNSItemProvider: Codable {
                     guard let url else {
                         return continuation.resume(throwing: error ?? Error.providerDidNotReturnValueNorError)
                     }
-                    let tempFile = shareExtensionDirectory.appendingPathComponent(url.lastPathComponent)
+                    let tempFile = directory.appendingPathComponent(url.lastPathComponent)
                     do {
                         // If an app shares a UIImage instead of a path (eg the native screenshot process)
                         // the file we receive is a PList so we need to load the UIImage differently.
@@ -109,7 +109,7 @@ public enum CodableNSItemProvider: Codable {
                         // This case adds support for sharing a long-pressed
                         // image in Safari which gives only a url to NSItemProvider
                         do {
-                            let localUrl = shareExtensionDirectory
+                            let localUrl = directory
                                 .appendingPathComponent(UUID().uuidString)
                                 .appendingPathExtension(imageFormat.rawValue)
                             try data.write(to: localUrl)

--- a/DcShare/Controller/ShareViewController.swift
+++ b/DcShare/Controller/ShareViewController.swift
@@ -22,8 +22,8 @@ class ShareViewController: UIViewController {
                 let inputItems = extensionContext?.inputItems as? [NSExtensionItem] ?? []
                 let attachments = try await inputItems
                     .flatMap { $0.attachments ?? [] }
-                    .asyncMap { try await CodableNSItemProvider.init(from: $0) }
-            
+                    .asyncMap { try await CodableNSItemProvider(from: $0, in: shareExtensionDirectory) }
+
                 // Create deeplink referencing shared items
                 if let jsonData = try? JSONEncoder().encode(attachments),
                    let json = String(data: jsonData, encoding: .utf8),

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2523,18 +2523,13 @@ extension ChatViewController: MediaPickerDelegate {
 
             // stage a single selected item
             if sendAsFile {
-                if let typeIdentifier = itemProvider.registeredTypeIdentifiers.first {
-                    itemProvider.loadFileRepresentation(forTypeIdentifier: typeIdentifier) { [weak self] url, error in
-                        if let url {
-                            var copyURL = URL.temporaryDirectory.appendingPathComponent(url.lastPathComponent)
-                            copyURL = FileHelper.copyIfPossible(src: url, dest: copyURL)
-                            self?.stageDocument(url: copyURL as NSURL)
-                        } else if let error {
-                            self?.logAndAlert(error: error.localizedDescription)
-                        }
+                Task { [weak self] in
+                    switch try? await CodableNSItemProvider(from: itemProvider, in: .cachesDirectory) {
+                    case .contentsAt(url: let url, viewType: _):
+                        self?.stageDocument(url: url as NSURL)
+                    default:
+                        self?.logAndAlert(error: "Failed to load file")
                     }
-                } else {
-                    logAndAlert(error: "No types registered")
                 }
             } else if itemProvider.canLoadVideo() {
                 let progressAlertHandler = ProgressAlertHandler()

--- a/deltachat-ios/Extensions/URL+Extension.swift
+++ b/deltachat-ios/Extensions/URL+Extension.swift
@@ -54,4 +54,9 @@ extension URL {
     @_disfavoredOverload public static var temporaryDirectory: URL {
         FileManager.default.temporaryDirectory
     }
+
+    /// This makes URL.cachesDirectory available pre iOS 16
+    @_disfavoredOverload public static var cachesDirectory: URL {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first ?? URL(fileURLWithPath: "")
+    }
 }


### PR DESCRIPTION
Fixes #3193 

I switched to using CodableNSItemProvider for extracting file from NSItemProvider

Live photos are still only sent as a jpeg instead of the short video.