### PR TITLE
Fix iOS 15 input bar

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -397,6 +397,11 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
                 }
                 self?.pipInsetViewController.additionalSafeAreaInsets.bottom = inset - safeAreaInsets.bottom
             }
+            if #unavailable(iOS 16) {
+                // On iOS 15 the SwiftUI input bar does not layout automatically
+                // when the keyboard changes so we just trigger it manually.
+                self.inputToolBarHost.view.setNeedsUpdateConstraints()
+            }
         }
         // Binding to the tableView will enable interactive dismissal
         // This doesn't work as good without an accessory view but
@@ -408,6 +413,11 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         keyboardManager?.on(event: .willShow, do: animateKeyboardChange)
         keyboardManager?.on(event: .didHide, do: animateKeyboardChange)
         keyboardManager?.on(event: .didShow, do: animateKeyboardChange)
+        if #unavailable(iOS 16) {
+            // We access the keyboardLayoutGuide in viewDidLayoutSubviews but on iOS 15
+            // its layoutFrame is wrong unless we initialize it here.
+            _ = view.keyboardLayoutGuide
+        }
 
         if !dcContext.isConfigured() {
             // TODO: display message about nothing being configured

--- a/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
+++ b/deltachat-ios/Chat/InputBarAccessoryView/InputBarView.swift
@@ -53,7 +53,10 @@ struct InputBarView: View {
                         .resizable()
                         .scaledToFit()
                         .padding(2)
-                }).frame(height: buttonSize)
+                })
+                .frame(height: buttonSize)
+                // This fixes the attach button being hidden sometimes on iOS 15
+                .fixedSize(horizontal: true, vertical: false)
                 VStack {
                     InputBarTextView(
                         text: $draft.text,


### PR DESCRIPTION
Attempts to address #3198

This fixes these iOS 15 issues:

- Input bar not staying above the keyboard on focus
- Content inset being too high (caused by keyboard guide layout frame not updating)
- Clipper button sometimes being hidden (eg when input bar is focussed, go to contact detail view and back)