### PR TITLE
Fixes for input bar

### DIFF
--- a/deltachat-ios.xcodeproj/project.pbxproj
+++ b/deltachat-ios.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		5F153E9A2CC38BAA00871ABE /* GiveBackMyFirstResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F153E992CC38BAA00871ABE /* GiveBackMyFirstResponder.swift */; };
 		5F4945AB2D315E7000DCD50A /* UIPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */; };
 		5F785F6E2CB9344F003FFFB9 /* ReusableCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */; };
+		640A4A3E3018FBBB008FB8C5 /* MissingAppearHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640A4A3D3018FBBB008FB8C5 /* MissingAppearHandlers.swift */; };
 		640C769B2FDD378F00F6BC8A /* Thumbnails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640C769A2FDD378F00F6BC8A /* Thumbnails.swift */; };
 		641620FC2ECFCDC70076CFA3 /* CallUIToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641620FB2ECFCDC70076CFA3 /* CallUIToggleButton.swift */; };
 		641620FE2ECFFA880076CFA3 /* WebRTC+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641620FD2ECFFA880076CFA3 /* WebRTC+Extensions.swift */; };
@@ -465,6 +466,7 @@
 		5F153E992CC38BAA00871ABE /* GiveBackMyFirstResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiveBackMyFirstResponder.swift; sourceTree = "<group>"; };
 		5F4945AA2D315E7000DCD50A /* UIPasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPasteboard.swift; sourceTree = "<group>"; };
 		5F785F6D2CB9344F003FFFB9 /* ReusableCellProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableCellProtocol.swift; sourceTree = "<group>"; };
+		640A4A3D3018FBBB008FB8C5 /* MissingAppearHandlers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingAppearHandlers.swift; sourceTree = "<group>"; };
 		640C769A2FDD378F00F6BC8A /* Thumbnails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnails.swift; sourceTree = "<group>"; };
 		641620FB2ECFCDC70076CFA3 /* CallUIToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallUIToggleButton.swift; sourceTree = "<group>"; };
 		641620FD2ECFFA880076CFA3 /* WebRTC+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebRTC+Extensions.swift"; sourceTree = "<group>"; };
@@ -907,6 +909,7 @@
 			isa = PBXGroup;
 			children = (
 				649876292FE2E119005F80F9 /* View+modifier.swift */,
+				640A4A3D3018FBBB008FB8C5 /* MissingAppearHandlers.swift */,
 				6498762B2FE2E140005F80F9 /* UncachedMenu.swift */,
 			);
 			path = SwiftUI;
@@ -1742,6 +1745,7 @@
 				AE4AEE3522B1030D000AA495 /* PreviewController.swift in Sources */,
 				640C769B2FDD378F00F6BC8A /* Thumbnails.swift in Sources */,
 				64AFC0802F0EB9E900F44416 /* NSLayoutConstraints+activateWithPriority.swift in Sources */,
+				640A4A3E3018FBBB008FB8C5 /* MissingAppearHandlers.swift in Sources */,
 				D84AED272B566C0700D753F6 /* ReactionsOverviewTableViewCell.swift in Sources */,
 				7070FB9B2101ECBB000DC258 /* NewGroupController.swift in Sources */,
 				D85DF9782C4A96CB00A01408 /* UserDefaults+Extensions.swift in Sources */,

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1337,6 +1337,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             toolbarContainerView.addSubview(inputToolBarHost.view)
             inputToolBarHost.didMove(toParent: self)
             inputToolBarHost.view.fillSuperview()
+            toolbarContainerView.invalidateIntrinsicContentSize()
         }
     }
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -113,6 +113,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             chatViewController: self,
             updateIntrinsicContentSize: { [weak self] in
                 self?.inputToolBarHost.view.invalidateIntrinsicContentSize()
+                self?.toolbarContainerView.layoutSubviews()
             })
         )
         host.view.backgroundColor = .clear

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -102,6 +102,15 @@ struct InputBarView: View {
         }
         .onAppear {
             textEditorFocus = draft.isFieldFocused
+            _updateIntrinsicContentSize(())
+        }
+        .onWillDisappear {
+            if textEditorFocus {
+                // iOS 26 doesn't correctly give back the first responder inside a SwiftUI
+                // view so we just resign it before another view is shown over this.
+                // It is not enough to just do `textEditorFocus = false`.
+                UIResponder.currentFirstResponder?.resignFirstResponder()
+            }
         }
         .modifier { view in
             if #available(iOS 26.0, *) {

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -115,6 +115,7 @@ struct InputBarView: View {
                     .padding(.top, 8)
             }
         }
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     @ViewBuilder var attachmentPreview: some View {

--- a/deltachat-ios/Helper/SwiftUI/MissingAppearHandlers.swift
+++ b/deltachat-ios/Helper/SwiftUI/MissingAppearHandlers.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+extension View {
+    func onWillDisappear(_ perform: @escaping () -> Void) -> some View {
+        self.background(MissingAppearHandlers(onWillDisappear: perform))
+    }
+
+    func onDidAppear(_ perform: @escaping () -> Void) -> some View {
+        self.background(MissingAppearHandlers(onDidAppear: perform))
+    }
+}
+
+private struct MissingAppearHandlers: UIViewControllerRepresentable {
+    var onWillDisappear: () -> Void = {}
+    var onDidAppear: () -> Void = {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onWillDisappear: onWillDisappear, onDidAppear: onDidAppear)
+    }
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        context.coordinator
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
+    class Coordinator: UIViewController {
+        let onWillDisappear: () -> Void
+        let onDidAppear: () -> Void
+
+        init(onWillDisappear: @escaping () -> Void, onDidAppear: @escaping () -> Void) {
+            self.onWillDisappear = onWillDisappear
+            self.onDidAppear = onDidAppear
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func viewWillDisappear(_ animated: Bool) {
+            super.viewWillDisappear(animated)
+            onWillDisappear()
+        }
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            onDidAppear()
+        }
+    }
+}


### PR DESCRIPTION
Attempts to address #3211 

The fixedSize modifier fixes the text outside of textview

Calling `_updateIntrinsicContentSize` in onAppear fixes the jump

Resigning first responder before disappearing fixes the issue where iOS 26 doesn't give back the first responder (but also doesn't close the keyboard??)