### PR TITLE
team profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Retire provider database
+- Add experimental "Team Profile" mode to profile creation
 
 
 ## v2.56.0

--- a/deltachat-ios/Controller/ProfileSetup/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/ProfileSetup/InstantOnboardingView.swift
@@ -34,14 +34,12 @@ class InstantOnboardingView: UIView {
         nameTextField.text = name
         nameTextField.textAlignment = .center
         nameTextField.translatesAutoresizingMaskIntoConstraints = false
-        nameTextField.placeholder = String.localized("pref_your_name")
         nameTextField.borderStyle = .roundedRect
 
         hintLabel = UILabel()
         hintLabel.translatesAutoresizingMaskIntoConstraints = false
         hintLabel.numberOfLines = 0
         hintLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
-        hintLabel.text = String.localized("set_name_and_avatar_explain")
 
         hintLabelWrapper = UIView()
         hintLabelWrapper.translatesAutoresizingMaskIntoConstraints = false
@@ -70,7 +68,7 @@ class InstantOnboardingView: UIView {
         contentStackView.distribution = .fill
         contentStackView.setCustomSpacing(16, after: imageButton)
         contentStackView.setCustomSpacing(16, after: nameTextField)
-        contentStackView.setCustomSpacing(8, after: hintLabelWrapper)
+        contentStackView.setCustomSpacing(16, after: hintLabelWrapper)
         contentStackView.setCustomSpacing(32, after: privacyButtonWrapper)
         contentStackView.setCustomSpacing(16, after: agreeButton)
 

--- a/deltachat-ios/Controller/ProfileSetup/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/ProfileSetup/InstantOnboardingViewController.swift
@@ -21,7 +21,10 @@ class InstantOnboardingViewController: UIViewController {
     private var qrCodeData: String?
     private lazy var menuButton: UIBarButtonItem = {
         let image = UIImage(systemName: .ellipsisNavigation())
-        return UIBarButtonItem(image: image, menu: moreButtonMenu())
+        let deferredMenu = UIDeferredMenuElement.uncached({ [weak self] completion in
+            completion(self?.moreButtonMenu().children ?? [])
+        })
+        return UIBarButtonItem(image: image, menu: UIMenu(children: [deferredMenu]))
     }()
 
     private lazy var proxyShieldButton: UIBarButtonItem = {
@@ -221,17 +224,35 @@ class InstantOnboardingViewController: UIViewController {
     }
 
     private func moreButtonMenu() -> UIMenu {
-        let actions = [
-            UIAction(title: String.localized("proxy_use_proxy"), image: UIImage(systemName: "shield")) { [weak self] _ in
-                self?.showProxySettings()
-            },
-        ]
-        return UIMenu(children: actions)
+        let proxyAction = UIAction(title: String.localized("proxy_use_proxy")) { [weak self] _ in
+            self?.showProxySettings()
+        }
+        let teamProfileAction = UIAction(title: String.localized("create_team_profile")) { [weak self] _ in
+            self?.toggleTeamProfile()
+        }
+        if dcContext.isTeamProfile {
+            teamProfileAction.state = .on
+        }
+
+        return UIMenu(children: [proxyAction, teamProfileAction])
     }
 
     @objc private func showProxySettings() {
         let proxySettingsController = ProxySettingsViewController(dcContext: dcContext, dcAccounts: dcAccounts)
         navigationController?.pushViewController(proxySettingsController, animated: true)
+    }
+
+    @objc private func toggleTeamProfile() {
+        if dcContext.isTeamProfile {
+            dcContext.isTeamProfile = false
+        } else {
+            let alert = UIAlertController(title: nil, message: String.localized("team_profile_explain"), preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
+            alert.addAction(UIAlertAction(title: String.localized("create_team_profile"), style: .default, handler: { [weak self] _ in
+                self?.dcContext.isTeamProfile = true
+            }))
+            present(alert, animated: true, completion: nil)
+        }
     }
 
     private func updateMenuButtons() {

--- a/deltachat-ios/Controller/ProfileSetup/InstantOnboardingViewController.swift
+++ b/deltachat-ios/Controller/ProfileSetup/InstantOnboardingViewController.swift
@@ -69,7 +69,6 @@ class InstantOnboardingViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         hidesBottomBarWhenPushed = true
-        title = String.localized("pref_profile_info_headline")
 
         NotificationCenter.default.addObserver(self, selector: #selector(InstantOnboardingViewController.keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(InstantOnboardingViewController.keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
@@ -77,6 +76,7 @@ class InstantOnboardingViewController: UIViewController {
 
         navigationItem.setRightBarButtonItems([menuButton], animated: true)
         updateProxyButton()
+        updateLabels()
     }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -243,16 +243,29 @@ class InstantOnboardingViewController: UIViewController {
     }
 
     @objc private func toggleTeamProfile() {
+        dismissKeyboard() // let ppl read the new hint
         if dcContext.isTeamProfile {
             dcContext.isTeamProfile = false
+            updateLabels()
         } else {
             let alert = UIAlertController(title: nil, message: String.localized("team_profile_explain"), preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: String.localized("cancel"), style: .cancel, handler: nil))
             alert.addAction(UIAlertAction(title: String.localized("create_team_profile"), style: .default, handler: { [weak self] _ in
-                self?.dcContext.isTeamProfile = true
+                guard let self else { return }
+
+                dcContext.isTeamProfile = true
+                updateLabels()
             }))
             present(alert, animated: true, completion: nil)
         }
+    }
+
+    private func updateLabels() {
+        let isTeamProfile = dcContext.isTeamProfile
+
+        title = String.localized(isTeamProfile ? "create_team_profile" : "pref_profile_info_headline")
+        contentView?.nameTextField.placeholder = String.localized(isTeamProfile ? "team_name" : "pref_your_name")
+        contentView?.hintLabel.text = String.localized(isTeamProfile ? "team_profile_explain" : "set_name_and_avatar_explain")
     }
 
     private func updateMenuButtons() {

--- a/deltachat-ios/Controller/ProfileSwitchViewController.swift
+++ b/deltachat-ios/Controller/ProfileSwitchViewController.swift
@@ -344,11 +344,13 @@ class AccountCell: UITableViewCell {
         refreshUnreadState(dcContext: dcContext)
 
         let connectivityString = DcUtils.getConnectivityString(dcContext: dcContext, connectedString: "")
-        if let label = dcContext.getConfig("private_tag") {
+        let privateTag = dcContext.getConfig("private_tag") ?? (dcContext.isTeamProfile ? "team" : nil)
+
+        if let privateTag {
             tagLabel.text = if !connectivityString.isEmpty {
-                connectivityString + " · " + label
+                connectivityString + " · " + privateTag
             } else {
-                label
+                privateTag
             }
             tagLabel.isHidden = false
         } else if !connectivityString.isEmpty {

--- a/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
+++ b/deltachat-ios/Controller/Settings/SelfProfileViewController.swift
@@ -39,7 +39,8 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     private var deleteAvatar: Bool = false
 
     private lazy var nameCell: TextFieldCell = {
-        let cell = TextFieldCell(description: String.localized("pref_your_name"), placeholder: String.localized("please_enter_name"))
+        let title = String.localized(dcContext.isTeamProfile ? "team_name" : "pref_your_name")
+        let cell = TextFieldCell(description: title, placeholder: String.localized("please_enter_name"))
         cell.setText(text: dcContext.displayname)
         cell.textFieldDelegate = self
         cell.textField.returnKeyType = .default
@@ -49,7 +50,7 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
     private lazy var sections: [SectionConfigs] = {
         let nameSection = SectionConfigs(
             headerTitle: nil,
-            footerTitle: String.localized("pref_who_can_see_profile_explain"),
+            footerTitle: String.localized(dcContext.isTeamProfile ? "team_profile_explain" : "pref_who_can_see_profile_explain"),
             cells: [nameCell, avatarSelectionCell, statusCell]
         )
         return [nameSection]
@@ -69,7 +70,7 @@ class SelfProfileViewController: UITableViewController, MediaPickerDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = String.localized("pref_profile_info_headline")
+        title = String.localized(dcContext.isTeamProfile ? "team_profile" : "pref_profile_info_headline")
         avatarSelectionCell.onAvatarTapped = { [weak self] in
             self?.onAvatarTapped()
         }

--- a/deltachat-ios/Controller/Settings/SettingsViewController.swift
+++ b/deltachat-ios/Controller/Settings/SettingsViewController.swift
@@ -131,7 +131,7 @@ internal final class SettingsViewController: UITableViewController {
             appNameAndVersion += " v" + appVersion
         }
         let profileSection = SectionConfigs(
-            headerTitle: String.localized("pref_profile_info_headline"),
+            headerTitle: String.localized(dcContext.isTeamProfile ? "team_profile" : "pref_profile_info_headline"),
             cells: [self.profileCell]
         )
         let preferencesSection = SectionConfigs(

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -785,6 +785,11 @@ public class DcContext {
         set { setConfigBool("force_encryption", newValue) }
     }
 
+    public var isTeamProfile: Bool {
+        get { return getConfigBool("team_profile") }
+        set { setConfigBool("team_profile", newValue) }
+    }
+
     public var isProxyEnabled: Bool {
         get { return getConfigBool("proxy_enabled") }
         set { setConfigBool("proxy_enabled", newValue) }


### PR DESCRIPTION
this PR adds the option "Create Team Profile" to the profile creation view controller, allowing to set the corresponding core flag.

moreover, the flag is checked in the further creation process, in the profile switcher and in the settings to adapt the UI

# team profile creation

<img width="320" src="https://github.com/user-attachments/assets/15d51d7d-d0cb-4cc7-9fd1-2898ba9394b3" />
<img width="320" src="https://github.com/user-attachments/assets/4e1c0942-9b6b-400f-b10b-6eb899717771" />

# settings

<img width="320" src="https://github.com/user-attachments/assets/e5329f07-1ffb-47d0-8090-c1e2b7489fa2" />
<img width="320" src="https://github.com/user-attachments/assets/cb42d58f-3ba1-4d76-85c5-dd2a283af7da" />


