### PR TITLE
Harden deeplinks parameters parsing fixes crashes and missbehaviours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Do not open "Connectivity View" from main title; use "Settigns" instead
 - Fix: If one relay is connected, assume overall connectivity
 - Fix marking messages as seen across devices
+- Harden deeplinks parameters parsing to address crash and missbehaviours
 - Update to core 2.59.0
 
 

--- a/DcTests/DcTests.swift
+++ b/DcTests/DcTests.swift
@@ -61,6 +61,49 @@ import UIKit
         }
         #expect(DcAccounts.shared.select(id: context.id))
     }
+
+    @Test @MainActor func invalidDeeplinkIdsAreRejected() throws {
+        let coordinator = AppCoordinator(window: UIWindow(), dcAccounts: DcAccounts.shared)
+        let accountId = context.id
+        let invalidChatId = 999
+
+        let urls = [
+            "chat.delta.deeplink://chat?accountId=-1&chatId=1",
+            "chat.delta.deeplink://chat?accountId=\(accountId)&chatId=-1",
+            "chat.delta.deeplink://chat?accountId=\(accountId)&chatId=4294967296",
+            "chat.delta.deeplink://chat?accountId=\(accountId)&chatId=\(invalidChatId)",
+            "chat.delta.deeplink://chat?accountId=\(accountId)&chaId=-1",
+            "chat.delta.deeplink://webxdc?accountId=\(accountId)&chatId=-1&msgId=-1",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=-1",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=invalid",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=\(accountId)&chatId=-1",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=\(accountId)&chatId=invalid",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=\(accountId)&chatId=\(invalidChatId)",
+        ]
+
+        for urlString in urls {
+            let url = try #require(URL(string: urlString))
+            #expect(coordinator.handleDeepLinkURL(url) == false, "Expected to reject \(urlString)")
+        }
+    }
+
+    @Test @MainActor func optionalShareDeeplinkIdsCanBeOmitted() throws {
+        #expect(DcAccounts.shared.select(id: context.id))
+        let coordinator = AppCoordinator(window: UIWindow(), dcAccounts: DcAccounts.shared)
+        let accountId = context.id
+        let chatId = context.createChatByContactId(contactId: Int(DC_CONTACT_ID_SELF))
+        let urls = [
+            "chat.delta.deeplink://share?data=%5B%5D",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=\(accountId)",
+            "chat.delta.deeplink://share?data=%5B%5D&chatId=\(chatId)",
+            "chat.delta.deeplink://share?data=%5B%5D&accountId=\(accountId)&chatId=\(chatId)",
+        ]
+
+        for urlString in urls {
+            let url = try #require(URL(string: urlString))
+            #expect(coordinator.handleDeepLinkURL(url), "Expected to accept \(urlString)")
+        }
+    }
 }
 
 

--- a/deltachat-ios/Coordinator/AppCoordinator.swift
+++ b/deltachat-ios/Coordinator/AppCoordinator.swift
@@ -123,6 +123,42 @@ class AppCoordinator: NSObject {
         }
     }
 
