### PR TITLE
Fix low padding on rounded chat title on iOS 26

### DIFF
--- a/deltachat-ios/View/ChatTitleView.swift
+++ b/deltachat-ios/View/ChatTitleView.swift
@@ -85,7 +85,7 @@ class ChatTitleView: UIButton {
             configuration = .glass()
         }
 
-        layoutMargins = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
+        layoutMargins = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 10)
         isAccessibilityElement = true
 
         addSubview(contentStack)


### PR DESCRIPTION
Before and after:
<img width="250" alt="IMG_0021" src="https://github.com/user-attachments/assets/340a133d-63c1-4877-88c7-b11686361410" /> <img width="250" alt="IMG_0020" src="https://github.com/user-attachments/assets/10c0fb23-720a-4e04-8c6a-cf78136bb16d" />