### PR TITLE
Harden deeplinks parameters parsing fixes crashes and missbehaviours

### DIFF
--- a/DcTests/DcTests.swift
+++ b/DcTests/DcTests.swift
@@ -187,6 +187,13 @@ import UIKit
         #expect(fileURL.lastPathComponent == "accounts.toml")
     }
 
+    @Test func externalURLPolicyRejectsLocalAndApplicationSchemes() throws {
+        #expect(try #require(URL(string: "https://delta.chat/source")).isHTTPURL)
+        #expect(try #require(URL(string: "http://example.org/source")).isHTTPURL)
+        #expect(try #require(URL(string: "chat.delta.deeplink://share?data=x")).isHTTPURL == false)
+        #expect(try #require(URL(string: "file:///private/account.toml")).isHTTPURL == false)
+    }
+
     private func makeShareDeeplink(items: [CodableNSItemProvider]) throws -> URL {
         let encodedItems = try JSONEncoder().encode(items)
         let json = try #require(String(data: encodedItems, encoding: .utf8))

--- a/DcTests/DcTests.swift
+++ b/DcTests/DcTests.swift
@@ -167,6 +167,26 @@ import UIKit
         }
     }
 
+    @Test func fileHelperConfinesUntrustedFilenames() throws {
+        #expect(FileHelper.safeFilename("../../accounts.toml") == "accounts.toml")
+        #expect(FileHelper.safeFilename("folder\\secret.txt") == "secret.txt")
+        #expect(FileHelper.safeFilename("..") == "file")
+
+        let path = try #require(FileHelper.saveData(
+            data: Data("test".utf8),
+            name: "../../accounts.toml",
+            directory: .cachesDirectory
+        ))
+        defer { FileHelper.deleteFile(path) }
+
+        let fileURL = URL(fileURLWithPath: path).standardizedFileURL
+        let caches = try #require(FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first)
+        let identifier = try #require(Bundle.main.bundleIdentifier)
+        let expectedDirectory = caches.appendingPathComponent(identifier, isDirectory: true).standardizedFileURL
+        #expect(fileURL.deletingLastPathComponent() == expectedDirectory)
+        #expect(fileURL.lastPathComponent == "accounts.toml")
+    }
+
     private func makeShareDeeplink(items: [CodableNSItemProvider]) throws -> URL {
         let encodedItems = try JSONEncoder().encode(items)
         let json = try #require(String(data: encodedItems, encoding: .utf8))

--- a/DcTests/DcTests.swift
+++ b/DcTests/DcTests.swift
@@ -61,6 +61,49 @@ import UIKit
         }
         #expect(DcAccounts.shared.select(id: context.id))
     }
+
+    @Test @MainActor func invalidDeeplinkIdsAreRejected() throws {
+        let coordinator = AppCoordinator(window: UIWindow(), dcAccounts: DcAccounts.shared)
+        let accountId = context.id
+        let invalidChatId = 999
+
+        let urls = [
+            "chat.delta.deeplink://chat?accountId=-1&chatId=1",
+            "chat.delta.deeplink://chat?accountId=\(accountId)&chatId=-1",
+            "chat.delta.deeplink://chat?accountId=\(accountId)&chatId=4294967296",
+            "chat.delta.deeplink://chat?accountId=\(accountId)&chatId=\(invalidChatId)",
+            "chat.delta.deeplink://chat?accountId=\(accountId)&chaId=-1",
+            "chat.delta.deeplink://webxdc?accountId=\(accountId)&chatId=-1&msgId=-1",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=-1",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=invalid",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=\(accountId)&chatId=-1",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=\(accountId)&chatId=invalid",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=\(accountId)&chatId=\(invalidChatId)",
+        ]
+
+        for urlString in urls {
+            let url = try #require(URL(string: urlString))
+            #expect(coordinator.handleDeepLinkURL(url) == false, "Expected to reject \(urlString)")
+        }
+    }
+
+    @Test @MainActor func optionalShareDeeplinkIdsCanBeOmitted() throws {
+        #expect(DcAccounts.shared.select(id: context.id))
+        let coordinator = AppCoordinator(window: UIWindow(), dcAccounts: DcAccounts.shared)
+        let accountId = context.id
+        let chatId = context.createChatByContactId(contactId: Int(DC_CONTACT_ID_SELF))
+        let urls = [
+            "chat.delta.deeplink://share?data=%5B%5D",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=\(accountId)",
+            "chat.delta.deeplink://share?data=%5B%5D&chatId=\(chatId)",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=\(accountId)&chatId=\(chatId)",
+        ]
+
+        for urlString in urls {
+            let url = try #require(URL(string: urlString))
+            #expect(coordinator.handleDeepLinkURL(url), "Expected to accept \(urlString)")
+        }
+    }
 }
 
 

