### PR TITLE
show all five default reactions

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1934,7 +1934,7 @@ extension ChatViewController {
         let myReactions = getMyReactions(messageId: messageId)
         var myReactionChecked = false
 
-        for reaction in [DefaultReactions.thumbsUp, .heart, .faceWithTearsOfJoy] {
+        for reaction in DefaultReactions.allCases {
             let sentThisReaction = myReactions.contains(where: { $0 == reaction.emoji })
             let title: String
             if sentThisReaction {
@@ -2013,9 +2013,8 @@ extension ChatViewController {
                     let reactionsMenu: UIMenu
                     var reactions: [UIMenuElement] = []
                     appendReactionItems(to: &reactions, messageId: messageId)
-                    if #available(iOS 16.0, *) {
-                        reactionsMenu = UIMenu(options: [.displayInline], children: reactions)
-                        reactionsMenu.preferredElementSize = .small
+                    if #available(iOS 17.0, *) {
+                        reactionsMenu = UIMenu(options: [.displayInline, .displayAsPalette], children: reactions)
 
                     } else {
                         reactionsMenu = UIMenu(title: String.localized("react"), image: UIImage(systemName: "face.smiling"), children: reactions)


### PR DESCRIPTION
this PR uses a "command palette" instead of "preferred element size" to show the default reactions. 

if there is few space, the command palette can be scrolled horizontally.

this is for (a) consistency with other platforms (when reactions were introduced, "command palette" was not or not widely available, or it was too complex, idk :) and (b) to be prepared for different default sets which may come with channel reactions

