### PR TITLE
Allow NSE to crash again instead of backing out when memory gets high

### DIFF
--- a/DcNotificationService/NotificationService.swift
+++ b/DcNotificationService/NotificationService.swift
@@ -2,8 +2,14 @@ import UserNotifications
 import CallKit
 import DcCore
 
+/// If one profile is stuck on connecting then all notifications are delayed by this amount of seconds
+/// so this is a tradeoff between how long we want to try to gather notifications and how long we want to let the user wait
+/// in case they have a broken profile.
+let fetchTimeout = 15.0
+
 class NotificationService: UNNotificationServiceExtension {
     let dcAccounts = DcAccounts.shared
+    let unc = UNUserNotificationCenter.current()
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
         Task {
@@ -12,7 +18,6 @@ class NotificationService: UNNotificationServiceExtension {
     }
 
     func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) async {
-        let bestAttemptContent = request.content
         let nowTimestamp = Date().timeIntervalSince1970
         UserDefaults.pushToDebugArray("🤜")
 
@@ -27,36 +32,36 @@ class NotificationService: UNNotificationServiceExtension {
             contentHandler(silentNotification())
             return
         }
-        UserDefaults.setNseFetching(for: 26)
+        UserDefaults.setNseFetching(for: fetchTimeout)
 
         dcAccounts.openDatabase(writeable: false)
         let eventEmitter = dcAccounts.getEventEmitter()
 
-        // Send the bestAttempt notification when memory is critical because the process will be killed
-        // by the system soon and any notification is better than nothing.
-        var exitedDueToCriticalMemory = false
+        // Queue the bestAttempt notification in case the NSE is killed due to memory usage
+        try? await unc.add(UNNotificationRequest(
+            identifier: "best_attempt",
+            content: request.content,
+            trigger: UNTimeIntervalNotificationTrigger(timeInterval: fetchTimeout + 1, repeats: false)
+        ))
+
+        // Log to debug array when memory is low
         let memoryPressureSource = DispatchSource.makeMemoryPressureSource(eventMask: .critical)
         memoryPressureSource.setEventHandler { [weak memoryPressureSource] in
-            guard let memoryPressureSource, !memoryPressureSource.isCancelled, !exitedDueToCriticalMemory else { return }
+            guard let memoryPressureSource, !memoryPressureSource.isCancelled else { return }
             memoryPressureSource.cancel()
-            // Order of importance because we might crash very soon
-            exitedDueToCriticalMemory = true
-            UserDefaults.setNseFetching(for: 3)
             UserDefaults.pushToDebugArray("ERR5_LOW_MEM")
-            contentHandler(bestAttemptContent)
         }
         memoryPressureSource.activate()
 
-        guard dcAccounts.backgroundFetch(timeout: 25) && !exitedDueToCriticalMemory else {
+        // Start bg fetch
+        guard dcAccounts.backgroundFetch(timeout: UInt64(fetchTimeout)) else {
             UserDefaults.pushToDebugArray("ERR3_CORE")
             UserDefaults.setNseFetchingDone()
-            if !exitedDueToCriticalMemory {
-                contentHandler(bestAttemptContent)
-            }
             return
         }
         UserDefaults.setNseFetchingDone()
-        memoryPressureSource.cancel()
+        unc.removePendingNotificationRequests(withIdentifiers: ["best_attempt"])
+        unc.removeDeliveredNotifications(withIdentifiers: ["best_attempt"])
 
         var notifications: [UNMutableNotificationContent] = []
         while true {
@@ -99,7 +104,7 @@ class NotificationService: UNNotificationServiceExtension {
                     let chat = dcContext.getChat(chatId: msg.chatId)
                     if let content = UNMutableNotificationContent(forIncomingCallMsg: msg, chat: chat, context: dcContext) {
                         let request = UNNotificationRequest(identifier: "incoming-call", content: content, trigger: nil)
-                        try? await UNUserNotificationCenter.current().add(request)
+                        try? await unc.add(request)
                     }
                 } else if #available(iOSApplicationExtension 14.5, *) {
                     // reportNewIncomingVoIPPushPayload ends up in didReceiveIncomingPushWith in the main app
@@ -140,11 +145,10 @@ class NotificationService: UNNotificationServiceExtension {
             } else if event.id == DC_EVENT_MSGS_NOTICED {
                 let noticedThreadId = "\(event.accountId)-\(event.data1Int)"
                 notifications = notifications.filter { $0.threadIdentifier != noticedThreadId }
-                let nc = UNUserNotificationCenter.current()
-                let deliveredNotificationIds = await nc.deliveredNotifications()
+                let deliveredNotificationIds = await unc.deliveredNotifications()
                     .filter { $0.request.content.threadIdentifier == noticedThreadId }
                     .map { $0.request.identifier }
-                nc.removeDeliveredNotifications(withIdentifiers: deliveredNotificationIds)
+                unc.removeDeliveredNotifications(withIdentifiers: deliveredNotificationIds)
             }
         }
 
@@ -152,7 +156,7 @@ class NotificationService: UNNotificationServiceExtension {
         for notification in notifications {
             let req = UNNotificationRequest(identifier: UUID().uuidString, content: notification, trigger: nil)
             do {
-                try await UNUserNotificationCenter.current().add(req)
+                try await unc.add(req)
             } catch {
                 UserDefaults.pushToDebugArray("ERR6_UNUNC")
             }

--- a/deltachat-ios.xcodeproj/xcshareddata/xcschemes/DcNotificationService.xcscheme
+++ b/deltachat-ios.xcodeproj/xcshareddata/xcschemes/DcNotificationService.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2610"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B2D0E4912B93A4B200791949"
+               BuildableName = "DcNotificationService.appex"
+               BlueprintName = "DcNotificationService"
+               ReferencedContainer = "container:deltachat-ios.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7A9FB13F1FB061E2001FEA36"
+               BuildableName = "deltachat-ios.app"
+               BlueprintName = "deltachat-ios"
+               ReferencedContainer = "container:deltachat-ios.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <RemoteRunnable
+         runnableDebuggingMode = "1"
+         BundleIdentifier = "com.apple.mobilesafari"
+         RemotePath = "/Applications/MobileSafari.app">
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7A9FB13F1FB061E2001FEA36"
+            BuildableName = "deltachat-ios.app"
+            BlueprintName = "deltachat-ios"
+            ReferencedContainer = "container:deltachat-ios.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7A9FB13F1FB061E2001FEA36"
+            BuildableName = "deltachat-ios.app"
+            BlueprintName = "deltachat-ios"
+            ReferencedContainer = "container:deltachat-ios.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -703,6 +703,9 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
         // Update the last seen indicator
         updateTitle()
+        let nc = UNUserNotificationCenter.current()
+        nc.removePendingNotificationRequests(withIdentifiers: ["best_attempt"])
+        nc.removeDeliveredNotifications(withIdentifiers: ["best_attempt"])
     }
 
     @objc func applicationWillResignActive(_ notification: NSNotification) {


### PR DESCRIPTION
I thought of a new way to still send a best attempt notification: Just queue it.

This is much simpler than the memory pressure event and protects against long periods of receiving the best attempt notification instead of actual notifications by letting the NSE process crash again when it runs out of memory. 

It is a bit counterintuitive: We don't want to let the NSE crash right? But a crash means the next notification will work again which is more important than not crashing because the crash is not visible to the user anyway.

100 lines of this PR are just adding a scheme to more easily test the NSE, so you don't have to: 
- launch the app
- close the app
- wait 30 seconds
- test

every time. Instead just run the new DcNotificationService scheme on a different app (eg Safari) and test right away. This also attaches the debugger to the NSE process.

This fixes the 2 cores running at the same time issue #3191