--- a/DcTests/DcTests.swift
+++ b/DcTests/DcTests.swift
@@ -46,7 +46,8 @@ import UIKit
         defer { try? FileManager.default.removeItem(at: shareExtensionDirectory) }
 
         let provider = CodableNSItemProvider.contentsAt(url: fileURL, viewType: DC_MSG_FILE)
-        RelayHelper.shared.setShareItems(items: [provider])
+        let shareItems = try #require(ValidatedShareItems([provider]))
+        RelayHelper.shared.setShareItems(items: shareItems)
 
         #expect(DcAccounts.shared.select(id: secondaryContext.id))
         let chatB = secondaryContext.createChatByContactId(contactId: Int(DC_CONTACT_ID_SELF))
@@ -103,6 +104,77 @@ import UIKit
             let url = try #require(URL(string: urlString))
             #expect(coordinator.handleDeepLinkURL(url), "Expected to accept \(urlString)")
         }
+    }
+
+    @Test @MainActor func shareDeeplinkFilesStayInsideStagingDirectory() throws {
+        #expect(DcAccounts.shared.select(id: context.id))
+        RelayHelper.shared.finishRelaying()
+
+        let fileManager = FileManager.default
+        let coordinator = AppCoordinator(window: UIWindow(), dcAccounts: DcAccounts.shared)
+        let stagingParent = shareExtensionDirectory.deletingLastPathComponent()
+        let identifier = UUID().uuidString
+        let privateFile = stagingParent.appendingPathComponent("private-\(identifier).txt")
+        let siblingDirectory = stagingParent.appendingPathComponent("share_extension_\(identifier)", isDirectory: true)
+        let siblingFile = siblingDirectory.appendingPathComponent("file.txt")
+        let stagedFile = shareExtensionDirectory.appendingPathComponent("staged-\(identifier).txt")
+        let stagedSymlink = shareExtensionDirectory.appendingPathComponent("link-\(identifier).txt")
+
+        try fileManager.createDirectory(at: shareExtensionDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: siblingDirectory, withIntermediateDirectories: true)
+        try Data("private".utf8).write(to: privateFile)
+        try Data("sibling".utf8).write(to: siblingFile)
+        try fileManager.createSymbolicLink(at: stagedSymlink, withDestinationURL: privateFile)
+        defer {
+            RelayHelper.shared.finishRelaying()
+            try? fileManager.removeItem(at: privateFile)
+            try? fileManager.removeItem(at: siblingDirectory)
+            try? fileManager.removeItem(at: stagedFile)
+            try? fileManager.removeItem(at: stagedSymlink)
+        }
+
+        let traversalURL = shareExtensionDirectory.appendingPathComponent("../\(privateFile.lastPathComponent)")
+        let rejectedURLs = [
+            privateFile,
+            siblingFile,
+            traversalURL,
+            stagedSymlink,
+            shareExtensionDirectory,
+            try #require(URL(string: "https://example.org/file.txt")),
+        ]
+
+        for fileURL in rejectedURLs {
+            let items = [
+                CodableNSItemProvider.text(text: "keep validation all-or-nothing"),
+                .contentsAt(url: fileURL, viewType: DC_MSG_FILE),
+            ]
+            #expect(coordinator.handleDeepLinkURL(try makeShareDeeplink(items: items)) == false)
+            #expect(RelayHelper.shared.isSharing() == false)
+        }
+
+        try Data("staged".utf8).write(to: stagedFile)
+        let validItems = [CodableNSItemProvider.contentsAt(url: stagedFile, viewType: DC_MSG_FILE)]
+        #expect(coordinator.handleDeepLinkURL(try makeShareDeeplink(items: validItems)))
+        #expect(RelayHelper.shared.isSharing())
+        if case .share(let shareItems) = RelayHelper.shared.data {
+            guard case .contentsAt(let url, _) = try #require(shareItems.providers.first) else {
+                Issue.record("Expected a staged file provider")
+                return
+            }
+            #expect(url == stagedFile.standardizedFileURL.resolvingSymlinksInPath())
+        } else {
+            Issue.record("Expected validated share items")
+        }
+    }
+
+    private func makeShareDeeplink(items: [CodableNSItemProvider]) throws -> URL {
+        let encodedItems = try JSONEncoder().encode(items)
+        let json = try #require(String(data: encodedItems, encoding: .utf8))
+        var components = URLComponents()
+        components.scheme = "chat.delta.deeplink"
+        components.host = "share"
+        components.queryItems = [.init(name: "data", value: json)]
+        return try #require(components.url)
     }
 }
 

