### PR TITLE
use "liquid glass buttons" in "instant onboarding"

### DIFF
--- a/DcCore/DcCore/Extensions/UIButton+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UIButton+Extensions.swift
@@ -4,7 +4,7 @@ public extension UIButton {
     private func applyStyle(_ config: UIButton.Configuration) {
         var config = config
         config.cornerStyle = .capsule
-        config.buttonSize = .large
+        config.buttonSize = .medium
         configuration = config
     }
 

--- a/deltachat-ios/Controller/ProfileSetup/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/ProfileSetup/InstantOnboardingView.swift
@@ -124,6 +124,8 @@ class InstantOnboardingView: UIView {
             hintLabel.leadingAnchor.constraint(equalTo: hintLabelWrapper.leadingAnchor),
             hintLabelWrapper.trailingAnchor.constraint(greaterThanOrEqualTo: hintLabel.trailingAnchor),
             hintLabelWrapper.bottomAnchor.constraint(equalTo: hintLabel.bottomAnchor),
+
+            otherOptionsButton.widthAnchor.constraint(greaterThanOrEqualTo: agreeButton.widthAnchor)
         ]
 
         NSLayoutConstraint.activate(constraints)

--- a/deltachat-ios/Controller/ProfileSetup/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/ProfileSetup/InstantOnboardingView.swift
@@ -49,11 +49,8 @@ class InstantOnboardingView: UIView {
 
         agreeButton = UIButton()
         agreeButton.setTitle(String.localized("instant_onboarding_create"), for: .normal)
-        agreeButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
-        agreeButton.setTitleColor(.white, for: .normal)
         agreeButton.translatesAutoresizingMaskIntoConstraints = false
-        agreeButton.layer.cornerRadius = 5
-        agreeButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 15, bottom: 8, right: 15)
+        agreeButton.primaryCapsule()
 
         privacyButton = UIButton(type: .system)
         privacyButton.translatesAutoresizingMaskIntoConstraints = false
@@ -63,8 +60,8 @@ class InstantOnboardingView: UIView {
 
         otherOptionsButton = UIButton(type: .system)
         otherOptionsButton.setTitle(String.localized("instant_onboarding_show_more_instances"), for: .normal)
-        otherOptionsButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         otherOptionsButton.translatesAutoresizingMaskIntoConstraints = false
+        otherOptionsButton.secondaryCapsule()
 
         contentStackView = UIStackView(arrangedSubviews: [imageButton, nameTextField, hintLabelWrapper, privacyButtonWrapper, agreeButton, otherOptionsButton])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
this PR applies the new button layout shortcuts introduced at https://github.com/deltachat/deltachat-ios/pull/3184 to the instant onboarding buttons.

this is okay, as the keyboard can be dismissed since https://github.com/deltachat/deltachat-ios/pull/3196 - also the buttons are not much larger anymore

successor of https://github.com/deltachat/deltachat-ios/pull/3184

#skip-changelog

# before / after


<img width="320" src="https://github.com/user-attachments/assets/cd9b53d0-ef31-44a5-b209-dc69173208e3" /> <img width="320" src="https://github.com/user-attachments/assets/f55252c1-5c41-4dde-894f-109a99377b27" />
