### PR TITLE
bring back reactions separator

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2088,8 +2088,7 @@ extension ChatViewController {
 
                 children.append(contentsOf: [
                     UIMenu(options: [.displayInline], children: [
-                        // as menu icons are not shaped by a circle, "ellipsis.circle" looks better than just "ellipsis" (which is used elsewhere to avoid double circles)
-                        UIMenu(title: String.localized("menu_more_options"), image: UIImage(systemName: "ellipsis.circle"), children: moreOptions)
+                        UIMenu(title: String.localized("menu_more_options"), children: moreOptions)
                     ])
                 ])
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2005,17 +2005,20 @@ extension ChatViewController {
                 let message = dcContext.getMessage(id: messageId)
                 var children: [UIMenuElement] = []
                 var moreOptions: [UIMenuElement] = []
-                var preferredElementSizeSmall = false
 
                 if canReply(to: message) {
+                    let reactionsMenu: UIMenu
+                    var reactions: [UIMenuElement] = []
+                    appendReactionItems(to: &reactions, messageId: messageId)
                     if #available(iOS 16.0, *) {
-                        appendReactionItems(to: &children, messageId: messageId)
-                        preferredElementSizeSmall = true
+                        reactionsMenu = UIMenu(options: [.displayInline], children: reactions)
+                        reactionsMenu.preferredElementSize = .small
+
                     } else {
-                        var items: [UIMenuElement] = []
-                        appendReactionItems(to: &items, messageId: messageId)
-                        children.append(UIMenu(title: String.localized("react"), image: UIImage(systemName: "face.smiling"), children: items))
+                        reactionsMenu = UIMenu(title: String.localized("react"), image: UIImage(systemName: "face.smiling"), children: reactions)
                     }
+                    children.append(reactionsMenu)
+
                     children.append(
                         UIAction.menuAction(localizationKey: "notify_reply_button", systemImageName: "arrowshape.turn.up.left", with: messageId, action: reply)
                     )
@@ -2090,11 +2093,7 @@ extension ChatViewController {
                     ])
                 ])
 
-                let menu = UIMenu(children: children)
-                if preferredElementSizeSmall, #available(iOS 16.0, *) {
-                    menu.preferredElementSize = .small
-                }
-                return menu
+                return UIMenu(children: children)
             }
         )
     }


### PR DESCRIPTION
before the move to LiquidGlass, there was a thin line below the reactions
(because there was a separator after each item).

this PR brings back that line, and removes the "menu" icon beside "more options", which is used less nowadays (cmp gallery etc.).

as a side effect, the code is more straight-forward.

both changes are quite cosmetic, sure :)

#skip-changelog

## before / after

<img width="320" src="https://github.com/user-attachments/assets/abb4389d-d1e4-49fa-9fc8-d544892ec786" />
<img width="320" src="https://github.com/user-attachments/assets/3981d39b-806d-4363-b89f-5c56f9b3901b" />

