### PR TITLE
fix: device owner authentication wording

### DIFF
--- a/deltachat-ios/Controller/ProfileSwitchViewController.swift
+++ b/deltachat-ios/Controller/ProfileSwitchViewController.swift
@@ -189,7 +189,7 @@ class ProfileSwitchViewController: UITableViewController {
 
     func deleteAccount(at indexPath: IndexPath) {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-        Utils.authenticateDeviceOwner(reason: String.localized("edit_transport")) { [weak self] in
+        Utils.authenticateDeviceOwner(reason: String.localized("delete_account")) { [weak self] in
             guard let self else { return }
             let accountId = accountIds[indexPath.row]
             let account = dcAccounts.get(id: accountId)


### PR DESCRIPTION
device owner authentication on profile deletion says 'delete profile' instead of 'edit relay' now. this was probably a copy+paste error.

#skip-changelog as this is a minot. for most user, the string is not even displayed as authentication is super-fast when using face-id or tough-id - it is only displayed when asking for a pin