### PR TITLE
Bring back "back" in the back-button on older versions

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -269,7 +269,9 @@ class ChatListViewController: UITableViewController {
     }
 
     private func updateNextScreensBackButton(accountId: Int? = nil, chatId: Int? = nil) {
-        navigationItem.backButtonDisplayMode = .minimal
+        if #available(iOS 26, *) {
+            navigationItem.backButtonDisplayMode = .minimal
+        }
         let numberOfUnreadMessages = DcAccounts.shared.getFreshMessagesCount()
 
         if isArchive {


### PR DESCRIPTION
This was removed for liquid glass but is ugly on older versions