### PR TITLE
Remove restore last chat feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Retire provider database
 - Add experimental "Team Profile" mode to profile creation
+- No longer open last chat when app is restarted
 - Fix notification info line
 
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -511,7 +511,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        AppStateRestorer.shared.storeLastActiveChat(chatId: chatId)
         updateScrollDownButtonVisibility()
         // things that do not affect the chatview
         // and are delayed after the view is displayed
@@ -534,7 +533,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        AppStateRestorer.shared.resetLastActiveChat()
         handleUserVisibility(isVisible: false)
         if #available(iOS 26.0, *), let previousValue = wasInteractiveContentPopGestureRecognizerEnabled {
             navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = previousValue

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -74,13 +74,6 @@ class AppCoordinator: NSObject {
             showTab(index: chatsTab)
         } else {
             showTab(index: lastActiveTab)
-            if let lastActiveChatId = appStateRestorer.restoreLastActiveChatId(), lastActiveTab == chatsTab {
-                // as getChat() returns an empty object for invalid chatId,
-                // check that the returned object is actually set up.
-                if dcContext.getChat(chatId: lastActiveChatId).id == lastActiveChatId {
-                    showChat(chatId: lastActiveChatId, animated: false)
-                }
-            }
         }
     }
 

--- a/deltachat-ios/Handler/AppStateRestorer.swift
+++ b/deltachat-ios/Handler/AppStateRestorer.swift
@@ -3,7 +3,6 @@ import UIKit
 class AppStateRestorer {
 
     private let lastActiveTabKey = "last_active_tab3"
-    private let lastActiveChatId = "last_active_chat_id"
     private let offsetKey = 11
 
     // UserDefaults returns 0 by default which conflicts with tab 0 -> therefore we map our tab indexes by adding an offsetKey
@@ -30,32 +29,6 @@ class AppStateRestorer {
 
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
         let activeTab = tabBarController.selectedIndex + offsetKey
-
-        if let tab = Tab(rawValue: activeTab), tab != .chatTab {
-            resetLastActiveChat()
-        }
-
         UserDefaults.standard.set(activeTab, forKey: lastActiveTabKey)
-    }
-
-    private func storeChat(chatId: Int?) {
-        let value = chatId ?? -1
-        UserDefaults.standard.set(value, forKey: lastActiveChatId)
-    }
-
-    func storeLastActiveChat(chatId: Int) {
-        storeChat(chatId: chatId)
-    }
-
-    func resetLastActiveChat() {
-        storeChat(chatId: nil)
-    }
-
-    func restoreLastActiveChatId() -> Int? {
-        let restoredChatId = UserDefaults.standard.integer(forKey: lastActiveChatId)
-        if restoredChatId == -1 || restoredChatId == 0 {
-            return nil
-        }
-        return restoredChatId
     }
 }


### PR DESCRIPTION
On liquid glass this feature has a visual bug with the back button and on all versions this feature is questionable: if a user manages to find an attachment to send with a preview that freezes/crashes the app when the chat is opened this feature would permanently lock a user out of the app because it keeps opening that same chat. 