### PR TITLE
Use native input bar size calculation instead of manual solution

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -112,10 +112,14 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             draft: draft,
             chatViewController: self,
             updateIntrinsicContentSize: { [weak self] in
-                self?.inputToolBarHost.view.invalidateIntrinsicContentSize()
-                self?.toolbarContainerView.layoutSubviews()
+                if #unavailable(iOS 16) {
+                    self?.inputToolBarHost.view.setNeedsUpdateConstraints()
+                }
             })
         )
+        if #available(iOS 16.0, *) {
+            host.sizingOptions = [.intrinsicContentSize]
+        }
         host.view.backgroundColor = .clear
         host.view.addInteraction(UIDropInteraction(delegate: dropInteraction))
         return host


### PR DESCRIPTION
This aims to address input bar sizing issues noted in #3211 in case they were not all fixed in #3221