### PR TITLE
Extend editing bar background into safe area on pre-liquid glass

### DIFF
--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -675,17 +675,18 @@ class ChatListViewController: UITableViewController {
     }
 
     private func addEditingView() {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-              editingConstraints == nil else { return }
+        guard editingConstraints == nil else { return }
 
         guard let parentView = self.navigationController?.view else { return }
         parentView.addSubview(editingBar)
         editingConstraints = [
             editingBar.leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
             editingBar.trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
-            editingBar.bottomAnchor.constraint(equalTo: parentView.safeAreaLayoutGuide.bottomAnchor),
+            editingBar.bottomAnchor.constraint(equalTo: parentView.bottomAnchor),
         ]
         NSLayoutConstraint.activate(editingConstraints ?? [])
+        // Updates UIToolbar to extend its background into safe area on pre liquid glass
+        editingBar.layoutSubviews()
     }
 
     private func setBottomTabBarHidden(_ hidden: Bool) {


### PR DESCRIPTION
Editing bar is a UIToolbar which handles safe area internally so we can just attach it to the bottom. This means the toolbar background will extend on pre-liquid glass.

Before vs after

<img width="250" alt="IMG_5188" src="https://github.com/user-attachments/assets/1820b9be-6de9-48be-8766-fb3bbdcdafc8" />
<img width="250" alt="IMG_5187" src="https://github.com/user-attachments/assets/ebb2ae6a-ddc9-4dd3-9f4a-e73fb49a14d7" />

