### PR TITLE
Disable logging by default and add settings toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Do not open "Connectivity View" from main title; use "Settigns" instead
 - Fix: If one relay is connected, assume overall connectivity
 - Fix marking messages as seen across devices
+- Disable logging by default and add an option in advanced settings
 - Update to core 2.59.0
 
 

--- a/DcCore/DcCore/DC/Logger.swift
+++ b/DcCore/DcCore/DC/Logger.swift
@@ -13,7 +13,16 @@ public class DcLogger {
     let osLog: Logger
 
     static var enabled: Bool {
-        get { UserDefaults.standard.bool(forKey: UserDefaults.loggingEnabledKey) }
+        get {
+            if UserDefaults.standard.object(forKey: UserDefaults.loggingEnabledKey) == nil {
+                #if DEBUG
+                return true
+                #else
+                return false
+                #endif
+            }
+            return UserDefaults.standard.bool(forKey: UserDefaults.loggingEnabledKey)
+        }
         set { UserDefaults.standard.set(newValue, forKey: UserDefaults.loggingEnabledKey) }
     }
 

--- a/DcCore/DcCore/DC/Logger.swift
+++ b/DcCore/DcCore/DC/Logger.swift
@@ -12,23 +12,30 @@ public class DcLogger {
     static let category = "deltachat"
     let osLog: Logger
 
+    static var enabled: Bool {
+        get { UserDefaults.standard.bool(forKey: UserDefaults.loggingEnabledKey) }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaults.loggingEnabledKey) }
+    }
+
     public init() {
         osLog = Logger(subsystem: DcLogger.subsystem, category: DcLogger.category)
     }
 
     public func error(_ message: String) {
-        osLog.error("❤️ \(message, privacy: .public)") // "public" is needed to show lines; core takes care of privacy
+        guard DcLogger.enabled else { return }
+        osLog.error("❤️ \(message, privacy: .public)")
     }
 
     public func warning(_ message: String) {
+        guard DcLogger.enabled else { return }
         osLog.warning("🧡 \(message, privacy: .public)")
     }
 
     public func info(_ message: String) {
-        osLog.notice("💙 \(message, privacy: .public)") // info() is not persisted
+        guard DcLogger.enabled else { return }
+        osLog.info("💙 \(message, privacy: .public)")
     }
 
-    // debug() marked as DEBUG as these lines are for, well debugging. and should not being released. otherwise, use info()
     #if DEBUG
     public func debug(_ message: String) {
         osLog.debug("💚 \(message, privacy: .public)")

--- a/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
+++ b/DcCore/DcCore/Extensions/UserDefaults+Extensions.swift
@@ -8,6 +8,7 @@ public extension UserDefaults {
     static var nseFetchingKey = "nseFetching"
     static var incomingCallPayloadKey = "incomingCallPayload"
     static var appPickerUrl = "appPickerUrl"
+    static var loggingEnabledKey = "loggingEnabled"
     static var defaultAppPickerUrlString = "https://webxdc.org/apps/"
 
     static var shared: UserDefaults? {

--- a/deltachat-ios/Controller/Settings/AdvancedViewController.swift
+++ b/deltachat-ios/Controller/Settings/AdvancedViewController.swift
@@ -63,6 +63,23 @@ internal final class AdvancedViewController: UITableViewController {
         })
     }()
 
+    lazy var loggingCell: SwitchCell = {
+        return SwitchCell(
+            textLabel: String.localized("pref_enable_logging"),
+            on: DcLogger.enabled,
+            action: { cell in
+                DcLogger.enabled = cell.isOn
+                if cell.isOn {
+                    let alert = UIAlertController(
+                        title: String.localized("pref_enable_logging"),
+                        message: String.localized("pref_enable_logging_explain"),
+                        preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: String.localized("ok"), style: .default, handler: nil))
+                    self.navigationController?.present(alert, animated: true, completion: nil)
+                }
+        })
+    }()
+
     lazy var locationStreamingCell: SwitchCell = {
         return SwitchCell(
             textLabel: String.localized("pref_on_demand_location_streaming"),
@@ -98,10 +115,6 @@ internal final class AdvancedViewController: UITableViewController {
     }()
 
     private lazy var sections: [SectionConfigs] = {
-        let viewLogSection = SectionConfigs(
-            headerTitle: nil,
-            footerTitle: nil,
-            cells: [viewLogCell])
         let serverSection = SectionConfigs(
             headerTitle: String.localized("pref_server"),
             footerTitle: String.localized("pref_multidevice_explain"),
@@ -110,8 +123,12 @@ internal final class AdvancedViewController: UITableViewController {
             headerTitle: String.localized("pref_experimental_features"),
             footerTitle: String.localized("pref_experimental_features_explain"),
             cells: [locationStreamingCell, appPickerCell])
+        let debugSection = SectionConfigs(
+            headerTitle: String.localized("pref_debug"),
+            footerTitle: String.localized("pref_enable_logging_explain"),
+            cells: [loggingCell, viewLogCell])
 
-        return [viewLogSection, serverSection, experimentalSection]
+        return [serverSection, experimentalSection, debugSection]
     }()
 
     init(dcAccounts: DcAccounts) {

--- a/deltachat-ios/en.lproj/Localizable.strings
+++ b/deltachat-ios/en.lproj/Localizable.strings
@@ -770,6 +770,9 @@
 "pref_show_emails_all" = "All";
 "pref_experimental_features" = "Experimental Features";
 "pref_experimental_features_explain" = "These features may be unstable and may be changed or removed";
+"pref_debug" = "Debug";
+"pref_enable_logging" = "Enable Logging";
+"pref_enable_logging_explain" = "When enabled, app activity is written to the system log. This includes sensitive data such as messages, contacts, and file paths. Disable this in production and when sharing your device with others.";
 "pref_on_demand_location_streaming" = "Location Streaming";
 "pref_background_default" = "Default image";
 "pref_background_default_color" = "Default color";


### PR DESCRIPTION
The DcLogger class wraps osLogger forcing all log messages to be .public, this breaks the privacy design of logged information and there are actually quite many logging lines leaking sensitive information in the logs, considering only debug builds will benefit from this information and i assume the purpose of this is to help users determine why something is not working i think the easiest and cleanest solution is to keep that buggy dclogger abstraction (that just adds a heart emoji to each call) and dont do anything unless the user permits it.

Ideally I would like to refactor the whole logging system to solve this problem from the root because its a bad secure coding practice to force .public privacy in oslog, But the PR would be much larger and it will be better to clarify the need for some of those logs before moving forward.

Sumarizing, this PR aims to address the problem without losing debugging capabilities for advanced users.