### PR TITLE
You can now share attachments of multiple selected messages at once

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -1856,10 +1856,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
     }
 
-    private func shareSingle(_ msgId: Int) {
-        Utils.share(message: dcContext.getMessage(id: msgId), parentViewController: self, sourceView: view)
-    }
-
     private func resendSingle(_ msgId: Int) {
         dcContext.resendMessages(msgIds: [msgId])
     }
@@ -2127,7 +2123,7 @@ extension ChatViewController {
                 }
 
                 if message.file != nil {
-                    moreOptions.append(UIAction.menuAction(localizationKey: "menu_share", systemImageName: "square.and.arrow.up", with: messageId, action: shareSingle))
+                    moreOptions.append(UIAction.menuAction(localizationKey: "menu_share", systemImageName: "square.and.arrow.up", with: [messageId], action: shareAttachments))
                 }
 
                 children.append(
@@ -2300,6 +2296,10 @@ extension ChatViewController {
         if refreshMessagesAfterEditing && isEditing == false {
             refreshMessages()
         }
+    }
+
+    private func shareAttachments(of msgIds: [Int]) {
+        Utils.share(attachmentsOf: msgIds.map(dcContext.getMessage(id:)), parentViewController: self, sourceView: view)
     }
 
     private func copyTextToClipboard(ids: [Int]) {
@@ -2659,6 +2659,14 @@ extension ChatViewController: ChatEditingDelegate {
         if canSaveOrUnsave {
             actions.append(UIAction(title: String.localized(doSave ? "save_desktop" : "unsave"), image: UIImage(systemName: doSave ? "bookmark" : "bookmark.slash.fill")) { [weak self] _ in
                 self?.onMultipleSaveOrUnsave(doSave: doSave)
+            })
+        }
+        let rows = tableView.indexPathsForSelectedRows ?? []
+        let ids = rows.compactMap { messages[$0.row].id }
+        if ids.contains(where: { dcContext.getMessage(id: $0).file != nil }) {
+            actions.append(UIAction(title: String.localized("menu_share"), image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
+                    self?.shareAttachments(of: ids)
+                    self?.setEditing(isEditing: false)
             })
         }
         return UIMenu(children: actions)

--- a/deltachat-ios/Controller/FilesViewController.swift
+++ b/deltachat-ios/Controller/FilesViewController.swift
@@ -237,7 +237,7 @@ extension FilesViewController {
     func shareAttachment(of indexPath: IndexPath) {
         if let cell = tableView.cellForRow(at: indexPath) {
             let msgId = fileMessageIds[indexPath.row]
-            Utils.share(message: dcContext.getMessage(id: msgId), parentViewController: self, sourceView: cell.contentView)
+            Utils.share(attachmentsOf: [dcContext.getMessage(id: msgId)], parentViewController: self, sourceView: cell.contentView)
         }
     }
 }

--- a/deltachat-ios/Controller/LogViewController.swift
+++ b/deltachat-ios/Controller/LogViewController.swift
@@ -162,7 +162,7 @@ public class LogViewController: UIViewController {
 
     @objc private func shareButtonPressed() {
         if let text = logText.text {
-            Utils.share(text: text, parentViewController: self, sourceItem: shareButton)
+            Utils.share(log: text, parentViewController: self, sourceItem: shareButton)
         }
     }
 

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -60,28 +60,34 @@ struct Utils {
         return context.getSecurejoinQr(chatId: chatId)
     }
 
-    public static func share(message: DcMsg, parentViewController: UIViewController, sourceView: UIView? = nil, sourceItem: UIBarButtonItem? = nil) {
-        guard let scrambledURL = message.fileURL else { return }
+    public static func share(attachmentsOf messages: [DcMsg], parentViewController: UIViewController, sourceView: UIView? = nil, sourceItem: UIBarButtonItem? = nil) {
+        var objectsToShare = [Any]()
+        for message in messages {
+            guard let scrambledURL = message.fileURL else { continue }
 
-        let shareURL: URL
-        if let filename = message.filename {
-            let cleanURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
-            shareURL = FileHelper.copyIfPossible(src: scrambledURL, dest: cleanURL)
-        } else {
-            shareURL = scrambledURL
+            let shareURL: URL
+            if let filename = message.filename {
+                let cleanURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+                shareURL = FileHelper.copyIfPossible(src: scrambledURL, dest: cleanURL)
+            } else {
+                shareURL = scrambledURL
+            }
+
+            if message.type == DC_MSG_WEBXDC {
+                let dict = message.getWebxdcInfoDict()
+                let previewImage = message.getWebxdcPreviewImage()
+                let previewText = dict["name"] as? String ?? shareURL.lastPathComponent
+                objectsToShare.append(WebxdcItemSource(
+                    title: previewText,
+                    previewImage: previewImage,
+                    url: shareURL
+                ))
+            } else {
+                objectsToShare.append(shareURL)
+            }
         }
 
-        let objectsToShare: [Any]
-        if message.type == DC_MSG_WEBXDC {
-            let dict = message.getWebxdcInfoDict()
-            let previewImage = message.getWebxdcPreviewImage()
-            let previewText = dict["name"] as? String ?? shareURL.lastPathComponent
-            objectsToShare = [WebxdcItemSource(title: previewText,
-                                               previewImage: previewImage,
-                                               url: shareURL)]
-        } else {
-            objectsToShare = [shareURL]
-        }
+        guard !objectsToShare.isEmpty else { return }
 
         let activityVC = UIActivityViewController(activityItems: objectsToShare, applicationActivities: nil)
         activityVC.excludedActivityTypes = [.copyToPasteboard]
@@ -96,18 +102,12 @@ struct Utils {
         parentViewController.present(activityVC, animated: true, completion: nil)
     }
 
-    public static func share(url: String, parentViewController: UIViewController, sourceItem: UIBarButtonItem) {
-        guard let url = URL(string: url) else { return }
-
-        Utils.share(url: url, parentViewController: parentViewController, sourceItem: sourceItem)
-    }
-
-    public static func share(text: String, parentViewController: UIViewController, sourceItem: UIBarButtonItem) {
-        guard let textData = text.data(using: .utf8) else { return }
+    public static func share(log: String, parentViewController: UIViewController, sourceItem: UIBarButtonItem) {
+        guard let logData = log.data(using: .utf8) else { return }
 
         // UTF-8 byte order mark, commonly seen in text files. See [List Of file signatures](https://en.wikipedia.org/wiki/List_of_file_signatures)
         var data = Data([0xEF, 0xBB, 0xBF])
-        data.append(textData)
+        data.append(logData)
 
         let tempLogfileURL = FileManager.default.temporaryDirectory.appendingPathComponent("deltachat-log.txt")
         try? FileManager.default.removeItem(at: tempLogfileURL)
@@ -116,20 +116,25 @@ struct Utils {
         Utils.share(url: tempLogfileURL, parentViewController: parentViewController, sourceItem: sourceItem)
     }
 
+    public static func share(url: String, parentViewController: UIViewController, sourceItem: UIBarButtonItem) {
+        guard let url = URL(string: url) else { return }
+        Utils.share(url: url, parentViewController: parentViewController, sourceItem: sourceItem)
+    }
+
     public static func share(url: URL, parentViewController: UIViewController, sourceItem: UIBarButtonItem) {
         let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         activityVC.popoverPresentationController?.barButtonItem = sourceItem
         parentViewController.present(activityVC, animated: true, completion: nil)
     }
 
-    public static func share(text: String, parentViewController: UIViewController, sourceView: UIView) {
-        let activityVC = UIActivityViewController(activityItems: [text], applicationActivities: nil)
+    public static func share(url: URL, parentViewController: UIViewController, sourceView: UIView) {
+        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         activityVC.popoverPresentationController?.sourceView = sourceView // iPad crashes without a source
         parentViewController.present(activityVC, animated: true, completion: nil)
     }
 
-    public static func share(url: URL, parentViewController: UIViewController, sourceView: UIView) {
-        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+    public static func share(text: String, parentViewController: UIViewController, sourceView: UIView) {
+        let activityVC = UIActivityViewController(activityItems: [text], applicationActivities: nil)
         activityVC.popoverPresentationController?.sourceView = sourceView // iPad crashes without a source
         parentViewController.present(activityVC, animated: true, completion: nil)
     }


### PR DESCRIPTION
This PR adds a "Share" option when selecting multiple messages with attachments. This does not share the text of the messages, just their attachments (in line with how the share works when long pressing a single message).

This is specifically for the usecase:

- Family member shares 10+ pictures of an event 
- I want to save them to my camera roll

Previously this meant long press > Share > Save Image on every single image, now you can do it from the multi select options.

Diff of Utils file is kinda messy but the main changes are:
- converted `share(message:[...])` to `share(attachmentsOf:[...])` and support multiple messages at once
- renamed `share(text:[...])` to `share(log:[...])` to make it clear that it share the text as a file (it is only used by the log share feature)
- moved all the `share(url:[...])` together