### PR TITLE
Fix status bar edge effect contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Delta Chat iOS Changelog
 
+## Unreleased
+
+- Fix chat edge contrast when iOS changes the status bar color
+
+
 ## v2.57.0
 2026-07
 

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -614,14 +614,13 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
               statusBarStyle != lastStatusBarStyle else { return }
 
         lastStatusBarStyle = statusBarStyle
-        let blurStyle: UIBlurEffect.Style
-        switch statusBarStyle {
+        let blurStyle: UIBlurEffect.Style = switch statusBarStyle {
         case .lightContent:
-            blurStyle = .systemUltraThinMaterialDark
+            .systemUltraThinMaterialDark
         case .darkContent:
-            blurStyle = .systemUltraThinMaterialLight
+            .systemUltraThinMaterialLight
         default:
-            blurStyle = .systemUltraThinMaterial
+            .systemUltraThinMaterial
         }
         edgeEffectBlurViews.top.effect = UIBlurEffect(style: blurStyle)
     }

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -58,6 +58,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         bottom: UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
     )
     private let edgeEffectBlurMasks = (top: CAGradientLayer(), bottom: CAGradientLayer())
+    private var lastStatusBarStyle: UIStatusBarStyle?
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.delegate = self
@@ -523,6 +524,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         handleUserVisibility(isVisible: true)
 
         if #available(iOS 26.0, *) {
+            updateTopEdgeEffectAppearance()
             wasInteractiveContentPopGestureRecognizerEnabled = navigationController?
                 .interactiveContentPopGestureRecognizer?.isEnabled
             // This new pop gesture happens when you swipe in the middle of the screen which
@@ -604,6 +606,24 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         let blurMaskColor = UIColor(white: 0, alpha: edgeEffectBlurStrength).cgColor
         edgeEffectBlurMasks.top.colors = [blurMaskColor, blurMaskColor, UIColor.clear.cgColor]
         edgeEffectBlurMasks.bottom.colors = [UIColor.clear.cgColor, blurMaskColor, blurMaskColor]
+    }
+
+    private func updateTopEdgeEffectAppearance() {
+        guard #available(iOS 26.0, *),
+              let statusBarStyle = view.window?.windowScene?.statusBarManager?.statusBarStyle,
+              statusBarStyle != lastStatusBarStyle else { return }
+
+        lastStatusBarStyle = statusBarStyle
+        let blurStyle: UIBlurEffect.Style
+        switch statusBarStyle {
+        case .lightContent:
+            blurStyle = .systemUltraThinMaterialDark
+        case .darkContent:
+            blurStyle = .systemUltraThinMaterialLight
+        default:
+            blurStyle = .systemUltraThinMaterial
+        }
+        edgeEffectBlurViews.top.effect = UIBlurEffect(style: blurStyle)
     }
 
     // MARK: - Notifications
@@ -842,6 +862,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         updateScrollDownButtonVisibility()
+        updateTopEdgeEffectAppearance()
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
@@ -1055,6 +1076,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             backgroundContainer.image = UIImage(named: traitCollection.userInterfaceStyle == .light ? "background_light" : "background_dark")
         }
         updateEdgeEffectAppearance()
+        updateTopEdgeEffectAppearance()
     }
 
     private func configureMessageStyle(for message: DcMsg, at indexPath: IndexPath) -> UIRectCorner {


### PR DESCRIPTION
Fixes #3214.

On iOS 26, the status bar text color changes while scrolling depending on the content behind it, but the top edge material did not follow. This could leave dark text over dark content.

This updates only the top edge effect when `statusBarStyle` changes:

- Uses dark material for light status bar content
- Uses light material for dark status bar content
- Keeps adaptive material for the default style

The mirrored table view and bottom edge effect are unchanged.

Tested:

- iPhone 17 Pro simulator, iOS 26.5: verified the `darkContent` → `lightContent` transition while scrolling
- iPad mini (A17 Pro) simulator, iOS 18.5: build succeeds

### Before / after

| Before | After |
| --- | --- |
|  <img width="1206" height="2622" alt="deltachat-3214-before" src="https://github.com/user-attachments/assets/80850c69-05f0-4ea5-8ce8-42e6c920bf51" /> | <img width="1206" height="2622" alt="deltachat-3214-after" src="https://github.com/user-attachments/assets/8a56b534-68f1-4b66-a138-abd36ea9bf03" /> | 


