### PR TITLE
Delete leftover logfile after sharing accessible via usb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Send messages to up to 5 relays
 - Do not open "Connectivity View" from main title; use "Settigns" instead
 - Fix: If one relay is connected, assume overall connectivity
+- Fix: Delete the temporary log file after sharing it, it stayed readable via USB otherwise
 - Fix marking messages as seen across devices
 - Update to core 2.59.0
 

--- a/deltachat-ios/Helper/Utils.swift
+++ b/deltachat-ios/Helper/Utils.swift
@@ -108,7 +108,9 @@ struct Utils {
         try? FileManager.default.removeItem(at: tempLogfileURL)
         try? data.write(to: tempLogfileURL)
         
-        Utils.share(url: tempLogfileURL, parentViewController: parentViewController, sourceItem: sourceItem)
+        Utils.share(url: tempLogfileURL, parentViewController: parentViewController, sourceItem: sourceItem) {
+            try? FileManager.default.removeItem(at: tempLogfileURL)
+        }
     }
 
     public static func share(url: String, parentViewController: UIViewController, sourceItem: UIBarButtonItem) {
@@ -116,9 +118,12 @@ struct Utils {
         Utils.share(url: url, parentViewController: parentViewController, sourceItem: sourceItem)
     }
 
-    public static func share(url: URL, parentViewController: UIViewController, sourceItem: UIBarButtonItem) {
+    public static func share(url: URL, parentViewController: UIViewController, sourceItem: UIBarButtonItem, onDismiss: (() -> Void)? = nil) {
         let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         activityVC.popoverPresentationController?.barButtonItem = sourceItem
+        if let onDismiss {
+            activityVC.completionWithItemsHandler = { _, _, _, _ in onDismiss() }
+        }
         parentViewController.present(activityVC, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
* When the user shares the logs, the log file is saved in disk
* file is accessible via libimobiledevice because ifuse mounts the entire sandbox