--- a/deltachat-ios/Chat/Apps/WebxdcStoreViewController.swift
+++ b/deltachat-ios/Chat/Apps/WebxdcStoreViewController.swift
@@ -50,7 +50,7 @@ extension WebxdcStoreViewController: WKNavigationDelegate {
         }
 
         // if url ends with .xdc -> download and store in core and call delegate
-        if url.pathExtension == "xdc" {
+        if url.pathExtension == "xdc", url.isHTTPURL {
             Task { [weak self] in
                 guard let self else { return }
                 // show spinner instead of close-button
@@ -67,9 +67,9 @@ extension WebxdcStoreViewController: WKNavigationDelegate {
                 delegate?.pickedAnDownloadedApp(self, fileURL: fileURL as URL)
                 decisionHandler(.cancel)
             }
-        } else if url.host == appPickerUrl?.host {
+        } else if let appPickerUrl, url.hasSameOrigin(as: appPickerUrl) {
             decisionHandler(.allow)
-        } else if UIApplication.shared.canOpenURL(url) {
+        } else if url.isHTTPURL, UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url)
             decisionHandler(.cancel)
         } else {

--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -492,7 +492,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
             draft.text = draftText ?? draft.text
             RelayHelper.shared.finishRelaying()
         case .share(let items):
-            let description = Dictionary(items.map { ($0.viewType, 1) }, uniquingKeysWith: +)
+            let description = Dictionary(items.providers.map { ($0.viewType, 1) }, uniquingKeysWith: +)
                 .compactMap { viewType, count in
                     switch viewType { // TODO: Localize
                     case DC_MSG_GIF: "\(count) GIF(s)"

--- a/deltachat-ios/Controller/FullMessageViewController.swift
+++ b/deltachat-ios/Controller/FullMessageViewController.swift
@@ -46,6 +46,24 @@ class FullMessageViewController: WebViewViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard navigationAction.navigationType == .linkActivated,
+              let url = navigationAction.request.url,
+              // the document is loaded with baseURL nil, so in-page anchor
+              // links resolve to about:blank#fragment and are harmless
+              url.scheme?.lowercased() != "about" else {
+            decisionHandler(.allow)
+            return
+        }
+
+        if url.scheme?.lowercased() == "mailto" {
+            openChatFor(url: url)
+        } else if url.isHTTPURL {
+            UIApplication.shared.open(url)
+        }
+        decisionHandler(.cancel)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         addFontUserScript()

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -495,7 +495,8 @@ class WebxdcViewController: WebViewViewController {
 
     private func openSourceCodeUrl() {
         if let sourceCodeUrl,
-           let url = URL(string: sourceCodeUrl) {
+           let url = URL(string: sourceCodeUrl),
+           url.isHTTPURL {
             UIApplication.shared.open(url)
         }
     }

--- a/deltachat-ios/Controller/WebxdcViewController.swift
+++ b/deltachat-ios/Controller/WebxdcViewController.swift
@@ -548,10 +548,11 @@ extension WebxdcViewController: WKScriptMessageHandler {
                 if let name = dict["name"] as? String {
                     let shareAction = UIAlertAction(title: String.localized("menu_share"), style: .default, handler: { [weak self] _ in
                         guard let self else { return }
-                        if let base64 = dict["base64"] as? String, let data = Data(base64Encoded: base64), let sourceItem = navigationItem.rightBarButtonItem {
-                            let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(name)
-                            try? FileManager.default.removeItem(at: fileURL)
-                            try? data.write(to: fileURL)
+                        if let base64 = dict["base64"] as? String,
+                           let data = Data(base64Encoded: base64),
+                           let sourceItem = navigationItem.rightBarButtonItem,
+                           let filepath = FileHelper.saveData(data: data, name: name, directory: .cachesDirectory) {
+                            let fileURL = URL(fileURLWithPath: filepath)
                             Utils.share(url: fileURL, parentViewController: self, sourceItem: sourceItem)
                         }
                     })

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -231,9 +231,10 @@ class AppCoordinator: NSObject {
     private func handleShareDeeplink(url: URL) -> Bool {
         guard let parameters = url.queryParameters,
               let data = parameters["data"]?.data(using: .utf8),
-              let providers = try? JSONDecoder().decode([CodableNSItemProvider].self, from: data)
+              let providers = try? JSONDecoder().decode([CodableNSItemProvider].self, from: data),
+              let shareItems = ValidatedShareItems(providers)
         else {
-            logger.error("Missing data parameter or incorrect format in URL \(url)")
+            logger.error("Invalid share deeplink data")
             return false
         }
 
@@ -260,7 +261,7 @@ class AppCoordinator: NSObject {
             let nvc = tabBarController.selectedViewController as? UINavigationController
             nvc?.popToRootViewController(animated: false)
         }
-        RelayHelper.shared.setShareItems(items: providers)
+        RelayHelper.shared.setShareItems(items: shareItems)
 
         return true
     }

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -123,6 +123,42 @@ class AppCoordinator: NSObject {
         }
     }
 
+    private func deepLinkId(named name: String, in parameters: [String: String]) -> Int? {
+        guard let string = parameters[name],
+              let id = UInt32(string),
+              id != 0 else {
+            logger.error("Invalid or missing \(name) in deeplink")
+            return nil
+        }
+        return Int(id)
+    }
+
+    /// Like deepLinkId(named:in:), but the parameter may be absent:
+    /// returns .some(nil) when absent, nil when present but invalid.
+    private func deepLinkId(ifPresent name: String, in parameters: [String: String]) -> Int?? {
+        guard parameters[name] != nil else { return Int?.none }
+        guard let id = deepLinkId(named: name, in: parameters) else { return nil }
+        return id
+    }
+
+    private func deepLinkContext(accountId: Int) -> DcContext? {
+        guard dcAccounts.getAll().contains(accountId) else {
+            logger.error("Invalid accountId in deeplink")
+            return nil
+        }
+        return dcAccounts.get(id: accountId)
+    }
+
+    private func selectDeepLinkAccountIfNeeded(accountId: Int) -> Bool {
+        guard dcAccounts.getSelected().id != accountId else { return true }
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+              dcAccounts.select(id: accountId) else {
+            return false
+        }
+        appDelegate.reloadDcContext()
+        return true
+    }
+
     private func handleWebxdcDeeplink(url: URL) -> Bool {
 
         guard let parameters = url.queryParameters else {
@@ -130,24 +166,23 @@ class AppCoordinator: NSObject {
             return false
         }
 
-        let accountId = Int(parameters["accountId"] ?? "-1") ?? -1
-        let chatId = Int(parameters["chatId"] ?? "-1") ?? -1
-        let messageId = Int(parameters["msgId"] ?? "-1") ?? -1
-
-        if !"\(url)".starts(with: "chat.delta.deeplink://webxdc?") ||
-           messageId == -1 ||
-           chatId == -1 ||
-           accountId == -1 {
+        guard let accountId = deepLinkId(named: "accountId", in: parameters),
+              let chatId = deepLinkId(named: "chatId", in: parameters),
+              let messageId = deepLinkId(named: "msgId", in: parameters),
+              let dcContext = deepLinkContext(accountId: accountId) else {
             return false
         }
 
-        if dcAccounts.getSelected().id != accountId {
-            if !dcAccounts.select(id: accountId) {
-                return false
-            }
-            guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return false }
-            appDelegate.reloadDcContext()
-        } else {
+        let dcMsg = dcContext.getMessage(id: messageId)
+        guard dcMsg.isValid,
+              dcMsg.type == DC_MSG_WEBXDC,
+              dcMsg.chatId == chatId,
+              dcContext.getChat(chatId: chatId).isValid else {
+            logger.error("Invalid chatId or msgId in webxdc deeplink")
+            return false
+        }
+
+        if dcAccounts.getSelected().id == accountId {
             // check if webxdc is already opened
             if let navController = self.tabBarController.selectedViewController as? UINavigationController,
                let topViewController = navController.topViewController,
@@ -158,34 +193,26 @@ class AppCoordinator: NSObject {
             }
         }
 
-        let dcContext = dcAccounts.getSelected()
-        let dcMsg = dcContext.getMessage(id: messageId)
-        if dcMsg.isValid, dcMsg.type == DC_MSG_WEBXDC {
-            showChat(chatId: chatId, msgId: messageId, openHighlightedMsg: true, animated: false, clearViewControllerStack: true)
-            return true
-        } else {
-            showChats()
-            return false
-        }
+        guard selectDeepLinkAccountIfNeeded(accountId: accountId) else { return false }
+        showChat(chatId: chatId, msgId: messageId, openHighlightedMsg: true, animated: false, clearViewControllerStack: true)
+        return true
     }
 
     private func handleOpenChatDeeplink(url: URL) -> Bool {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-              let parameters = url.queryParameters,
-              let accountIdString = parameters["accountId"],
-              let accountId = Int(accountIdString),
-              let chatIdString = parameters["chatId"],
-              let chatId = Int(chatIdString) else {
+        guard let parameters = url.queryParameters,
+              let accountId = deepLinkId(named: "accountId", in: parameters),
+              let chatId = deepLinkId(named: "chatId", in: parameters),
+              let dcContext = deepLinkContext(accountId: accountId) else {
             logger.error("Missing parameters in URL \(url)")
             return false
         }
 
-        if dcAccounts.getSelected().id != accountId {
-            if !dcAccounts.select(id: accountId) {
-                return false
-            }
-            appDelegate.reloadDcContext()
-        } else {
+        guard dcContext.getChat(chatId: chatId).isValid else {
+            logger.error("Invalid chatId in chat deeplink")
+            return false
+        }
+
+        if dcAccounts.getSelected().id == accountId {
             // check if chat is already opened
             if let navController = self.tabBarController.selectedViewController as? UINavigationController,
                let topViewController = navController.topViewController,
@@ -196,12 +223,8 @@ class AppCoordinator: NSObject {
             }
         }
 
-        let chat = dcAccounts.getSelected().getChat(chatId: chatId)
-        if chat.isValid {
-            showChat(chatId: chatId, animated: false, clearViewControllerStack: true)
-        } else {
-            showChats()
-        }
+        guard selectDeepLinkAccountIfNeeded(accountId: accountId) else { return false }
+        showChat(chatId: chatId, animated: false, clearViewControllerStack: true)
         return true
     }
     
@@ -213,18 +236,24 @@ class AppCoordinator: NSObject {
             logger.error("Missing data parameter or incorrect format in URL \(url)")
             return false
         }
-        
-        // Switch account if needed
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-           let accountId = parameters["accountId"].flatMap(Int.init) {
-            if dcAccounts.getSelected().id != accountId {
-                if !dcAccounts.select(id: accountId) { return false }
-                appDelegate.reloadDcContext()
-            }
+
+        guard let accountId = deepLinkId(ifPresent: "accountId", in: parameters),
+              let chatId = deepLinkId(ifPresent: "chatId", in: parameters) else {
+            return false
+        }
+
+        let targetAccountId = accountId ?? dcAccounts.getSelected().id
+        guard let dcContext = deepLinkContext(accountId: targetAccountId) else { return false }
+        if let chatId, !dcContext.getChat(chatId: chatId).isValid {
+            logger.error("Invalid chatId in share deeplink")
+            return false
         }
         
+        // Switch account if needed
+        guard selectDeepLinkAccountIfNeeded(accountId: targetAccountId) else { return false }
+        
         // Ask for sending messages
-        if let chatId = parameters["chatId"].flatMap(Int.init) {
+        if let chatId {
             showChat(chatId: chatId)
         } else {
             showChats()

--- a/deltachat-ios/Extensions/URL+Extension.swift
+++ b/deltachat-ios/Extensions/URL+Extension.swift
@@ -15,6 +15,17 @@ extension URL {
         }
     }
 
+    var isHTTPURL: Bool {
+        guard let scheme = scheme?.lowercased() else { return false }
+        return scheme == "https" || scheme == "http"
+    }
+
+    func hasSameOrigin(as other: URL) -> Bool {
+        scheme?.lowercased() == other.scheme?.lowercased()
+            && host?.lowercased() == other.host?.lowercased()
+            && port == other.port
+    }
+
     /// Note: This copies the file at URL to a temporary file in case the original is deleted (or access is lost) during conversion.
     public func convertToMp4(completionHandler: ((URL?, Error?) -> Void)?) {
         let filename = self.deletingPathExtension().lastPathComponent.replacingOccurrences(of: ".", with: "-")

--- a/deltachat-ios/Helper/FileHelper.swift
+++ b/deltachat-ios/Helper/FileHelper.swift
@@ -1,12 +1,23 @@
 import Foundation
 
 public class FileHelper {
+
+    /// Converts an untrusted display name into one filesystem path component.
+    /// Both slash styles are handled because filenames can originate on other
+    /// platforms (for example through webxdc or email metadata).
+    static func safeFilename(_ filename: String) -> String {
+        let normalized = filename.replacingOccurrences(of: "\\", with: "/")
+        let component = normalized
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .last
+            .map(String.init)?
+            .replacingOccurrences(of: "\0", with: "") ?? ""
+        return component.isEmpty || component == "." || component == ".." ? "file" : component
+    }
     
     // implementation is following Apple's recommendations
     // https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/AccessingFilesandDirectories/AccessingFilesandDirectories.html
     public static func saveData(data: Data, name: String? = nil, suffix: String? = nil, directory: FileManager.SearchPathDirectory = .applicationSupportDirectory) -> String? {
-        var path: URL?
-
         // ensure directory exists (application support dir doesn't exist per default)
         let fileManager = FileManager.default
         let urls = fileManager.urls(for: directory, in: .userDomainMask) as [URL]
@@ -38,18 +49,22 @@ public class FileHelper {
             return nil
         }
 
-        // add file name to path
+        // Add a single file name to the path. `name` may originate in message
+        // metadata, so it must never be allowed to add path components.
+        let filename: String
         if let name {
             if let suffix {
-                path = subdirectoryURL.appendingPathComponent("\(name).\(suffix)")
+                filename = "\(name).\(suffix)"
             } else {
-                path = subdirectoryURL.appendingPathComponent(name)
+                filename = name
             }
         } else if let suffix {
             let timestamp = Double(Date().timeIntervalSince1970)
-            path = subdirectoryURL.appendingPathComponent("\(timestamp).\(suffix)")
+            filename = "\(timestamp).\(suffix)"
+        } else {
+            return nil
         }
-        guard let path else { return nil }
+        let path = subdirectoryURL.appendingPathComponent(safeFilename(filename), isDirectory: false)
 
         // write data
         do {

--- a/deltachat-ios/Helper/RelayHelper.swift
+++ b/deltachat-ios/Helper/RelayHelper.swift
@@ -6,13 +6,55 @@ enum RelayData {
     case forwardMessage(text: String?, fileData: Data?, fileName: String?)
     case forwardVCard(Data)
     case mailto(address: String, draft: String?)
-    case share([CodableNSItemProvider])
+    case share(ValidatedShareItems)
+}
+
+/// Share-extension items whose file URLs have been resolved and confined to
+/// the app-group staging directory.
+struct ValidatedShareItems {
+    let providers: [CodableNSItemProvider]
+
+    init?(_ providers: [CodableNSItemProvider]) {
+        let root = shareExtensionDirectory
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        let rootComponents = root.pathComponents
+        var validatedProviders = [CodableNSItemProvider]()
+
+        for provider in providers {
+            switch provider {
+            case .text:
+                validatedProviders.append(provider)
+            case let .contentsAt(url, viewType):
+                guard url.isFileURL else {
+                    logger.error("Rejected non-file URL in share deeplink")
+                    return nil
+                }
+
+                let resolvedURL = url
+                    .standardizedFileURL
+                    .resolvingSymlinksInPath()
+                let resolvedComponents = resolvedURL.pathComponents
+                guard resolvedComponents.count > rootComponents.count,
+                      resolvedComponents.prefix(rootComponents.count).elementsEqual(rootComponents),
+                      let resourceValues = try? resolvedURL.resourceValues(forKeys: [.isRegularFileKey]),
+                      resourceValues.isRegularFile == true else {
+                    logger.error("Rejected file outside the share-extension staging directory")
+                    return nil
+                }
+
+                validatedProviders.append(.contentsAt(url: resolvedURL, viewType: viewType))
+            }
+        }
+
+        self.providers = validatedProviders
+    }
 }
 
 class RelayHelper {
     static var shared: RelayHelper = RelayHelper()
     var dialogTitle: String = ""
-    var data: RelayData? {
+    private(set) var data: RelayData? {
         didSet {
             NotificationCenter.default.post(name: Event.relayHelperDidChange, object: nil)
         }
@@ -38,7 +80,7 @@ class RelayHelper {
         self.data = .forwardMessages(srcContextId: DcAccounts.shared.getSelected().id, ids: messageIds)
     }
     
-    func setShareItems(items: [CodableNSItemProvider]) {
+    func setShareItems(items: ValidatedShareItems) {
         finishRelaying()
         self.dialogTitle = String.localized("chat_share_with_title")
         self.data = .share(items)
@@ -58,7 +100,7 @@ class RelayHelper {
     func shareAndFinishRelaying(to chatId: Int) {
         if case .share(let items) = data {
             let dcContext = DcAccounts.shared.getSelected()
-            for item in items {
+            for item in items.providers {
                 let msg: DcMsg
                 switch item {
                 case let .contentsAt(url, viewType):

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -62,7 +62,8 @@ struct Utils {
 
             let shareURL: URL
             if let filename = message.filename {
-                let cleanURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+                let cleanURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(FileHelper.safeFilename(filename), isDirectory: false)
                 shareURL = FileHelper.copyIfPossible(src: scrambledURL, dest: cleanURL)
             } else {
                 shareURL = scrambledURL


### PR DESCRIPTION
* Add tests to verify all possible bad combinations
  - IDs cant be malformed, negative or larger than UInt32.max, or missing if required
* Current deeplink parameter parsing misses many corner cases which resulted in:
  - Crash when chatId is out of range (application closes, DoS on click)
  - Reference chats from the wrong accountId (invalid accountId were accepted as valid,
  which may confuse users or trick them)
  - WebXDC handler took negative ids as invalid but missed large ints