### PR TITLE
consistent delete position

### DIFF
--- a/deltachat-ios/Chat/Views/ChatEditingBar.swift
+++ b/deltachat-ios/Chat/Views/ChatEditingBar.swift
@@ -70,7 +70,7 @@ public class ChatEditingBar: UIView {
 
     private lazy var toolbar: UIToolbar = {
         let view = UIToolbar()
-        view.items = [forwardButton, copyButton, deleteButton, .flexibleSpace(), moreButton]
+        view.items = [forwardButton, copyButton, .flexibleSpace(), deleteButton, .fixedSpace(0), moreButton]
         return view
     }()
 

--- a/deltachat-ios/View/ChatListEditingBar.swift
+++ b/deltachat-ios/View/ChatListEditingBar.swift
@@ -59,7 +59,7 @@ class ChatListEditingBar: UIView {
 
     private lazy var toolbar: UIToolbar = {
         let toolbar = UIToolbar()
-        toolbar.items = [archiveButton, .flexibleSpace(), deleteButton, moreButton]
+        toolbar.items = [archiveButton, .flexibleSpace(), deleteButton, .fixedSpace(0), moreButton]
         return toolbar
     }()
 


### PR DESCRIPTION
this PR unified the position of the "delete" button in the chatlist's and chat's toolbars.

the fixedSpace(0) results in the visual separation,on non-liquid-glass, that is a no-op.

still a bit unsure about the position and the added space in general (comments welcome!), but it is an improvement in any case :)

#skip-changelog


## before 

<img width="320" src="https://github.com/user-attachments/assets/21dc1a26-a3a8-43e0-989d-48f187562d00" /> <br> <img width="320" src="https://github.com/user-attachments/assets/593f40e7-304a-439f-8e46-b57b6fecce75" />

## after


<img width="320" src="https://github.com/user-attachments/assets/870ab394-1c5c-4a14-8fe2-57cc66ff968d" /> <br> <img width="320" src="https://github.com/user-attachments/assets/df608419-2f27-4211-93d2-8d07eaf409ab" />