### PR TITLE
do not open connectivity from main title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Collect call information from all relays
 - Reduce traffic (no unncessary keys attached to group chats, improve read receipts)
 - Send messages to up to 5 relays
+- Do not open "Connectivity View" from main title; use "Settigns" instead
 - Fix: If one relay is connected, assume overall connectivity
 - Update to core 2.58.0
 

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -16,7 +16,6 @@ class ChatListViewController: UITableViewController {
 
     private lazy var titleView: UILabel = {
         let view = UILabel()
-        view.isUserInteractionEnabled = false
         view.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         view.accessibilityTraits = .header
         return view

--- a/deltachat-ios/Controller/ChatListViewController.swift
+++ b/deltachat-ios/Controller/ChatListViewController.swift
@@ -16,9 +16,7 @@ class ChatListViewController: UITableViewController {
 
     private lazy var titleView: UILabel = {
         let view = UILabel()
-        let navTapGesture = UITapGestureRecognizer(target: self, action: #selector(onNavigationTitleTapped))
-        view.addGestureRecognizer(navTapGesture)
-        view.isUserInteractionEnabled = true
+        view.isUserInteractionEnabled = false
         view.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         view.accessibilityTraits = .header
         return view
@@ -295,18 +293,6 @@ class ChatListViewController: UITableViewController {
         } else { // if numberOfUnreadMessages == 0
             navigationItem.backBarButtonItem = nil
             navigationItem.backButtonTitle = String.localized("pref_chats")
-        }
-    }
-
-    @objc
-    public func onNavigationTitleTapped() {
-        titleView.isEnabled = false // immedidate feedback
-        CATransaction.flush()
-
-        self.navigationController?.pushViewController(ConnectivityViewController(dcContext: self.dcContext), animated: true)
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { // /immedidate feedback
-            self.titleView.isEnabled = true
         }
     }
 


### PR DESCRIPTION
tune down connectivity view;
the connectivity view is kind of advanced debugging view, a bit raw, with multi-relay even more.

it is sufficient if one can open that at "settings", at some point, we probabyl want to combine that with "relay"

cmp https://github.com/deltachat/deltachat-android/pull/4589