### PR TITLE
allow reactions to channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow to react in channels
+- Offer five default reactions when long-tapping a message
 - Show phased out relays in connectivity view as such
 - Sending relay is a per-device setting now
 - Collect call information from all relays

--- a/DcCore/DcCore/Helper/UNMutableNotificationContent+init.swift
+++ b/DcCore/DcCore/Helper/UNMutableNotificationContent+init.swift
@@ -27,7 +27,8 @@ public extension UNMutableNotificationContent {
     /// Initialiser that returns a notification for an incoming reaction. Returns nil if no notification should be sent (eg if chat is muted)
     convenience init?(forReaction reaction: String, from contact: Int, msg: DcMsg, chat: DcChat, context: DcContext) {
         guard !context.isMuted() else { return nil }
-        guard !chat.isMuted || (chat.isMultiUser && context.isMentionsEnabled) else { return nil }
+        guard !chat.isMuted || (chat.isMultiUser && !chat.isOutBroadcast && context.isMentionsEnabled) else { return nil }
+
         let contact = context.getContact(id: contact)
         let summary = msg.summary(chars: Self.pushNotificationCharLimit) ?? ""
         self.init()

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2019,35 +2019,37 @@ extension ChatViewController {
             })
         }
 
-        let showPicker = myReactions.isEmpty || myReactionChecked
-        let title: String
-        let accessibilityLabel: String?
-        if showPicker {
-            title = "•••"
-            accessibilityLabel = String.localized("pref_other")
-        } else {
-            title = (myReactions.first ?? "?") + "✓"
-            accessibilityLabel = nil
-        }
-        let action = UIAction(title: title) { [weak self] _ in
-            guard let self else { return }
+        if !(dcChat.isInBroadcast || dcChat.isOutBroadcast) {
+            let showPicker = myReactions.isEmpty || myReactionChecked
+            let title: String
+            let accessibilityLabel: String?
             if showPicker {
-                reactionMessageId = messageId
-                let pickerViewController = MCEmojiPickerViewController()
-                pickerViewController.navigationItem.title = String.localized("react")
-                pickerViewController.delegate = self
-
-                let navigationController = UINavigationController(rootViewController: pickerViewController)
-                if let sheet = navigationController.sheetPresentationController {
-                    sheet.detents = [.medium(), .large()]
-                }
-                present(navigationController, animated: true)
+                title = "•••"
+                accessibilityLabel = String.localized("pref_other")
             } else {
-                dcContext.sendReaction(messageId: messageId, reaction: nil)
+                title = (myReactions.first ?? "?") + "✓"
+                accessibilityLabel = nil
             }
+            let action = UIAction(title: title) { [weak self] _ in
+                guard let self else { return }
+                if showPicker {
+                    reactionMessageId = messageId
+                    let pickerViewController = MCEmojiPickerViewController()
+                    pickerViewController.navigationItem.title = String.localized("react")
+                    pickerViewController.delegate = self
+
+                    let navigationController = UINavigationController(rootViewController: pickerViewController)
+                    if let sheet = navigationController.sheetPresentationController {
+                        sheet.detents = [.medium(), .large()]
+                    }
+                    present(navigationController, animated: true)
+                } else {
+                    dcContext.sendReaction(messageId: messageId, reaction: nil)
+                }
+            }
+            action.accessibilityLabel = accessibilityLabel
+            menuElements.append(action)
         }
-        action.accessibilityLabel = accessibilityLabel
-        menuElements.append(action)
     }
 
     private func isLinkTapped(indexPath: IndexPath, point: CGPoint) -> String? {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1999,7 +1999,7 @@ extension ChatViewController {
         let myReactions = getMyReactions(messageId: messageId)
         var myReactionChecked = false
 
-        for reaction in [DefaultReactions.thumbsUp, .heart, .faceWithTearsOfJoy] {
+        for reaction in DefaultReactions.allCases {
             let sentThisReaction = myReactions.contains(where: { $0 == reaction.emoji })
             let title: String
             if sentThisReaction {
@@ -2080,10 +2080,8 @@ extension ChatViewController {
                     let reactionsMenu: UIMenu
                     var reactions: [UIMenuElement] = []
                     appendReactionItems(to: &reactions, messageId: messageId)
-                    if #available(iOS 16.0, *) {
-                        reactionsMenu = UIMenu(options: [.displayInline], children: reactions)
-                        reactionsMenu.preferredElementSize = .small
-
+                    if #available(iOS 17.0, *) {
+                        reactionsMenu = UIMenu(options: [.displayInline, .displayAsPalette], children: reactions)
                     } else {
                         reactionsMenu = UIMenu(title: String.localized("react"), image: UIImage(systemName: "face.smiling"), children: reactions)
                     }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2486,6 +2486,7 @@ extension ChatViewController: BaseMessageCellDelegate {
     }
 
     @objc func reactionsTapped(indexPath: IndexPath) {
+        guard !dcChat.isInBroadcast else { return }
         guard let reactions = dcContext.getMessageReactions(messageId: messages[indexPath.row].id) else { return }
 
         let reactionsOverview = ReactionsOverviewViewController(reactions: reactions, context: dcContext)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2486,10 +2486,9 @@ extension ChatViewController: BaseMessageCellDelegate {
     }
 
     @objc func reactionsTapped(indexPath: IndexPath) {
-        guard !dcChat.isInBroadcast else { return }
         guard let reactions = dcContext.getMessageReactions(messageId: messages[indexPath.row].id) else { return }
 
-        let reactionsOverview = ReactionsOverviewViewController(reactions: reactions, context: dcContext)
+        let reactionsOverview = ReactionsOverviewViewController(reactions: reactions, showFrequencies: dcChat.isInBroadcast || dcChat.isOutBroadcast, context: dcContext)
         reactionsOverview.delegate = self
         let navigationController = UINavigationController(rootViewController: reactionsOverview)
         if let sheet = navigationController.sheetPresentationController {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2039,9 +2039,7 @@ extension ChatViewController {
                     pickerViewController.delegate = self
 
                     let navigationController = UINavigationController(rootViewController: pickerViewController)
-                    if let sheet = navigationController.sheetPresentationController {
-                        sheet.detents = [.medium(), .large()]
-                    }
+                    navigationController.sheetPresentationController?.detents = [.medium(), .large()]
                     present(navigationController, animated: true)
                 } else {
                     dcContext.sendReaction(messageId: messageId, reaction: nil)

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1226,6 +1226,13 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         return !message.isMarkerOrInfo && dcChat.canSend
     }
 
+    private func canReact(to message: DcMsg) -> Bool {
+        if dcChat.isInBroadcast {
+            return dcContext.isContactInChat(chatId: dcChat.id, contactId: DC_CONTACT_ID_SELF)
+        }
+        return canReply(to: message)
+    }
+
     private func canReplyPrivately(to message: DcMsg) -> Bool {
         return !message.isMarkerOrInfo && dcChat.isMultiUser && !message.isFromCurrentSender
     }
@@ -2067,7 +2074,7 @@ extension ChatViewController {
                 var children: [UIMenuElement] = []
                 var moreOptions: [UIMenuElement] = []
 
-                if canReply(to: message) {
+                if canReact(to: message) {
                     let reactionsMenu: UIMenu
                     var reactions: [UIMenuElement] = []
                     appendReactionItems(to: &reactions, messageId: messageId)

--- a/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
+++ b/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
@@ -18,6 +18,7 @@ class ReactionsOverviewViewController: UIViewController {
 
         self.showFrequencies = showFrequencies
 
+        // layout by strings is not great, but good enough for now for a secondary UI
         if showFrequencies {
             self.contactIds = []
             self.texts = reactions.reactions.map { reaction in

--- a/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
+++ b/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
@@ -8,17 +8,31 @@ protocol ReactionsOverviewViewControllerDelegate: AnyObject {
 class ReactionsOverviewViewController: UIViewController {
 
     private let tableView: UITableView
-    private let reactions: DcReactions
+    private let showFrequencies: Bool
+    private let texts: [String]
     private let contactIds: [Int]
-    private let context: DcContext
 
     weak var delegate: ReactionsOverviewViewControllerDelegate?
 
-    init(reactions: DcReactions, context: DcContext) {
+    init(reactions: DcReactions, showFrequencies: Bool, context: DcContext) {
 
-        self.reactions = reactions
-        self.contactIds = Array(self.reactions.reactionsByContact.keys)
-        self.context = context
+        self.showFrequencies = showFrequencies
+
+        if showFrequencies {
+            self.contactIds = []
+            self.texts = reactions.reactions.map { reaction in
+                return "\(reaction.emoji)   " + String.localized(stringID: "n_reactions", parameter: reaction.count)
+            }
+        } else {
+            self.contactIds = Array(reactions.reactionsByContact.keys)
+            self.texts = self.contactIds.map { contactId in
+                let contact = context.getContact(id: contactId)
+                if let emojis = reactions.reactionsByContact[contactId] {
+                    return "\(contact.displayName): \(emojis.joined(separator: ","))"
+                }
+                return ""
+            }
+        }
 
         tableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false
@@ -61,20 +75,14 @@ class ReactionsOverviewViewController: UIViewController {
 // MARK: - UITableViewDataSource
 extension ReactionsOverviewViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return contactIds.count
+        return texts.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: ReactionsOverviewTableViewCell.reuseIdentifier, for: indexPath) as? ReactionsOverviewTableViewCell
         else { fatalError("WTF?! Wrong cell!") }
-        
-        let contactId = contactIds[indexPath.row]
-        let contact = context.getContact(id: contactId)
 
-        if let emojis = reactions.reactionsByContact[contactId] {
-            cell.configure(emojis: emojis, contact: contact)
-        }
-
+        cell.textLabel?.text = texts[indexPath.row]
         return cell
     }
 }
@@ -84,9 +92,11 @@ extension ReactionsOverviewViewController: UITableViewDataSource {
 extension ReactionsOverviewViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        let contactId = contactIds[indexPath.row]
-        if contactId != DC_CONTACT_ID_SELF {
-            delegate?.showContact(self, with: contactId)
+        if !showFrequencies {
+            let contactId = contactIds[indexPath.row]
+            if contactId != DC_CONTACT_ID_SELF {
+                delegate?.showContact(self, with: contactId)
+            }
         }
     }
 }

--- a/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
+++ b/deltachat-ios/Chat/Reactions/ReactionsOverviewViewController.swift
@@ -22,7 +22,7 @@ class ReactionsOverviewViewController: UIViewController {
         if showFrequencies {
             self.contactIds = []
             self.texts = reactions.reactions.map { reaction in
-                return "\(reaction.emoji)   " + String.localized(stringID: "n_reactions", parameter: reaction.count)
+                "\(reaction.emoji)   " + String.localized(stringID: "n_reactions", parameter: reaction.count)
             }
         } else {
             self.contactIds = Array(reactions.reactionsByContact.keys)

--- a/deltachat-ios/Controller/ProfileViewController.swift
+++ b/deltachat-ios/Controller/ProfileViewController.swift
@@ -302,7 +302,7 @@ class ProfileViewController: UITableViewController {
             } else if isMultiUser && !isMailinglist && (chat?.canSend ?? false) && (chat?.isEncrypted ?? false) {
                 primaryOptions.append(action("global_menu_edit_desktop", "pencil", showEditController))
             }
-            if let chat, !isOutBroadcast && !isSavedMessages {
+            if let chat, !isSavedMessages {
                 primaryOptions.append(action(chat.isMuted ? "menu_unmute" : "mute", chat.isMuted ? "speaker.wave.2" : "speaker.slash", toggleMuteChat))
             }
             if let chat, chat.canSend { // search is buggy in combination with contact request panel, that needs to be fixed if we want to allow search in general

--- a/deltachat-ios/DC/DcContext.swift
+++ b/deltachat-ios/DC/DcContext.swift
@@ -329,6 +329,10 @@ public class DcContext {
         return dc_remove_contact_from_chat(contextPointer, UInt32(chatId), UInt32(contactId)) == 1
     }
 
+    public func isContactInChat(chatId: Int, contactId: Int32) -> Bool {
+        return dc_is_contact_in_chat(contextPointer, UInt32(chatId), UInt32(contactId)) == 1
+    }
+
     public func setChatName(chatId: Int, name: String) -> Bool {
         return dc_set_chat_name(contextPointer, UInt32(chatId), name) == 1
     }


### PR DESCRIPTION
this PR allows channel subscribers to react to messages.

- **reactions are broadcasted** as other messages from the channel owner, this requires core with https://github.com/chatmail/core/pull/8450 and is done about every ten minutes

- **allow to mute/unmute outgoing channels**

- **shows all full 5 default reactions,** in the future, it is planned to make that configurable, so having a different default than on android/desktop/ubuntutouch becomes worse.
for direct display, iOS 17 is required. otherwise a submenu is used (before, direct display required iOS 16 only, but that allows to display only  3~4 defaults easily directly) (as around 2-3% are still on iOS 16, they will get a submenu to react now, as for iOS 15. this drawback is accepted for easier maintainance and to make it better for 95% of the user)

- **reaction summary** shows counts for incoming channels - channel subscribers do not know the exact details

- **reactions in channels** are not be considered mentions, that's too annoying, cmp android PR

the layout of the 5 default reactions can be tweaked a bit in a subsequent PR, i'd like to have the typical separator below, and maybe also little larger emojis, but these are no blockers, and i prefer to keep diff and review easy.

requires a core with https://github.com/chatmail/core/pull/8450

counterpart of https://github.com/deltachat/deltachat-android/pull/4560