### PR TITLE
Fixed onboarding page buttons

### DIFF
--- a/deltachat-ios/Controller/ProfileSetup/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/ProfileSetup/InstantOnboardingView.swift
@@ -131,6 +131,7 @@ class InstantOnboardingView: UIView {
 
     func validateTextfield(text: String?) {
         agreeButton.isEnabled = text?.isEmpty == false
+        otherOptionsButton.isEnabled = text?.isEmpty == false
     }
 
     func updateContent(with customProvider: String?) {

--- a/deltachat-ios/Controller/ProfileSetup/InstantOnboardingView.swift
+++ b/deltachat-ios/Controller/ProfileSetup/InstantOnboardingView.swift
@@ -130,22 +130,7 @@ class InstantOnboardingView: UIView {
     }
 
     func validateTextfield(text: String?) {
-        let buttonShouldBeEnabled: Bool
-
-        if let text {
-            buttonShouldBeEnabled = (text.isEmpty == false)
-        } else {
-            buttonShouldBeEnabled = false
-        }
-        agreeButton.isEnabled = buttonShouldBeEnabled
-
-        if buttonShouldBeEnabled {
-            agreeButton.backgroundColor = .systemBlue
-            otherOptionsButton.setTitleColor(.systemBlue, for: .normal)
-        } else {
-            agreeButton.backgroundColor = UIColor.systemGray.withAlphaComponent(0.3)
-            otherOptionsButton.setTitleColor(UIColor.systemGray.withAlphaComponent(0.5), for: .normal)
-        }
+        agreeButton.isEnabled = text?.isEmpty == false
     }
 
     func updateContent(with customProvider: String?) {


### PR DESCRIPTION
On pre liquid glass setting background *and* capsule breaks the rounded corners of the capsule. Background changes automatically in the capsule button anyway based on enabled state. 

Removed changing the title color of "Use Other Server" button because it does not make sense to do that when the button stays enabled. If it should be disabled then title color would change automatically anyway.