+    private func deepLinkId(named name: String, in parameters: [String: String]) -> Int? {
+        guard let string = parameters[name],
+              let id = UInt32(string),
+              id != 0 else {
+            logger.error("Invalid or missing \(name) in deeplink")
+            return nil
+        }
+        return Int(id)
+    }
+
+    /// Like deepLinkId(named:in:), but the parameter may be absent:
+    /// returns .some(nil) when absent, nil when present but invalid.
+    private func deepLinkId(ifPresent name: String, in parameters: [String: String]) -> Int?? {
+        guard parameters[name] != nil else { return Int?.none }
+        guard let id = deepLinkId(named: name, in: parameters) else { return nil }
+        return id
+    }
+
+    private func deepLinkContext(accountId: Int) -> DcContext? {
+        guard dcAccounts.getAll().contains(accountId) else {
+            logger.error("Invalid accountId in deeplink")
+            return nil
+        }
+        return dcAccounts.get(id: accountId)
+    }
+
+    private func selectDeepLinkAccountIfNeeded(accountId: Int) -> Bool {
+        guard dcAccounts.getSelected().id != accountId else { return true }
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+              dcAccounts.select(id: accountId) else {
+            return false
+        }
+        appDelegate.reloadDcContext()
+        return true
+    }
+
     private func handleWebxdcDeeplink(url: URL) -> Bool {
 
         guard let parameters = url.queryParameters else {
@@ -130,24 +166,23 @@ class AppCoordinator: NSObject {
             return false
         }
 
-        let accountId = Int(parameters["accountId"] ?? "-1") ?? -1
-        let chatId = Int(parameters["chatId"] ?? "-1") ?? -1
-        let messageId = Int(parameters["msgId"] ?? "-1") ?? -1
-
-        if !"\(url)".starts(with: "chat.delta.deeplink://webxdc?") ||
-           messageId == -1 ||
-           chatId == -1 ||
-           accountId == -1 {
+        guard let accountId = deepLinkId(named: "accountId", in: parameters),
+              let chatId = deepLinkId(named: "chatId", in: parameters),
+              let messageId = deepLinkId(named: "msgId", in: parameters),
+              let dcContext = deepLinkContext(accountId: accountId) else {
             return false
         }
 
-        if dcAccounts.getSelected().id != accountId {
-            if !dcAccounts.select(id: accountId) {
-                return false
-            }
-            guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return false }
-            appDelegate.reloadDcContext()
-        } else {
+        let dcMsg = dcContext.getMessage(id: messageId)
+        guard dcMsg.isValid,
+              dcMsg.type == DC_MSG_WEBXDC,
+              dcMsg.chatId == chatId,
+              dcContext.getChat(chatId: chatId).isValid else {
+            logger.error("Invalid chatId or msgId in webxdc deeplink")
+            return false
+        }
+
+        if dcAccounts.getSelected().id == accountId {
             // check if webxdc is already opened
             if let navController = self.tabBarController.selectedViewController as? UINavigationController,
                let topViewController = navController.topViewController,
@@ -158,34 +193,26 @@ class AppCoordinator: NSObject {
             }
         }
 
-        let dcContext = dcAccounts.getSelected()
-        let dcMsg = dcContext.getMessage(id: messageId)
-        if dcMsg.isValid, dcMsg.type == DC_MSG_WEBXDC {
-            showChat(chatId: chatId, msgId: messageId, openHighlightedMsg: true, animated: false, clearViewControllerStack: true)
-            return true
-        } else {
-            showChats()
-            return false
-        }
+        guard selectDeepLinkAccountIfNeeded(accountId: accountId) else { return false }
+        showChat(chatId: chatId, msgId: messageId, openHighlightedMsg: true, animated: false, clearViewControllerStack: true)
+        return true
     }
 
     private func handleOpenChatDeeplink(url: URL) -> Bool {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-              let parameters = url.queryParameters,
-              let accountIdString = parameters["accountId"],
-              let accountId = Int(accountIdString),
-              let chatIdString = parameters["chatId"],
-              let chatId = Int(chatIdString) else {
+        guard let parameters = url.queryParameters,
+              let accountId = deepLinkId(named: "accountId", in: parameters),
+              let chatId = deepLinkId(named: "chatId", in: parameters),
+              let dcContext = deepLinkContext(accountId: accountId) else {
             logger.error("Missing parameters in URL \(url)")
             return false
         }
 
-        if dcAccounts.getSelected().id != accountId {
-            if !dcAccounts.select(id: accountId) {
-                return false
-            }
-            appDelegate.reloadDcContext()
-        } else {
+        guard dcContext.getChat(chatId: chatId).isValid else {
+            logger.error("Invalid chatId in chat deeplink")
+            return false
+        }
+
+        if dcAccounts.getSelected().id == accountId {
             // check if chat is already opened
             if let navController = self.tabBarController.selectedViewController as? UINavigationController,
                let topViewController = navController.topViewController,
@@ -196,12 +223,8 @@ class AppCoordinator: NSObject {
             }
         }
 
-        let chat = dcAccounts.getSelected().getChat(chatId: chatId)
-        if chat.isValid {
-            showChat(chatId: chatId, animated: false, clearViewControllerStack: true)
-        } else {
-            showChats()
-        }
+        guard selectDeepLinkAccountIfNeeded(accountId: accountId) else { return false }
+        showChat(chatId: chatId, animated: false, clearViewControllerStack: true)
         return true
     }
     
@@ -213,18 +236,24 @@ class AppCoordinator: NSObject {
             logger.error("Missing data parameter or incorrect format in URL \(url)")
             return false
         }
-        
-        // Switch account if needed
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-           let accountId = parameters["accountId"].flatMap(Int.init) {
-            if dcAccounts.getSelected().id != accountId {
-                if !dcAccounts.select(id: accountId) { return false }
-                appDelegate.reloadDcContext()
-            }
+
+        guard let accountId = deepLinkId(ifPresent: "accountId", in: parameters),
+              let chatId = deepLinkId(ifPresent: "chatId", in: parameters) else {
+            return false
+        }
+
+        let targetAccountId = accountId ?? dcAccounts.getSelected().id
+        guard let dcContext = deepLinkContext(accountId: targetAccountId) else { return false }
+        if let chatId, !dcContext.getChat(chatId: chatId).isValid {
+            logger.error("Invalid chatId in share deeplink")
+            return false
         }
         
+        // Switch account if needed
+        guard selectDeepLinkAccountIfNeeded(accountId: targetAccountId) else { return false }
+        
         // Ask for sending messages
-        if let chatId = parameters["chatId"].flatMap(Int.init) {
+        if let chatId {
             showChat(chatId: chatId)
         } else {
             showChats()


### PR DESCRIPTION
* Add tests to verify all possible bad combinations
  - IDs cant be malformed, negative or larger than UInt32.max, or missing if required
* Current deeplink parameter parsing misses many corner cases which resulted in:
  - Crash when chatId is out of range (application closes, DoS on click)
  - Reference chats from the wrong accountId (invalid accountId was accepted as valid), which may confuse users or trick them.
  - WebXDC handler took negative ids as invalid but missed large ints