### PR TITLE
Increase the remove quote/attachment button size

### DIFF
--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -30,7 +30,7 @@ struct InputBarView: View {
                         } else {
                             draft.setQuote(quotedMsg: nil)
                         }
-                    }.layoutPriority(-1).labelStyle(.iconOnly)
+                    }.layoutPriority(-1).labelStyle(.iconOnly).font(.title2)
                 }.modifier { glassEffect(view: $0, interactive: false) }
             }
             if draft.attachment != nil {
@@ -39,7 +39,7 @@ struct InputBarView: View {
                     Spacer()
                     Button(String.localized("cancel"), systemImage: "xmark") {
                         draft.clearAttachment()
-                    }.layoutPriority(-1).labelStyle(.iconOnly)
+                    }.layoutPriority(-1).labelStyle(.iconOnly).font(.title2)
                 }
                 .onTapGesture {
                     chatViewController?.onAttachmentTapped()


### PR DESCRIPTION
Clearing quote was sometimes impossible due to small button on pre liquid glass.