### PR TITLE
Prevent input bar placeholder from eating the tap event

### DIFF
--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -62,7 +62,7 @@ struct InputBarView: View {
                         maxHeight: 150
                     )
                     .focused($textEditorFocus)
-                    .overlay(alignment: .leading) {
+                    .background(alignment: .leading) {
                         if draft.text.isEmpty && !textEditorFocus {
                             Text(String.localized("chat_input_placeholder"))
                                 .foregroundColor(Color(uiColor: DcColors.placeholderColor))


### PR DESCRIPTION
Previously if you tapped on the placeholder in the input bar it wouldn't focus.