### PR TITLE
Don't show new messages indicator in the back button on liquid glass

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -2905,6 +2905,9 @@ extension ChatViewController: ReactionsOverviewViewControllerDelegate {
 
 extension ChatViewController: BackButtonUpdateable {
     func shouldUpdateBackButton(_ viewController: UIViewController, chatId: Int, accountId: Int) -> Bool {
+        // On liquid glass we don't show new messages indicator in the back button
+        guard #unavailable(iOS 26.0) else { return false }
+
         if chatId == self.chatId && accountId == dcContext.id {
             return false
         } else {


### PR DESCRIPTION
Fixes #3192

Signal doesn't do this either and it is currently broken on liquid glass, so lets remove this feature for now and create an issue if we really want this still. 

Now we show notifications from other chats even if app is in foreground this feature is not as important anymore (#3174)