### PR TITLE
Better visibility handling for read receipts

### DIFF
--- a/deltachat-ios/Chat/ChatViewController.swift
+++ b/deltachat-ios/Chat/ChatViewController.swift
@@ -14,7 +14,13 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     private var dcContext: DcContext
     private var messages: [(id: Int, timestamp: TimeInterval)] = []
-    private var isVisibleToUser: Bool = false
+    private var isVisibleToUser: Bool {
+        let delegate = UIApplication.shared.delegate as? AppDelegate
+        guard delegate?.appIsInForeground() == true else { return false }
+        guard delegate?.callWindow.isHidden == true else { return false }
+        guard navigationController?.visibleViewController == self else { return false }
+        return true
+    }
     private var reactionMessageId: Int?
     private var contextMenuVisible = false
     private var isDraggingScrollView = false
@@ -528,14 +534,13 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         updateScrollDownButtonVisibility()
+        markSeenMessagesInVisibleArea()
         // things that do not affect the chatview
         // and are delayed after the view is displayed
         DispatchQueue.global().async { [weak self] in
             guard let self else { return }
             self.dcContext.marknoticedChat(chatId: self.chatId)
         }
-
-        handleUserVisibility(isVisible: true)
 
         if #available(iOS 26.0, *) {
             updateTopEdgeEffectAppearance()
@@ -550,7 +555,6 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        handleUserVisibility(isVisible: false)
         if #available(iOS 26.0, *), let previousValue = wasInteractiveContentPopGestureRecognizerEnabled {
             navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = previousValue
         }
@@ -756,9 +760,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     @objc func applicationDidBecomeActive(_ notification: NSNotification) {
-        if navigationController?.visibleViewController == self {
-            handleUserVisibility(isVisible: true)
-        }
+        markSeenMessagesInVisibleArea()
         // Update the last seen indicator
         updateTitle()
         let nc = UNUserNotificationCenter.current()
@@ -767,17 +769,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     @objc func applicationWillResignActive(_ notification: NSNotification) {
-        if navigationController?.visibleViewController == self {
-            handleUserVisibility(isVisible: false)
-            draft.save(context: dcContext)
-        }
-    }
-
-    func handleUserVisibility(isVisible: Bool) {
-        isVisibleToUser = isVisible
-        if isVisible {
-            markSeenMessagesInVisibleArea()
-        }
+        draft.save(context: dcContext)
     }
 
     /// UITableView methods
@@ -1004,8 +996,7 @@ class ChatViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     func markSeenMessagesInVisibleArea() {
-        if isVisibleToUser,
-           let indexPaths = tableView.indexPathsForVisibleRows {
+        if isVisibleToUser, let indexPaths = tableView.indexPathsForVisibleRows {
             let visibleMessagesIds = indexPaths.map { UInt32(messages[$0.row].id) }
             if !visibleMessagesIds.isEmpty {
                 DispatchQueue.global().async { [weak self] in


### PR DESCRIPTION
Don't send read receipts when call window is over the messages