### PR TITLE
Log to a file in release builds instead of the system oslog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Log to a private file instead of the system log, so logs are no longer readable from outside the app (e.g. via USB or Wi-Fi); "View Log" keeps the last two executions
 - Allow to react in channels
 - Offer five default reactions when long-tapping a message
 - Show phased out relays in connectivity view as such

--- a/DcCore/DcCore/DC/Logger.swift
+++ b/DcCore/DcCore/DC/Logger.swift
@@ -79,9 +79,13 @@ public class DcLogger {
     }
 
     private func openCurrentLogFile() {
-        guard let currentUrl = DcLogger.logFileURLs.last else { return }
+        guard var currentUrl = DcLogger.logFileURLs.last else { return }
         // O_APPEND keeps concurrent writes from the main app and the extensions intact
         fileDescriptor = open(currentUrl.path, O_WRONLY | O_APPEND | O_CREAT, 0o600)
+        // keep the logs out of iCloud/iTunes backups; renaming preserves the flag
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        try? currentUrl.setResourceValues(resourceValues)
         openedAt = Date()
     }
 

--- a/DcCore/DcCore/DC/Logger.swift
+++ b/DcCore/DcCore/DC/Logger.swift
@@ -10,6 +10,8 @@ public func getDcLogger() -> DcLogger {
 public class DcLogger {
     public static let subsystem = "chat.delta"
     static let category = "deltachat"
+
+    #if DEBUG
     let osLog: Logger
 
     public init() {
@@ -29,9 +31,94 @@ public class DcLogger {
     }
 
     // debug() marked as DEBUG as these lines are for, well debugging. and should not being released. otherwise, use info()
-    #if DEBUG
     public func debug(_ message: String) {
         osLog.debug("💚 \(message, privacy: .public)")
+    }
+
+    #else
+    // Release builds log to a file in the shared app-group container instead of the
+    // unified system log, so that messages are not readable from outside the sandbox
+    // (Console.app via USB/Wi-Fi, sysdiagnose) but stay available to "View Log".
+    // Only the last two executions are kept: on launch the current file becomes the
+    // previous one, so after a crash the old log can still be inspected. To keep
+    // long-running sessions bounded, the current file restarts after maxLogDuration.
+    private static let maxLogDuration: TimeInterval = 60 * 60
+
+    // previous file first, so that concatenating the contents gives chronological order
+    static var logFileURLs: [URL] {
+        guard let container = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: DatabaseHelper.applicationGroupIdentifier) else { return [] }
+        return [container.appendingPathComponent("deltachat-log-old.txt"),
+                container.appendingPathComponent("deltachat-log.txt")]
+    }
+
+    private let queue = DispatchQueue(label: "chat.delta.logger")
+    private var fileDescriptor: Int32 = -1
+    private var openedAt = Date()
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return formatter
+    }()
+
+    public init() {
+        // only the main app starts a new execution; extensions append to the current log
+        if !Bundle.main.bundlePath.hasSuffix(".appex"),
+           let previousUrl = DcLogger.logFileURLs.first, let currentUrl = DcLogger.logFileURLs.last {
+            try? FileManager.default.removeItem(at: previousUrl)
+            try? FileManager.default.moveItem(at: currentUrl, to: previousUrl)
+        }
+        openCurrentLogFile()
+    }
+
+    deinit {
+        if fileDescriptor >= 0 {
+            close(fileDescriptor)
+        }
+    }
+
+    private func openCurrentLogFile() {
+        guard let currentUrl = DcLogger.logFileURLs.last else { return }
+        // O_APPEND keeps concurrent writes from the main app and the extensions intact
+        fileDescriptor = open(currentUrl.path, O_WRONLY | O_APPEND | O_CREAT, 0o600)
+        openedAt = Date()
+    }
+
+    private func log(_ prefix: String, _ message: String) {
+        queue.async { [self] in
+            if fileDescriptor >= 0, Date().timeIntervalSince(openedAt) > DcLogger.maxLogDuration {
+                close(fileDescriptor)
+                // the previous-run log is even older, remove it as well for consistency
+                for url in DcLogger.logFileURLs {
+                    try? FileManager.default.removeItem(at: url)
+                }
+                openCurrentLogFile()
+            }
+            guard fileDescriptor >= 0,
+                  let data = "[\(dateFormatter.string(from: Date()))] \(prefix) \(message)\n".data(using: .utf8) else { return }
+            data.withUnsafeBytes { _ = write(fileDescriptor, $0.baseAddress, $0.count) }
+        }
+    }
+
+    public func getLogText() -> String {
+        return queue.sync {
+            DcLogger.logFileURLs
+                .compactMap { try? String(contentsOf: $0, encoding: .utf8) }
+                .joined()
+        }
+    }
+
+    public func error(_ message: String) {
+        log("❤️", message)
+    }
+
+    public func warning(_ message: String) {
+        log("🧡", message)
+    }
+
+    public func info(_ message: String) {
+        log("💙", message)
     }
     #endif
 }

--- a/deltachat-ios/Controller/LogViewController.swift
+++ b/deltachat-ios/Controller/LogViewController.swift
@@ -133,6 +133,7 @@ public class LogViewController: UIViewController {
     public func getLogLines() -> String {
         var log = ""
 
+        #if DEBUG
         do {
             let store = try OSLogStore(scope: .currentProcessIdentifier)
             let position = store.position(timeIntervalSinceLatestBoot: 1)
@@ -154,6 +155,13 @@ public class LogViewController: UIViewController {
         }
 
         log += "\n\nTo get the full log, use Console.app on a Mac."
+        #else
+        // release builds log to a file in the app-group container, see DcLogger
+        log = getDcLogger().getLogText()
+        if log.isEmpty {
+            log = "\nEmpty log."
+        }
+        #endif
 
         return log
     }


### PR DESCRIPTION
following for https://github.com/deltachat/deltachat-ios/pull/3263

The idea here is that release builds will use a custom logger that just save the logs inside the app home, these files are not accessible from outside the app and are protected by the sandbox.

Also, i have enforced the files to not be backuped or saved in the icloud. i think that we shuold be careful about doing that with other files...because me as a user i wont like to backup/restore anything but the profile credentials.. but that's another topic outside the scope of this pr.

The new code have 2 logger implementations

* in debug builds it works like before
* in release builds we save the logs for the last hour (i tried to make this as optimal as possible to reduce syscalls and disk access, because as said, ideally the app shouldnt be logging anything unless the user really wants that, but considering this path is not an option).

im open to discussion about the strategy to rotate logs too,but i hope this appraoch fits better

PD: users must be warned not to share the logs as verbatim without review/redacted because it can include sensitive information. this message must be appearing somewhere around the "View Logs" button.