### PR TITLE
hide bottom tabbar on multi-select

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -176,6 +176,7 @@ class ChatListViewController: UITableViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        setBottomTabBarHidden(hasEditingView())
 
         // create view
         navigationItem.titleView = titleView
@@ -659,12 +660,14 @@ class ChatListViewController: UITableViewController {
     func setLongTapEditing(_ editing: Bool, initialIndexPath: IndexPath? = nil) {
         setEditing(editing, animated: true)
         if editing {
+            setBottomTabBarHidden(true)
             tableView.selectRow(at: initialIndexPath, animated: true, scrollPosition: .none)
             addEditingView()
             updateTitleAndEditingBar()
         } else {
             removeEditingView()
             updateTitle()
+            setBottomTabBarHidden(false)
         }
     }
 
@@ -680,6 +683,14 @@ class ChatListViewController: UITableViewController {
             editingBar.bottomAnchor.constraint(equalTo: parentView.safeAreaLayoutGuide.bottomAnchor),
         ]
         NSLayoutConstraint.activate(editingConstraints ?? [])
+    }
+
+    private func setBottomTabBarHidden(_ hidden: Bool) {
+        guard !isArchive, let tabBar = tabBarController?.tabBar, tabBar.isHidden != hidden else { return }
+
+        tabBar.isHidden = hidden
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
     }
 
     private func removeEditingView() {


### PR DESCRIPTION

this PR hides the bottom tabbar in multi-select mode - it removes clutter, but it also does not makes few sense to switch to other parts while in multi-select mode, before liquidglass, it was always like that

targets #3157

#skip-changelog as there is no change to the previous release

# before / after on liquid-glass

<img width="320" src="https://github.com/user-attachments/assets/9970bbc3-8593-4402-be12-51788144b2a0" />
<img width="320" src="https://github.com/user-attachments/assets/556dd86c-1621-4c3d-95d3-70328e0644db" />

# before / after on non-liquid-glass

<img width="320" src="https://github.com/user-attachments/assets/0c5f9474-6eaa-45ec-91b1-1cffd477b7a7" />
<img width="320" src="https://github.com/user-attachments/assets/7e144deb-ed2d-405e-8dc3-35440d99adfb" />

