### PR TITLE
clearer "more" navigation buttons

### DIFF
--- a/DcCore/DcCore/Extensions/String+Extensions.swift
+++ b/DcCore/DcCore/Extensions/String+Extensions.swift
@@ -7,6 +7,14 @@ public extension String {
         return self + " ↗"
     }
 
+    static func ellipsisNavigation() -> String {
+        if #available(iOS 26.0, *) {
+            return "ellipsis"
+        } else {
+            return "ellipsis.circle"
+        }
+    }
+
     static func localized(_ stringID: String) -> String {
         let value = NSLocalizedString(stringID, comment: "")
         if value != stringID || NSLocale.preferredLanguages.first == "en" {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2085,6 +2085,7 @@ extension ChatViewController {
 
                 children.append(contentsOf: [
                     UIMenu(options: [.displayInline], children: [
+                        // as menu icons are not shaped by a circle, "ellipsis.circle" looks better than just "ellipsis" (which is used elsewhere to avoid double circles)
                         UIMenu(title: String.localized("menu_more_options"), image: UIImage(systemName: "ellipsis.circle"), children: moreOptions)
                     ])
                 ])

--- a/deltachat-ios/Chat/Views/ChatEditingBar.swift
+++ b/deltachat-ios/Chat/Views/ChatEditingBar.swift
@@ -23,7 +23,7 @@ public class ChatEditingBar: UIView {
 
     public lazy var moreButton: UIBarButtonItem = {
         let moreButton = UIBarButtonItem(
-            image: UIImage(systemName: "ellipsis"),
+            image: UIImage(systemName: .ellipsisNavigation()),
             menu: UIMenu(children: [
                 UIDeferredMenuElement.uncached({ [weak self] completion in
                     completion(self?.delegate?.onMorePressed().children ?? [])

--- a/deltachat-ios/Chat/Views/ChatEditingBar.swift
+++ b/deltachat-ios/Chat/Views/ChatEditingBar.swift
@@ -23,7 +23,7 @@ public class ChatEditingBar: UIView {
 
     public lazy var moreButton: UIBarButtonItem = {
         let moreButton = UIBarButtonItem(
-            image: UIImage(systemName: "ellipsis.circle"),
+            image: UIImage(systemName: "ellipsis"),
             menu: UIMenu(children: [
                 UIDeferredMenuElement.uncached({ [weak self] completion in
                     completion(self?.delegate?.onMorePressed().children ?? [])

--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -251,7 +251,7 @@ class BackupTransferViewController: UIViewController {
 
     private func updateMenuItems() {
         let menu = moreButtonMenu()
-        let button =  UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: menu)
+        let button =  UIBarButtonItem(image: UIImage(systemName: .ellipsisNavigation()), menu: menu)
         navigationItem.rightBarButtonItem = button
     }
 

--- a/deltachat-ios/Controller/BackupTransferViewController.swift
+++ b/deltachat-ios/Controller/BackupTransferViewController.swift
@@ -251,7 +251,7 @@ class BackupTransferViewController: UIViewController {
 
     private func updateMenuItems() {
         let menu = moreButtonMenu()
-        let button =  UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), menu: menu)
+        let button =  UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: menu)
         navigationItem.rightBarButtonItem = button
     }
 

--- a/deltachat-ios/Controller/FullMessageViewController.swift
+++ b/deltachat-ios/Controller/FullMessageViewController.swift
@@ -9,7 +9,7 @@ class FullMessageViewController: WebViewViewController {
         // just to see whether the message they get will change, this is a very generic icon.
         // (best would be if we know before if an HTML message contains images and thelike,
         // but we don't and this is probably also not worth  the effort. so we used the second best approach :)
-        let image = UIImage(systemName: "ellipsis.circle")
+        let image = UIImage(systemName: "ellipsis")
 
         let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(showLoadOptions))
         button.accessibilityLabel = String.localized("load_remote_content")

--- a/deltachat-ios/Controller/FullMessageViewController.swift
+++ b/deltachat-ios/Controller/FullMessageViewController.swift
@@ -9,7 +9,7 @@ class FullMessageViewController: WebViewViewController {
         // just to see whether the message they get will change, this is a very generic icon.
         // (best would be if we know before if an HTML message contains images and thelike,
         // but we don't and this is probably also not worth  the effort. so we used the second best approach :)
-        let image = UIImage(systemName: "ellipsis")
+        let image = UIImage(systemName: .ellipsisNavigation())
 
         let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(showLoadOptions))
         button.accessibilityLabel = String.localized("load_remote_content")

--- a/deltachat-ios/Controller/HelpViewController.swift
+++ b/deltachat-ios/Controller/HelpViewController.swift
@@ -31,7 +31,7 @@ class HelpViewController: WebViewViewController {
     }()
 
     private lazy var moreButton: UIBarButtonItem = {
-        let image = UIImage(systemName: "ellipsis.circle")
+        let image = UIImage(systemName: "ellipsis")
         return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
 

--- a/deltachat-ios/Controller/HelpViewController.swift
+++ b/deltachat-ios/Controller/HelpViewController.swift
@@ -31,7 +31,7 @@ class HelpViewController: WebViewViewController {
     }()
 
     private lazy var moreButton: UIBarButtonItem = {
-        let image = UIImage(systemName: "ellipsis")
+        let image = UIImage(systemName: .ellipsisNavigation())
         return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
 

--- a/deltachat-ios/Controller/ProfileSetup/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/ProfileSetup/InstantOnboardingViewController.swift
@@ -20,7 +20,7 @@ class InstantOnboardingViewController: UIViewController {
     private var providerHostURL: URL
     private var qrCodeData: String?
     private lazy var menuButton: UIBarButtonItem = {
-        let image = UIImage(systemName: "ellipsis")
+        let image = UIImage(systemName: .ellipsisNavigation())
         return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
 

--- a/deltachat-ios/Controller/ProfileSetup/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/ProfileSetup/InstantOnboardingViewController.swift
@@ -20,7 +20,7 @@ class InstantOnboardingViewController: UIViewController {
     private var providerHostURL: URL
     private var qrCodeData: String?
     private lazy var menuButton: UIBarButtonItem = {
-        let image = UIImage(systemName: "ellipsis.circle")
+        let image = UIImage(systemName: "ellipsis")
         return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
 

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -277,7 +277,7 @@ class ProfileViewController: UITableViewController {
     }
 
     private func updateMenuItems() {
-        let menuButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), menu: moreButtonMenu())
+        let menuButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: moreButtonMenu())
         var buttonItems: [UIBarButtonItem] = [menuButton]
         if !isSavedMessages && !isDeviceChat && contact != nil {
             let editButton = UIBarButtonItem(image: UIImage(systemName: "pencil"), style: .plain, target: self, action: #selector(showEditController))

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -277,7 +277,7 @@ class ProfileViewController: UITableViewController {
     }
 
     private func updateMenuItems() {
-        let menuButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: moreButtonMenu())
+        let menuButton = UIBarButtonItem(image: UIImage(systemName: .ellipsisNavigation()), menu: moreButtonMenu())
         var buttonItems: [UIBarButtonItem] = [menuButton]
         if !isSavedMessages && !isDeviceChat && contact != nil {
             let editButton = UIBarButtonItem(image: UIImage(systemName: "pencil"), style: .plain, target: self, action: #selector(showEditController))

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -24,7 +24,7 @@ class QrCodeReaderController: UIViewController {
     }()
 
     private lazy var moreButton: UIBarButtonItem = {
-        let image = UIImage(systemName: "ellipsis.circle")
+        let image = UIImage(systemName: "ellipsis")
         return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
 

--- a/deltachat-ios/Controller/QrCodeReaderController.swift
+++ b/deltachat-ios/Controller/QrCodeReaderController.swift
@@ -24,7 +24,7 @@ class QrCodeReaderController: UIViewController {
     }()
 
     private lazy var moreButton: UIBarButtonItem = {
-        let image = UIImage(systemName: "ellipsis")
+        let image = UIImage(systemName: .ellipsisNavigation())
         return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
 

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -80,7 +80,7 @@ class QrPageController: UIPageViewController {
 
     private func updateMenuItems() {
         let menu = moreButtonMenu()
-        let button =  UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), menu: menu)
+        let button =  UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: menu)
         navigationItem.rightBarButtonItem = button
     }
 

--- a/deltachat-ios/Controller/QrPageController.swift
+++ b/deltachat-ios/Controller/QrPageController.swift
@@ -80,7 +80,7 @@ class QrPageController: UIPageViewController {
 
     private func updateMenuItems() {
         let menu = moreButtonMenu()
-        let button =  UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: menu)
+        let button =  UIBarButtonItem(image: UIImage(systemName: .ellipsisNavigation()), menu: menu)
         navigationItem.rightBarButtonItem = button
     }
 

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -13,7 +13,7 @@ class QrViewController: UIViewController {
     private let shareLinkButton: UIButton
 
     private lazy var moreButton: UIBarButtonItem = {
-        let moreButtonImage = UIImage(systemName: "ellipsis.circle")
+        let moreButtonImage = UIImage(systemName: "ellipsis")
         return UIBarButtonItem(image: moreButtonImage, menu: showMoreOptions())
     }()
 

--- a/deltachat-ios/Controller/QrViewController.swift
+++ b/deltachat-ios/Controller/QrViewController.swift
@@ -13,7 +13,7 @@ class QrViewController: UIViewController {
     private let shareLinkButton: UIButton
 
     private lazy var moreButton: UIBarButtonItem = {
-        let moreButtonImage = UIImage(systemName: "ellipsis")
+        let moreButtonImage = UIImage(systemName: .ellipsisNavigation())
         return UIBarButtonItem(image: moreButtonImage, menu: showMoreOptions())
     }()
 

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -25,7 +25,7 @@ class WebxdcViewController: WebViewViewController {
     private var allowInternet: Bool = false
 
     private lazy var moreButton: UIBarButtonItem = {
-        let image = UIImage(systemName: "ellipsis")
+        let image = UIImage(systemName: .ellipsisNavigation())
         return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
     

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -25,7 +25,7 @@ class WebxdcViewController: WebViewViewController {
     private var allowInternet: Bool = false
 
     private lazy var moreButton: UIBarButtonItem = {
-        let image = UIImage(systemName: "ellipsis.circle")
+        let image = UIImage(systemName: "ellipsis")
         return UIBarButtonItem(image: image, menu: moreButtonMenu())
     }()
     

--- a/deltachat-ios/View/ChatListEditingBar.swift
+++ b/deltachat-ios/View/ChatListEditingBar.swift
@@ -46,7 +46,7 @@ class ChatListEditingBar: UIView {
 
     private lazy var moreButton: UIBarButtonItem = {
         let button = UIBarButtonItem(
-            image: UIImage(systemName: "ellipsis.circle"),
+            image: UIImage(systemName: "ellipsis"),
             menu: UIMenu(children: [
                 UIDeferredMenuElement.uncached({ [weak self] completion in
                     completion(self?.delegate?.onMorePressed().children ?? [])

--- a/deltachat-ios/View/ChatListEditingBar.swift
+++ b/deltachat-ios/View/ChatListEditingBar.swift
@@ -46,7 +46,7 @@ class ChatListEditingBar: UIView {
 
     private lazy var moreButton: UIBarButtonItem = {
         let button = UIBarButtonItem(
-            image: UIImage(systemName: "ellipsis"),
+            image: UIImage(systemName: .ellipsisNavigation()),
             menu: UIMenu(children: [
                 UIDeferredMenuElement.uncached({ [weak self] completion in
                     completion(self?.delegate?.onMorePressed().children ?? [])


### PR DESCRIPTION
with liquidglass, navigation buttons got a circular or partly circular shape. therefore and additional shape is unneeded clutter, and we use just `ellipsis` instead of `ellipsis.circle`. this is also what many other apps do, it just looks better.

only for the unshaped "more icon" in the bubble's context menu, we stay with `ellipsis.circle`

~~this change also happens for pre-liquid-glass,
however, it is okay also there, even looks fresh, and also before, not surround all ellipsis were surrounded by a circle (eg. reactions). considering that pre-liquid-glass will fade out
(it is less than 20% already), it is not worth to do extra stuff for such side things.~~ EDIT i added a commit to preserve the old icon on pre-liquid-glass

#skip-changelog as liquidglass was not released

## before / after

<img width="320" src="https://github.com/user-attachments/assets/10c77d87-10e7-4c08-b690-69b6466807a4" />
<img width="320" src="https://github.com/user-attachments/assets/4d2b58a0-fb8c-4ca5-ac86-9b422044ccc6" />

